### PR TITLE
Prepare the repository for public development

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,52 @@
+name: Bug report
+description: Something isn't working
+labels: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please don't attach copyrighted sheet music. Describe the file instead —
+        how it was produced matters far more than the music in it.
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened
+      description: What you did, and what happened instead of what you expected.
+    validations:
+      required: true
+  - type: textarea
+    id: file
+    attributes:
+      label: The file involved, if any
+      description: >
+        For import or display problems: is it a PDF, MusicXML, Guitar Pro?
+        A scan or vector output? Which program exported it (Finale, Sibelius,
+        MuseScore, something else)? Does it have a tab staff, standard
+        notation, or both?
+  - type: textarea
+    id: warnings
+    attributes:
+      label: Reported warnings
+      description: >
+        For a transcription problem, paste the warnings shown with the staff.
+        They usually say exactly which part was uncertain.
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: A release, or the commit you're running.
+  - type: dropdown
+    id: how-run
+    attributes:
+      label: How are you running it
+      options:
+        - Docker Compose
+        - Docker directly
+        - From source
+        - Other
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs
+      description: Relevant container or browser console output.
+      render: shell

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,26 @@
+name: Feature idea
+description: Suggest something Fermata should do
+labels: []
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What are you trying to do
+      description: >
+        Describe the situation rather than the solution. Knowing what you're
+        practising, performing, or organising usually suggests a better answer
+        than a feature described in the abstract.
+    validations:
+      required: true
+  - type: textarea
+    id: idea
+    attributes:
+      label: What you had in mind
+      description: Optional. If you already have a shape in mind, describe it.
+  - type: input
+    id: instrument
+    attributes:
+      label: Instrument
+      description: >
+        Fermata aims to be instrument-agnostic with particularly good guitar
+        support, so it helps to know what you play.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,18 @@
+## What this changes
+
+<!-- One or two sentences. Link the issue it addresses. -->
+
+## How it was verified
+
+<!--
+What you actually ran or observed, not just "tests pass". For anything that
+reads music out of a file, say what it produced and why that output is right —
+a passing test suite doesn't prove a rhythm was read correctly.
+-->
+
+## Anything left uncertain
+
+<!--
+If the change infers something, say what it can get wrong and whether the app
+tells the user about it. Reporting uncertainty is preferred over hiding it.
+-->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,54 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  server:
+    name: Server tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install
+        working-directory: server
+        run: pip install -e ".[dev]"
+      # Tests that need a sheet music library read it from FERMATA_TEST_LIBRARY
+      # and skip when it is unset, so this runs the rest without one.
+      - name: Test
+        working-directory: server
+        run: python -m pytest -q
+
+  web:
+    name: Frontend build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+      - name: Install
+        working-directory: web
+        run: npm ci
+      # The build also asserts the renderer's font and soundfont were copied,
+      # which a plain compile would not catch.
+      - name: Build
+        working-directory: web
+        run: npm run build
+
+  image:
+    name: Container image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build
+        run: docker build -t fermata:ci .

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,38 @@
+# Code of Conduct
+
+## The short version
+
+Be decent to people. This is a small project about sheet music; there is no
+version of a disagreement here that justifies being cruel.
+
+## What's expected
+
+- Assume the person on the other end is trying to help.
+- Criticise work, not people. "This breaks on scanned PDFs" is useful; "this is
+  garbage" is not.
+- Accept that people have different levels of experience, different instruments,
+  different reasons for using this, and different amounts of time to give it.
+- Take correction gracefully, including when it comes from someone newer than you.
+
+## What isn't
+
+Harassment, insults, or demeaning comments. Discriminatory language or jokes,
+including about someone's identity, background, or ability. Sexual attention or
+imagery. Publishing someone's private information. Sustained disruption of
+discussions.
+
+## Scope
+
+This applies to issues, pull requests, commit messages, and anywhere else the
+project is being discussed by its participants.
+
+## Enforcement
+
+Report a problem privately through the **Security** tab's *Report a
+vulnerability* form, which reaches the maintainer and no one else, or open an
+issue if it can be discussed publicly. Reports will be read and taken
+seriously, and details will be kept private.
+
+The maintainer may remove comments, close threads, or block accounts. Anything
+beyond a single unambiguous incident will get an explanation of what happened
+and why, so enforcement isn't arbitrary.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,67 @@
+# Contributing
+
+Thanks for looking. Fermata is developed in the open, and issues are genuinely
+useful even when they don't come with a patch.
+
+## Issues are welcome
+
+Bug reports, feature ideas, and "this didn't work with my library" reports are
+all wanted. For a bug, the most useful thing you can include is what kind of
+PDF or score file was involved — how it was produced matters more than almost
+anything else, because import behaviour depends heavily on how a file was
+engraved.
+
+Please don't attach copyrighted sheet music to an issue. Describe the file
+instead: what program exported it, whether it's a scan or vector output,
+whether it has a tab staff.
+
+## Pull requests
+
+Changes land through pull requests, which are reviewed before merging. `main` is
+protected, so this applies to everyone including the maintainer.
+
+Before opening one:
+
+- Open or find an issue first for anything beyond a small fix, so the approach
+  can be agreed before you spend time on it.
+- Keep the change focused. A pull request that does one thing gets reviewed;
+  one that does five things stalls.
+- Run the checks locally (below). CI runs the same ones.
+- Explain how you verified the change, not just what you changed. For anything
+  touching score import, "the tests pass" is weaker evidence than "here is what
+  it produced for this kind of file, and here is why that's correct."
+
+## Running the checks
+
+Backend:
+
+```bash
+cd server
+pip install -e ".[dev]"
+python -m pytest -q
+```
+
+Some tests need a folder of sheet music and skip without one. To include them,
+point `FERMATA_TEST_LIBRARY` at a directory of your own files.
+
+Frontend:
+
+```bash
+cd web
+npm ci
+npm run build
+```
+
+Whole thing, as it actually ships:
+
+```bash
+docker compose up --build
+```
+
+## A note on accuracy
+
+A lot of this project reads music out of files that were never meant to be
+read programmatically, so it is frequently uncertain. The rule throughout is
+that uncertainty gets reported rather than hidden: it is better for the app to
+say a rhythm may be wrong than to present a confident guess. If you add
+something that infers, please also add the honest caveat that goes with it.

--- a/README.md
+++ b/README.md
@@ -28,8 +28,22 @@ them.
   both staves at once, with audio playback, adjustable speed, and a moving
   cursor. The built-in synthesizer also drives practice tools: drag-select a
   passage on the score to loop it, plus metronome and count-in toggles.
+- **Tab out of a PDF** — engraved guitar PDFs carry their tab as real text and
+  their rhythm in the music font's own glyphs, so Fermata reads both directly
+  instead of guessing at pixels, and renders the result as a playable,
+  editable staff beside the original page. Fret numbers, strings and chords
+  come out reliably; how much of the rhythm survives depends on the engraving,
+  and whatever stayed uncertain is listed with the staff rather than hidden.
+  Music written in two voices is still flattened into one, so bars in
+  polyphonic pieces frequently do not add up yet — the count is reported.
+  Scanned PDFs have nothing to read and are not transcribed.
+- **Practice tracking** — a session timer per piece, with recently-practised
+  and neglected views so the library reflects what you are actually working on.
+- **Gig mode** — fullscreen, screen kept awake, oversized tap targets and
+  half-page turns for a tablet on a music stand.
 - **Organize** — collections (from your folder layout), free-form tags,
-  favorites, content-type labels (notation / tab / both), full-text search.
+  favorites, content-type labels (notation / tab / both), full-text search,
+  and duplicate detection by file contents.
 - **Upload** — drag files in through the browser; they land in your library
   folder and are indexed immediately.
 - **Single container** — SQLite inside, two volume mounts, no external
@@ -75,28 +89,36 @@ npm run dev
 
 ## Formats
 
-| Format                          | Viewer                                     |
-| ------------------------------- | ------------------------------------------ |
-| PDF                             | Practice reader (fixed layout)             |
-| MusicXML (`.musicxml`, `.mxl`)  | Interactive: notation / tab / both, audio  |
+| Format | How it reads |
+| --- | --- |
+| PDF, engraved with a tab staff | Practice reader, plus transcription to a playable staff you can view beside the page |
+| PDF, engraved without tab | Practice reader; nothing to transcribe from |
+| PDF, scanned | Practice reader only — a scan holds no text or glyphs to read |
+| MusicXML (`.musicxml`, `.mxl`) | Interactive: notation / tab / both, audio, full fidelity |
 | Guitar Pro (`.gp3`–`.gp5`, `.gpx`, `.gp`) | Interactive: notation / tab / both, audio |
 
-PDFs are fixed renderings, so the notation/tab toggle applies to the semantic
-formats. There's a bundled demo (sidebar → *Notation/tab demo*) if your
-library is PDF-only so far.
+A PDF is a fixed rendering, so the notation/tab toggle belongs to the
+structured formats — and to a transcription made from a PDF, which is what the
+side-by-side view is for. There's a bundled demo (sidebar → *Notation/tab
+demo*) if your library is PDF-only so far.
 
 ## Roadmap
 
+- **Separating voices when transcribing** — the largest gap between a
+  transcription and a score you could practise from, and the reason bars in
+  polyphonic pieces overfill today
 - **Score creation and editing** — build a staff from scratch in the browser,
   instrument-agnostic with first-class guitar tablature support
-- **Optical music recognition** — convert engraved PDFs into editable,
-  playable scores
-- **Richer import metadata** — author/title extraction across more formats
+- **More import formats** — MIDI and plain-text tab in particular, since those
+  accompany most freely-licensed sheet music you can download
+- **A fretboard trainer** — note finding, chord flash cards and reach drills,
+  scoped to the strings and frets you are working on
 - Setlists and practice sessions with per-piece progress
 - Annotations on PDFs (fingerings, markings)
+- Reverse proxy authentication, then multi-user accounts
 - Splitting compilation books into individual pieces
-- Multi-user accounts
 - Tablet-first PWA mode with pedal-friendly full-screen
+- Recognition for scanned PDFs, which carry no readable text or glyphs
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,42 @@
+# Security
+
+## Reporting a vulnerability
+
+Please report security problems privately, not as a public issue.
+
+Use GitHub's private vulnerability reporting: go to the **Security** tab of this
+repository and choose **Report a vulnerability**. That opens a private thread
+visible only to the maintainer.
+
+Please include what you did, what happened, and what an attacker could get out
+of it. A working proof of concept is welcome but not required.
+
+You'll get a first response within a week. If a fix is needed, you'll be told
+what it is and when it ships, and you'll be credited unless you'd rather not be.
+
+## What's in scope
+
+Fermata is a self-hosted server that reads files you give it and serves them to
+your own browser. The interesting attack surface is roughly:
+
+- Parsing untrusted score files. Import reads PDFs and other formats with
+  third-party libraries; a malicious file causing something worse than a failed
+  import is worth reporting.
+- Path handling on upload and on serving library files, including anything that
+  escapes the configured library directory.
+- Anything that lets a request read or write outside the library and config
+  volumes.
+
+## What isn't
+
+- Fermata ships with no authentication and assumes it sits on a network you
+  control, or behind a reverse proxy that handles access. "Anyone who can reach
+  the port can use it" is the documented design, not a vulnerability.
+- Denial of service through deliberately enormous or pathological files. Worth
+  an ordinary issue, not a security report.
+- Vulnerabilities in a dependency with no demonstrated path through Fermata.
+  Those are better reported upstream, though a note here is welcome.
+
+## Supported versions
+
+This is a young project with no release branches yet. Fixes go to `main`.


### PR DESCRIPTION
Prepares the repository for public development.

**Continuous integration** runs the server tests, the frontend build and the container build on every pull request. Tests that need a folder of sheet music read it from `FERMATA_TEST_LIBRARY` and skip without one, so CI runs the rest: 58 pass, 24 skip locally. The frontend job uses the ordinary build, which also asserts the renderer's font and soundfont were copied — something a plain compile does not catch.

**Contributor documentation**: how to run the checks, why a focused pull request gets reviewed and a sprawling one stalls, and a request to describe how a file was engraved rather than attaching copyrighted sheet music, since how a file was produced is what determines import behaviour. The security policy points at private vulnerability reporting and is explicit that shipping without authentication is the documented design rather than a vulnerability.

**Issue and pull request templates** ask for the things that are actually diagnostic: which program exported the file, scan or vector, and the warnings shown alongside a transcription. The pull request template asks how a change was verified, because a passing test suite does not demonstrate that a rhythm was read correctly.

**Readme** now describes reading tab out of a PDF, which the feature list had omitted entirely despite it being the thing this project does that others do not, and states the limits in the same breath: rhythm depends on the engraving, voices merged into one overfill bars in polyphonic music, and a scan holds nothing to read. The roadmap no longer promises recognition work that direct extraction replaced.

Repository settings already applied: squash-only merges, automatic deletion of merged branches, read-only workflow permissions, and workflows barred from approving pull requests. Branch protection and private vulnerability reporting both require the repository to be public on this plan and are tracked in #41.
