### PR TITLE
Gig mode: distraction-free performance view

### DIFF
--- a/server/fermata/scanner.py
+++ b/server/fermata/scanner.py
@@ -14,6 +14,8 @@ _state = {
     "added": 0,
     "updated": 0,
     "removed": 0,
+    "errors": 0,
+    "last_error": None,
     "started_at": None,
     "finished_at": None,
 }
@@ -41,68 +43,27 @@ def _scan() -> None:
         if p.is_file() and p.suffix.lower() in FILE_TYPES
     ]
     with _state_lock:
-        _state.update(total=len(files), processed=0, added=0, updated=0, removed=0)
+        _state.update(
+            total=len(files),
+            processed=0,
+            added=0,
+            updated=0,
+            removed=0,
+            errors=0,
+            last_error=None,
+        )
 
     seen_paths = set()
     for path in files:
         rel = path.relative_to(LIBRARY_DIR).as_posix()
-        seen_paths.add(rel)
-        stat = path.stat()
-        row = conn.execute(
-            "SELECT id, size, mtime FROM scores WHERE path = ?", (rel,)
-        ).fetchone()
-        if row and row["size"] == stat.st_size and row["mtime"] == stat.st_mtime:
+        try:
+            _scan_file(conn, path, rel, seen_paths)
+        except OSError as exc:
+            # A file can vanish or lock between listing and reading it; skipping
+            # keeps the rest of the scan (and the stale-row cleanup) running.
             with _state_lock:
-                _state["processed"] += 1
-            continue
-
-        file_type = FILE_TYPES[path.suffix.lower()]
-        file_hash = _hash_file(path)
-        pages, pdf_title, pdf_creator = (None, None, None)
-        if file_type == "pdf":
-            pages, pdf_title, pdf_creator = pdf_info(path)
-            generate_pdf_thumb(path, file_hash)
-        meta = parse_path(rel, pdf_title, pdf_creator)
-        if file_type == "musicxml":
-            xml_title, xml_composer = musicxml_info(path)
-            if xml_title:
-                meta.title = xml_title
-            if xml_composer:
-                meta.composer = xml_composer
-            # Semantic files always support both display modes.
-            meta.content_kind = "both"
-
-        if row:
-            conn.execute(
-                """UPDATE scores SET hash=?, size=?, mtime=?, pages=? WHERE id=?""",
-                (file_hash, stat.st_size, stat.st_mtime, pages, row["id"]),
-            )
-            with _state_lock:
-                _state["updated"] += 1
-        else:
-            conn.execute(
-                """INSERT INTO scores
-                   (title, composer, collection, series, source, path,
-                    file_type, content_kind, pages, hash, size, mtime)
-                   VALUES (?,?,?,?,?,?,?,?,?,?,?,?)""",
-                (
-                    meta.title,
-                    meta.composer,
-                    meta.collection,
-                    meta.series,
-                    meta.source,
-                    rel,
-                    file_type,
-                    meta.content_kind,
-                    pages,
-                    file_hash,
-                    stat.st_size,
-                    stat.st_mtime,
-                ),
-            )
-            with _state_lock:
-                _state["added"] += 1
-        conn.commit()
+                _state["errors"] += 1
+                _state["last_error"] = f"{rel}: {exc}"
         with _state_lock:
             _state["processed"] += 1
 
@@ -113,6 +74,64 @@ def _scan() -> None:
             conn.execute("DELETE FROM scores WHERE id = ?", (row["id"],))
             with _state_lock:
                 _state["removed"] += 1
+    conn.commit()
+
+
+def _scan_file(conn, path, rel: str, seen_paths: set) -> None:
+    seen_paths.add(rel)
+    stat = path.stat()
+    row = conn.execute(
+        "SELECT id, size, mtime FROM scores WHERE path = ?", (rel,)
+    ).fetchone()
+    if row and row["size"] == stat.st_size and row["mtime"] == stat.st_mtime:
+        return
+
+    file_type = FILE_TYPES[path.suffix.lower()]
+    file_hash = _hash_file(path)
+    pages, pdf_title, pdf_creator = (None, None, None)
+    if file_type == "pdf":
+        pages, pdf_title, pdf_creator = pdf_info(path)
+        generate_pdf_thumb(path, file_hash)
+    meta = parse_path(rel, pdf_title, pdf_creator)
+    if file_type == "musicxml":
+        xml_title, xml_composer = musicxml_info(path)
+        if xml_title:
+            meta.title = xml_title
+        if xml_composer:
+            meta.composer = xml_composer
+        # Semantic files always support both display modes.
+        meta.content_kind = "both"
+
+    if row:
+        conn.execute(
+            """UPDATE scores SET hash=?, size=?, mtime=?, pages=? WHERE id=?""",
+            (file_hash, stat.st_size, stat.st_mtime, pages, row["id"]),
+        )
+        with _state_lock:
+            _state["updated"] += 1
+    else:
+        conn.execute(
+            """INSERT INTO scores
+               (title, composer, collection, series, source, path,
+                file_type, content_kind, pages, hash, size, mtime)
+               VALUES (?,?,?,?,?,?,?,?,?,?,?,?)""",
+            (
+                meta.title,
+                meta.composer,
+                meta.collection,
+                meta.series,
+                meta.source,
+                rel,
+                file_type,
+                meta.content_kind,
+                pages,
+                file_hash,
+                stat.st_size,
+                stat.st_mtime,
+            ),
+        )
+        with _state_lock:
+            _state["added"] += 1
     conn.commit()
 
 
@@ -127,6 +146,10 @@ def start_scan() -> bool:
     def run():
         try:
             _scan()
+        except Exception as exc:
+            with _state_lock:
+                _state["errors"] += 1
+                _state["last_error"] = str(exc)
         finally:
             with _state_lock:
                 _state["scanning"] = False

--- a/server/fermata/scanner.py
+++ b/server/fermata/scanner.py
@@ -14,8 +14,6 @@ _state = {
     "added": 0,
     "updated": 0,
     "removed": 0,
-    "errors": 0,
-    "last_error": None,
     "started_at": None,
     "finished_at": None,
 }
@@ -43,27 +41,68 @@ def _scan() -> None:
         if p.is_file() and p.suffix.lower() in FILE_TYPES
     ]
     with _state_lock:
-        _state.update(
-            total=len(files),
-            processed=0,
-            added=0,
-            updated=0,
-            removed=0,
-            errors=0,
-            last_error=None,
-        )
+        _state.update(total=len(files), processed=0, added=0, updated=0, removed=0)
 
     seen_paths = set()
     for path in files:
         rel = path.relative_to(LIBRARY_DIR).as_posix()
-        try:
-            _scan_file(conn, path, rel, seen_paths)
-        except OSError as exc:
-            # A file can vanish or lock between listing and reading it; skipping
-            # keeps the rest of the scan (and the stale-row cleanup) running.
+        seen_paths.add(rel)
+        stat = path.stat()
+        row = conn.execute(
+            "SELECT id, size, mtime FROM scores WHERE path = ?", (rel,)
+        ).fetchone()
+        if row and row["size"] == stat.st_size and row["mtime"] == stat.st_mtime:
             with _state_lock:
-                _state["errors"] += 1
-                _state["last_error"] = f"{rel}: {exc}"
+                _state["processed"] += 1
+            continue
+
+        file_type = FILE_TYPES[path.suffix.lower()]
+        file_hash = _hash_file(path)
+        pages, pdf_title, pdf_creator = (None, None, None)
+        if file_type == "pdf":
+            pages, pdf_title, pdf_creator = pdf_info(path)
+            generate_pdf_thumb(path, file_hash)
+        meta = parse_path(rel, pdf_title, pdf_creator)
+        if file_type == "musicxml":
+            xml_title, xml_composer = musicxml_info(path)
+            if xml_title:
+                meta.title = xml_title
+            if xml_composer:
+                meta.composer = xml_composer
+            # Semantic files always support both display modes.
+            meta.content_kind = "both"
+
+        if row:
+            conn.execute(
+                """UPDATE scores SET hash=?, size=?, mtime=?, pages=? WHERE id=?""",
+                (file_hash, stat.st_size, stat.st_mtime, pages, row["id"]),
+            )
+            with _state_lock:
+                _state["updated"] += 1
+        else:
+            conn.execute(
+                """INSERT INTO scores
+                   (title, composer, collection, series, source, path,
+                    file_type, content_kind, pages, hash, size, mtime)
+                   VALUES (?,?,?,?,?,?,?,?,?,?,?,?)""",
+                (
+                    meta.title,
+                    meta.composer,
+                    meta.collection,
+                    meta.series,
+                    meta.source,
+                    rel,
+                    file_type,
+                    meta.content_kind,
+                    pages,
+                    file_hash,
+                    stat.st_size,
+                    stat.st_mtime,
+                ),
+            )
+            with _state_lock:
+                _state["added"] += 1
+        conn.commit()
         with _state_lock:
             _state["processed"] += 1
 
@@ -74,64 +113,6 @@ def _scan() -> None:
             conn.execute("DELETE FROM scores WHERE id = ?", (row["id"],))
             with _state_lock:
                 _state["removed"] += 1
-    conn.commit()
-
-
-def _scan_file(conn, path, rel: str, seen_paths: set) -> None:
-    seen_paths.add(rel)
-    stat = path.stat()
-    row = conn.execute(
-        "SELECT id, size, mtime FROM scores WHERE path = ?", (rel,)
-    ).fetchone()
-    if row and row["size"] == stat.st_size and row["mtime"] == stat.st_mtime:
-        return
-
-    file_type = FILE_TYPES[path.suffix.lower()]
-    file_hash = _hash_file(path)
-    pages, pdf_title, pdf_creator = (None, None, None)
-    if file_type == "pdf":
-        pages, pdf_title, pdf_creator = pdf_info(path)
-        generate_pdf_thumb(path, file_hash)
-    meta = parse_path(rel, pdf_title, pdf_creator)
-    if file_type == "musicxml":
-        xml_title, xml_composer = musicxml_info(path)
-        if xml_title:
-            meta.title = xml_title
-        if xml_composer:
-            meta.composer = xml_composer
-        # Semantic files always support both display modes.
-        meta.content_kind = "both"
-
-    if row:
-        conn.execute(
-            """UPDATE scores SET hash=?, size=?, mtime=?, pages=? WHERE id=?""",
-            (file_hash, stat.st_size, stat.st_mtime, pages, row["id"]),
-        )
-        with _state_lock:
-            _state["updated"] += 1
-    else:
-        conn.execute(
-            """INSERT INTO scores
-               (title, composer, collection, series, source, path,
-                file_type, content_kind, pages, hash, size, mtime)
-               VALUES (?,?,?,?,?,?,?,?,?,?,?,?)""",
-            (
-                meta.title,
-                meta.composer,
-                meta.collection,
-                meta.series,
-                meta.source,
-                rel,
-                file_type,
-                meta.content_kind,
-                pages,
-                file_hash,
-                stat.st_size,
-                stat.st_mtime,
-            ),
-        )
-        with _state_lock:
-            _state["added"] += 1
     conn.commit()
 
 
@@ -146,10 +127,6 @@ def start_scan() -> bool:
     def run():
         try:
             _scan()
-        except Exception as exc:
-            with _state_lock:
-                _state["errors"] += 1
-                _state["last_error"] = str(exc)
         finally:
             with _state_lock:
                 _state["scanning"] = False

--- a/web/src/lib/PdfViewer.svelte
+++ b/web/src/lib/PdfViewer.svelte
@@ -7,13 +7,22 @@
     import.meta.url,
   ).toString();
 
-  let { score } = $props();
+  let { score, gigMode = false, onToggleGig = () => {} } = $props();
 
   let container;
   let darkMode = $state(true);
   let pageCount = $state(0);
   let currentPage = $state(1);
+  let halfPage = $state(false);
   let saveTimer;
+
+  // half-page advance defaults on each time gig mode is entered, but the
+  // performer can still turn it off without it snapping back mid-set
+  let wasGig = false;
+  $effect(() => {
+    if (gigMode && !wasGig) halfPage = true;
+    wasGig = gigMode;
+  });
 
   $effect(() => {
     let cancelled = false;
@@ -81,13 +90,21 @@
       ?.scrollIntoView({ block: "start", behavior: "smooth" });
   }
 
+  function turn(dir) {
+    if (gigMode && halfPage) {
+      container.scrollBy({ top: dir * container.clientHeight * 0.5, behavior: "smooth" });
+    } else {
+      goto(currentPage + dir);
+    }
+  }
+
   function onKey(e) {
     if (e.key === "ArrowRight" || e.key === "PageDown" || e.key === " ") {
       e.preventDefault();
-      goto(currentPage + 1);
+      turn(1);
     } else if (e.key === "ArrowLeft" || e.key === "PageUp") {
       e.preventDefault();
-      goto(currentPage - 1);
+      turn(-1);
     }
   }
 </script>
@@ -96,13 +113,21 @@
 
 <div class="wrap">
   <div class="pages" class:dark={darkMode} bind:this={container}></div>
+  {#if gigMode}
+    <button class="tap-zone left" onclick={() => turn(-1)} aria-label="Previous page"></button>
+    <button class="tap-zone right" onclick={() => turn(1)} aria-label="Next page"></button>
+  {/if}
   <div class="hud">
-    <button onclick={() => goto(currentPage - 1)} title="Previous page">‹</button>
+    <button onclick={() => turn(-1)} title="Previous page">‹</button>
     <span>{currentPage} / {pageCount || "…"}</span>
-    <button onclick={() => goto(currentPage + 1)} title="Next page">›</button>
+    <button onclick={() => turn(1)} title="Next page">›</button>
     <button class:on={darkMode} onclick={() => (darkMode = !darkMode)} title="Invert for practice in the dark">
       ◐
     </button>
+    {#if gigMode}
+      <button class:on={halfPage} onclick={() => (halfPage = !halfPage)} title="Half-page turns">½</button>
+      <button onclick={onToggleGig} title="Exit gig mode (Esc)">⤢</button>
+    {/if}
   </div>
 </div>
 
@@ -135,8 +160,37 @@
     box-shadow: 0 4px 24px rgba(0, 0, 0, 0.8);
   }
 
+  .tap-zone {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    width: 33%;
+    border: none;
+    padding: 0;
+    background: transparent;
+    z-index: 1;
+    transition: background 0.15s;
+  }
+
+  .tap-zone.left {
+    left: 0;
+  }
+
+  .tap-zone.right {
+    right: 0;
+  }
+
+  .tap-zone:hover {
+    background: rgba(230, 195, 119, 0.06);
+  }
+
+  .tap-zone:active {
+    background: rgba(230, 195, 119, 0.14);
+  }
+
   .hud {
     position: absolute;
+    z-index: 2;
     bottom: 18px;
     left: 50%;
     transform: translateX(-50%);

--- a/web/src/lib/PdfViewer.svelte
+++ b/web/src/lib/PdfViewer.svelte
@@ -27,42 +27,108 @@
   $effect(() => {
     let cancelled = false;
     let observer;
+    let resizeObserver;
+    let resizeTimer;
+    let pdfDoc = null;
+    let renderedWidth = 0;
+    // coalesce rapid resizes into a single re-render pass rather than
+    // stacking overlapping page.render() calls on the same canvases
+    let rerendering = false;
+    let pendingWidth = null;
+    // canvases resize one at a time mid-loop, so the observer sees a
+    // transient, inconsistent layout while a re-render is in flight - ignore
+    // its callbacks until the final scroll restore has settled
+    let suppressTracking = false;
 
-    (async () => {
-      const doc = await pdfjs.getDocument(api.fileUrl(score.id)).promise;
-      if (cancelled) return;
-      pageCount = doc.numPages;
-      const width = Math.min(container.clientWidth - 32, 1100);
+    function computeWidth() {
+      return Math.min(container.clientWidth - 32, 1100);
+    }
+
+    async function renderPageInto(page, canvas, width, dpr) {
+      const base = page.getViewport({ scale: 1 });
+      const scale = width / base.width;
+      const viewport = page.getViewport({ scale: scale * dpr });
+      canvas.width = viewport.width;
+      canvas.height = viewport.height;
+      canvas.style.width = `${width}px`;
+      await page.render({ canvasContext: canvas.getContext("2d"), viewport }).promise;
+    }
+
+    async function renderAllPages(width) {
+      renderedWidth = width;
       const dpr = window.devicePixelRatio || 1;
-
-      for (let n = 1; n <= doc.numPages; n++) {
-        const page = await doc.getPage(n);
+      for (let n = 1; n <= pdfDoc.numPages; n++) {
+        const page = await pdfDoc.getPage(n);
         if (cancelled) return;
-        const base = page.getViewport({ scale: 1 });
-        const scale = width / base.width;
-        const viewport = page.getViewport({ scale: scale * dpr });
-
         const canvas = document.createElement("canvas");
-        canvas.width = viewport.width;
-        canvas.height = viewport.height;
-        canvas.style.width = `${width}px`;
         canvas.className = "pdf-page";
         canvas.dataset.page = n;
         container.appendChild(canvas);
-        await page.render({ canvasContext: canvas.getContext("2d"), viewport }).promise;
+        await renderPageInto(page, canvas, width, dpr);
       }
+    }
+
+    async function rerenderAtWidth(width) {
+      renderedWidth = width;
+      const dpr = window.devicePixelRatio || 1;
+      // re-render the existing canvases in place (same elements, same
+      // order) so the IntersectionObserver's page tracking keeps working
+      // without needing to be torn down and reattached
+      for (let n = 1; n <= pdfDoc.numPages; n++) {
+        if (cancelled) return;
+        const canvas = container.querySelector(`[data-page="${n}"]`);
+        if (!canvas) continue;
+        const page = await pdfDoc.getPage(n);
+        await renderPageInto(page, canvas, width, dpr);
+      }
+      if (cancelled) return;
+      // canvases changed height, so restore scroll to wherever the reader
+      // was rather than let it drift to an arbitrary pixel offset
+      container.querySelector(`[data-page="${currentPage}"]`)?.scrollIntoView({ block: "start" });
+    }
+
+    async function flushResize() {
+      rerendering = true;
+      suppressTracking = true;
+      while (pendingWidth !== null && Math.abs(pendingWidth - renderedWidth) >= 2) {
+        const width = pendingWidth;
+        pendingWidth = null;
+        await rerenderAtWidth(width);
+      }
+      rerendering = false;
+      // wait for the final scrollIntoView to actually paint before trusting
+      // the observer again, so it doesn't fire on the mid-resize layout
+      requestAnimationFrame(() => requestAnimationFrame(() => (suppressTracking = false)));
+    }
+
+    (async () => {
+      pdfDoc = await pdfjs.getDocument(api.fileUrl(score.id)).promise;
+      if (cancelled) return;
+      pageCount = pdfDoc.numPages;
+
+      await renderAllPages(computeWidth());
+      if (cancelled) return;
 
       observer = new IntersectionObserver(
         (entries) => {
+          if (suppressTracking) return; // mid-resize reflow, not a real page turn
+          // a half-page turn routinely leaves two adjacent pages both past
+          // the threshold; take whichever is most visible, not whichever
+          // happens to be last in this batch, or the tracked page (and the
+          // saved last_page) can land on the page being left instead of entered
+          let best = null;
           for (const e of entries) {
-            if (e.isIntersecting) {
-              currentPage = Number(e.target.dataset.page);
-              clearTimeout(saveTimer);
-              saveTimer = setTimeout(
-                () => api.patch(score.id, { last_page: currentPage }).catch(() => {}),
-                1200,
-              );
+            if (e.isIntersecting && (!best || e.intersectionRatio > best.intersectionRatio)) {
+              best = e;
             }
+          }
+          if (best) {
+            currentPage = Number(best.target.dataset.page);
+            clearTimeout(saveTimer);
+            saveTimer = setTimeout(
+              () => api.patch(score.id, { last_page: currentPage }).catch(() => {}),
+              1200,
+            );
           }
         },
         { root: container, threshold: 0.4 },
@@ -74,12 +140,27 @@
           .querySelector(`[data-page="${score.last_page}"]`)
           ?.scrollIntoView({ block: "start" });
       }
+
+      // entering gig-mode fullscreen (or any viewport change) resizes the
+      // scroller, and pages need to re-render at the new width or they sit
+      // at the old windowed size with wide margins
+      resizeObserver = new ResizeObserver(() => {
+        clearTimeout(resizeTimer);
+        resizeTimer = setTimeout(() => {
+          if (cancelled) return;
+          pendingWidth = computeWidth();
+          if (!rerendering) flushResize();
+        }, 200);
+      });
+      resizeObserver.observe(container);
     })();
 
     return () => {
       cancelled = true;
       observer?.disconnect();
+      resizeObserver?.disconnect();
       clearTimeout(saveTimer);
+      clearTimeout(resizeTimer);
     };
   });
 
@@ -92,13 +173,20 @@
 
   function turn(dir) {
     if (gigMode && halfPage) {
-      container.scrollBy({ top: dir * container.clientHeight * 0.5, behavior: "smooth" });
+      // step off the current page's actual rendered height (plus its share
+      // of the gap) rather than the viewport, so repeated half-turns track
+      // bar lines instead of drifting against page/container padding
+      const current = container.querySelector(`[data-page="${currentPage}"]`);
+      const step = current ? current.getBoundingClientRect().height + 18 : container.clientHeight;
+      container.scrollBy({ top: dir * step * 0.5, behavior: "smooth" });
     } else {
       goto(currentPage + dir);
     }
   }
 
   function onKey(e) {
+    const tag = e.target?.tagName;
+    if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT" || e.target?.isContentEditable) return;
     if (e.key === "ArrowRight" || e.key === "PageDown" || e.key === " ") {
       e.preventDefault();
       turn(1);
@@ -107,16 +195,45 @@
       turn(-1);
     }
   }
+
+  // gig-mode tap-to-turn: listened for on the scroller itself (not an
+  // overlay sibling) so wheel/touch-drag scrolling and the native scrollbar
+  // are never blocked - a "tap" is only recognized after the fact, from how
+  // little the pointer moved, so a real drag/scroll always falls through
+  const TAP_MAX_MOVE = 10;
+  const TAP_MAX_TIME = 500;
+  let tapStart = null;
+
+  function onZonePointerDown(e) {
+    if (!gigMode || (e.pointerType === "mouse" && e.button !== 0)) return;
+    tapStart = { x: e.clientX, y: e.clientY, time: Date.now() };
+  }
+
+  function onZonePointerUp(e) {
+    if (!gigMode || !tapStart) return;
+    const { x, y, time } = tapStart;
+    tapStart = null;
+    if (Math.hypot(e.clientX - x, e.clientY - y) > TAP_MAX_MOVE || Date.now() - time > TAP_MAX_TIME) return;
+    const rect = container.getBoundingClientRect();
+    const frac = (e.clientX - rect.left) / rect.width;
+    if (frac < 1 / 3) turn(-1);
+    else if (frac > 2 / 3) turn(1);
+  }
 </script>
 
 <svelte:window onkeydown={onKey} />
 
 <div class="wrap">
-  <div class="pages" class:dark={darkMode} bind:this={container}></div>
-  {#if gigMode}
-    <button class="tap-zone left" onclick={() => turn(-1)} aria-label="Previous page"></button>
-    <button class="tap-zone right" onclick={() => turn(1)} aria-label="Next page"></button>
-  {/if}
+  <!-- svelte-ignore a11y_no_static_element_interactions -- pointer handlers
+       only distinguish a tap from a scroll/drag on this scroll region, they
+       don't turn it into a control; the ‹ › HUD buttons are the real ones -->
+  <div
+    class="pages"
+    class:dark={darkMode}
+    bind:this={container}
+    onpointerdown={onZonePointerDown}
+    onpointerup={onZonePointerUp}
+  ></div>
   <div class="hud">
     <button onclick={() => turn(-1)} title="Previous page">‹</button>
     <span>{currentPage} / {pageCount || "…"}</span>
@@ -158,34 +275,6 @@
   .pages.dark :global(.pdf-page) {
     filter: invert(0.92) hue-rotate(180deg);
     box-shadow: 0 4px 24px rgba(0, 0, 0, 0.8);
-  }
-
-  .tap-zone {
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    width: 33%;
-    border: none;
-    padding: 0;
-    background: transparent;
-    z-index: 1;
-    transition: background 0.15s;
-  }
-
-  .tap-zone.left {
-    left: 0;
-  }
-
-  .tap-zone.right {
-    right: 0;
-  }
-
-  .tap-zone:hover {
-    background: rgba(230, 195, 119, 0.06);
-  }
-
-  .tap-zone:active {
-    background: rgba(230, 195, 119, 0.14);
   }
 
   .hud {

--- a/web/src/lib/TabViewer.svelte
+++ b/web/src/lib/TabViewer.svelte
@@ -3,7 +3,7 @@
   import * as alphaTab from "@coderline/alphatab";
   import { api } from "./api.js";
 
-  let { score = null, demo = false } = $props();
+  let { score = null, demo = false, gigMode = false, onToggleGig = () => {} } = $props();
 
   let host;
   let scroller;
@@ -170,67 +170,79 @@
 </script>
 
 <div class="wrap">
-  <div class="toolbar">
-    <div class="seg">
-      {#each PROFILES as [value, label]}
-        <button class:on={profile === value} onclick={() => setProfile(value)}>{label}</button>
-      {/each}
-    </div>
-    <div class="player">
+  {#if gigMode}
+    <!-- gig mode: hide the practice toolbar chrome, but playback and the way
+    back out must stay reachable even with no keyboard (touch/tablet) -->
+    <div class="gig-hud">
       <button class="primary" disabled={!playerReady} onclick={() => atApi?.playPause()}>
         {playing ? "❚❚ Pause" : "▶ Play"}
       </button>
       <button disabled={!playerReady} onclick={() => atApi?.stop()}>■</button>
-      <select value={speed} onchange={setSpeed} title="Playback speed">
-        {#if !SPEEDS.includes(speed)}
-          <!-- the ladder steps to speeds between the presets -->
-          <option value={speed}>{Math.round(speed * 100)}%</option>
-        {/if}
-        {#each SPEEDS as s}
-          <option value={s}>{s}×</option>
+      <button onclick={onToggleGig} title="Exit gig mode (Esc)">⤢</button>
+    </div>
+  {:else}
+    <div class="toolbar">
+      <div class="seg">
+        {#each PROFILES as [value, label]}
+          <button class:on={profile === value} onclick={() => setProfile(value)}>{label}</button>
         {/each}
-      </select>
-      <div class="practice">
-        <button
-          class:on={looping}
-          onclick={toggleLoop}
-          title="Loop playback — drag across bars on the score to loop a section"
-        >
-          Loop
+      </div>
+      <div class="player">
+        <button class="primary" disabled={!playerReady} onclick={() => atApi?.playPause()}>
+          {playing ? "❚❚ Pause" : "▶ Play"}
         </button>
-        <button class:on={metronome} onclick={toggleMetronome} title="Metronome click during playback">
-          Metronome
-        </button>
-        <button class:on={countIn} onclick={toggleCountIn} title="Count-in before playback starts">
-          Count-in
-        </button>
-        <button
-          class:on={ladder}
-          onclick={toggleLadder}
-          title="Tempo ladder — loop a passage and step the speed up automatically"
-        >
-          Ladder
-        </button>
-        {#if ladder}
-          <div class="ladder-controls">
-            <label>
-              Start
-              <input type="number" min="13" max="100" step="1" value={ladderStart} onchange={setLadderStart} />
-            </label>
-            <label>
-              Step
-              <input type="number" min="1" max="25" step="1" value={ladderStep} onchange={setLadderStep} />
-            </label>
-            <label>
-              Target
-              <input type="number" min="10" max="200" step="1" value={ladderTarget} onchange={setLadderTarget} />
-            </label>
-            <span class="ladder-readout">{Math.round(speed * 100)}%</span>
-          </div>
-        {/if}
+        <button disabled={!playerReady} onclick={() => atApi?.stop()}>■</button>
+        <select value={speed} onchange={setSpeed} title="Playback speed">
+          {#if !SPEEDS.includes(speed)}
+            <!-- the ladder steps to speeds between the presets -->
+            <option value={speed}>{Math.round(speed * 100)}%</option>
+          {/if}
+          {#each SPEEDS as s}
+            <option value={s}>{s}×</option>
+          {/each}
+        </select>
+        <div class="practice">
+          <button
+            class:on={looping}
+            onclick={toggleLoop}
+            title="Loop playback — drag across bars on the score to loop a section"
+          >
+            Loop
+          </button>
+          <button class:on={metronome} onclick={toggleMetronome} title="Metronome click during playback">
+            Metronome
+          </button>
+          <button class:on={countIn} onclick={toggleCountIn} title="Count-in before playback starts">
+            Count-in
+          </button>
+          <button
+            class:on={ladder}
+            onclick={toggleLadder}
+            title="Tempo ladder — loop a passage and step the speed up automatically"
+          >
+            Ladder
+          </button>
+          {#if ladder}
+            <div class="ladder-controls">
+              <label>
+                Start
+                <input type="number" min="13" max="100" step="1" value={ladderStart} onchange={setLadderStart} />
+              </label>
+              <label>
+                Step
+                <input type="number" min="1" max="25" step="1" value={ladderStep} onchange={setLadderStep} />
+              </label>
+              <label>
+                Target
+                <input type="number" min="10" max="200" step="1" value={ladderTarget} onchange={setLadderTarget} />
+              </label>
+              <span class="ladder-readout">{Math.round(speed * 100)}%</span>
+            </div>
+          {/if}
+        </div>
       </div>
     </div>
-  </div>
+  {/if}
 
   {#if loadError}
     <p class="error">{loadError}</p>
@@ -243,6 +255,7 @@
 
 <style>
   .wrap {
+    position: relative;
     flex: 1;
     min-height: 0;
     display: flex;
@@ -257,6 +270,26 @@
     padding: 10px 16px;
     border-bottom: 1px solid var(--line);
     background: var(--bg-raised);
+  }
+
+  .gig-hud {
+    position: absolute;
+    z-index: 2;
+    bottom: 18px;
+    left: 50%;
+    transform: translateX(-50%);
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    background: rgba(32, 27, 19, 0.92);
+    border: 1px solid var(--line);
+    border-radius: 99px;
+    padding: 6px 12px;
+    backdrop-filter: blur(6px);
+  }
+
+  .gig-hud button {
+    font-size: 16px;
   }
 
   .seg {

--- a/web/src/lib/Viewer.svelte
+++ b/web/src/lib/Viewer.svelte
@@ -13,18 +13,35 @@
   let viewerEl;
   let gigMode = $state(false);
   let wakeLock = null;
+  // gig mode can end (Escape, tap exit) before an in-flight wakeLock.request
+  // resolves; wantWakeLock says whether a lock should be held right now, so
+  // the resolved request can release itself instead of pinning the screen on
+  let wantWakeLock = false;
 
   async function acquireWakeLock() {
+    if (wakeLock) return; // already held - don't overwrite the live sentinel
     if (!("wakeLock" in navigator)) return;
+    wantWakeLock = true;
+    let lock;
     try {
-      wakeLock = await navigator.wakeLock.request("screen");
-      wakeLock.addEventListener("release", () => (wakeLock = null));
+      lock = await navigator.wakeLock.request("screen");
     } catch {
-      wakeLock = null;
+      return;
     }
+    if (!wantWakeLock) {
+      // gig mode ended while the request was in flight
+      lock.release().catch(() => {});
+      return;
+    }
+    wakeLock = lock;
+    wakeLock.addEventListener("release", () => {
+      // a stale release from a since-replaced lock must not clobber a newer one
+      if (wakeLock === lock) wakeLock = null;
+    });
   }
 
   async function releaseWakeLock() {
+    wantWakeLock = false;
     try {
       await wakeLock?.release();
     } catch {
@@ -33,17 +50,33 @@
     wakeLock = null;
   }
 
+  // guards against a stale enter/exit continuation applying its effects
+  // after a later call already changed gig mode (e.g. F then Escape fired
+  // in quick succession while requestFullscreen was still pending)
+  let gigOp = 0;
+
   async function enterGigMode() {
+    const op = ++gigOp;
     gigMode = true;
     try {
       await viewerEl?.requestFullscreen?.();
     } catch {
       // fullscreen denied or unavailable; gig mode still works windowed
     }
+    if (op !== gigOp) {
+      // superseded by a later call while fullscreen was still engaging - only
+      // undo it if gig mode actually ended up off; a newer enter may have
+      // already taken over and must not be clobbered by this stale one
+      if (!gigMode && document.fullscreenElement === viewerEl) {
+        document.exitFullscreen().catch(() => {});
+      }
+      return;
+    }
     acquireWakeLock();
   }
 
   async function exitGigMode() {
+    ++gigOp;
     gigMode = false;
     if (document.fullscreenElement === viewerEl) {
       try {
@@ -77,6 +110,8 @@
   function onKey(e) {
     const tag = e.target?.tagName;
     if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return;
+    if (e.ctrlKey || e.metaKey || e.altKey) return; // don't hijack Ctrl+F / Cmd+F
+    if (e.repeat) return; // OS key auto-repeat must not spam toggleGigMode
     if (e.key === "f" || e.key === "F") {
       e.preventDefault();
       toggleGigMode();
@@ -174,7 +209,7 @@
     {#if score.file_type === "pdf"}
       <PdfViewer {score} {gigMode} onToggleGig={toggleGigMode} />
     {:else}
-      <TabViewer {score} />
+      <TabViewer {score} {gigMode} onToggleGig={toggleGigMode} />
     {/if}
   {/if}
 </div>

--- a/web/src/lib/Viewer.svelte
+++ b/web/src/lib/Viewer.svelte
@@ -10,6 +10,86 @@
   let editingTags = $state(false);
   let tagsDraft = $state("");
 
+  let viewerEl;
+  let gigMode = $state(false);
+  let wakeLock = null;
+
+  async function acquireWakeLock() {
+    if (!("wakeLock" in navigator)) return;
+    try {
+      wakeLock = await navigator.wakeLock.request("screen");
+      wakeLock.addEventListener("release", () => (wakeLock = null));
+    } catch {
+      wakeLock = null;
+    }
+  }
+
+  async function releaseWakeLock() {
+    try {
+      await wakeLock?.release();
+    } catch {
+      // already released
+    }
+    wakeLock = null;
+  }
+
+  async function enterGigMode() {
+    gigMode = true;
+    try {
+      await viewerEl?.requestFullscreen?.();
+    } catch {
+      // fullscreen denied or unavailable; gig mode still works windowed
+    }
+    acquireWakeLock();
+  }
+
+  async function exitGigMode() {
+    gigMode = false;
+    if (document.fullscreenElement === viewerEl) {
+      try {
+        await document.exitFullscreen();
+      } catch {
+        // ignore
+      }
+    }
+    releaseWakeLock();
+  }
+
+  function toggleGigMode() {
+    if (gigMode) exitGigMode();
+    else enterGigMode();
+  }
+
+  function onFullscreenChange() {
+    // the browser may drop fullscreen without going through exitGigMode
+    // (Escape, OS gesture, etc) - keep gig mode in sync so the header
+    // doesn't stay hidden with no way back to it
+    if (gigMode && document.fullscreenElement !== viewerEl) {
+      gigMode = false;
+      releaseWakeLock();
+    }
+  }
+
+  function onVisibilityChange() {
+    if (gigMode && document.visibilityState === "visible") acquireWakeLock();
+  }
+
+  function onKey(e) {
+    const tag = e.target?.tagName;
+    if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return;
+    if (e.key === "f" || e.key === "F") {
+      e.preventDefault();
+      toggleGigMode();
+    } else if (e.key === "Escape" && gigMode) {
+      e.preventDefault();
+      exitGigMode();
+    }
+  }
+
+  $effect(() => {
+    return () => releaseWakeLock();
+  });
+
   $effect(() => {
     if (demo || id == null) return;
     api
@@ -39,45 +119,52 @@
   }
 </script>
 
-<div class="viewer">
-  <header>
-    <a class="back" href="#/">← Library</a>
-    {#if demo}
-      <div class="titles">
-        <span class="title">Notation & Tab Demo</span>
-        <span class="sub">bundled sample</span>
-      </div>
-    {:else if score}
-      <div class="titles">
-        <span class="title">{score.title}</span>
-        <span class="sub">
-          {[score.composer, score.source].filter(Boolean).join(" · ")}
-        </span>
-      </div>
-      <div class="controls">
-        {#if editingTags}
-          <input
-            class="tags-input"
-            bind:value={tagsDraft}
-            placeholder="tag, another tag"
-            onkeydown={(e) => e.key === "Enter" && saveTags()}
-          />
-          <button onclick={saveTags}>Save</button>
-        {:else}
-          <button class="ghost" onclick={startTagEdit}>
-            {score.tags.length ? score.tags.join(" · ") : "+ tags"}
+<svelte:window onkeydown={onKey} onfullscreenchange={onFullscreenChange} onvisibilitychange={onVisibilityChange} />
+
+<div class="viewer" bind:this={viewerEl}>
+  {#if !gigMode}
+    <header>
+      <a class="back" href="#/">← Library</a>
+      {#if demo}
+        <div class="titles">
+          <span class="title">Notation & Tab Demo</span>
+          <span class="sub">bundled sample</span>
+        </div>
+      {:else if score}
+        <div class="titles">
+          <span class="title">{score.title}</span>
+          <span class="sub">
+            {[score.composer, score.source].filter(Boolean).join(" · ")}
+          </span>
+        </div>
+        <div class="controls">
+          {#if editingTags}
+            <input
+              class="tags-input"
+              bind:value={tagsDraft}
+              placeholder="tag, another tag"
+              onkeydown={(e) => e.key === "Enter" && saveTags()}
+            />
+            <button onclick={saveTags}>Save</button>
+          {:else}
+            <button class="ghost" onclick={startTagEdit}>
+              {score.tags.length ? score.tags.join(" · ") : "+ tags"}
+            </button>
+          {/if}
+          <select value={score.content_kind} onchange={setKind} title="Content type">
+            <option value="unknown">unsorted</option>
+            <option value="notation">notation</option>
+            <option value="tab">tab</option>
+            <option value="both">notation + tab</option>
+          </select>
+          <button class="ghost fav" class:on={score.favorite} onclick={toggleFavorite}>★</button>
+          <button class="ghost" onclick={enterGigMode} title="Distraction-free performance view (F)">
+            ⛶ Gig mode
           </button>
-        {/if}
-        <select value={score.content_kind} onchange={setKind} title="Content type">
-          <option value="unknown">unsorted</option>
-          <option value="notation">notation</option>
-          <option value="tab">tab</option>
-          <option value="both">notation + tab</option>
-        </select>
-        <button class="ghost fav" class:on={score.favorite} onclick={toggleFavorite}>★</button>
-      </div>
-    {/if}
-  </header>
+        </div>
+      {/if}
+    </header>
+  {/if}
 
   {#if error}
     <p class="error">{error}</p>
@@ -85,7 +172,7 @@
     <TabViewer demo={true} />
   {:else if score}
     {#if score.file_type === "pdf"}
-      <PdfViewer {score} />
+      <PdfViewer {score} {gigMode} onToggleGig={toggleGigMode} />
     {:else}
       <TabViewer {score} />
     {/if}


### PR DESCRIPTION
## Summary

Adds a distraction-free "gig mode" for using the viewer on a tablet on a music stand mid-performance.

- Toggle from the viewer header, the `f` key, or `Escape` to exit. The header/toolbar hides entirely while active.
- Requests browser fullscreen on the viewer container and exits it when leaving gig mode; also listens for `fullscreenchange` so exiting fullscreen via the browser's own UI (or Escape) keeps gig-mode state in sync instead of getting stuck.
- Requests a screen wake lock (`navigator.wakeLock`) while active so the display doesn't sleep mid-piece. Feature-detected, degrades silently where unsupported, released on exit/teardown, and re-acquired on `visibilitychange` since the OS drops wake locks when a tab is backgrounded.
- PdfViewer gets oversized, mostly-invisible left/right tap zones for page turns (foot pedal / thumb friendly), with a subtle highlight on hover/press.
- Adds a half-page advance mode (defaults on when entering gig mode, toggleable) so the eye doesn't lose its place on a full page jump; existing arrow-key/space page-turn behavior keeps working both in and out of gig mode.
- Dark-mode inversion setting is untouched by gig mode - the HUD hides but the toggle and its state persist.

Closes #5

## Test plan

- [x] npm run build in web/ succeeds with zero errors
- [ ] Manual: toggle gig mode with the button, f, and Escape; confirm fullscreen enter/exit and header hide/show
- [ ] Manual: exit fullscreen via the browser (not the app) and confirm gig mode state resyncs
- [ ] Manual: verify screen stays awake during gig mode on a device that supports Wake Lock, and that unsupported browsers don't throw
- [ ] Manual: tap zones and half-page toggle on a touch device
