### PR TITLE
Extract guitar tablature from engraved PDFs

### DIFF
--- a/server/fermata/api.py
+++ b/server/fermata/api.py
@@ -1,20 +1,23 @@
+import json
 import re
 import shutil
 from pathlib import Path
 
-from fastapi import APIRouter, HTTPException, UploadFile
+from fastapi import APIRouter, Body, HTTPException, UploadFile
 from fastapi.responses import FileResponse
 from pydantic import BaseModel, Field
 
 from . import scanner
 from .config import FILE_TYPES, LIBRARY_DIR
 from .db import connect, tx
+from .tabextract import analyze as analyze_pdf, extract as extract_pdf
 from .thumbs import thumb_path
 
 router = APIRouter(prefix="/api")
 
 VALID_KINDS = {"notation", "tab", "both", "unknown"}
 VALID_PRACTICED = {"recent", "neglected"}
+MAX_TRANSCRIPTION_CHARS = 2_000_000
 
 
 def _score_row(conn, score_id: int):
@@ -28,6 +31,7 @@ def _with_tags(conn, rows):
     ids = [r["id"] for r in rows]
     tag_map: dict[int, list[str]] = {i: [] for i in ids}
     practice_map: dict[int, dict] = {}
+    transcribed_ids: set[int] = set()
     if ids:
         placeholders = ",".join("?" * len(ids))
         for r in conn.execute(
@@ -46,11 +50,17 @@ def _with_tags(conn, rows):
                 "practice_seconds": r["practice_seconds"],
                 "last_practiced": r["last_practiced"],
             }
+        for r in conn.execute(
+            f"""SELECT DISTINCT score_id FROM transcriptions WHERE score_id IN ({placeholders})""",
+            ids,
+        ):
+            transcribed_ids.add(r["score_id"])
     out = []
     for r in rows:
         d = dict(r)
         d["favorite"] = bool(d["favorite"])
         d["tags"] = tag_map.get(r["id"], [])
+        d["has_transcription"] = r["id"] in transcribed_ids
         d.update(practice_map.get(r["id"], {"practice_seconds": 0, "last_practiced": None}))
         out.append(d)
     return out
@@ -271,6 +281,126 @@ def get_thumb(score_id: int):
     if not path.is_file():
         raise HTTPException(404, "no thumbnail")
     return FileResponse(path, media_type="image/png")
+
+
+def _transcription_row(conn, score_id: int):
+    """Edited beats extracted when both exist - see db.py's schema comment
+    for why they're kept as separate rows instead of one mutated in place."""
+    return conn.execute(
+        """SELECT * FROM transcriptions WHERE score_id = ?
+           ORDER BY CASE source WHEN 'edited' THEN 0 ELSE 1 END LIMIT 1""",
+        (score_id,),
+    ).fetchone()
+
+
+def _transcription_dict(row) -> dict:
+    d = dict(row)
+    if d.get("confidence"):
+        try:
+            d["confidence"] = json.loads(d["confidence"])
+        except (TypeError, ValueError):
+            pass
+    return d
+
+
+@router.get("/scores/{score_id}/transcription")
+def get_transcription(score_id: int):
+    conn = connect()
+    _score_row(conn, score_id)
+    row = _transcription_row(conn, score_id)
+    if not row:
+        raise HTTPException(404, "no transcription for this score")
+    return _transcription_dict(row)
+
+
+@router.get("/scores/{score_id}/transcription/analysis")
+def get_transcription_analysis(score_id: int):
+    conn = connect()
+    row = _score_row(conn, score_id)
+    if row["file_type"] != "pdf":
+        return {
+            "extractable": False,
+            "reason": "transcription is only supported for pdf scores",
+            "vector": False,
+            "tab_staff_count": 0,
+            "standard_staff_count": 0,
+            "page_count": 0,
+        }
+    path = LIBRARY_DIR / row["path"]
+    if not path.is_file():
+        raise HTTPException(404, "file missing from library")
+    return analyze_pdf(path)
+
+
+class TranscribeIn(BaseModel):
+    time_signature: tuple[int, int] | None = None
+
+
+@router.post("/scores/{score_id}/transcribe")
+def transcribe(score_id: int, body: TranscribeIn | None = Body(default=None)):
+    conn = connect()
+    row = _score_row(conn, score_id)
+    if row["file_type"] != "pdf":
+        raise HTTPException(422, "transcription is only supported for pdf scores")
+    path = LIBRARY_DIR / row["path"]
+    if not path.is_file():
+        raise HTTPException(404, "file missing from library")
+
+    ts = tuple(body.time_signature) if body and body.time_signature else None
+    result = extract_pdf(path, time_signature=ts)
+    if not result.extractable:
+        raise HTTPException(422, result.reason or "pdf is not extractable")
+
+    # Only ever writes the source='extracted' row (see unique index on
+    # (score_id, source) in db.py) - a source='edited' row is untouched.
+    confidence_json = json.dumps({"warnings": result.warnings, "confidence": result.confidence})
+    with tx() as tx_conn:
+        tx_conn.execute(
+            """INSERT INTO transcriptions(score_id, format, content, source, confidence, updated_at)
+               VALUES (?, 'alphatex', ?, 'extracted', ?, datetime('now'))
+               ON CONFLICT(score_id, source) DO UPDATE SET
+                   content = excluded.content, confidence = excluded.confidence,
+                   updated_at = datetime('now')""",
+            (score_id, result.alphatex, confidence_json),
+        )
+
+    conn = connect()
+    saved = conn.execute(
+        "SELECT * FROM transcriptions WHERE score_id = ? AND source = 'extracted'", (score_id,)
+    ).fetchone()
+    d = _transcription_dict(saved)
+    d["warnings"] = result.warnings
+    d["bars"] = result.bars
+    d["beats"] = result.beats
+    d["notes"] = result.notes
+    d["tempo"] = result.tempo
+    d["tuning"] = result.tuning
+    d["tuning_label"] = result.tuning_label
+    d["time_signature"] = list(result.time_signature) if result.time_signature else None
+    d["time_signature_source"] = result.time_signature_source
+    return d
+
+
+class TranscriptionEditIn(BaseModel):
+    content: str = Field(min_length=1, max_length=MAX_TRANSCRIPTION_CHARS)
+
+
+@router.put("/scores/{score_id}/transcription")
+def save_transcription(score_id: int, body: TranscriptionEditIn):
+    with tx() as conn:
+        _score_row(conn, score_id)
+        conn.execute(
+            """INSERT INTO transcriptions(score_id, format, content, source, updated_at)
+               VALUES (?, 'alphatex', ?, 'edited', datetime('now'))
+               ON CONFLICT(score_id, source) DO UPDATE SET
+                   content = excluded.content, updated_at = datetime('now')""",
+            (score_id, body.content),
+        )
+    conn = connect()
+    row = conn.execute(
+        "SELECT * FROM transcriptions WHERE score_id = ? AND source = 'edited'", (score_id,)
+    ).fetchone()
+    return _transcription_dict(row)
 
 
 @router.post("/scan")

--- a/server/fermata/api.py
+++ b/server/fermata/api.py
@@ -336,6 +336,19 @@ class TranscribeIn(BaseModel):
     time_signature: tuple[int, int] | None = None
 
 
+# alphaTab accepts a \ts numerator/denominator of 1-32; the denominator must
+# also be a power of two to mean anything as a note-duration unit.
+_VALID_TS_DENOMINATORS = {1, 2, 4, 8, 16, 32}
+
+
+def _validate_time_signature(ts: tuple[int, int]) -> None:
+    num, den = ts
+    if not 1 <= num <= 32:
+        raise HTTPException(422, "time_signature numerator must be between 1 and 32")
+    if den not in _VALID_TS_DENOMINATORS:
+        raise HTTPException(422, f"time_signature denominator must be one of {sorted(_VALID_TS_DENOMINATORS)}")
+
+
 @router.post("/scores/{score_id}/transcribe")
 def transcribe(score_id: int, body: TranscribeIn | None = Body(default=None)):
     conn = connect()
@@ -347,6 +360,8 @@ def transcribe(score_id: int, body: TranscribeIn | None = Body(default=None)):
         raise HTTPException(404, "file missing from library")
 
     ts = tuple(body.time_signature) if body and body.time_signature else None
+    if ts is not None:
+        _validate_time_signature(ts)
     result = extract_pdf(path, time_signature=ts)
     if not result.extractable:
         raise HTTPException(422, result.reason or "pdf is not extractable")
@@ -400,6 +415,28 @@ def save_transcription(score_id: int, body: TranscriptionEditIn):
     row = conn.execute(
         "SELECT * FROM transcriptions WHERE score_id = ? AND source = 'edited'", (score_id,)
     ).fetchone()
+    return _transcription_dict(row)
+
+
+@router.delete("/scores/{score_id}/transcription")
+def delete_transcription(score_id: int):
+    """Discard a hand edit, reverting to the extracted transcription.
+
+    Deletes only the source='edited' row - the source='extracted' row (if
+    any) is left untouched, mirroring transcribe()'s promise that it never
+    touches an edited row. Returns whatever transcription remains, or 404
+    if there's none. Deleting an already-gone edited row is a harmless
+    no-op, not an error - only "no transcription at all" is a 404.
+    """
+    with tx() as conn:
+        _score_row(conn, score_id)
+        conn.execute(
+            "DELETE FROM transcriptions WHERE score_id = ? AND source = 'edited'", (score_id,)
+        )
+    conn = connect()
+    row = _transcription_row(conn, score_id)
+    if not row:
+        raise HTTPException(404, "no transcription for this score")
     return _transcription_dict(row)
 
 

--- a/server/fermata/db.py
+++ b/server/fermata/db.py
@@ -47,6 +47,22 @@ CREATE TABLE IF NOT EXISTS practice_sessions (
     note TEXT
 );
 CREATE INDEX IF NOT EXISTS idx_practice_score ON practice_sessions(score_id);
+
+-- One extracted row and (at most) one edited row per score, distinguished by
+-- `source`. Kept as separate rows rather than one row with fields that get
+-- overwritten in place, so a re-extraction can freely replace the extracted
+-- row without ever touching an edited one - see api.py's transcribe().
+CREATE TABLE IF NOT EXISTS transcriptions (
+    id INTEGER PRIMARY KEY,
+    score_id INTEGER NOT NULL REFERENCES scores(id) ON DELETE CASCADE,
+    format TEXT NOT NULL DEFAULT 'alphatex',
+    content TEXT NOT NULL,
+    source TEXT NOT NULL DEFAULT 'extracted',
+    confidence TEXT,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_transcriptions_score_source ON transcriptions(score_id, source);
 """
 
 

--- a/server/fermata/tabextract.py
+++ b/server/fermata/tabextract.py
@@ -50,6 +50,9 @@ class ExtractionResult:
     bars: int = 0
     beats: int = 0
     notes: int = 0
+    # Total tab / standard staff systems found across the whole document
+    # (summed across pages) - same definition analyze() uses, not a
+    # per-page maximum.
     tab_staff_count: int = 0
     standard_staff_count: int = 0
     pages_processed: int = 0
@@ -194,9 +197,16 @@ def _vertical_segments(page, min_len=15.0):
     return segs
 
 
-def _detect_barlines(page, staff):
-    """Vertical segments whose y-span covers most of this staff's height."""
-    segs = _vertical_segments(page)
+def _detect_barlines(segs, staff):
+    """Vertical segments whose y-span covers most of this staff's height.
+
+    `segs` is the page's full set of vertical line primitives (see
+    _vertical_segments) - callers must compute it once per page and reuse it
+    across staves. get_drawings() re-parses the page's whole content stream,
+    so calling _vertical_segments(page) once per staff here made a 2-page,
+    ~7-staves-per-page file re-parse the same page content ~14 times inside
+    a single synchronous request.
+    """
     xs = []
     span = staff.bottom - staff.top
     for x, y0, y1 in segs:
@@ -282,36 +292,69 @@ def _assign_tokens_to_tab_staves(tokens, tab_staves):
     return by_staff, unmatched
 
 
+# No standard guitar has more frets than this; a merge result above it is a
+# sign two unrelated notes were concatenated, not a real fret number.
+_MAX_SANE_FRET = 24
+
+
 def _merge_multidigit(tokens_for_staff, staff):
     """Merge adjacent 1-digit tokens on the same string line into 2-digit
-    fret numbers (e.g. "1" then "2" immediately right -> "12")."""
+    fret numbers (e.g. "1" then "2" immediately right -> "12").
+
+    Returns (merged_notes, rejected_count, suspicious_count):
+    - rejected_count is how many candidate merges were declined because the
+      result exceeded _MAX_SANE_FRET (kept as two separate notes instead).
+    - suspicious_count is how many notes - merged or original two-character
+      spans straight from the PDF text (e.g. Finale can emit a two-digit
+      fret as a single span, and occasionally two adjacent single-digit
+      frets end up close enough to read as one) - are still above
+      _MAX_SANE_FRET and were emitted as-is because there's no safe way to
+      split an already-single span back into two notes.
+    Callers should surface both as warnings rather than silently trusting
+    an impossible fret number.
+    """
     per_string = collections.defaultdict(list)
     for tok in tokens_for_staff:
         s = staff.string_for_y(tok.yc)
         per_string[s].append(tok)
 
     merged_notes = []  # (x0, string, fret_text, yc)
+    rejected = 0
+    suspicious = 0
     for s, toks in per_string.items():
         toks.sort(key=lambda t: t.x0)
         i = 0
-        avg_w = sum(t.width for t in toks) / len(toks) if toks else 5.0
+        # Only 1-char tokens are merge candidates; averaging in already-merged
+        # 2-char token widths inflated the window enough that two separate
+        # adjacent single-digit notes (e.g. a "5" then, well clear of it, a
+        # "7") could be pulled together into a nonsense fret like "57".
+        single_widths = [t.width for t in toks if len(t.text) == 1]
+        avg_w = sum(single_widths) / len(single_widths) if single_widths else 5.0
         while i < len(toks):
             t = toks[i]
             if (
                 len(t.text) == 1
                 and i + 1 < len(toks)
                 and len(toks[i + 1].text) == 1
-                and (toks[i + 1].x0 - t.x1) < avg_w * 0.5
+                and (toks[i + 1].x0 - t.x1) < avg_w * 0.35
                 and abs(toks[i + 1].yc - t.yc) < 1.5
             ):
                 nxt = toks[i + 1]
-                merged_notes.append((t.x0, s, t.text + nxt.text, (t.yc + nxt.yc) / 2))
-                i += 2
+                fret_text = t.text + nxt.text
+                if int(fret_text) > _MAX_SANE_FRET:
+                    rejected += 1
+                    merged_notes.append((t.x0, s, t.text, t.yc))
+                    i += 1
+                else:
+                    merged_notes.append((t.x0, s, fret_text, (t.yc + nxt.yc) / 2))
+                    i += 2
             else:
+                if len(t.text) == 2 and int(t.text) > _MAX_SANE_FRET:
+                    suspicious += 1
                 merged_notes.append((t.x0, s, t.text, t.yc))
                 i += 1
     merged_notes.sort(key=lambda n: n[0])
-    return merged_notes
+    return merged_notes, rejected, suspicious
 
 
 # ---------------------------------------------------------------------------
@@ -419,10 +462,25 @@ def _snap_duration(quarter_units):
     return best[1]
 
 
-def _infer_measure_rhythm(columns_in_measure, measure_quarter_len):
-    """Treat the x-gap from each column to the next as proportional to that
-    column's duration, normalized so gaps sum to measure_quarter_len, then
-    snapped per-column. Not a real rhythm decoder - see module docstring."""
+def _measure_quarter_length(ts: tuple[int, int]) -> float:
+    """Quarter-note budget for one measure of this time signature, e.g. 3/4
+    and 6/8 both budget 3.0 quarters. The denominator matters: using the
+    numerator alone would give 6/8 a budget of 6.0, doubling every
+    spacing-inferred duration in a compound meter."""
+    return ts[0] * 4.0 / ts[1]
+
+
+def _infer_measure_rhythm(columns_in_measure, measure_quarter_len, bar_end_x):
+    """Treat the x-gap from each column to the next - and from the last
+    column to the measure's own barline (bar_end_x) - as proportional to
+    that column's duration, normalized so gaps sum to measure_quarter_len,
+    then snapped per-column. Not a real rhythm decoder - see module
+    docstring.
+
+    bar_end_x must be the actual barline (or staff end) position for this
+    measure: using the mean of the preceding gaps instead systematically
+    shortened the last note of any bar that ends on a long note.
+    """
     if not columns_in_measure:
         return []
     xs = [c["x"] for c in columns_in_measure]
@@ -430,7 +488,7 @@ def _infer_measure_rhythm(columns_in_measure, measure_quarter_len):
         gaps = [measure_quarter_len]
     else:
         gaps = [b - a for a, b in zip(xs, xs[1:])]
-        gaps.append(sum(gaps) / len(gaps))
+        gaps.append(bar_end_x - xs[-1])
     total = sum(gaps)
     if total <= 0:
         return [measure_quarter_len / len(xs)] * len(xs)
@@ -447,6 +505,10 @@ def _fmt_note(string, fret):
 
 
 def _fmt_beat(duration_code, notes):
+    # An empty notes list marks a rest bar (see _extract's rest-only-measure
+    # handling) - alphaTex spells a rest beat as the bare identifier "r".
+    if not notes:
+        return f":{duration_code} r"
     body = (
         " ".join(_fmt_note(s, f) for s, f in notes)
         if len(notes) == 1
@@ -455,15 +517,28 @@ def _fmt_beat(duration_code, notes):
     return f":{duration_code} {body}"
 
 
+def _escape_tex_string(s: str) -> str:
+    """Escape a value for embedding inside an alphaTex quoted string
+    (backslash then double-quote, in that order so a literal backslash
+    isn't doubled by the quote-escaping pass)."""
+    return s.replace("\\", "\\\\").replace('"', '\\"')
+
+
 def _build_alphatex(title, tempo, tuning, ts, measures):
     """measures: list of list of (duration_code, notes) beats."""
-    lines = [f'\\title "{title}"']
+    lines = [f'\\title "{_escape_tex_string(title)}"']
     if tempo:
         lines.append(f"\\tempo {tempo}")
     if ts:
         lines.append(f"\\ts {ts[0]} {ts[1]}")
     if tuning:
-        lines.append("\\tuning " + " ".join(tuning))
+        # alphaTex binds the FIRST \tuning entry to string 1, and
+        # _Staff.string_for_y assigns string 1 to the top tab line (the
+        # highest-pitched string). `tuning`/DEFAULT_TUNING/DROP_D_TUNING are
+        # kept low-to-high (index 0 = lowest string) everywhere else in this
+        # module and in the API response, so they must be reversed here -
+        # emitting them as-is puts every note on its mirrored string.
+        lines.append("\\tuning " + " ".join(reversed(tuning)))
     lines.append(".")
     body_lines = []
     for measure in measures:
@@ -585,8 +660,11 @@ def _extract(doc, pdf_path, time_signature: tuple[int, int] | None) -> Extractio
     tempo = None
     tuning = list(DEFAULT_TUNING)
     tuning_label = None
-    max_tab_count = 0
-    max_std_count = 0
+    # tab_staff_count / standard_staff_count are the total number of tab /
+    # standard staff systems found across the whole document (summed across
+    # pages), matching analyze()'s definition - see ExtractionResult.
+    tab_count = 0
+    std_count = 0
     vector_pages = 0
     pages_with_tab = []  # (page, tab_staves) in page order
 
@@ -608,8 +686,8 @@ def _extract(doc, pdf_path, time_signature: tuple[int, int] | None) -> Extractio
             )
         tab_staves = sorted((s for s in staves if s.kind == "tab"), key=lambda s: s.top)
         std_staves = sorted((s for s in staves if s.kind == "standard"), key=lambda s: s.top)
-        max_tab_count = max(max_tab_count, len(tab_staves))
-        max_std_count = max(max_std_count, len(std_staves))
+        tab_count += len(tab_staves)
+        std_count += len(std_staves)
 
         if ts is None and std_staves:
             detected = _detect_time_signature(page, std_staves[0])
@@ -642,8 +720,8 @@ def _extract(doc, pdf_path, time_signature: tuple[int, int] | None) -> Extractio
                 "no 6-line tab staff groups found - pages are vector but appear to be "
                 "standard-notation only (fingering numbers are not fret numbers)"
             ),
-            tab_staff_count=max_tab_count,
-            standard_staff_count=max_std_count,
+            tab_staff_count=tab_count,
+            standard_staff_count=std_count,
             warnings=warnings,
         )
 
@@ -660,20 +738,29 @@ def _extract(doc, pdf_path, time_signature: tuple[int, int] | None) -> Extractio
         "the score - treat as low confidence (no dotted notes or ties modeled)"
     )
 
+    measure_quarter_len = _measure_quarter_length(ts)
+
     # Pass 2: real extraction, now that ts/tempo/tuning are settled.
     all_measures = []  # list of measures, each a list of (duration_code, notes) beats
     unmatched_total = 0
+    rejected_merges_total = 0
+    suspicious_frets_total = 0
     for page, tab_staves in pages_with_tab:
         tokens = _extract_digit_tokens(page)
         by_staff, unmatched = _assign_tokens_to_tab_staves(tokens, tab_staves)
         unmatched_total += len(unmatched)
+        # Computed once per page and reused for every staff on it - see
+        # _detect_barlines docstring.
+        vseg = _vertical_segments(page)
         for si, staff in enumerate(tab_staves):
             toks = by_staff.get(si, [])
             if not toks:
                 continue
-            notes = _merge_multidigit(toks, staff)
+            notes, rejected, suspicious = _merge_multidigit(toks, staff)
+            rejected_merges_total += rejected
+            suspicious_frets_total += suspicious
             columns = _group_into_columns(notes)
-            barline_xs = _detect_barlines(page, staff)
+            barline_xs = _detect_barlines(vseg, staff)
             col_xs = [c["x"] for c in columns]
             lo, hi = min(col_xs) - 5, max(col_xs) + 5
             bars = [x for x in barline_xs if lo <= x <= hi]
@@ -686,16 +773,48 @@ def _extract(doc, pdf_path, time_signature: tuple[int, int] | None) -> Extractio
                     measure_idx += 1
                 measures_for_staff[measure_idx].append(col)
 
-            for m_cols in measures_for_staff:
+            for i, m_cols in enumerate(measures_for_staff):
+                bar_end_x = bounds[i + 1]
                 if not m_cols:
+                    # No digit columns landed in this bar - emit an explicit
+                    # rest bar instead of dropping it. Skipping it entirely
+                    # would omit its "|" separator and shift every later
+                    # bar's number one position earlier than the PDF, which
+                    # breaks side-by-side comparison against the original.
+                    all_measures.append([(_snap_duration(measure_quarter_len), [])])
                     continue
-                durations_q = _infer_measure_rhythm(m_cols, float(ts[0]))
+                durations_q = _infer_measure_rhythm(m_cols, measure_quarter_len, bar_end_x)
                 beats = [(_snap_duration(dq), col["notes"]) for col, dq in zip(m_cols, durations_q)]
                 all_measures.append(beats)
 
     if unmatched_total:
         warnings.append(
             f"{unmatched_total} digit token(s) near a tab staff could not be assigned to a string"
+        )
+    if rejected_merges_total:
+        warnings.append(
+            f"{rejected_merges_total} adjacent-digit merge(s) were rejected because they would "
+            f"have produced a fret number above {_MAX_SANE_FRET} - kept as separate notes instead"
+        )
+    if suspicious_frets_total:
+        warnings.append(
+            f"{suspicious_frets_total} fret number(s) above {_MAX_SANE_FRET} were read directly "
+            "from the PDF's own text (not from a merge) - likely two adjacent notes rendered as "
+            "one text span in the source - treat those frets as low confidence"
+        )
+
+    if not all_measures:
+        return ExtractionResult(
+            extractable=False,
+            reason=(
+                "tab staff systems were found but no fret-number digits could be matched to a "
+                "string - likely an outlined-text export where fret numbers are vector paths, "
+                "not selectable text"
+            ),
+            tab_staff_count=tab_count,
+            standard_staff_count=std_count,
+            pages_processed=len(pages_with_tab),
+            warnings=warnings,
         )
 
     title = Path(pdf_path).stem
@@ -724,8 +843,8 @@ def _extract(doc, pdf_path, time_signature: tuple[int, int] | None) -> Extractio
         bars=len(all_measures),
         beats=beats_total,
         notes=notes_total,
-        tab_staff_count=max_tab_count,
-        standard_staff_count=max_std_count,
+        tab_staff_count=tab_count,
+        standard_staff_count=std_count,
         pages_processed=len(pages_with_tab),
         confidence=confidence,
         warnings=warnings,

--- a/server/fermata/tabextract.py
+++ b/server/fermata/tabextract.py
@@ -1,0 +1,732 @@
+"""Guitar tablature extraction from vector-engraved PDF scores.
+
+Staff systems are located from vector line primitives (page.get_drawings()):
+a run of 6 evenly spaced long horizontal lines is a tab staff, 5 is a
+standard staff. Fret numbers come from text spans that are pure digits,
+assigned to a tab staff and string by proximity - font name is deliberately
+not used as a filter, since different engravers (Finale, Sibelius, Opus)
+pick different fonts for fret numbers. Barlines come from vertical line
+primitives spanning a staff's height.
+
+Rhythm is the weak link: durations are inferred from the horizontal spacing
+between note columns, normalized to a measure's quarter-note budget and
+snapped to the nearest plain duration. There is no dotted-note or tie model.
+Time signatures usually can't be read either - the glyphs live inside
+subsetted music fonts (Maestro, Opus, ...) at remapped codepoints that don't
+correspond to their visual meaning. Both limitations are surfaced through
+ExtractionResult.warnings rather than papered over; callers should treat
+durations as low confidence throughout and offer a manual time-signature
+override (see extract()'s time_signature argument).
+"""
+
+from __future__ import annotations
+
+import collections
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import fitz  # PyMuPDF
+
+DEFAULT_TUNING = ["E2", "A2", "D3", "G3", "B3", "E4"]
+DROP_D_TUNING = ["D2", "A2", "D3", "G3", "B3", "E4"]
+
+# Plain (non-dotted) duration budgets, in quarter-note units, used to snap
+# spacing-derived durations to an alphaTex duration code.
+_PLAIN_DURATIONS = [(4.0, 1), (2.0, 2), (1.0, 4), (0.5, 8), (0.25, 16), (0.125, 32)]
+
+
+@dataclass
+class ExtractionResult:
+    extractable: bool
+    reason: str | None = None
+    alphatex: str | None = None
+    title: str | None = None
+    tempo: int | None = None
+    tuning: list[str] = field(default_factory=lambda: list(DEFAULT_TUNING))
+    tuning_label: str | None = None
+    time_signature: tuple[int, int] | None = None
+    time_signature_source: str = "not detected"
+    bars: int = 0
+    beats: int = 0
+    notes: int = 0
+    tab_staff_count: int = 0
+    standard_staff_count: int = 0
+    pages_processed: int = 0
+    confidence: dict = field(default_factory=dict)
+    warnings: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        return {
+            "extractable": self.extractable,
+            "reason": self.reason,
+            "alphatex": self.alphatex,
+            "title": self.title,
+            "tempo": self.tempo,
+            "tuning": self.tuning,
+            "tuning_label": self.tuning_label,
+            "time_signature": list(self.time_signature) if self.time_signature else None,
+            "time_signature_source": self.time_signature_source,
+            "bars": self.bars,
+            "beats": self.beats,
+            "notes": self.notes,
+            "tab_staff_count": self.tab_staff_count,
+            "standard_staff_count": self.standard_staff_count,
+            "pages_processed": self.pages_processed,
+            "confidence": self.confidence,
+            "warnings": self.warnings,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Staff detection
+# ---------------------------------------------------------------------------
+
+
+class _Staff:
+    def __init__(self, kind, line_ys, x0, x1):
+        self.kind = kind  # "tab" (6 lines) or "standard" (5 lines)
+        self.line_ys = line_ys  # sorted top->bottom
+        self.x0 = x0
+        self.x1 = x1
+
+    @property
+    def top(self):
+        return self.line_ys[0]
+
+    @property
+    def bottom(self):
+        return self.line_ys[-1]
+
+    @property
+    def spacing(self):
+        return (self.bottom - self.top) / (len(self.line_ys) - 1)
+
+    def string_for_y(self, y):
+        """Nearest line index -> string number (1 = top line = high string)."""
+        best_i, best_d = 0, abs(y - self.line_ys[0])
+        for i, ly in enumerate(self.line_ys):
+            d = abs(y - ly)
+            if d < best_d:
+                best_i, best_d = i, d
+        return best_i + 1
+
+
+def _long_horizontal_segments(page, min_len_ratio=0.25):
+    """Near-horizontal vector primitives long enough to plausibly be staff
+    lines, as opposed to beams, ledger lines, or stems."""
+    min_len = page.rect.width * min_len_ratio
+    segs = []
+    for d in page.get_drawings():
+        for item in d.get("items", []):
+            if item[0] == "l":
+                p1, p2 = item[1], item[2]
+                if abs(p1.y - p2.y) < 0.08 and abs(p1.x - p2.x) >= min_len:
+                    y = (p1.y + p2.y) / 2
+                    segs.append((y, min(p1.x, p2.x), max(p1.x, p2.x)))
+            elif item[0] == "re":
+                r = item[1]
+                if r.height < 1.0 and r.width >= min_len:
+                    y = (r.y0 + r.y1) / 2
+                    segs.append((y, r.x0, r.x1))
+    return segs
+
+
+def _detect_staves(page):
+    """Cluster long horizontal line primitives into staff systems.
+
+    Returns (staves, anomalies): anomalies records line-groups whose size was
+    neither 5 nor 6, so callers can surface what was thrown away.
+    """
+    segs = _long_horizontal_segments(page)
+    if not segs:
+        return [], []
+
+    by_y = {}
+    for y, x0, x1 in segs:
+        key = round(y, 1)
+        if key not in by_y:
+            by_y[key] = [x0, x1]
+        else:
+            by_y[key][0] = min(by_y[key][0], x0)
+            by_y[key][1] = max(by_y[key][1], x1)
+    ys = sorted(by_y.keys())
+
+    clusters = []
+    cur = [ys[0]]
+    for prev, y in zip(ys, ys[1:]):
+        if (y - prev) > 15.0:
+            clusters.append(cur)
+            cur = [y]
+        else:
+            cur.append(y)
+    clusters.append(cur)
+
+    staves = []
+    anomalies = []
+    for c in clusters:
+        n = len(c)
+        x0 = min(by_y[y][0] for y in c)
+        x1 = max(by_y[y][1] for y in c)
+        if n == 6:
+            staves.append(_Staff("tab", c, x0, x1))
+        elif n == 5:
+            staves.append(_Staff("standard", c, x0, x1))
+        else:
+            anomalies.append({"line_count": n, "ys": c, "x0": x0, "x1": x1})
+    return staves, anomalies
+
+
+def _vertical_segments(page, min_len=15.0):
+    segs = []
+    for d in page.get_drawings():
+        for item in d.get("items", []):
+            if item[0] == "l":
+                p1, p2 = item[1], item[2]
+                if abs(p1.x - p2.x) < 0.08 and abs(p1.y - p2.y) >= min_len:
+                    x = (p1.x + p2.x) / 2
+                    segs.append((x, min(p1.y, p2.y), max(p1.y, p2.y)))
+            elif item[0] == "re":
+                r = item[1]
+                if r.width < 1.0 and r.height >= min_len:
+                    x = (r.x0 + r.x1) / 2
+                    segs.append((x, r.y0, r.y1))
+    return segs
+
+
+def _detect_barlines(page, staff):
+    """Vertical segments whose y-span covers most of this staff's height."""
+    segs = _vertical_segments(page)
+    xs = []
+    span = staff.bottom - staff.top
+    for x, y0, y1 in segs:
+        if y0 <= staff.top + span * 0.3 and y1 >= staff.bottom - span * 0.3:
+            if staff.x0 - 2 <= x <= staff.x1 + 2:
+                xs.append(round(x, 1))
+    xs = sorted(set(xs))
+    merged = []
+    for x in xs:
+        if merged and x - merged[-1] < 2.0:
+            continue
+        merged.append(x)
+    return merged
+
+
+# ---------------------------------------------------------------------------
+# Digit (fret number) extraction
+# ---------------------------------------------------------------------------
+
+
+class _DigitToken:
+    __slots__ = ("text", "bbox", "font", "size")
+
+    def __init__(self, text, bbox, font, size):
+        self.text = text
+        self.bbox = bbox  # (x0, y0, x1, y1)
+        self.font = font
+        self.size = size
+
+    @property
+    def x0(self):
+        return self.bbox[0]
+
+    @property
+    def x1(self):
+        return self.bbox[2]
+
+    @property
+    def yc(self):
+        return (self.bbox[1] + self.bbox[3]) / 2
+
+    @property
+    def width(self):
+        return self.bbox[2] - self.bbox[0]
+
+
+def _extract_digit_tokens(page):
+    """All spans that are purely ASCII digits, 1-2 chars, any font. Font name
+    is deliberately not used as a filter - position relative to a detected
+    tab staff is what identifies a fret number, not the exporter's font
+    choice for it."""
+    tokens = []
+    d = page.get_text("dict")
+    for block in d.get("blocks", []):
+        if block.get("type") != 0:
+            continue
+        for line in block.get("lines", []):
+            for span in line.get("spans", []):
+                text = span.get("text", "").strip()
+                if text.isdigit() and 1 <= len(text) <= 2:
+                    tokens.append(_DigitToken(text, span["bbox"], span.get("font"), span.get("size")))
+    return tokens
+
+
+def _assign_tokens_to_tab_staves(tokens, tab_staves):
+    """Return ({staff_index: [tokens]}, unmatched_tokens)."""
+    by_staff = collections.defaultdict(list)
+    unmatched = []
+    for tok in tokens:
+        best = None
+        best_d = None
+        for i, st in enumerate(tab_staves):
+            pad = st.spacing * 0.75
+            if st.top - pad <= tok.yc <= st.bottom + pad and st.x0 - 5 <= tok.x0 <= st.x1 + 5:
+                center = (st.top + st.bottom) / 2
+                d = abs(tok.yc - center)
+                if best is None or d < best_d:
+                    best, best_d = i, d
+        if best is None:
+            unmatched.append(tok)
+        else:
+            by_staff[best].append(tok)
+    return by_staff, unmatched
+
+
+def _merge_multidigit(tokens_for_staff, staff):
+    """Merge adjacent 1-digit tokens on the same string line into 2-digit
+    fret numbers (e.g. "1" then "2" immediately right -> "12")."""
+    per_string = collections.defaultdict(list)
+    for tok in tokens_for_staff:
+        s = staff.string_for_y(tok.yc)
+        per_string[s].append(tok)
+
+    merged_notes = []  # (x0, string, fret_text, yc)
+    for s, toks in per_string.items():
+        toks.sort(key=lambda t: t.x0)
+        i = 0
+        avg_w = sum(t.width for t in toks) / len(toks) if toks else 5.0
+        while i < len(toks):
+            t = toks[i]
+            if (
+                len(t.text) == 1
+                and i + 1 < len(toks)
+                and len(toks[i + 1].text) == 1
+                and (toks[i + 1].x0 - t.x1) < avg_w * 0.5
+                and abs(toks[i + 1].yc - t.yc) < 1.5
+            ):
+                nxt = toks[i + 1]
+                merged_notes.append((t.x0, s, t.text + nxt.text, (t.yc + nxt.yc) / 2))
+                i += 2
+            else:
+                merged_notes.append((t.x0, s, t.text, t.yc))
+                i += 1
+    merged_notes.sort(key=lambda n: n[0])
+    return merged_notes
+
+
+# ---------------------------------------------------------------------------
+# Column / chord grouping
+# ---------------------------------------------------------------------------
+
+
+def _group_into_columns(notes, x_tol=1.5, wide_chord_ratio=0.35):
+    """notes: list of (x0, string, fret_text, yc) sorted by x0.
+    Returns [{"x": float, "notes": [(string, fret_text), ...]}].
+
+    Two passes: tight x-proximity clustering catches chords engraved at
+    exactly the same column; a second pass merges adjacent columns whose gap
+    is small relative to the local column spacing, since engravers commonly
+    offset a bass tab number a couple points right of a treble number in the
+    same chord to keep both legible.
+    """
+    columns = []
+    for x0, s, fret, yc in notes:
+        if columns and (x0 - columns[-1]["x"]) < x_tol:
+            columns[-1]["notes"].append((s, fret))
+            columns[-1]["x"] = min(columns[-1]["x"], x0)
+        else:
+            columns.append({"x": x0, "notes": [(s, fret)]})
+
+    if len(columns) > 2:
+        gaps = [b["x"] - a["x"] for a, b in zip(columns, columns[1:])]
+        median_gap = sorted(gaps)[len(gaps) // 2]
+        merged = [columns[0]]
+        for col, gap in zip(columns[1:], gaps):
+            used_strings = {s for s, _ in merged[-1]["notes"]}
+            new_strings = {s for s, _ in col["notes"]}
+            if (
+                median_gap > 0
+                and gap < median_gap * wide_chord_ratio
+                and not (used_strings & new_strings)
+            ):
+                merged[-1]["notes"].extend(col["notes"])
+            else:
+                merged.append(col)
+        columns = merged
+
+    for col in columns:
+        seen = set()
+        deduped = []
+        for s, fret in col["notes"]:
+            if s in seen:
+                continue
+            seen.add(s)
+            deduped.append((s, fret))
+        col["notes"] = sorted(deduped, key=lambda n: n[0])
+    return columns
+
+
+# ---------------------------------------------------------------------------
+# Time signature (best-effort)
+# ---------------------------------------------------------------------------
+
+
+def _detect_time_signature(page, standard_staff):
+    """Look for two stacked plain digits near the start of a standard staff.
+    Frequently fails - see module docstring - callers should treat a None
+    result as normal, not an error."""
+    d = page.get_text("dict")
+    candidates = []
+    for block in d.get("blocks", []):
+        if block.get("type") != 0:
+            continue
+        for line in block.get("lines", []):
+            for span in line.get("spans", []):
+                text = span.get("text", "").strip()
+                if text.isdigit() and len(text) == 1:
+                    bbox = span["bbox"]
+                    yc = (bbox[1] + bbox[3]) / 2
+                    x0 = bbox[0]
+                    if (
+                        standard_staff.top - 2 <= yc <= standard_staff.bottom + 2
+                        and standard_staff.x0 - 5 <= x0 <= standard_staff.x0 + 40
+                    ):
+                        candidates.append((x0, yc, text))
+    if len(candidates) < 2:
+        return None
+    candidates.sort(key=lambda c: c[0])
+    mid = (standard_staff.top + standard_staff.bottom) / 2
+    for i in range(len(candidates)):
+        for j in range(len(candidates)):
+            if i == j:
+                continue
+            x0a, ya, ta = candidates[i]
+            x0b, yb, tb = candidates[j]
+            if abs(x0a - x0b) < 3.0 and ya < mid < yb:
+                return int(ta), int(tb)
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Rhythm inference (heuristic, low confidence - see module docstring)
+# ---------------------------------------------------------------------------
+
+
+def _snap_duration(quarter_units):
+    """Snap a duration in quarter-note units to the nearest alphaTex
+    duration code, ignoring dotted values (not modeled)."""
+    best = min(_PLAIN_DURATIONS, key=lambda p: abs(p[0] - quarter_units))
+    return best[1]
+
+
+def _infer_measure_rhythm(columns_in_measure, measure_quarter_len):
+    """Treat the x-gap from each column to the next as proportional to that
+    column's duration, normalized so gaps sum to measure_quarter_len, then
+    snapped per-column. Not a real rhythm decoder - see module docstring."""
+    if not columns_in_measure:
+        return []
+    xs = [c["x"] for c in columns_in_measure]
+    if len(xs) == 1:
+        gaps = [measure_quarter_len]
+    else:
+        gaps = [b - a for a, b in zip(xs, xs[1:])]
+        gaps.append(sum(gaps) / len(gaps))
+    total = sum(gaps)
+    if total <= 0:
+        return [measure_quarter_len / len(xs)] * len(xs)
+    return [g / total * measure_quarter_len for g in gaps]
+
+
+# ---------------------------------------------------------------------------
+# alphaTex emission
+# ---------------------------------------------------------------------------
+
+
+def _fmt_note(string, fret):
+    return f"{fret}.{string}"
+
+
+def _fmt_beat(duration_code, notes):
+    body = (
+        " ".join(_fmt_note(s, f) for s, f in notes)
+        if len(notes) == 1
+        else "(" + " ".join(_fmt_note(s, f) for s, f in notes) + ")"
+    )
+    return f":{duration_code} {body}"
+
+
+def _build_alphatex(title, tempo, tuning, ts, measures):
+    """measures: list of list of (duration_code, notes) beats."""
+    lines = [f'\\title "{title}"']
+    if tempo:
+        lines.append(f"\\tempo {tempo}")
+    if ts:
+        lines.append(f"\\ts {ts[0]} {ts[1]}")
+    if tuning:
+        lines.append("\\tuning " + " ".join(tuning))
+    lines.append(".")
+    body_lines = []
+    for measure in measures:
+        beats = " ".join(_fmt_beat(dur, notes) for dur, notes in measure)
+        body_lines.append(beats + " |")
+    lines.append("\n".join(body_lines))
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def _page_is_raster(page) -> bool:
+    return not page.get_fonts(full=True) and not page.get_drawings() and not page.get_text("text").strip()
+
+
+def analyze(pdf_path) -> dict:
+    """Cheap triage: is this PDF vector or raster, how many tab/notation
+    staves does it have, is tab extraction worth attempting. Never raises -
+    a malformed PDF comes back as extractable: false with a reason."""
+    try:
+        doc = fitz.open(pdf_path)
+    except Exception as exc:
+        return {
+            "extractable": False,
+            "reason": f"could not open pdf: {exc}",
+            "vector": False,
+            "tab_staff_count": 0,
+            "standard_staff_count": 0,
+            "page_count": 0,
+        }
+    try:
+        if doc.page_count == 0:
+            return {
+                "extractable": False,
+                "reason": "pdf has no pages",
+                "vector": False,
+                "tab_staff_count": 0,
+                "standard_staff_count": 0,
+                "page_count": 0,
+            }
+        vector_pages = 0
+        tab_total = 0
+        std_total = 0
+        for page in doc:
+            if _page_is_raster(page):
+                continue
+            vector_pages += 1
+            staves, _ = _detect_staves(page)
+            tab_total += sum(1 for s in staves if s.kind == "tab")
+            std_total += sum(1 for s in staves if s.kind == "standard")
+        if vector_pages == 0:
+            return {
+                "extractable": False,
+                "reason": "no fonts, no vector drawings, no text on any page - pdf is a raster scan",
+                "vector": False,
+                "tab_staff_count": 0,
+                "standard_staff_count": 0,
+                "page_count": doc.page_count,
+            }
+        extractable = tab_total > 0
+        reason = None
+        if not extractable:
+            reason = (
+                "no 6-line tab staff groups found - pages are vector but appear to be "
+                "standard-notation only (fingering numbers are not fret numbers)"
+            )
+        return {
+            "extractable": extractable,
+            "reason": reason,
+            "vector": True,
+            "tab_staff_count": tab_total,
+            "standard_staff_count": std_total,
+            "page_count": doc.page_count,
+        }
+    except Exception as exc:
+        return {
+            "extractable": False,
+            "reason": f"analysis failed: {exc}",
+            "vector": False,
+            "tab_staff_count": 0,
+            "standard_staff_count": 0,
+            "page_count": 0,
+        }
+    finally:
+        doc.close()
+
+
+def extract(pdf_path, time_signature: tuple[int, int] | None = None) -> ExtractionResult:
+    """Full extraction: returns alphaTex plus bars/beats/notes, tuning,
+    per-section confidence, and an explicit list of warnings. Never raises -
+    a malformed PDF or one with no tab staves comes back as
+    extractable: false with a reason, not an exception.
+
+    time_signature lets a caller supply the numerator/denominator by hand,
+    since auto-detection frequently fails (see module docstring).
+    """
+    try:
+        doc = fitz.open(pdf_path)
+    except Exception as exc:
+        return ExtractionResult(extractable=False, reason=f"could not open pdf: {exc}")
+    try:
+        return _extract(doc, pdf_path, time_signature)
+    except Exception as exc:
+        return ExtractionResult(extractable=False, reason=f"extraction failed: {exc}")
+    finally:
+        doc.close()
+
+
+def _extract(doc, pdf_path, time_signature: tuple[int, int] | None) -> ExtractionResult:
+    if doc.page_count == 0:
+        return ExtractionResult(extractable=False, reason="pdf has no pages")
+
+    warnings: list[str] = []
+    ts = tuple(time_signature) if time_signature else None
+    ts_source = "manual override" if ts else None
+    tempo = None
+    tuning = list(DEFAULT_TUNING)
+    tuning_label = None
+    max_tab_count = 0
+    max_std_count = 0
+    vector_pages = 0
+    pages_with_tab = []  # (page, tab_staves) in page order
+
+    # Pass 1: staff census plus tempo/tuning/time-signature hints, cheapest
+    # first so we know up front whether there's anything worth extracting.
+    for page_no in range(doc.page_count):
+        page = doc[page_no]
+        text = page.get_text("text")
+        if not page.get_fonts(full=True) and not page.get_drawings() and not text.strip():
+            warnings.append(f"page {page_no + 1} has no fonts, drawings, or text (raster scan) - skipped")
+            continue
+        vector_pages += 1
+
+        staves, anomalies = _detect_staves(page)
+        if anomalies:
+            warnings.append(
+                f"page {page_no + 1}: {len(anomalies)} staff-line group(s) with an unexpected "
+                "line count were ignored"
+            )
+        tab_staves = sorted((s for s in staves if s.kind == "tab"), key=lambda s: s.top)
+        std_staves = sorted((s for s in staves if s.kind == "standard"), key=lambda s: s.top)
+        max_tab_count = max(max_tab_count, len(tab_staves))
+        max_std_count = max(max_std_count, len(std_staves))
+
+        if ts is None and std_staves:
+            detected = _detect_time_signature(page, std_staves[0])
+            if detected:
+                ts = detected
+                ts_source = "auto-detected"
+
+        if tempo is None:
+            q_match = re.search(r"=\s*(\d{2,3})", text)
+            if q_match:
+                tempo = int(q_match.group(1))
+
+        if tuning_label is None and "Drop D" in text:
+            tuning_label = "Drop D"
+            tuning = list(DROP_D_TUNING)
+
+        if tab_staves:
+            pages_with_tab.append((page, tab_staves))
+
+    if vector_pages == 0:
+        return ExtractionResult(
+            extractable=False,
+            reason="no fonts, no vector drawings, no text on any page - pdf is a raster scan",
+        )
+
+    if not pages_with_tab:
+        return ExtractionResult(
+            extractable=False,
+            reason=(
+                "no 6-line tab staff groups found - pages are vector but appear to be "
+                "standard-notation only (fingering numbers are not fret numbers)"
+            ),
+            tab_staff_count=max_tab_count,
+            standard_staff_count=max_std_count,
+            warnings=warnings,
+        )
+
+    if ts is None:
+        ts = (4, 4)
+        ts_source = "not detected (assumed 4/4)"
+        warnings.append(
+            "time signature not detected - glyphs live in a subsetted music font at remapped "
+            "codepoints; assumed 4/4 for bar/beat grouping, pass time_signature to override"
+        )
+
+    warnings.append(
+        "note durations are inferred from horizontal spacing between columns, not decoded from "
+        "the score - treat as low confidence (no dotted notes or ties modeled)"
+    )
+
+    # Pass 2: real extraction, now that ts/tempo/tuning are settled.
+    all_measures = []  # list of measures, each a list of (duration_code, notes) beats
+    unmatched_total = 0
+    for page, tab_staves in pages_with_tab:
+        tokens = _extract_digit_tokens(page)
+        by_staff, unmatched = _assign_tokens_to_tab_staves(tokens, tab_staves)
+        unmatched_total += len(unmatched)
+        for si, staff in enumerate(tab_staves):
+            toks = by_staff.get(si, [])
+            if not toks:
+                continue
+            notes = _merge_multidigit(toks, staff)
+            columns = _group_into_columns(notes)
+            barline_xs = _detect_barlines(page, staff)
+            col_xs = [c["x"] for c in columns]
+            lo, hi = min(col_xs) - 5, max(col_xs) + 5
+            bars = [x for x in barline_xs if lo <= x <= hi]
+            bounds = sorted(set([staff.x0] + bars + [staff.x1]))
+
+            measure_idx = 0
+            measures_for_staff = [[] for _ in range(len(bounds) - 1)]
+            for col in columns:
+                while measure_idx < len(bounds) - 2 and col["x"] >= bounds[measure_idx + 1]:
+                    measure_idx += 1
+                measures_for_staff[measure_idx].append(col)
+
+            for m_cols in measures_for_staff:
+                if not m_cols:
+                    continue
+                durations_q = _infer_measure_rhythm(m_cols, float(ts[0]))
+                beats = [(_snap_duration(dq), col["notes"]) for col, dq in zip(m_cols, durations_q)]
+                all_measures.append(beats)
+
+    if unmatched_total:
+        warnings.append(
+            f"{unmatched_total} digit token(s) near a tab staff could not be assigned to a string"
+        )
+
+    title = Path(pdf_path).stem
+    alphatex = _build_alphatex(title, tempo, tuning, ts, all_measures)
+    beats_total = sum(len(m) for m in all_measures)
+    notes_total = sum(len(notes) for m in all_measures for _, notes in m)
+
+    confidence = {
+        "frets": "high - read directly from vector text spans positioned against detected tab staff lines",
+        "rhythm": "low - inferred from note spacing only, no dotted notes or ties modeled",
+        "time_signature": {
+            "manual override": "n/a - caller supplied",
+            "auto-detected": "medium - read from page text",
+        }.get(ts_source, "low - not detected, assumed 4/4"),
+    }
+
+    return ExtractionResult(
+        extractable=True,
+        alphatex=alphatex,
+        title=title,
+        tempo=tempo,
+        tuning=tuning,
+        tuning_label=tuning_label,
+        time_signature=ts,
+        time_signature_source=ts_source,
+        bars=len(all_measures),
+        beats=beats_total,
+        notes=notes_total,
+        tab_staff_count=max_tab_count,
+        standard_staff_count=max_std_count,
+        pages_processed=len(pages_with_tab),
+        confidence=confidence,
+        warnings=warnings,
+    )

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -15,5 +15,11 @@ dependencies = [
     "python-multipart>=0.0.9",
 ]
 
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0",
+    "httpx>=0.27",
+]
+
 [tool.hatch.build.targets.wheel]
 packages = ["fermata"]

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -1,0 +1,85 @@
+"""Shared fixtures for the transcription tests.
+
+Real sample PDFs from the user's library are used as fixtures (they exercise
+paths synthetic PDFs can't: real Finale/Sibelius engraving output). They're
+read-only and never bundled with the repo - point FERMATA_TEST_LIBRARY at a
+copy of the library root to run these; tests skip themselves otherwise.
+"""
+
+import os
+from pathlib import Path
+
+import pytest
+
+_FIXTURE_RELATIVE_PATHS = {
+    "zanarkand": "Patreon/John Oeth/Final Fantasy/FF X/To Zanarkand (Final Fantasy X).pdf",
+    "tarrega": "Classical/Tarrega/Tarrega-Study-in-C-Guitar-Free.pdf",
+    "claire_de_lune": "Favorites/ClairDeLuneGuitar.pdf",
+}
+
+
+def _library_root() -> Path | None:
+    root = os.environ.get("FERMATA_TEST_LIBRARY")
+    if not root:
+        return None
+    p = Path(root)
+    return p if p.is_dir() else None
+
+
+def _fixture_path(name: str) -> Path | None:
+    root = _library_root()
+    if root is None:
+        return None
+    p = root / _FIXTURE_RELATIVE_PATHS[name]
+    return p if p.is_file() else None
+
+
+@pytest.fixture
+def zanarkand_pdf() -> Path:
+    p = _fixture_path("zanarkand")
+    if p is None:
+        pytest.skip("FERMATA_TEST_LIBRARY not set (or missing 'To Zanarkand' fixture)")
+    return p
+
+
+@pytest.fixture
+def tarrega_pdf() -> Path:
+    p = _fixture_path("tarrega")
+    if p is None:
+        pytest.skip("FERMATA_TEST_LIBRARY not set (or missing Tarrega fixture)")
+    return p
+
+
+@pytest.fixture
+def claire_de_lune_pdf() -> Path:
+    p = _fixture_path("claire_de_lune")
+    if p is None:
+        pytest.skip("FERMATA_TEST_LIBRARY not set (or missing Clair de Lune fixture)")
+    return p
+
+
+@pytest.fixture
+def app_env(tmp_path, monkeypatch):
+    """Point the db module at a throwaway sqlite file for one test, and reset
+    the per-thread cached connection so the swap actually takes effect."""
+    from fermata import db
+
+    monkeypatch.setattr(db, "DB_PATH", tmp_path / "fermata_test.db")
+    db._local.conn = None
+    db.init_db()
+    yield
+    db._local.conn = None
+
+
+@pytest.fixture
+def insert_score():
+    def _insert(conn, rel_path: str, title: str = "Test Score") -> int:
+        cur = conn.execute(
+            """INSERT INTO scores(title, path, file_type, hash, size, mtime)
+               VALUES (?, ?, 'pdf', 'deadbeef', 1, 0.0)""",
+            (title, rel_path),
+        )
+        conn.commit()
+        return cur.lastrowid
+
+    return _insert

--- a/server/tests/test_tabextract.py
+++ b/server/tests/test_tabextract.py
@@ -1,12 +1,48 @@
+import fitz
+import pytest
+
 from fermata import tabextract
+
+
+def _make_tab_pdf(path, pages):
+    """Build a minimal PDF with one 6-line tab staff per page - good enough
+    to exercise _detect_staves / _detect_barlines / _extract_digit_tokens
+    without a real engraved score.
+
+    `pages` is a list of dicts, one per page:
+        notes: [(x, string, fret_text), ...]
+        barline_xs: [x, ...] vertical barline positions (include the
+            staff's own left/right edges to bound the first/last measure)
+        staff_x0, staff_x1, staff_top, spacing: staff geometry (optional)
+    """
+    doc = fitz.open()
+    for spec in pages:
+        staff_x0 = spec.get("staff_x0", 50)
+        staff_x1 = spec.get("staff_x1", 350)
+        staff_top = spec.get("staff_top", 50)
+        spacing = spec.get("spacing", 10)
+        page = doc.new_page(width=600, height=200)
+        ys = [staff_top + i * spacing for i in range(6)]
+        for y in ys:
+            page.draw_line((staff_x0, y), (staff_x1, y))
+        for x in spec.get("barline_xs", [staff_x0, staff_x1]):
+            page.draw_line((x, staff_top - 10), (x, ys[-1] + 10))
+        for x, string, fret in spec.get("notes", []):
+            page.insert_text((x, ys[string - 1] + 3), fret, fontsize=7)
+    doc.save(path)
+    doc.close()
+    return path
 
 
 def test_finale_tab_pdf_extracts_notes_and_bars(zanarkand_pdf):
     result = tabextract.extract(zanarkand_pdf, time_signature=(3, 4))
     assert result.extractable
     assert result.reason is None
-    assert result.tab_staff_count == 5
-    assert result.standard_staff_count == 5
+    # tab_staff_count / standard_staff_count are summed across pages (see
+    # ExtractionResult) - the file has 2 pages, so use a floor rather than
+    # pinning an exact count.
+    assert result.tab_staff_count >= 5
+    assert result.standard_staff_count >= 5
     # Validated against this exact file: page 1 alone extracts 185 notes
     # across 24 bars. The score is 2 pages, so the combined total can only
     # be more - use these as a floor rather than pinning an exact count.
@@ -19,7 +55,11 @@ def test_finale_tab_pdf_extracts_notes_and_bars(zanarkand_pdf):
     assert result.time_signature_source == "manual override"
     assert result.tempo == 88
     assert result.alphatex is not None
-    assert '\\tuning D2 A2 D3 G3 B3 E4' in result.alphatex
+    # alphaTex binds the FIRST \tuning entry to string 1, and string 1 is
+    # the top tab line (the high string) - see string_for_y and the
+    # \tuning-order test below. The emitted line is therefore high-to-low,
+    # the reverse of result.tuning (which stays low-to-high).
+    assert '\\tuning E4 B3 G3 D3 A2 D2' in result.alphatex
     assert '\\ts 3 4' in result.alphatex
     assert any("low confidence" in w for w in result.warnings)
 
@@ -85,3 +125,184 @@ def test_missing_pdf_never_raises(tmp_path):
     assert info["extractable"] is False
     result = tabextract.extract(missing)
     assert result.extractable is False
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for code-review findings on the tab-extraction PR
+# ---------------------------------------------------------------------------
+
+
+def test_tuning_emitted_high_string_first_for_alphatex_binding():
+    """alphaTex binds the FIRST \\tuning entry to string 1, and
+    _Staff.string_for_y assigns string 1 to the top tab line (the highest
+    string). tabextract keeps `tuning` low-to-high everywhere else (see
+    DEFAULT_TUNING, DROP_D_TUNING, ExtractionResult.tuning), so the emitted
+    line must be the reverse of that list - emitting it as-is would put
+    every note on its mirrored string (e.g. Drop D would land on the wrong
+    end of the neck). Independently confirmed against the real alphaTab
+    importer: with this emission order, "0.1" parses to MIDI 64 (high E)
+    and "0.6" parses to MIDI 40 (low E); the pre-fix low-to-high order gave
+    "0.1" a MIDI pitch of 40, the mirrored string - see PR verification
+    notes."""
+    tex = tabextract._build_alphatex(
+        "T", None, ["E2", "A2", "D3", "G3", "B3", "E4"], None, []
+    )
+    assert "\\tuning E4 B3 G3 D3 A2 E2" in tex
+
+
+def test_measure_quarter_length_scales_by_denominator():
+    """6/8 and 3/4 both budget 3 quarters per measure - the denominator
+    must scale the numerator, or 6/8 gets a budget of 6.0 (double every
+    inferred duration)."""
+    assert tabextract._measure_quarter_length((4, 4)) == 4.0
+    assert tabextract._measure_quarter_length((3, 4)) == 3.0
+    assert tabextract._measure_quarter_length((6, 8)) == 3.0
+    assert tabextract._measure_quarter_length((9, 8)) == 4.5
+
+
+def test_six_eight_and_three_four_extract_identically(zanarkand_pdf):
+    """6/8 and 3/4 share the same 3-quarter measure budget, so rhythm
+    inference (driven purely by that budget) must produce the same bars,
+    notes, and duration codes for either - before the fix, 6/8 doubled the
+    budget and every duration diverged."""
+    three_four = tabextract.extract(zanarkand_pdf, time_signature=(3, 4))
+    six_eight = tabextract.extract(zanarkand_pdf, time_signature=(6, 8))
+    assert six_eight.extractable
+    assert six_eight.bars == three_four.bars
+    assert six_eight.notes == three_four.notes
+    body_3_4 = three_four.alphatex.split(".\n", 1)[1]
+    body_6_8 = six_eight.alphatex.split(".\n", 1)[1]
+    assert body_3_4 == body_6_8
+
+
+def test_escape_tex_string_handles_quotes_and_backslashes():
+    assert tabextract._escape_tex_string('say "hi"') == 'say \\"hi\\"'
+    assert tabextract._escape_tex_string("back\\slash") == "back\\\\slash"
+    assert tabextract._escape_tex_string('mix "a"\\b') == 'mix \\"a\\"\\\\b'
+
+
+def test_hostile_title_is_escaped_in_alphatex():
+    """A filename stem containing a double quote or backslash used to be
+    interpolated straight into \\title "...", producing alphaTex that
+    alphaTab's parser rejects outright."""
+    hostile_title = 'she said "hi"\\bye'
+    tex = tabextract._build_alphatex(hostile_title, None, [], None, [])
+    assert '\\title "she said \\"hi\\"\\\\bye"' in tex
+    # The line still opens and closes with an unescaped quote - no stray
+    # unescaped quote from the title broke out of the string early.
+    first_line = tex.splitlines()[0]
+    assert first_line == '\\title "she said \\"hi\\"\\\\bye"'
+
+
+def test_rest_only_bar_is_emitted_not_skipped(tmp_path):
+    """A bar with no digit columns must still produce a rest beat and a
+    '|' separator - skipping it would shift every later bar's number one
+    position earlier than the PDF, breaking side-by-side comparison."""
+    pdf = _make_tab_pdf(
+        tmp_path / "rest_bar.pdf",
+        [
+            {
+                "notes": [(70, 1, "3"), (270, 5, "5")],
+                "barline_xs": [50, 150, 250, 350],  # 3 measures; middle one empty
+            }
+        ],
+    )
+    result = tabextract.extract(pdf, time_signature=(4, 4))
+    assert result.extractable
+    assert result.bars == 3
+    lines = result.alphatex.split(".\n", 1)[1].strip().splitlines()
+    assert len(lines) == 3
+    assert "3.1" in lines[0]
+    assert lines[1].strip() == ":1 r |"
+    assert "5.5" in lines[2]
+
+
+def test_last_column_duration_uses_barline_not_average_gap():
+    """The final column's duration must come from the gap to the measure's
+    own barline, not the mean of the preceding gaps - averaging
+    systematically shortened the last note of any bar ending on a long
+    note."""
+    columns = [{"x": 0.0}, {"x": 1.0}, {"x": 2.0}]
+    durations = tabextract._infer_measure_rhythm(columns, measure_quarter_len=10.0, bar_end_x=10.0)
+    # gaps: 1.0, 1.0, (10.0 - 2.0) = 8.0, total 10.0 -> proportional shares.
+    assert durations == pytest.approx([1.0, 1.0, 8.0])
+
+
+def test_tab_staff_count_is_summed_across_pages(tmp_path):
+    """tab_staff_count (and standard_staff_count) must mean the same thing
+    in analyze() and extract(): the total number of staff systems found
+    across the whole document, not the maximum found on any single page."""
+    pdf = _make_tab_pdf(
+        tmp_path / "two_pages.pdf",
+        [
+            {"notes": [(70, 1, "3")], "barline_xs": [50, 150]},
+            {"notes": [(70, 1, "4")], "barline_xs": [50, 150]},
+        ],
+    )
+    info = tabextract.analyze(pdf)
+    assert info["tab_staff_count"] == 2
+    result = tabextract.extract(pdf, time_signature=(4, 4))
+    assert result.tab_staff_count == 2
+    assert result.pages_processed == 2
+
+
+def test_digit_merge_rejects_impossible_frets():
+    """Two adjacent single-digit notes close enough to look like one
+    two-digit fret must not be merged if the result is above any real
+    guitar's fret count - they stay as two separate notes instead of
+    silently emitting nonsense like fret 59."""
+    staff = tabextract._Staff("tab", [50, 60, 70, 80, 90, 100], 50, 350)
+
+    def tok(text, x0, yc, width=5.0):
+        return tabextract._DigitToken(text, (x0, yc - 3, x0 + width, yc + 3), "Helvetica", 7)
+
+    impossible = [tok("5", 100.0, 50), tok("9", 101.5, 50)]
+    merged, rejected, suspicious = tabextract._merge_multidigit(impossible, staff)
+    assert rejected == 1
+    assert suspicious == 0
+    assert [n[2] for n in merged] == ["5", "9"]
+
+    valid = [tok("2", 100.0, 50), tok("4", 101.5, 50)]
+    merged2, rejected2, suspicious2 = tabextract._merge_multidigit(valid, staff)
+    assert rejected2 == 0
+    assert suspicious2 == 0
+    assert [n[2] for n in merged2] == ["24"]
+
+
+def test_digit_merge_flags_suspicious_native_two_digit_span():
+    """A two-character span straight from the PDF's own text (not produced
+    by our merge heuristic - e.g. Finale can emit a two-digit fret as one
+    span, or two adjacent notes can end up rendered as one span) that's
+    still above the sane fret ceiling must be flagged, not silently
+    trusted. There's no safe way to split an already-single span back into
+    two notes, so it's kept and counted rather than rejected."""
+    staff = tabextract._Staff("tab", [50, 60, 70, 80, 90, 100], 50, 350)
+
+    def tok(text, x0, yc, width=8.0):
+        return tabextract._DigitToken(text, (x0, yc - 3, x0 + width, yc + 3), "Helvetica", 7)
+
+    native_high = [tok("26", 100.0, 50)]
+    merged, rejected, suspicious = tabextract._merge_multidigit(native_high, staff)
+    assert rejected == 0
+    assert suspicious == 1
+    assert [n[2] for n in merged] == ["26"]
+
+    native_valid = [tok("12", 100.0, 50)]
+    merged2, rejected2, suspicious2 = tabextract._merge_multidigit(native_valid, staff)
+    assert rejected2 == 0
+    assert suspicious2 == 0
+    assert [n[2] for n in merged2] == ["12"]
+
+
+def test_tab_staff_found_but_no_digits_is_not_extractable(tmp_path):
+    """Staves can be detected from vector staff lines even when no fret
+    numbers could be read as text (e.g. an outlined-text export) - that
+    must not be reported as a successful, empty extraction."""
+    pdf = _make_tab_pdf(tmp_path / "no_digits.pdf", [{"notes": [], "barline_xs": [50, 150]}])
+    info = tabextract.analyze(pdf)
+    assert info["extractable"] is True  # staff lines alone look extractable
+    result = tabextract.extract(pdf)
+    assert result.extractable is False
+    assert result.bars == 0
+    assert result.notes == 0
+    assert "no fret-number digits" in result.reason

--- a/server/tests/test_tabextract.py
+++ b/server/tests/test_tabextract.py
@@ -1,0 +1,87 @@
+from fermata import tabextract
+
+
+def test_finale_tab_pdf_extracts_notes_and_bars(zanarkand_pdf):
+    result = tabextract.extract(zanarkand_pdf, time_signature=(3, 4))
+    assert result.extractable
+    assert result.reason is None
+    assert result.tab_staff_count == 5
+    assert result.standard_staff_count == 5
+    # Validated against this exact file: page 1 alone extracts 185 notes
+    # across 24 bars. The score is 2 pages, so the combined total can only
+    # be more - use these as a floor rather than pinning an exact count.
+    assert result.bars >= 24
+    assert result.notes >= 185
+    assert result.pages_processed == 2
+    assert result.tuning_label == "Drop D"
+    assert result.tuning == ["D2", "A2", "D3", "G3", "B3", "E4"]
+    assert result.time_signature == (3, 4)
+    assert result.time_signature_source == "manual override"
+    assert result.tempo == 88
+    assert result.alphatex is not None
+    assert '\\tuning D2 A2 D3 G3 B3 E4' in result.alphatex
+    assert '\\ts 3 4' in result.alphatex
+    assert any("low confidence" in w for w in result.warnings)
+
+
+def test_finale_tab_pdf_analyze(zanarkand_pdf):
+    info = tabextract.analyze(zanarkand_pdf)
+    assert info["extractable"] is True
+    assert info["vector"] is True
+    assert info["tab_staff_count"] >= 5
+    assert info["standard_staff_count"] >= 5
+    assert info["page_count"] == 2
+
+
+def test_finale_tab_pdf_without_ts_override_still_extracts(zanarkand_pdf):
+    # Auto time-signature detection is a known-broken heuristic (see module
+    # docstring) - without an override the extractor must fall back to an
+    # assumed 4/4 and say so, not fail or silently mis-report success.
+    result = tabextract.extract(zanarkand_pdf)
+    assert result.extractable
+    assert result.time_signature == (4, 4)
+    assert result.time_signature_source == "not detected (assumed 4/4)"
+    assert any("time signature not detected" in w for w in result.warnings)
+
+
+def test_notation_only_pdf_has_no_tab_staves(tarrega_pdf):
+    info = tabextract.analyze(tarrega_pdf)
+    assert info["extractable"] is False
+    assert info["vector"] is True
+    assert info["tab_staff_count"] == 0
+    assert info["standard_staff_count"] > 0
+
+    result = tabextract.extract(tarrega_pdf)
+    assert result.extractable is False
+    assert result.alphatex is None
+    assert "standard-notation only" in result.reason
+
+
+def test_raster_pdf_is_not_extractable(claire_de_lune_pdf):
+    info = tabextract.analyze(claire_de_lune_pdf)
+    assert info["extractable"] is False
+    assert info["vector"] is False
+    assert "raster" in info["reason"]
+
+    result = tabextract.extract(claire_de_lune_pdf)
+    assert result.extractable is False
+    assert "raster" in result.reason
+
+
+def test_malformed_pdf_never_raises(tmp_path):
+    bogus = tmp_path / "not_a_pdf.pdf"
+    bogus.write_bytes(b"this is not a pdf file, just garbage bytes")
+    info = tabextract.analyze(bogus)
+    assert info["extractable"] is False
+    assert info["reason"]
+    result = tabextract.extract(bogus)
+    assert result.extractable is False
+    assert result.reason
+
+
+def test_missing_pdf_never_raises(tmp_path):
+    missing = tmp_path / "does_not_exist.pdf"
+    info = tabextract.analyze(missing)
+    assert info["extractable"] is False
+    result = tabextract.extract(missing)
+    assert result.extractable is False

--- a/server/tests/test_transcription_api.py
+++ b/server/tests/test_transcription_api.py
@@ -79,3 +79,82 @@ def test_transcription_analysis_endpoint(app_env, zanarkand_pdf, monkeypatch, in
     analysis = api.get_transcription_analysis(score_id)
     assert analysis["extractable"] is True
     assert analysis["tab_staff_count"] >= 5
+
+
+@pytest.mark.parametrize(
+    "time_signature",
+    [
+        (0, 4),  # numerator below 1
+        (33, 4),  # numerator above 32
+        (4, 0),  # zero denominator
+        (4, 3),  # denominator not a power of two
+        (4, 6),  # denominator not a power of two
+    ],
+)
+def test_transcribe_rejects_invalid_time_signature(
+    app_env, zanarkand_pdf, monkeypatch, insert_score, time_signature
+):
+    """[0, 4] used to be accepted straight through to \\ts 0 4, which
+    alphaTab rejects and which also zeroed the per-measure quarter-note
+    budget so every duration snapped to :32."""
+    monkeypatch.setattr(api, "LIBRARY_DIR", zanarkand_pdf.parent)
+    conn = db.connect()
+    score_id = insert_score(conn, zanarkand_pdf.name)
+    with pytest.raises(HTTPException) as exc_info:
+        api.transcribe(score_id, body=api.TranscribeIn(time_signature=time_signature))
+    assert exc_info.value.status_code == 422
+
+
+def test_transcribe_accepts_valid_time_signature(app_env, zanarkand_pdf, monkeypatch, insert_score):
+    monkeypatch.setattr(api, "LIBRARY_DIR", zanarkand_pdf.parent)
+    conn = db.connect()
+    score_id = insert_score(conn, zanarkand_pdf.name)
+    result = api.transcribe(score_id, body=api.TranscribeIn(time_signature=(6, 8)))
+    assert result["source"] == "extracted"
+    assert result["time_signature"] == [6, 8]
+
+
+def test_delete_transcription_reverts_to_extracted(app_env, zanarkand_pdf, monkeypatch, insert_score):
+    monkeypatch.setattr(api, "LIBRARY_DIR", zanarkand_pdf.parent)
+    conn = db.connect()
+    score_id = insert_score(conn, zanarkand_pdf.name)
+
+    api.transcribe(score_id, body=None)
+    edited_content = '\\title "hand edited"\n.\n:4 0.1 |'
+    api.save_transcription(score_id, api.TranscriptionEditIn(content=edited_content))
+
+    current = api.get_transcription(score_id)
+    assert current["source"] == "edited"
+
+    # Deleting the edit must revert GET to the extracted transcription, not
+    # remove the extracted row too.
+    after_delete = api.delete_transcription(score_id)
+    assert after_delete["source"] == "extracted"
+
+    reverted = api.get_transcription(score_id)
+    assert reverted["source"] == "extracted"
+    assert reverted["content"] != edited_content
+
+    rows = conn.execute(
+        "SELECT source FROM transcriptions WHERE score_id = ?", (score_id,)
+    ).fetchall()
+    assert {r["source"] for r in rows} == {"extracted"}
+
+    # A second delete finds no edited row to remove - that's a clean no-op
+    # (the extracted transcription is still returned), not an error.
+    again = api.delete_transcription(score_id)
+    assert again["source"] == "extracted"
+
+
+def test_delete_transcription_404_when_none_exists(app_env, insert_score):
+    conn = db.connect()
+    score_id = insert_score(conn, "nope.pdf")
+    with pytest.raises(HTTPException) as exc_info:
+        api.delete_transcription(score_id)
+    assert exc_info.value.status_code == 404
+
+    # Calling it again on a score that has genuinely never had any
+    # transcription is still a clean 404, not a crash.
+    with pytest.raises(HTTPException) as exc_info2:
+        api.delete_transcription(score_id)
+    assert exc_info2.value.status_code == 404

--- a/server/tests/test_transcription_api.py
+++ b/server/tests/test_transcription_api.py
@@ -1,0 +1,81 @@
+import pytest
+from fastapi import HTTPException
+
+from fermata import api, db
+
+
+def test_edited_transcription_survives_re_extraction(app_env, zanarkand_pdf, monkeypatch, insert_score):
+    monkeypatch.setattr(api, "LIBRARY_DIR", zanarkand_pdf.parent)
+    conn = db.connect()
+    score_id = insert_score(conn, zanarkand_pdf.name)
+
+    first = api.transcribe(score_id, body=None)
+    assert first["source"] == "extracted"
+    assert first["bars"] > 0
+    assert first["notes"] > 0
+
+    edited_content = '\\title "hand edited"\n.\n:4 0.1 |'
+    edited = api.save_transcription(score_id, api.TranscriptionEditIn(content=edited_content))
+    assert edited["source"] == "edited"
+    assert edited["content"] == edited_content
+
+    current = api.get_transcription(score_id)
+    assert current["source"] == "edited"
+    assert current["content"] == edited_content
+
+    # Re-running extraction must update the extracted row only, never the
+    # edited one - this is the whole point of keeping them as separate rows.
+    second = api.transcribe(score_id, body=None)
+    assert second["source"] == "extracted"
+
+    still_current = api.get_transcription(score_id)
+    assert still_current["source"] == "edited"
+    assert still_current["content"] == edited_content
+
+    rows = conn.execute(
+        "SELECT source FROM transcriptions WHERE score_id = ? ORDER BY source", (score_id,)
+    ).fetchall()
+    assert {r["source"] for r in rows} == {"edited", "extracted"}
+
+
+def test_get_transcription_404_when_none_exists(app_env, insert_score):
+    conn = db.connect()
+    score_id = insert_score(conn, "nope.pdf")
+    with pytest.raises(HTTPException) as exc_info:
+        api.get_transcription(score_id)
+    assert exc_info.value.status_code == 404
+
+
+def test_has_transcription_flag_is_batched_and_accurate(app_env, zanarkand_pdf, monkeypatch, insert_score):
+    monkeypatch.setattr(api, "LIBRARY_DIR", zanarkand_pdf.parent)
+    conn = db.connect()
+    score_id = insert_score(conn, zanarkand_pdf.name)
+
+    before = api.get_score(score_id)
+    assert before["has_transcription"] is False
+
+    api.transcribe(score_id, body=None)
+
+    after = api.get_score(score_id)
+    assert after["has_transcription"] is True
+
+    listed = {row["id"]: row["has_transcription"] for row in api.list_scores()}
+    assert listed[score_id] is True
+
+
+def test_transcribe_rejects_non_extractable_pdf(app_env, tarrega_pdf, monkeypatch, insert_score):
+    monkeypatch.setattr(api, "LIBRARY_DIR", tarrega_pdf.parent)
+    conn = db.connect()
+    score_id = insert_score(conn, tarrega_pdf.name)
+    with pytest.raises(HTTPException) as exc_info:
+        api.transcribe(score_id, body=None)
+    assert exc_info.value.status_code == 422
+
+
+def test_transcription_analysis_endpoint(app_env, zanarkand_pdf, monkeypatch, insert_score):
+    monkeypatch.setattr(api, "LIBRARY_DIR", zanarkand_pdf.parent)
+    conn = db.connect()
+    score_id = insert_score(conn, zanarkand_pdf.name)
+    analysis = api.get_transcription_analysis(score_id)
+    assert analysis["extractable"] is True
+    assert analysis["tab_staff_count"] >= 5


### PR DESCRIPTION
## Summary

Adds server-side tablature extraction: a PDF whose pages carry a real 6-line
tab staff (Finale/Sibelius/Opus-style vector engraving) can be turned into
alphaTex and stored against the score.

- `server/fermata/tabextract.py` - staff systems are located from vector
  line primitives (6 evenly-spaced long horizontal lines = tab staff, 5 =
  standard staff); fret numbers come from digit-only text spans assigned to
  the nearest tab staff/string by position, not by font (different
  engravers use different fonts for fret numbers). Barlines come from
  vertical line primitives. `analyze()` is a cheap triage (vector vs.
  raster, staff counts); `extract()` does the full pass and returns an
  `ExtractionResult` (alphaTex, bars/beats/notes, tuning, per-section
  confidence, warnings). Neither function ever raises - a malformed PDF or
  one with no tab staves comes back as `extractable: false` with a reason.

- `transcriptions` table (`server/fermata/db.py`) - one `source='extracted'`
  row and at most one `source='edited'` row per score, enforced by a unique
  index on `(score_id, source)`. Re-running extraction only ever
  `INSERT ... ON CONFLICT` upserts the `extracted` row, so a hand-edited
  transcription can never be silently overwritten by a re-extraction.
  `GET .../transcription` prefers the edited row when both exist.

- New endpoints on the existing `/api` router:
  - `GET /api/scores/{id}/transcription/analysis` - cheap triage result
  - `POST /api/scores/{id}/transcribe` - runs extraction, accepts an
    optional `{time_signature: [num, den]}` override, stores + returns the
    extracted row plus warnings
  - `GET /api/scores/{id}/transcription` - current transcription (edited
    wins) or 404
  - `PUT /api/scores/{id}/transcription` - save hand-edited alphaTex
    (`source='edited'`)
  - `GET/api/scores` and `GET /api/scores/{id}` now include a batched
    `has_transcription` boolean (extends the existing `_with_tags` helper,
    no N+1 query)

- **Sync, not background-thread**: measured full extraction (both pages of
  a real 2-page tab score) at ~0.06-0.2s including DB round trip, so
  `POST /api/scores/{id}/transcribe` runs synchronously rather than reusing
  `scanner.py`'s background-thread/status-polling pattern - there's no
  latency problem to solve.

## Accuracy (validated against real library files)

- Finale-engraved tab PDF (a library score, 2 pages): 5 tab + 5 notation
  staves per page detected, 357 notes across 49 bars extracted, tuning
  correctly read as Drop D, alphaTex parses cleanly.
- Standard-notation-only PDF (Tarrega study, fingering digits present but
  no tab staff): correctly reports `extractable: false` - fingering numbers
  are not mistaken for fret numbers.
- Raster-scanned PDF (Clair de Lune): correctly reports `extractable: false`
  with reason "raster scan" (no fonts/drawings/text on any page).

## Known limitation - please read

**Durations and time signatures are low confidence.** Rhythm is inferred
from horizontal spacing between note columns snapped to the nearest plain
duration - there is no dotted-note or tie model, so it will get simple
passages roughly right and can be wrong wherever engraving spacing doesn't
scale linearly with duration. Time-signature auto-detection is essentially
non-functional: the glyphs live inside subsetted music fonts (Maestro,
Opus, ...) at remapped codepoints that don't correspond to their visual
meaning, so it fails silently on real files. `extract()` accepts a manual
`time_signature` override for exactly this reason, and every extraction
result carries this out explicitly in `warnings` / `confidence` rather than
papering over it - callers (and the UI) should surface these, not hide them.

## Test plan

- [x] `server/tests/` - pytest suite covering: Finale tab PDF extracts
  expected notes/bars (>=185 notes / >=24 bars, floor from the validated
  single-page numbers since this file is 2 pages), notation-only PDF yields
  `extractable: false` with no tab staves, raster PDF reports
  not-extractable, malformed/missing PDF never raises, and an edited
  transcription survives a re-extraction. Uses the real sample PDFs
  read-only via `FERMATA_TEST_LIBRARY`, skips if unset/missing.
- [x] Ran in a clean `python:3.12-slim` container against the real library
  (12 passed).
- [x] Built the full Docker image from this branch and exercised the new
  endpoints against the real library with curl: transcribed a library score (3/4 override), confirmed warnings are present and honest, confirmed
  `has_transcription` flips true, confirmed a `PUT` edit survives a
  follow-up `POST /transcribe`.

https://claude.ai/code/session_017T6Jz8bFWsowh55GKfBv6i