### PR TITLE
Stop pre-judging how much rhythm a PDF will yield

### DIFF
--- a/web/src/lib/ScoreCompare.svelte
+++ b/web/src/lib/ScoreCompare.svelte
@@ -259,13 +259,14 @@
           <h3>No staff transcription yet</h3>
           <p>
             Fermata can pull the guitar tab out of this PDF and render it as a playable,
-            editable staff. Fret and string extraction is accurate, but the rhythm and time
-            signature are guessed from spacing on the page — treat the staff as a draft to
-            check against the PDF, not a verified score.
+            editable staff. Fret and string extraction is accurate; how much of the rhythm
+            can be recovered depends on how the PDF was engraved, and anything left
+            uncertain is listed alongside the finished staff. Check it against the PDF
+            before trusting it.
           </p>
           <div class="ts-input">
             <label>
-              Time signature <span class="opt">(optional — helps the rhythm guess)</span>
+              Time signature <span class="opt">(optional — used only if it can't be read from the score)</span>
               <span class="ts-fields">
                 <input type="number" min="1" max="32" placeholder="4" bind:value={tsNum} />
                 <span class="slash">/</span>


### PR DESCRIPTION
The empty state shown before a PDF is transcribed asserted that "the rhythm and time signature are guessed from spacing on the page", and labelled the optional time-signature field as helping "the rhythm guess".

That copy renders unconditionally, before any extraction has run, so it cannot reflect what a particular PDF will actually yield. It is accurate for some engravings and wrong for others — an engraved score whose rhythm is read directly from its notation is described to the reader as guesswork.

This replaces the claim with what is true in every case: fret and string extraction is accurate, how much rhythm can be recovered depends on the source PDF, and anything left uncertain is reported alongside the finished staff. The per-transcription warning list already carries the specifics, so the pre-extraction copy no longer needs to predict them.

The time-signature field is now described as being used only when the signature cannot be read from the score, which is what it is for.
