### PR TITLE
Separate voices when transcribing polyphonic music

### DIFF
--- a/server/fermata/glyph_rhythm.py
+++ b/server/fermata/glyph_rhythm.py
@@ -296,6 +296,12 @@ _SP = {
     # notehead <-> stem attachment
     "stem_x_tol": 0.68,           # was 3.5pt
     "stem_y_tol": 1.17,           # was 6.0pt
+    # How far outside a stem's own y-span an inner chord notehead may sit and
+    # still count as threaded onto it (see _stem_through_notehead). A third
+    # of a staff space is under half a notehead height, so it forgives the
+    # stroke ending a hair short of the outermost notehead's centre without
+    # reaching the next staff position.
+    "stem_span_slack": 0.35,
     # flags
     "flag_x_tol": 0.98,           # was 5.0pt
     "flag_y_tol": 1.76,           # was 9.0pt
@@ -934,9 +940,10 @@ DURATION_CODE = {4.0: 1, 2.0: 2, 1.0: 4, 0.5: 8, 0.25: 16, 0.125: 32}
 
 class NoteEvent:
     __slots__ = ("x", "y", "base_units", "flags", "dotted", "is_rest",
-                 "category", "notehead_kind", "tied_next")
+                 "category", "notehead_kind", "tied_next", "stem_dir", "stem_key")
 
-    def __init__(self, x, y, base_units, flags, dotted, is_rest, category, notehead_kind=None):
+    def __init__(self, x, y, base_units, flags, dotted, is_rest, category,
+                 notehead_kind=None, stem_key=None):
         self.x = x
         self.y = y
         self.base_units = base_units
@@ -946,6 +953,14 @@ class NoteEvent:
         self.category = category
         self.notehead_kind = notehead_kind
         self.tied_next = False  # best-effort: see _mark_ties()
+        # Voice signals. stem_key identifies the ONE engraved stem this
+        # notehead hangs off, so the several noteheads of a chord - which
+        # share a single stem - can be recognised as one beat rather than
+        # several. stem_dir is "up"/"down" (see _assign_stem_directions), the
+        # signal engravers use to separate an upper from a lower voice. Both
+        # are None for a notehead with no stem at all (a whole note).
+        self.stem_key = stem_key
+        self.stem_dir = None
 
     @property
     def quarter_units(self):
@@ -1009,6 +1024,38 @@ def _best_stem(stems, stem_xs, x0, x1, yc, tol, x_tol=None, y_tol=None):
     return best
 
 
+def _stem_through_notehead(stems, stem_xs, x0, x1, yc, tol):
+    """The stem this notehead is THREADED ONTO, for a notehead sitting part
+    way along a chord's shared stem rather than at its end.
+
+    _best_stem deliberately only attaches a notehead at a stem's END, which
+    is where the flag or beam that decides the duration lives, and keeping
+    that window tight is what stops a neighbouring voice's stem being read
+    for flags. But a chord is several noteheads on ONE stem, and every member
+    except the one at the stem's end sits far outside that end window - up to
+    an octave away. Those members still have to be recognised as the same
+    beat, so accept a stem whose x is beside this notehead and whose span
+    covers the notehead's centre.
+
+    This does not confuse the two voices of conventional polyphonic writing:
+    there the upper voice's stem goes UP and the lower voice's goes DOWN, so
+    each points AWAY from the other and neither spans the other's notehead.
+    """
+    lo, hi = _bounds(stem_xs, min(x0, x1) - tol.stem_x_tol, max(x0, x1) + tol.stem_x_tol)
+    slack = tol.stem_span_slack
+    best, best_dx = None, None
+    for i in range(lo, hi):
+        s = stems[i]
+        dx = min(abs(s.x - x0), abs(s.x - x1))
+        if dx > tol.stem_x_tol:
+            continue
+        if not (s.y0 - slack <= yc <= s.y1 + slack):
+            continue
+        if best_dx is None or dx < best_dx:
+            best, best_dx = s, dx
+    return best
+
+
 def _has_stem_near(stems, stem_xs, x0, x1, yc, tol):
     return _best_stem(stems, stem_xs, x0, x1, yc, tol,
                       x_tol=tol.rest_stem_x_tol, y_tol=tol.rest_stem_y_tol) is not None
@@ -1063,6 +1110,42 @@ def _beam_count_near(beams, stem, notehead_yc, tol):
         if y - clusters[-1] > tol.beam_level_gap:
             clusters.append(y)
     return len(clusters)
+
+
+def _stem_key(stem):
+    """Hashable identity for one engraved stem, so every notehead attached to
+    it can be recognised as belonging to the same beat."""
+    return (round(stem.x, 2), round(stem.y0, 2), round(stem.y1, 2))
+
+
+def _assign_stem_directions(notes, stems_by_key):
+    """Resolve each stem's direction ONCE, from every notehead hanging off it.
+
+    Direction cannot be read from a single notehead's own position on its
+    stem: a chord shares one stem that runs PAST all of its noteheads, so
+    the end further from any given notehead is on the wrong side for every
+    member but the outermost one - reading "the free end is below me,
+    therefore stem down" off the top note of an up-stemmed chord inverts it.
+
+    What identifies the direction is which end OVERHANGS the notehead group:
+    a stem sticks out roughly an octave beyond the note it points away from
+    and stops dead at the note it points toward. Page y grows DOWNWARD, so
+    the overhang above the group is (topmost notehead y - stem y0).
+    """
+    by_stem = collections.defaultdict(list)
+    for n in notes:
+        if n.stem_key is not None:
+            by_stem[n.stem_key].append(n)
+    for key, members in by_stem.items():
+        stem = stems_by_key.get(key)
+        if stem is None:
+            continue
+        ys = [m.y for m in members]
+        overhang_up = min(ys) - stem.y0
+        overhang_down = stem.y1 - max(ys)
+        direction = "up" if overhang_up > overhang_down else "down"
+        for m in members:
+            m.stem_dir = direction
 
 
 def _mark_ties(notes, curves, tol):
@@ -1188,8 +1271,10 @@ def decode_note_events(page, staff_top, staff_bottom, staff_x0, staff_x1, line_y
     dot_counts = _assign_dots(dot_owners, dot_events, tol)
 
     notes = []
+    stems_by_key = {}
     for ev in staff_events:
         if ev.category in NOTEHEAD_CATS:
+            stem = None
             if ev.category == "notehead_whole":
                 # whole notes never take a stem, flag or beam by definition -
                 # don't even look for one (a nearby unrelated stem in a dense
@@ -1199,8 +1284,12 @@ def decode_note_events(page, staff_top, staff_bottom, staff_x0, staff_x1, line_y
                 # half notes have a stem but categorically cannot carry a
                 # flag or beam - counting one here would only ever be a
                 # false positive from a neighboring voice's stem/beam sitting
-                # nearby (2-voice writing), so don't even look.
+                # nearby (2-voice writing), so don't count either. The stem
+                # is still looked up, for its DIRECTION only: a lower voice
+                # in this repertoire is very often written in half notes, and
+                # without its stem it has no voice signal at all.
                 base, flags = 2.0, 0
+                stem = _best_stem(stems, stem_xs, ev.x0, ev.x1, ev.yc, tol)
             else:
                 base = 1.0  # filled/x/diamond head: quarter-or-shorter
                 flags = 0
@@ -1209,8 +1298,20 @@ def decode_note_events(page, staff_top, staff_bottom, staff_x0, staff_x1, line_y
                     hooks = _flag_count_near(flag_events, flag_xs, stem, ev.yc, tol)
                     beam_levels = _beam_count_near(beams, stem, ev.yc, tol)
                     flags = max(hooks, beam_levels)
+            if stem is None and ev.category != "notehead_whole":
+                # An inner or far member of a chord: no stem END is near it,
+                # but its chord's stem runs through it. Voice grouping only -
+                # the duration it was given above stands, and a chord's
+                # duration is recomposed from all its members together (see
+                # tabextract._stem_group_duration).
+                stem = _stem_through_notehead(stems, stem_xs, ev.x0, ev.x1, ev.yc, tol)
+            key = None
+            if stem is not None:
+                key = _stem_key(stem)
+                stems_by_key[key] = stem
             notes.append(NoteEvent(ev.xc, ev.yc, base, flags, min(dot_counts.get(id(ev), 0), 2),
-                                   False, ev.category, notehead_kind=ev.category))
+                                   False, ev.category, notehead_kind=ev.category,
+                                   stem_key=key))
         elif ev.category in REST_CATS:
             # disambiguate flag8_or_rest_quarter by stem proximity: a real
             # stem near it means it's actually a flag glyph, not a rest.
@@ -1236,6 +1337,7 @@ def decode_note_events(page, staff_top, staff_bottom, staff_x0, staff_x1, line_y
                                    True, cat))
 
     notes.sort(key=lambda n: n.x)
+    _assign_stem_directions(notes, stems_by_key)
     _mark_ties(notes, curves, tol)
 
     # Unrecognised glyphs sitting where a flag attaches are the dangerous

--- a/server/fermata/glyph_rhythm.py
+++ b/server/fermata/glyph_rhythm.py
@@ -1131,6 +1131,22 @@ def _assign_stem_directions(notes, stems_by_key):
     a stem sticks out roughly an octave beyond the note it points away from
     and stops dead at the note it points toward. Page y grows DOWNWARD, so
     the overhang above the group is (topmost notehead y - stem y0).
+
+    The answer is then CHECKED against which side of the noteheads the stem
+    sits on, because an up-stem leaves a notehead at its right edge and a
+    down-stem at its left - a convention the library keeps on 99.7% of
+    stemmed filled noteheads and 97.7% of half notes (measured over 21700 of
+    them). A stem whose side and overhang contradict each other is not this
+    notehead's: _best_stem accepts any stem end within about a staff space,
+    which in close-spaced two-voice writing the OTHER voice's stem can
+    satisfy. Such a stem is dropped rather than believed - the notehead keeps
+    no stem at all and is placed by position instead, which can lose
+    information but cannot invert it.
+
+    This catches only the contradictory subset. A neighbouring voice's stem
+    that happens to sit where this notehead's own stem WOULD sit is
+    indistinguishable from it here, and still yields a wrong direction; see
+    the residual-risk note on the half-note branch of decode_note_events.
     """
     by_stem = collections.defaultdict(list)
     for n in notes:
@@ -1144,6 +1160,14 @@ def _assign_stem_directions(notes, stems_by_key):
         overhang_up = min(ys) - stem.y0
         overhang_down = stem.y1 - max(ys)
         direction = "up" if overhang_up > overhang_down else "down"
+        # Mean over the members, so the one notehead a second-interval chord
+        # displaces to the far side of the stem cannot outvote the rest.
+        mean_x = sum(m.x for m in members) / len(members)
+        on_right = stem.x > mean_x
+        if on_right != (direction == "up"):
+            for m in members:
+                m.stem_key = None
+            continue
         for m in members:
             m.stem_dir = direction
 
@@ -1281,13 +1305,30 @@ def decode_note_events(page, staff_top, staff_bottom, staff_x0, staff_x1, line_y
                 # chord/2-voice passage would otherwise be a false positive).
                 base, flags = 4.0, 0
             elif ev.category == "notehead_half":
-                # half notes have a stem but categorically cannot carry a
-                # flag or beam - counting one here would only ever be a
-                # false positive from a neighboring voice's stem/beam sitting
-                # nearby (2-voice writing), so don't count either. The stem
-                # is still looked up, for its DIRECTION only: a lower voice
+                # A half note has a stem but categorically cannot carry a
+                # flag or beam, so none is ever counted for one - any that
+                # turned up would be a neighbouring voice's.
+                #
+                # Its stem IS looked up, for the stem's DIRECTION only, which
+                # is what says which voice the note belongs to: a lower voice
                 # in this repertoire is very often written in half notes, and
-                # without its stem it has no voice signal at all.
+                # without its stem it carries no voice signal at all.
+                #
+                # KNOWN RESIDUAL RISK, accepted deliberately: _best_stem
+                # accepts any stem end within about a staff space of the
+                # notehead's centre, and a real half note's own stem end is
+                # measured at up to 0.94 spacings from it (median 0.44, over
+                # 2004 of them), so the window cannot be tightened without
+                # losing real attachments - at 0.5 spacings it loses 46% of
+                # them. Where this note's own stem is missing from the vector
+                # pass entirely, a neighbouring voice's stem can therefore be
+                # picked, and if it sits in a position consistent with the
+                # engraving convention nothing here can tell. That yields a
+                # wrong voice for the note and breaks both voices' arithmetic
+                # for that bar, which shows up in the overfull-bar count.
+                # _assign_stem_directions rejects the subset where the
+                # stem's side and its overhang contradict each other; the
+                # consistent-looking case remains.
                 base, flags = 2.0, 0
                 stem = _best_stem(stems, stem_xs, ev.x0, ev.x1, ev.yc, tol)
             else:

--- a/server/fermata/tabextract.py
+++ b/server/fermata/tabextract.py
@@ -722,6 +722,15 @@ _REST_ONSET_MERGE_SPACINGS = 0.8
 # more than an order of magnitude and still cannot merge two real onsets.
 _ONSET_SHARE_SPACINGS = 0.6
 
+# How far from the column it already claimed one onset may reach for ANOTHER
+# column, in notation-staff line spacings. Engravers offset a bass tab number
+# a couple of points right of a treble one in the same chord, so an onset's
+# digits can arrive as two columns a fraction of a note-spacing apart - but
+# the next ONSET's column is a full note-spacing away (about 2.5 spacings for
+# eighths, 1.25 for sixteenths), so this has to stay well under that or an
+# onset short of digits eats its neighbour's column.
+_CHORD_SPLIT_SPACINGS = 0.6
+
 # Guitar fingerstyle and classical writing is two voices: a melody over an
 # accompaniment. Three genuinely independent voices on one guitar staff are
 # rare enough that a third simultaneous stem is far more likely to be a chord
@@ -785,6 +794,15 @@ def _stem_groups(events, onset_tol):
       - two groups sounding together whose stems point the SAME way. That is
         not three-voice writing; it is one chord whose stem came through as
         two separate strokes.
+
+    Sharing a stem is necessary but NOT sufficient to be one beat: the
+    noteheads also have to sound together. A notehead whose own stem the
+    vector pass missed can end up threaded onto a neighbouring note's stem
+    (see glyph_rhythm._stem_through_notehead, which deliberately drops the
+    tight end-window), and keying on the stem alone then welded two
+    consecutive onsets into a single chord positioned between them - losing
+    an onset and its duration outright. So a stem's noteheads are additionally
+    split into runs that actually share an onset.
     """
     by_stem = {}
     member_lists = []
@@ -792,12 +810,17 @@ def _stem_groups(events, onset_tol):
         if ev.stem_key is None:
             member_lists.append([ev])
             continue
-        members = by_stem.get(ev.stem_key)
-        if members is None:
-            members = []
-            by_stem[ev.stem_key] = members
-            member_lists.append(members)
-        members.append(ev)
+        runs = by_stem.setdefault(ev.stem_key, [])
+        target = None
+        for run in runs:
+            if abs(ev.x - run[0].x) <= onset_tol:
+                target = run
+                break
+        if target is None:
+            target = []
+            runs.append(target)
+            member_lists.append(target)
+        target.append(ev)
     pending = [_StemGroup(m) for m in member_lists]
 
     # Stem-bearing groups settle first, so a notehead with no stem has
@@ -923,7 +946,7 @@ def _assign_group_voices(groups, onset_tol):
     return voices or [groups]
 
 
-def _match_onset_columns(onset_groups, cols_sorted, col_xcs, used, x_tol):
+def _match_onset_columns(onset_groups, cols_sorted, col_xcs, used, x_tol, split_tol):
     """Hand the tab digits sounding at one onset out to the groups there.
 
     A chord and two simultaneous voices are the same shape in the tab - a
@@ -934,6 +957,17 @@ def _match_onset_columns(onset_groups, cols_sorted, col_xcs, used, x_tol):
     puts each voice's note on the string the engraver actually wrote it on,
     and does so whether the onset is one chord or two voices.
 
+    An onset can need MORE than one column, because engravers offset a bass
+    tab number a couple of points right of a treble one in the same chord to
+    keep both legible and _group_into_columns does not always merge the two
+    back. But the search for those extra columns has to stay inside this
+    onset's own neighbourhood (`split_tol`), not the full notehead-to-digit
+    window (`x_tol`, which is wider than the gap between consecutive
+    columns): searching that far let an onset whose own column held fewer
+    digits than it had noteheads consume the NEXT onset's column instead,
+    sounding those frets a beat early and dropping the notes that column
+    belonged to.
+
     Returns ({id(group): [(string, fret), ...]}, noteheads_with_no_digit).
     """
     heads = sorted(((m, g) for g in onset_groups for m in g.members),
@@ -942,19 +976,25 @@ def _match_onset_columns(onset_groups, cols_sorted, col_xcs, used, x_tol):
     ox = sum(m.x for m, _ in heads) / needed
 
     digits = []
+    anchor = None
     while len(digits) < needed:
-        lo = bisect.bisect_left(col_xcs, ox - x_tol)
-        hi = bisect.bisect_right(col_xcs, ox + x_tol)
+        # The first column is found from the notehead x; any further one has
+        # to sit beside THAT column, not merely somewhere in the window.
+        centre, reach = (ox, x_tol) if anchor is None else (anchor, split_tol)
+        lo = bisect.bisect_left(col_xcs, centre - reach)
+        hi = bisect.bisect_right(col_xcs, centre + reach)
         best_i, best_d = None, None
         for i in range(lo, hi):
             if used[i]:
                 continue
-            d = abs(col_xcs[i] - ox)
+            d = abs(col_xcs[i] - centre)
             if best_d is None or d < best_d:
                 best_i, best_d = i, d
         if best_i is None:
             break
         used[best_i] = True
+        if anchor is None:
+            anchor = col_xcs[best_i]
         digits.extend(cols_sorted[best_i]["notes"])
 
     digits.sort(key=lambda n: n[0])  # by string: 1 is the highest-pitched
@@ -1063,6 +1103,7 @@ def _build_measure_beats_glyph(m_cols, m_lo, m_hi, note_events, note_xs, x_tol,
     measure_events = note_events[lo_i:hi_i]
     onset_tol = notation_spacing * _ONSET_SHARE_SPACINGS
     merge_tol = notation_spacing * _REST_ONSET_MERGE_SPACINGS
+    split_tol = notation_spacing * _CHORD_SPLIT_SPACINGS
     groups = _stem_groups([n for n in measure_events if not n.is_rest], onset_tol)
     rest_clusters = _cluster_pitched_glyph_events([n for n in measure_events if n.is_rest])
 
@@ -1079,7 +1120,7 @@ def _build_measure_beats_glyph(m_cols, m_lo, m_hi, note_events, note_xs, x_tol,
     onsets = _onsets(groups, onset_tol)
     for onset in onsets:
         per_group, missing = _match_onset_columns(
-            onset, cols_sorted, col_xcs, used, x_tol)
+            onset, cols_sorted, col_xcs, used, x_tol, split_tol)
         unmatched_glyph_notes += missing
         for g in onset:
             notes = per_group[id(g)]
@@ -1106,15 +1147,24 @@ def _build_measure_beats_glyph(m_cols, m_lo, m_hi, note_events, note_xs, x_tol,
     for t in tagged:
         t.sort(key=lambda b: b[0])
 
+    # A voice only exists if something in it actually plays. One whose every
+    # group lost its fret number holds no notes at all, and padding it filled
+    # a whole bar with inferred silence - a phantom voice that counted as
+    # polyphony, overstated how much rest was deduced from the meter, and
+    # wrote a meaningless `\voice :2 r :4 r` into the stored transcription.
+    # A bar of nothing but decoded rests keeps them, though - that is a real
+    # silent bar, not a phantom beside a voice that plays.
+    noted = [t for t in tagged if any(notes for _x, _c, _d, notes in t)]
+    live = noted if noted else [t for t in tagged if t]
+
     inferred = 0.0
-    if polyphonic and budget:
-        first_x = min((t[0][0] for t in tagged if t), default=0.0)
-        for t in tagged:
+    if len(live) > 1 and budget:
+        first_x = min(t[0][0] for t in live)
+        for t in live:
             inferred += _pad_voice_to_budget(t, budget, first_x, onset_tol)
 
-    voices = [[(code, dots, notes) for _x, code, dots, notes in t] for t in tagged]
-    voices = [v for v in voices if v]
-    return voices, unmatched_columns, unmatched_glyph_notes, inferred
+    return ([[(code, dots, notes) for _x, code, dots, notes in t] for t in live],
+            unmatched_columns, unmatched_glyph_notes, inferred)
 
 
 def _voice_mean_y(groups):
@@ -1161,6 +1211,14 @@ def _place_rest_clusters(rest_clusters, onsets, voice_groups, voice_of, tagged,
     says which voice is silent at that onset. So it is assigned to a voice
     that has nothing sounding there rather than dropped, and two rests at one
     onset become one beat in each voice.
+
+    That only holds for a rest that IS at a known onset. A rest glyph engraved
+    further than merge_tol from every decoded onset says nothing about which
+    voice it belongs to or where in the bar it falls, and adding it anyway
+    made a voice hold a beat more than its meter and pushed everything after
+    it late - the same phantom-rest fault the monophonic branch exists to
+    prevent. Those are dropped here too, and the silence they stood for is
+    recovered by _pad_voice_to_budget from the meter instead.
     """
     onset_xs = [sum(g.x for g in o) / len(o) for o in onsets]
     voice_y = {vi: _voice_mean_y(gs) for vi, gs in enumerate(voice_groups)}
@@ -1183,9 +1241,14 @@ def _place_rest_clusters(rest_clusters, onsets, voice_groups, voice_of, tagged,
             tagged[0].append((rx, rep.duration_code, rep.dotted, []))
             continue
 
-        free = set(voice_y)
-        if hit is not None:
-            free -= {voice_of[id(g)] for g in hit}
+        if hit is None:
+            continue  # no onset to pin it to - see the docstring
+        # Voices sounding at this onset, plus any voice that already holds a
+        # beat here at all: a rest cannot share an onset with the voice's own
+        # note, and two rests must not stack in one voice either.
+        free = set(voice_y) - {voice_of[id(g)] for g in hit}
+        free = {v for v in free
+                if not any(abs(bx - rx) <= merge_tol for bx, _c, _d, _n in tagged[v])}
         if not free:
             continue  # every voice is already sounding here
         for ev in sorted(cluster, key=lambda e: e.y):

--- a/server/fermata/tabextract.py
+++ b/server/fermata/tabextract.py
@@ -51,11 +51,26 @@ ExtractionResult.warnings, .confidence and .rhythm_provenance rather than
 papered over; callers can also offer a manual time-signature override (see
 extract()'s time_signature argument) for when auto-detection comes up empty.
 
-KNOWN LIMITATION, deliberately not modeled: two-voice writing is collapsed
-into one voice (one onset, one duration - see _cluster_glyph_duration), so a
-bar whose voices genuinely differ sums to more than its meter's budget. This
-is the dominant residual error in the emitted rhythm and it is a modelling
-gap, not a decode bug.
+VOICES: classical and fingerstyle guitar is polyphonic - a melody sounding
+OVER an independent bass line - so a bar's notes are not one sequence. Each
+notehead is grouped with the others on ITS OWN STEM (a chord is one beat),
+and where two stems genuinely sound at the same onset the bar is split into
+concurrent voices by stem direction, which is the signal engravers use for
+exactly this (see _assign_group_voices). Each voice is then filled out with
+rests so it accounts for the bar on its own, and the bar is emitted with
+alphaTex's `\\voice` separator. Assembling every note into one sequence
+instead made a bar hold the SUM of its voices - typically about double its
+meter - while every individual duration in it was decoded correctly.
+
+Stem direction alone is not enough and is not used alone: in ordinary
+single-voice writing stems also flip with pitch around the middle line, so
+splitting on direction wherever it changes would shred a monophonic melody
+into two voices at every crossing. Simultaneity is what distinguishes the
+two, because one voice never has two stems at one onset.
+
+KNOWN LIMITATIONS, deliberately not modeled: tuplets, ties, and any bar
+whose voices the stems do not separate. Bars that still do not add up are
+counted and reported (see _overfull_bars) rather than smoothed over.
 """
 
 from __future__ import annotations
@@ -693,105 +708,492 @@ def _cluster_pitched_glyph_events(events, cluster_x_tol=1.5):
 _REST_ONSET_MERGE_SPACINGS = 0.8
 
 
-def _cluster_glyph_duration(cluster):
-    """Pick one representative (duration_code, dots) for a cluster. Members
-    usually agree (chord noteheads share one stem, so one duration); when
-    they genuinely don't (overlapping voices with different notated values
-    at the same onset), take the most common reading, breaking ties toward
-    the longer value - true polyphony isn't modeled here (one beat, one
-    duration), so when two voices genuinely disagree something is picked
-    rather than fragmenting the beat."""
-    counts = collections.Counter((ev.duration_code, ev.dotted) for ev in cluster)
-    return max(counts.items(), key=lambda kv: (kv[1], -kv[0][0]))[0]
+# ---------------------------------------------------------------------------
+# Voices
+# ---------------------------------------------------------------------------
+
+# Two stem groups whose x differ by less than this SHARE AN ONSET - they
+# sound together, so they are separate voices rather than consecutive beats.
+# In notation-staff line spacings. Measured on the library's two-voice
+# writing: an upper and a lower voice notated at the same onset are engraved
+# within about 0.1pt of each other (0.02 spacings), while the closest
+# DIFFERENT onsets this must never fuse - consecutive sixteenths - sit about
+# 1.25 spacings apart. 0.6 is half of that, so it clears real simultaneity by
+# more than an order of magnitude and still cannot merge two real onsets.
+_ONSET_SHARE_SPACINGS = 0.6
+
+# Guitar fingerstyle and classical writing is two voices: a melody over an
+# accompaniment. Three genuinely independent voices on one guitar staff are
+# rare enough that a third simultaneous stem is far more likely to be a chord
+# whose shared stem was not found than a real third voice, so extra groups
+# join the lower voice and the bar reports itself as overfull rather than
+# inventing a voice.
+_MAX_VOICES = 2
 
 
-def _build_measure_beats_glyph(m_cols, m_lo, m_hi, note_events, note_xs, x_tol, spacing):
-    """Build one measure's beats from glyph-decoded note/rest events on the
+class _StemGroup:
+    """One beat: every notehead hanging off ONE engraved stem (a chord), or a
+    notehead with no stem to hang off."""
+
+    __slots__ = ("members", "x", "y", "stem_dir", "signal", "voice")
+
+    def __init__(self, members):
+        self.members = list(members)
+        first = self.members[0]
+        self.stem_dir = first.stem_dir
+        # What this group says about which voice it belongs to. Two groups
+        # sounding together are only two voices if they say DIFFERENT things.
+        if first.stem_dir:
+            self.signal = first.stem_dir
+        elif first.notehead_kind == "notehead_whole":
+            self.signal = "whole"  # never takes a stem in any notation
+        else:
+            self.signal = None  # a stem that should exist and was not found
+        self.voice = 0
+        self._recentre()
+
+    def absorb(self, other):
+        self.members.extend(other.members)
+        self._recentre()
+
+    def _recentre(self):
+        self.x = sum(m.x for m in self.members) / len(self.members)
+        self.y = sum(m.y for m in self.members) / len(self.members)
+
+
+def _stem_groups(events, onset_tol):
+    """Partition a measure's pitched glyph events into one group per beat, in
+    x order.
+
+    This is the basis of both voice separation and of telling a chord apart
+    from two simultaneous voices - the one distinction the tab staff cannot
+    make. A chord is several noteheads threaded on ONE stem and has to stay
+    ONE beat; two noteheads at the same onset on DIFFERENT stems are two
+    voices and have to become two beats. In the tab both are the same thing,
+    a vertical stack of fret numbers at one x. Only the stems separate them,
+    because an engraver draws exactly one per beat.
+
+    Two things are therefore folded back together rather than being allowed
+    to look like extra voices:
+
+      - a notehead whose stem was NOT found joins whatever else sounds at its
+        onset. Stems are what two-voice writing is notated with, so an onset
+        carrying no stem evidence is not evidence of two voices - it is a
+        chord. Some scores in the library engrave chords whose stem the
+        vector pass cannot see at all, and splitting those by pitch invented
+        a second voice out of one chord and left both halves short.
+      - two groups sounding together whose stems point the SAME way. That is
+        not three-voice writing; it is one chord whose stem came through as
+        two separate strokes.
+    """
+    by_stem = {}
+    member_lists = []
+    for ev in sorted(events, key=lambda e: e.x):
+        if ev.stem_key is None:
+            member_lists.append([ev])
+            continue
+        members = by_stem.get(ev.stem_key)
+        if members is None:
+            members = []
+            by_stem[ev.stem_key] = members
+            member_lists.append(members)
+        members.append(ev)
+    pending = [_StemGroup(m) for m in member_lists]
+
+    # Stem-bearing groups settle first, so a notehead with no stem has
+    # something real to attach itself to.
+    groups = []
+    for g in sorted(pending, key=lambda g: (g.signal is None, g.x)):
+        host = None
+        best = None
+        for h in groups:
+            if abs(h.x - g.x) > onset_tol:
+                continue
+            if g.signal is not None and h.signal != g.signal:
+                continue
+            d = abs(h.y - g.y)
+            if best is None or d < best:
+                host, best = h, d
+        if host is None:
+            groups.append(g)
+        else:
+            host.absorb(g)
+    groups.sort(key=lambda g: g.x)
+    return groups
+
+
+def _stem_group_duration(group):
+    """One (duration_code, dots) for a whole chord, composed from every
+    notehead on the stem rather than voted on.
+
+    Only the notehead at the stem's END can see the flag or beam that
+    shortens the chord (see glyph_rhythm._best_stem, and the looser
+    _stem_through_notehead that attaches the rest of them); the inner members
+    read a plain quarter, and in a three-note chord they would outvote the
+    one member that actually read the duration. A flag can be missed but
+    never invented, so take the largest flag and dot count found anywhere on
+    the stem, over the notehead value its members agree on.
+    """
+    counts = collections.Counter(m.base_units for m in group.members)
+    base = max(counts.items(), key=lambda kv: (kv[1], kv[0]))[0]
+    flags = max(m.flags for m in group.members)
+    dots = max(m.dotted for m in group.members)
+    plain = base / (2 ** flags)
+    codes = glyph.DURATION_CODE
+    code = codes.get(plain) or codes[min(codes, key=lambda k: abs(k - plain))]
+    return code, min(dots, 2)
+
+
+def _onsets(groups, onset_tol):
+    """Cluster x-sorted stem groups into the onsets they sound at."""
+    onsets = []
+    for g in groups:
+        if onsets and (g.x - onsets[-1][0].x) <= onset_tol:
+            onsets[-1].append(g)
+        else:
+            onsets.append([g])
+    return onsets
+
+
+def _stemless_voice(group, up_y, down_y):
+    """Which voice a notehead with no stem belongs to.
+
+    A whole note is the case that matters: it never takes a stem in any
+    notation, so the only signal left is where it sits relative to the voices
+    that do have one. Page y grows downward, so the upper voice has the
+    smaller y.
+    """
+    if up_y is not None and down_y is not None:
+        return 0 if abs(group.y - up_y) <= abs(group.y - down_y) else 1
+    if up_y is not None:
+        return 1 if group.y > up_y else 0
+    if down_y is not None:
+        return 0 if group.y < down_y else 1
+    return 0
+
+
+def _assign_group_voices(groups, onset_tol):
+    """Split one bar's stem groups into voices - a list of voices in
+    top-to-bottom order, each a list of groups in x order. A single-element
+    result means the bar is monophonic and must stay that way.
+
+    Stem direction is the signal engravers use: an upper voice's stems are
+    forced up and a lower voice's forced down, whatever the pitches do. But
+    stem direction ALSO flips with pitch in ordinary single-voice writing - a
+    melody crossing the middle line is engraved stems-down above it and
+    stems-up below it - so direction ON ITS OWN would shred a monophonic line
+    into two voices at every crossing.
+
+    What separates the two cases is simultaneity: a single voice never has
+    two stems at one onset. So a bar counts as polyphonic only where some
+    onset genuinely carries more than one group - which after _stem_groups
+    has folded chords back together means two stems saying different things -
+    and stem direction is used to sort the notes into voices only once that
+    is established.
+    """
+    onsets = _onsets(groups, onset_tol)
+    if not any(len(o) > 1 for o in onsets):
+        return [groups]
+
+    ups = [g for g in groups if g.stem_dir == "up"]
+    downs = [g for g in groups if g.stem_dir == "down"]
+    up_y = sum(g.y for g in ups) / len(ups) if ups else None
+    down_y = sum(g.y for g in downs) / len(downs) if downs else None
+
+    for g in groups:
+        if g.stem_dir == "up":
+            g.voice = 0
+        elif g.stem_dir == "down":
+            g.voice = 1
+        else:
+            g.voice = _stemless_voice(g, up_y, down_y)
+
+    # Two groups sounding at one onset cannot be the same voice. Where that
+    # happened - two stemless noteheads, or two stems the same way up - fall
+    # back to pitch order within the onset, which is what "upper" and "lower"
+    # voice mean in the first place.
+    for onset in onsets:
+        if len(onset) < 2 or len({g.voice for g in onset}) == len(onset):
+            continue
+        for rank, g in enumerate(sorted(onset, key=lambda g: g.y)):
+            g.voice = min(rank, _MAX_VOICES - 1)
+
+    voices = [[g for g in groups if g.voice == v] for v in range(_MAX_VOICES)]
+    voices = [v for v in voices if v]
+    return voices or [groups]
+
+
+def _match_onset_columns(onset_groups, cols_sorted, col_xcs, used, x_tol):
+    """Hand the tab digits sounding at one onset out to the groups there.
+
+    A chord and two simultaneous voices are the same shape in the tab - a
+    stack of fret numbers at one x - so the split cannot be read from the tab
+    at all. It is read from the notation instead: the noteheads at this onset
+    ordered by PITCH correspond one for one to the digits at this column
+    ordered by STRING (string 1 is the highest-pitched). Rank-matching them
+    puts each voice's note on the string the engraver actually wrote it on,
+    and does so whether the onset is one chord or two voices.
+
+    Returns ({id(group): [(string, fret), ...]}, noteheads_with_no_digit).
+    """
+    heads = sorted(((m, g) for g in onset_groups for m in g.members),
+                   key=lambda mg: mg[0].y)
+    needed = len(heads)
+    ox = sum(m.x for m, _ in heads) / needed
+
+    digits = []
+    while len(digits) < needed:
+        lo = bisect.bisect_left(col_xcs, ox - x_tol)
+        hi = bisect.bisect_right(col_xcs, ox + x_tol)
+        best_i, best_d = None, None
+        for i in range(lo, hi):
+            if used[i]:
+                continue
+            d = abs(col_xcs[i] - ox)
+            if best_d is None or d < best_d:
+                best_i, best_d = i, d
+        if best_i is None:
+            break
+        used[best_i] = True
+        digits.extend(cols_sorted[best_i]["notes"])
+
+    digits.sort(key=lambda n: n[0])  # by string: 1 is the highest-pitched
+    per_group = {id(g): [] for g in onset_groups}
+    for (_m, g), digit in zip(heads, digits):
+        per_group[id(g)].append(digit)
+    leftover = digits[needed:]
+    if leftover:
+        # More fret numbers at this onset than noteheads were read from the
+        # notation. The tab plainly shows those notes, so give them to the
+        # lowest voice sounding here rather than dropping them.
+        per_group[id(max(onset_groups, key=lambda g: g.y))].extend(leftover)
+    for g in onset_groups:
+        per_group[id(g)].sort(key=lambda n: n[0])
+    return per_group, max(0, needed - len(digits))
+
+
+def _rest_beats_for(quarters, limit=12):
+    """Decompose a span of silence into plain rest beats, longest first."""
+    out = []
+    remaining = quarters
+    for q, code in _PLAIN_DURATIONS:
+        while remaining >= q - 1e-6 and len(out) < limit:
+            out.append((code, 0, []))
+            remaining -= q
+    return out
+
+
+def _pad_voice_to_budget(tagged, budget, bar_first_x, onset_tol):
+    """Fill a voice's silence so it accounts for the whole bar on its own.
+
+    A voice that sounds for only part of a bar is engraved with rests for the
+    remainder, and those rests are what make the arithmetic work: without
+    them every voice but the busiest reads as a short bar and the others
+    drift out of time against it. Where the decoded rest glyphs already
+    account for the silence this adds nothing.
+
+    Returns the quarters of rest that had to be inferred, so the caller can
+    say how much of the emitted silence was read from the score and how much
+    was deduced from the meter.
+    """
+    total = sum(_beat_quarters(code, dots) for _x, code, dots, _n in tagged)
+    deficit = budget - total
+    if deficit <= 1e-6:
+        return 0.0
+    fills = _rest_beats_for(deficit)
+    if not fills:
+        return 0.0
+    # A voice whose first note sits well right of the bar's first onset
+    # entered late, so its silence belongs at the front.
+    late = not tagged or (tagged[0][0] - bar_first_x) > onset_tol
+    x = (bar_first_x - 1.0) if late else (tagged[-1][0] + 1.0)
+    inserted = [(x, code, dots, notes) for code, dots, notes in fills]
+    if late:
+        tagged[:0] = inserted
+    else:
+        tagged.extend(inserted)
+    return sum(_beat_quarters(c, d) for _x, c, d, _n in inserted)
+
+
+def _build_measure_beats_glyph(m_cols, m_lo, m_hi, note_events, note_xs, x_tol,
+                               notation_spacing, budget=None):
+    """Build one measure's VOICES from glyph-decoded note/rest events on the
     tab staff's paired standard-notation staff, matching each event to the
     tab column at (approximately) the same x. A tab column with no matching
     glyph event within x_tol falls back to an eighth-note placeholder
     (counted in the returned unmatched-column total rather than silently
     trusted - see _extract's unmatched-column warning).
 
-    Rests are clustered by onset and dropped where a pitched onset already
-    sits, because the library's core content is two-voice fingerstyle
-    writing: a voice-2 quarter rest engraved under a voice-1 note is the
-    same beat, not an extra one. Emitting every rest glyph as its own beat
-    made a 3/4 bar hold `:4 r` plus three notes - four beats' worth - and
-    shifted the whole bar's playback while still reporting high confidence.
-    Simultaneous rests in two voices collapse to one beat for the same
-    reason.
+    Classical and fingerstyle guitar is polyphonic - a melody sounding OVER
+    an independent bass line - so the notes of a bar do not form one
+    sequence. They are grouped by the stem each hangs off (_stem_groups),
+    split into voices by stem direction wherever two stems genuinely sound
+    together (_assign_group_voices), and each voice is then filled out with
+    rests so it accounts for the bar on its own (_pad_voice_to_budget).
+    Assembling everything into one sequence instead made a bar hold the SUM
+    of its voices - typically about double its meter - with every individual
+    duration decoded correctly.
+
+    Rests: in a monophonic bar they are clustered by onset and dropped where
+    a pitched onset already sits, since a rest under a sounding note is the
+    other voice's and not a beat of its own (emitting it made a 3/4 bar hold
+    `:4 r` plus three notes). In a polyphonic bar that same rest is real
+    information - it says WHICH voice is silent there - so it is assigned to
+    a voice instead of dropped.
 
     `note_events` must be sorted by x and `note_xs` their x values, so each
     measure takes a bisect-bounded slice instead of rescanning the staff's
     whole event list (O(M*E) across a staff's measures).
+    `notation_spacing` is the NOTATION staff's line spacing: every tolerance
+    here compares the positions of two glyphs on that staff, not on the tab
+    staff. `budget` is the measure's quarter-note allowance, needed to know
+    how much of each voice is silence; without it no rests are inferred.
 
-    Returns (beats, unmatched_columns, unmatched_glyph_notes) where beats is
-    a list of (duration_code, dots, notes) triples in x order, ready for
+    Returns (voices, unmatched_columns, unmatched_glyph_notes,
+    inferred_rest_quarters): voices is a list of one or more beat lists, each
+    a list of (duration_code, dots, notes) triples in x order ready for
     _fmt_beat; unmatched_columns is how many tab columns had no glyph note
-    within x_tol; unmatched_glyph_notes is how many pitched glyph notes had
-    no tab column to match (expected to be rare - every played tab note
-    should have a fret number).
+    within x_tol; unmatched_glyph_notes is how many decoded noteheads had no
+    fret number to match (expected to be rare - every played tab note should
+    have one); inferred_rest_quarters is how much silence was deduced from
+    the meter rather than read from a rest glyph.
     """
     lo_i = bisect.bisect_left(note_xs, m_lo)
     hi_i = bisect.bisect_left(note_xs, m_hi)
     measure_events = note_events[lo_i:hi_i]
-    pitched_clusters = _cluster_pitched_glyph_events([n for n in measure_events if not n.is_rest])
+    onset_tol = notation_spacing * _ONSET_SHARE_SPACINGS
+    merge_tol = notation_spacing * _REST_ONSET_MERGE_SPACINGS
+    groups = _stem_groups([n for n in measure_events if not n.is_rest], onset_tol)
     rest_clusters = _cluster_pitched_glyph_events([n for n in measure_events if n.is_rest])
+
+    voice_groups = _assign_group_voices(groups, onset_tol)
+    polyphonic = len(voice_groups) > 1
+    voice_of = {id(g): vi for vi, gs in enumerate(voice_groups) for g in gs}
 
     cols_sorted = sorted(m_cols, key=lambda c: c["x"])
     col_xcs = [c["xc"] for c in cols_sorted]
     used = [False] * len(cols_sorted)
 
-    tagged = []  # (x, duration_code, dots, notes)
+    tagged = [[] for _ in voice_groups]  # per voice: (x, code, dots, notes)
     unmatched_glyph_notes = 0
-
-    pitched_xs = sorted(sum(ev.x for ev in c) / len(c) for c in pitched_clusters)
-    merge_tol = spacing * _REST_ONSET_MERGE_SPACINGS
-    for cluster in rest_clusters:
-        rx = sum(ev.x for ev in cluster) / len(cluster)
-        j = bisect.bisect_left(pitched_xs, rx)
-        near = False
-        for k in (j - 1, j):
-            if 0 <= k < len(pitched_xs) and abs(pitched_xs[k] - rx) <= merge_tol:
-                near = True
-                break
-        if near:
-            continue  # a second voice's rest under a sounding note, not a beat
-        # one beat per rest onset; pick the longest reading among voices so a
-        # collapsed pair doesn't silently shorten the bar
-        rep = min(cluster, key=lambda ev: (ev.duration_code, -ev.dotted))
-        tagged.append((rx, rep.duration_code, rep.dotted, []))
-
-    for cluster in pitched_clusters:
-        cx = sum(ev.x for ev in cluster) / len(cluster)
-        code, dots = _cluster_glyph_duration(cluster)
-        lo = bisect.bisect_left(col_xcs, cx - x_tol)
-        hi = bisect.bisect_right(col_xcs, cx + x_tol)
-        best_i, best_d = None, None
-        for i in range(lo, hi):
-            if used[i]:
+    onsets = _onsets(groups, onset_tol)
+    for onset in onsets:
+        per_group, missing = _match_onset_columns(
+            onset, cols_sorted, col_xcs, used, x_tol)
+        unmatched_glyph_notes += missing
+        for g in onset:
+            notes = per_group[id(g)]
+            if not notes:
+                # A decoded notehead with no fret number anywhere near it -
+                # already counted above. Nothing to emit a note for, so skip
+                # rather than fabricate one.
                 continue
-            d = abs(col_xcs[i] - cx)
-            if best_d is None or d < best_d:
-                best_i, best_d = i, d
-        if best_i is None:
-            # a pitched glyph cluster with no matching tab digit column - can
-            # happen on decode noise; nothing to emit a fret number for, so
-            # skip rather than fabricate one.
-            unmatched_glyph_notes += len(cluster)
-            continue
-        used[best_i] = True
-        tagged.append((cx, code, dots, cols_sorted[best_i]["notes"]))
+            code, dots = _stem_group_duration(g)
+            tagged[voice_of[id(g)]].append((g.x, code, dots, notes))
+
+    _place_rest_clusters(rest_clusters, onsets, voice_groups, voice_of, tagged,
+                         merge_tol, polyphonic)
 
     unmatched_columns = 0
     for i, col in enumerate(cols_sorted):
         if not used[i]:
             unmatched_columns += 1
-            tagged.append((col["x"], 8, 0, col["notes"]))  # conservative fallback
+            # A conservative placeholder, in whichever voice already plays
+            # nearest to it on the fretboard.
+            tagged[_placeholder_voice(col, tagged)].append(
+                (col["x"], 8, 0, col["notes"]))
 
-    tagged.sort(key=lambda t: t[0])
-    return [(code, dots, notes) for _, code, dots, notes in tagged], unmatched_columns, unmatched_glyph_notes
+    for t in tagged:
+        t.sort(key=lambda b: b[0])
+
+    inferred = 0.0
+    if polyphonic and budget:
+        first_x = min((t[0][0] for t in tagged if t), default=0.0)
+        for t in tagged:
+            inferred += _pad_voice_to_budget(t, budget, first_x, onset_tol)
+
+    voices = [[(code, dots, notes) for _x, code, dots, notes in t] for t in tagged]
+    voices = [v for v in voices if v]
+    return voices, unmatched_columns, unmatched_glyph_notes, inferred
+
+
+def _voice_mean_y(groups):
+    return sum(g.y for g in groups) / len(groups) if groups else 0.0
+
+
+def _mean_string(notes):
+    return sum(s for s, _f in notes) / len(notes) if notes else 0.0
+
+
+def _placeholder_voice(col, tagged):
+    """Which voice an unmatched tab column's placeholder belongs to: whichever
+    already plays nearest to it on the fretboard.
+
+    A column with no notation event beside it has no stem to read, so the
+    STRING it is written on is the only signal left - and a string number can
+    only be compared against other string numbers, never against a notehead's
+    position on the notation staff, which is a different quantity in
+    different units.
+    """
+    target = _mean_string(col["notes"])
+    best, best_d = 0, None
+    for vi, beats in enumerate(tagged):
+        strings = [s for _x, _c, _d, notes in beats for s, _f in notes]
+        if not strings:
+            continue
+        d = abs(sum(strings) / len(strings) - target)
+        if best_d is None or d < best_d:
+            best, best_d = vi, d
+    return best
+
+
+def _place_rest_clusters(rest_clusters, onsets, voice_groups, voice_of, tagged,
+                         merge_tol, polyphonic):
+    """Turn decoded rest glyphs into beats in the right voice.
+
+    In a MONOPHONIC bar a rest sharing an onset with a sounding note is the
+    other voice's rest and is not a beat here at all - emitting it made a 3/4
+    bar hold four beats' worth and shifted the whole bar's playback while
+    still reporting high confidence. Simultaneous rests collapse to one beat
+    for the same reason.
+
+    In a POLYPHONIC bar that same rest is exactly the information needed: it
+    says which voice is silent at that onset. So it is assigned to a voice
+    that has nothing sounding there rather than dropped, and two rests at one
+    onset become one beat in each voice.
+    """
+    onset_xs = [sum(g.x for g in o) / len(o) for o in onsets]
+    voice_y = {vi: _voice_mean_y(gs) for vi, gs in enumerate(voice_groups)}
+
+    for cluster in rest_clusters:
+        rx = sum(ev.x for ev in cluster) / len(cluster)
+        j = bisect.bisect_left(onset_xs, rx)
+        hit = None
+        for k in (j - 1, j):
+            if 0 <= k < len(onset_xs) and abs(onset_xs[k] - rx) <= merge_tol:
+                hit = onsets[k]
+                break
+
+        if not polyphonic:
+            if hit is not None:
+                continue  # the other voice's rest under a sounding note
+            # one beat per rest onset; take the longest reading so a
+            # collapsed pair doesn't silently shorten the bar
+            rep = min(cluster, key=lambda ev: (ev.duration_code, -ev.dotted))
+            tagged[0].append((rx, rep.duration_code, rep.dotted, []))
+            continue
+
+        free = set(voice_y)
+        if hit is not None:
+            free -= {voice_of[id(g)] for g in hit}
+        if not free:
+            continue  # every voice is already sounding here
+        for ev in sorted(cluster, key=lambda e: e.y):
+            if not free:
+                break
+            v = min(free, key=lambda k: abs(voice_y[k] - ev.y))
+            free.discard(v)
+            tagged[v].append((ev.x, ev.duration_code, ev.dotted, []))
 
 
 # ---------------------------------------------------------------------------
@@ -907,22 +1309,39 @@ _TIE_WARNING = (
 _DOT_FACTORS = (1.0, 1.5, 1.75)
 
 
+def _beat_quarters(code, dots) -> float:
+    if not code:
+        return 0.0
+    return (4.0 / code) * _DOT_FACTORS[min(dots, len(_DOT_FACTORS) - 1)]
+
+
+def _voices_of(beats):
+    """A measure's beats as a list of voices. A measure is normally a list of
+    voices already; a plain flat list of beats is accepted as the one-voice
+    case, which is what the spacing-heuristic path and callers with no
+    polyphony to model hand over."""
+    if not beats:
+        return []
+    return list(beats) if isinstance(beats[0], list) else [beats]
+
+
 def _bar_quarters(beats) -> float:
-    total = 0.0
-    for code, dots, _notes in beats:
-        if not code:
-            continue
-        total += (4.0 / code) * _DOT_FACTORS[min(dots, len(_DOT_FACTORS) - 1)]
-    return total
+    """The longest voice in this bar, in quarter notes. Voices sound
+    CONCURRENTLY, so a bar is as long as its longest voice - not the sum of
+    them, which is exactly the mistake that made a bar of two-voice writing
+    read as double its meter."""
+    return max((sum(_beat_quarters(code, dots) for code, dots, _n in v)
+                for v in _voices_of(beats)), default=0.0)
 
 
 def _overfull_bars(measures) -> tuple[int, int]:
-    """Count bars holding more than their time signature allows.
+    """Count bars where some voice holds more than its time signature allows.
 
-    Polyphony flattened into one voice lands here: each note's own duration
-    can be decoded correctly while the bar sums to roughly the total of its
-    voices. Every individual reading is right and the bar is still wrong, so
-    this is measured separately from how the durations were obtained.
+    A bar is counted once however many of its voices overflow: it is the bar
+    that plays wrong. Undetected tuplets, a flag the decoder missed, and two
+    voices the stems did not separate all land here, so this stays measured
+    separately from how the durations were obtained - every individual
+    reading can be right while the bar is still not.
     """
     overfull = 0
     counted = 0
@@ -987,21 +1406,22 @@ def _rhythm_report(counts, details, overfull=0, bars=0):
             )
 
     # Bars that don't add up outrank how the durations were obtained: a
-    # confident reading of every notehead still produces a wrong bar when two
-    # voices were merged into one, and playback follows the bar.
+    # confident reading of every notehead still produces a wrong bar when its
+    # voices don't come apart, and playback follows the bar.
     if bars and overfull:
         share = overfull / bars
         warnings.append(
-            f"{overfull} of {bars} bar(s) hold more than their time signature allows, usually "
-            "because music written in two voices (a melody over a separate bass line) is "
-            "flattened into a single voice - the notes and their individual durations can still "
-            "be right while the bar as a whole is not, so playback timing will drift in those bars"
+            f"{overfull} of {bars} bar(s) hold more than their time signature allows. Music "
+            "written in two voices (a melody over a separate bass line) is separated into "
+            "concurrent voices where the stems say so, but a bar whose voices the stems do not "
+            "separate is still flattened into one, and an undetected tuplet or a missed flag "
+            "lands here too - the notes and their individual durations can still be right while "
+            "the bar as a whole is not, so playback timing will drift in those bars"
         )
         if share >= 0.25:
             confidence = (
                 "low overall - individual durations were read from the score's own engraving, but "
-                f"{overfull} of {bars} bar(s) do not add up to their time signature because "
-                "separate voices are merged into one"
+                f"{overfull} of {bars} bar(s) do not add up to their time signature"
             )
 
     # Surface the concrete per-staff reasons behind any downgrade, capped so
@@ -1050,21 +1470,32 @@ def _escape_tex_string(s: str) -> str:
 
 
 def _build_alphatex(title, tempo, tuning, ts, measures):
-    """measures: list of (beats, measure_ts) where beats is a list of
-    (duration_code, dots, notes). measure_ts may be None (meaning "whatever
-    is already in effect"); where it differs from the meter currently in
-    effect, a `\\ts` is emitted on that bar, so a score that changes meter
-    part-way through is transcribed with the change in it rather than having
-    every later bar measured against the opening meter.
+    """measures: list of (beats, measure_ts) where beats is a list of VOICES,
+    each voice a list of (duration_code, dots, notes). A flat list of beats
+    is accepted as the one-voice case. measure_ts may be None (meaning
+    "whatever is already in effect"); where it differs from the meter
+    currently in effect, a `\\ts` is emitted on that bar, so a score that
+    changes meter part-way through is transcribed with the change in it
+    rather than having every later bar measured against the opening meter.
 
     A plain list of beats per measure is also accepted, for callers that
     have no per-measure meter to carry.
+
+    Concurrent voices are separated by `\\voice` INSIDE the bar, which needs
+    `\\voicemode barwise` in the header - alphaTex's default (staffwise) reads
+    `\\voice` as "start the whole staff again for the next voice" and would
+    take everything after the first one as bar 1 onwards of voice 2. Verified
+    against the installed renderer: barwise gives one bar per line with the
+    intended voices in it, and `|` closes the bar and returns to voice 1.
     """
     lines = [f'\\title "{_escape_tex_string(title)}"']
     if tempo:
         lines.append(f"\\tempo {tempo}")
     if ts:
         lines.append(f"\\ts {ts[0]} {ts[1]}")
+    if any(len(_voices_of(m[0] if isinstance(m, tuple) and len(m) == 2 else m)) > 1
+           for m in measures):
+        lines.append("\\voicemode barwise")
     if tuning:
         # alphaTex binds the FIRST \tuning entry to string 1, and
         # _Staff.string_for_y assigns string 1 to the top tab line (the
@@ -1085,8 +1516,11 @@ def _build_alphatex(title, tempo, tuning, ts, measures):
         if measure_ts and tuple(measure_ts) != in_effect:
             in_effect = tuple(measure_ts)
             prefix = f"\\ts {in_effect[0]} {in_effect[1]} "
-        beats = " ".join(_fmt_beat(dur, dots, notes) for dur, dots, notes in beats_in)
-        body_lines.append(prefix + beats + " |")
+        voices = " \\voice ".join(
+            " ".join(_fmt_beat(dur, dots, notes) for dur, dots, notes in voice)
+            for voice in _voices_of(beats_in)
+        )
+        body_lines.append(prefix + voices + " |")
     lines.append("\n".join(body_lines))
     return "\n".join(lines)
 
@@ -1365,6 +1799,12 @@ def _extract(doc, pdf_path, time_signature: tuple[int, int] | None) -> Extractio
     prov_details = collections.defaultdict(list)
     unmatched_columns_glyph = 0
     unmatched_glyph_notes_total = 0
+    # How many bars were transcribed as concurrent voices, and how much of
+    # the silence in them was deduced from the meter rather than read from a
+    # rest glyph - both reported, so "the voices add up" can be told apart
+    # from "the voices were padded until they added up".
+    multivoice_bars = 0
+    inferred_rest_quarters = 0.0
     font_warnings_seen = []
     for page_idx, page, tab_staves, std_staves in pages_with_tab:
         tokens = _extract_digit_tokens(page)
@@ -1434,18 +1874,23 @@ def _extract(doc, pdf_path, time_signature: tuple[int, int] | None) -> Extractio
             for i, m_cols in enumerate(measures_for_staff):
                 m_lo, m_hi = bounds[i], bounds[i + 1]
                 if source.uses_glyphs:
-                    beats, unmatched_cols, unmatched_notes = _build_measure_beats_glyph(
-                        m_cols, m_lo, m_hi, source.note_events, source.note_xs,
-                        x_tol, staff.spacing,
+                    voices, unmatched_cols, unmatched_notes, inferred = (
+                        _build_measure_beats_glyph(
+                            m_cols, m_lo, m_hi, source.note_events, source.note_xs,
+                            x_tol, std_staff.spacing, measure_quarter_len,
+                        )
                     )
                     unmatched_columns_glyph += unmatched_cols
                     unmatched_glyph_notes_total += unmatched_notes
-                    if not beats:
+                    inferred_rest_quarters += inferred
+                    if len(voices) > 1:
+                        multivoice_bars += 1
+                    if not voices:
                         # Nothing decoded and no tab columns either - still
                         # emit an explicit rest bar rather than dropping the
                         # measure (see the non-glyph branch below for why).
-                        beats = [(_snap_duration(measure_quarter_len), 0, [])]
-                    all_measures.append((beats, staff_ts))
+                        voices = [_rest_beats_for(measure_quarter_len)]
+                    all_measures.append((voices, staff_ts))
                     continue
                 if not m_cols:
                     # No digit columns landed in this bar - emit an explicit
@@ -1453,7 +1898,10 @@ def _extract(doc, pdf_path, time_signature: tuple[int, int] | None) -> Extractio
                     # would omit its "|" separator and shift every later
                     # bar's number one position earlier than the PDF, which
                     # breaks side-by-side comparison against the original.
-                    all_measures.append(([(_snap_duration(measure_quarter_len), 0, [])], staff_ts))
+                    # Rests that ADD UP to the meter, not one snapped to the
+                    # nearest plain value: a 3/4 bar's 3.0 quarters snap to a
+                    # whole rest, which is a third longer than the bar.
+                    all_measures.append((_rest_beats_for(measure_quarter_len), staff_ts))
                     continue
                 durations_q = _infer_measure_rhythm(m_cols, measure_quarter_len, m_hi)
                 beats = [(_snap_duration(dq), 0, col["notes"]) for col, dq in zip(m_cols, durations_q)]
@@ -1475,6 +1923,18 @@ def _extract(doc, pdf_path, time_signature: tuple[int, int] | None) -> Extractio
         if fw not in already:
             warnings.append(f"music font: {fw}")
 
+    if multivoice_bars:
+        warnings.append(
+            f"{multivoice_bars} bar(s) were transcribed as two concurrent voices, split by the "
+            "direction of the stems the score engraves them with"
+        )
+    if inferred_rest_quarters:
+        warnings.append(
+            f"about {inferred_rest_quarters:.4g} quarter note(s) of rest across those bars were "
+            "deduced from the time signature rather than read from a rest printed in the score - "
+            "a voice with a note missing from it is padded with silence the same way a genuinely "
+            "resting voice is"
+        )
     if unmatched_columns_glyph:
         warnings.append(
             f"{unmatched_columns_glyph} fret number(s) could not be matched to a note in the "
@@ -1518,8 +1978,9 @@ def _extract(doc, pdf_path, time_signature: tuple[int, int] | None) -> Extractio
 
     title = Path(pdf_path).stem
     alphatex = _build_alphatex(title, tempo, tuning, ts, all_measures)
-    beats_total = sum(len(beats) for beats, _ in all_measures)
-    notes_total = sum(len(notes) for beats, _ in all_measures for _, _, notes in beats)
+    beats_total = sum(len(v) for beats, _ in all_measures for v in _voices_of(beats))
+    notes_total = sum(len(notes) for beats, _ in all_measures
+                      for v in _voices_of(beats) for _, _, notes in v)
 
     ts_confidence = {
         "manual override": "n/a - caller supplied",

--- a/server/tests/test_glyph_rhythm.py
+++ b/server/tests/test_glyph_rhythm.py
@@ -442,8 +442,10 @@ def _note(x, y, key):
 def test_stem_direction_comes_from_which_end_overhangs_the_notehead():
     """Page y grows DOWNWARD. An up-stem runs about an octave ABOVE its
     notehead and stops dead at it, so the overhang is on the small-y side."""
-    up = G.Stem(x=50.0, y0=60.0, y1=100.0)      # tip above a notehead at y=100
-    down = G.Stem(x=80.0, y0=100.0, y1=140.0)   # tip below a notehead at y=100
+    # Stems attach at a notehead's EDGE, never its centre: an up-stem on the
+    # right, a down-stem on the left (see _assign_stem_directions).
+    up = G.Stem(x=54.0, y0=60.0, y1=100.0)      # tip above a notehead at y=100
+    down = G.Stem(x=76.0, y0=100.0, y1=140.0)   # tip below a notehead at y=100
     notes = [_note(50.0, 100.0, "u"), _note(80.0, 100.0, "d")]
     G._assign_stem_directions(notes, {"u": up, "d": down})
     assert [n.stem_dir for n in notes] == ["up", "down"]
@@ -454,15 +456,15 @@ def test_a_chords_direction_is_not_read_off_one_of_its_noteheads():
     end further from any given member is on the wrong side for every member
     but the outermost - reading "the free end is below me, therefore stem
     down" off the top note of an up-stemmed chord inverts it."""
-    # up-stem chord: noteheads at y=100/110/120, stem from its tip at y=60
-    # down to the lowest notehead at y=120.
-    stem = G.Stem(x=50.0, y0=60.0, y1=120.0)
+    # up-stem chord: noteheads at y=100/110/120, stem on their RIGHT running
+    # from its tip at y=60 down to the lowest notehead at y=120.
+    stem = G.Stem(x=54.0, y0=60.0, y1=120.0)
     notes = [_note(50.0, y, "c") for y in (100.0, 110.0, 120.0)]
     G._assign_stem_directions(notes, {"c": stem})
     assert [n.stem_dir for n in notes] == ["up", "up", "up"]
 
-    # and the mirror image
-    stem_d = G.Stem(x=50.0, y0=100.0, y1=160.0)
+    # and the mirror image: down-stem on their LEFT
+    stem_d = G.Stem(x=46.0, y0=100.0, y1=160.0)
     notes_d = [_note(50.0, y, "c") for y in (100.0, 110.0, 120.0)]
     G._assign_stem_directions(notes_d, {"c": stem_d})
     assert [n.stem_dir for n in notes_d] == ["down", "down", "down"]
@@ -480,3 +482,40 @@ def test_a_notehead_partway_along_a_chord_stem_still_finds_it():
     assert G._stem_through_notehead(stems, stem_xs, 44.0, 50.0, 100.0, tol) is stem
     # ...but a notehead the stem does not span is not on it
     assert G._stem_through_notehead(stems, stem_xs, 44.0, 50.0, 200.0, tol) is None
+
+
+def test_a_stem_whose_side_contradicts_its_overhang_is_not_believed():
+    """An up-stem leaves a notehead at its RIGHT edge and a down-stem at its
+    left. _best_stem accepts any stem end within about a staff space, which a
+    neighbouring voice's stem can satisfy in close-spaced two-voice writing,
+    so a stem on the wrong side for the direction it implies is not this
+    notehead's - and believing it would file the note in the wrong voice.
+    Dropping it loses information; believing it inverts it."""
+    contradictory = G.Stem(x=44.0, y0=65.0, y1=100.0)  # left of the head, points up
+    n = _note(48.0, 100.0, "c")
+    G._assign_stem_directions([n], {"c": contradictory})
+    assert n.stem_dir is None
+    assert n.stem_key is None, "and it must not group with that stem either"
+
+    # a genuine right-edge up-stem is still believed
+    own = G.Stem(x=52.0, y0=65.0, y1=100.0)
+    m = _note(48.0, 100.0, "own")
+    G._assign_stem_directions([m], {"own": own})
+    assert m.stem_dir == "up"
+
+    # ...as is a genuine left-edge down-stem
+    down = G.Stem(x=44.0, y0=100.0, y1=135.0)
+    d = _note(48.0, 100.0, "d")
+    G._assign_stem_directions([d], {"d": down})
+    assert d.stem_dir == "down"
+
+
+def test_a_seconds_chord_keeps_its_stem_despite_one_displaced_notehead():
+    """A chord containing a second displaces one notehead to the far side of
+    the shared stem, so the side test has to be taken over the group's mean -
+    per notehead it would throw the whole chord's stem away."""
+    stem = G.Stem(x=52.0, y0=60.0, y1=110.0)
+    members = [_note(48.0, 110.0, "c"), _note(48.0, 105.0, "c"),
+               _note(57.0, 100.0, "c")]  # the displaced one, right of the stem
+    G._assign_stem_directions(members, {"c": stem})
+    assert [m.stem_dir for m in members] == ["up", "up", "up"]

--- a/server/tests/test_glyph_rhythm.py
+++ b/server/tests/test_glyph_rhythm.py
@@ -427,3 +427,56 @@ def test_non_truetype_embedding_is_refused_by_flavour():
     mf, warn = G._load_one_font(doc=None, xref=1, base="Maestro", ext="cff")
     assert mf is None
     assert "cff" in warn
+
+
+# ---------------------------------------------------------------------------
+# Stem direction: the signal voices are separated by
+# ---------------------------------------------------------------------------
+
+
+def _note(x, y, key):
+    return G.NoteEvent(x, y, 1.0, 0, 0, False, "notehead_filled",
+                       notehead_kind="notehead_filled", stem_key=key)
+
+
+def test_stem_direction_comes_from_which_end_overhangs_the_notehead():
+    """Page y grows DOWNWARD. An up-stem runs about an octave ABOVE its
+    notehead and stops dead at it, so the overhang is on the small-y side."""
+    up = G.Stem(x=50.0, y0=60.0, y1=100.0)      # tip above a notehead at y=100
+    down = G.Stem(x=80.0, y0=100.0, y1=140.0)   # tip below a notehead at y=100
+    notes = [_note(50.0, 100.0, "u"), _note(80.0, 100.0, "d")]
+    G._assign_stem_directions(notes, {"u": up, "d": down})
+    assert [n.stem_dir for n in notes] == ["up", "down"]
+
+
+def test_a_chords_direction_is_not_read_off_one_of_its_noteheads():
+    """A chord shares ONE stem that runs PAST all of its noteheads, so the
+    end further from any given member is on the wrong side for every member
+    but the outermost - reading "the free end is below me, therefore stem
+    down" off the top note of an up-stemmed chord inverts it."""
+    # up-stem chord: noteheads at y=100/110/120, stem from its tip at y=60
+    # down to the lowest notehead at y=120.
+    stem = G.Stem(x=50.0, y0=60.0, y1=120.0)
+    notes = [_note(50.0, y, "c") for y in (100.0, 110.0, 120.0)]
+    G._assign_stem_directions(notes, {"c": stem})
+    assert [n.stem_dir for n in notes] == ["up", "up", "up"]
+
+    # and the mirror image
+    stem_d = G.Stem(x=50.0, y0=100.0, y1=160.0)
+    notes_d = [_note(50.0, y, "c") for y in (100.0, 110.0, 120.0)]
+    G._assign_stem_directions(notes_d, {"c": stem_d})
+    assert [n.stem_dir for n in notes_d] == ["down", "down", "down"]
+
+
+def test_a_notehead_partway_along_a_chord_stem_still_finds_it():
+    """_best_stem only attaches a notehead at a stem's END, which is where
+    the flag lives. A chord's inner members sit far outside that window and
+    would each become a beat - and, at one onset, a phantom second voice."""
+    tol = G._Tol(REF)
+    stem = G.Stem(x=50.0, y0=60.0, y1=120.0)
+    stems, stem_xs = [stem], [stem.x]
+    # a notehead centred at y=100: halfway up the stem, nowhere near an end
+    assert G._best_stem(stems, stem_xs, 44.0, 50.0, 100.0, tol) is None
+    assert G._stem_through_notehead(stems, stem_xs, 44.0, 50.0, 100.0, tol) is stem
+    # ...but a notehead the stem does not span is not on it
+    assert G._stem_through_notehead(stems, stem_xs, 44.0, 50.0, 200.0, tol) is None

--- a/server/tests/test_tabextract.py
+++ b/server/tests/test_tabextract.py
@@ -155,6 +155,10 @@ def test_glyph_decoded_alphatex_parses_with_dotted_beats(zanarkand_pdf):
     assert parsed["notes"] == result.notes
     assert parsed["dottedBeats"] > 0
     assert parsed["firstNoteMidi"] == 64
+    # This piece is two-voice fingerstyle writing, so the emitted `\voice`
+    # separators must actually have landed their beats in a SECOND concurrent
+    # voice - more sounding voices than bars - rather than merely parsing.
+    assert parsed["voices"] > parsed["bars"], parsed
 
 
 def test_notation_only_pdf_has_no_tab_staves(tarrega_pdf):
@@ -458,14 +462,42 @@ def test_ambiguous_pairing_returns_no_notation_staff():
 # ---------------------------------------------------------------------------
 
 
-def _note_event(x, code, dots=0, rest=False, y=100.0):
-    base = {1: 4.0, 2: 2.0, 4: 1.0, 8: 0.5, 16: 0.25}[code]
-    return glyph_rhythm.NoteEvent(x, y, base, 0, dots, rest,
-                                  "rest_quarter" if rest else "notehead_filled")
+def _note_event(x, code, dots=0, rest=False, y=100.0, stem=None, stem_id=None,
+                kind="notehead_filled", flags=0):
+    """One decoded glyph event. `stem` is the stem direction ("up"/"down") and
+    `stem_id` the identity of the stem it hangs off - two noteheads sharing a
+    stem_id are a chord on one stem, which is what makes them one beat.
+
+    `flags` is how many flag hooks or beam levels the decoder counted at the
+    stem, which is how it actually shortens a filled notehead: base stays a
+    quarter and each flag halves it. Passing `code` alone gives an unflagged
+    notehead of that value.
+    """
+    base = {1: 4.0, 2: 2.0, 4: 1.0, 8: 0.5, 16: 0.25}[code] * (2 ** flags)
+    key = stem_id if stem_id is not None else (None if stem is None else (stem, round(x, 1)))
+    ev = glyph_rhythm.NoteEvent(
+        x, y, base, flags, dots, rest,
+        "rest_quarter" if rest else kind,
+        notehead_kind=None if rest else kind,
+        stem_key=key,
+    )
+    ev.stem_dir = stem
+    return ev
 
 
 def _cols(*xs):
     return [{"x": x, "xc": x + 2.0, "notes": [(1, "3")]} for x in xs]
+
+
+def _col(x, *notes):
+    return {"x": x, "xc": x + 2.0, "notes": list(notes)}
+
+
+def _measure(cols, events, budget=None, x_tol=12.0, spacing=5.125):
+    events = sorted(events, key=lambda n: n.x)
+    return tabextract._build_measure_beats_glyph(
+        cols, 90.0, 600.0, events, [n.x for n in events],
+        x_tol=x_tol, notation_spacing=spacing, budget=budget)
 
 
 def test_second_voice_rest_under_a_note_is_not_an_extra_beat():
@@ -478,9 +510,9 @@ def test_second_voice_rest_under_a_note_is_not_an_extra_beat():
         _note_event(102.0, 4), _note_event(122.0, 4), _note_event(142.0, 4),
         _note_event(102.3, 4, rest=True, y=118.0),  # voice 2 rest, same onset
     ]
-    events.sort(key=lambda n: n.x)
-    beats, unmatched_cols, unmatched_notes = tabextract._build_measure_beats_glyph(
-        cols, 90.0, 160.0, events, [n.x for n in events], x_tol=12.0, spacing=5.125)
+    voices, unmatched_cols, unmatched_notes, _ = _measure(cols, events)
+    assert len(voices) == 1, voices
+    beats = voices[0]
     assert len(beats) == 3, beats
     assert all(notes for _, _, notes in beats), "no phantom rest beat"
 
@@ -492,22 +524,316 @@ def test_simultaneous_rests_in_two_voices_collapse_to_one_beat():
         _note_event(100.4, 4, rest=True, y=118.0),
         _note_event(142.0, 4),
     ]
-    events.sort(key=lambda n: n.x)
-    beats, _, _ = tabextract._build_measure_beats_glyph(
-        cols, 90.0, 160.0, events, [n.x for n in events], x_tol=12.0, spacing=5.125)
-    rests = [b for b in beats if not b[2]]
-    assert len(rests) == 1, beats
+    voices, _, _, _ = _measure(cols, events)
+    assert len(voices) == 1, voices
+    rests = [b for b in voices[0] if not b[2]]
+    assert len(rests) == 1, voices
 
 
 def test_a_genuinely_separate_rest_is_still_its_own_beat():
     """The dedupe must not swallow a real rest that sits on its own onset."""
     cols = _cols(100.0)
     events = [_note_event(102.0, 4), _note_event(140.0, 4, rest=True)]
-    events.sort(key=lambda n: n.x)
-    beats, _, _ = tabextract._build_measure_beats_glyph(
-        cols, 90.0, 160.0, events, [n.x for n in events], x_tol=12.0, spacing=5.125)
-    assert len(beats) == 2
-    assert [bool(n) for _, _, n in beats] == [True, False]
+    voices, _, _, _ = _measure(cols, events)
+    assert len(voices) == 1
+    assert [bool(n) for _, _, n in voices[0]] == [True, False]
+
+
+# ---------------------------------------------------------------------------
+# Voice separation
+# ---------------------------------------------------------------------------
+
+
+def _quarters(beats):
+    return sum(tabextract._beat_quarters(code, dots) for code, dots, _n in beats)
+
+
+def test_stem_direction_splits_a_bar_into_concurrent_voices():
+    """The library's core content: a melody in quarters, stems up, over an
+    accompaniment in eighths, stems down. Assembled into one sequence the 3/4
+    bar holds 6 quarters; as two voices each holds exactly 3."""
+    xs_mel = [100.0, 140.0, 180.0]
+    xs_bass = [100.0, 120.0, 140.0, 160.0, 180.0, 200.0]
+    events = [_note_event(x, 4, y=60.0, stem="up") for x in xs_mel]
+    events += [_note_event(x, 8, y=120.0, stem="down") for x in xs_bass]
+    cols = [_col(100.0, (1, "7"), (5, "3")), _col(120.0, (4, "5")),
+            _col(140.0, (1, "7"), (2, "3")), _col(160.0, (3, "5")),
+            _col(180.0, (1, "7"), (2, "5")), _col(200.0, (2, "7"))]
+    voices, _, unmatched_notes, inferred = _measure(cols, events, budget=3.0)
+
+    assert len(voices) == 2, voices
+    assert unmatched_notes == 0
+    assert _quarters(voices[0]) == 3.0
+    assert _quarters(voices[1]) == 3.0
+    assert inferred == 0.0, "both voices already account for the bar"
+    # The upper voice is the melody: three quarters, each one note.
+    assert [(c, d) for c, d, _n in voices[0]] == [(4, 0)] * 3
+    assert [(c, d) for c, d, _n in voices[1]] == [(8, 0)] * 6
+
+
+def test_a_shared_onset_splits_its_tab_digits_by_pitch_between_the_voices():
+    """Two simultaneous notes in different voices are two tab digits on
+    different strings - which is also exactly what a chord looks like. The
+    split cannot come from the tab, so it comes from the notation: noteheads
+    ordered by pitch against digits ordered by string."""
+    events = [
+        _note_event(100.0, 4, y=60.0, stem="up"),     # melody, high
+        _note_event(100.0, 8, y=120.0, stem="down"),  # bass, low
+    ]
+    cols = [_col(100.0, (1, "7"), (5, "3"))]
+    voices, _, _, _ = _measure(cols, events, budget=3.0)
+    assert len(voices) == 2
+    assert voices[0][0][2] == [(1, "7")], "the melody takes the high string"
+    assert voices[1][0][2] == [(5, "3")], "the bass takes the low string"
+
+
+def test_a_chord_on_one_stem_stays_one_beat_in_one_voice():
+    """Several noteheads on ONE stem is a chord: one beat, however many tab
+    digits are stacked under it. Matching each notehead separately let a
+    chord's members go hunting for their own columns."""
+    events = [
+        _note_event(100.0, 4, y=60.0, stem="down", stem_id="A"),
+        _note_event(100.0, 4, y=70.0, stem="down", stem_id="A"),
+        _note_event(100.0, 4, y=80.0, stem="down", stem_id="A"),
+    ]
+    cols = [_col(100.0, (1, "7"), (2, "8"), (3, "5"))]
+    voices, unmatched_cols, unmatched_notes, _ = _measure(cols, events, budget=3.0)
+    assert len(voices) == 1, "a chord is not two voices"
+    assert len(voices[0]) == 1, voices
+    assert voices[0][0][2] == [(1, "7"), (2, "8"), (3, "5")]
+    assert unmatched_cols == 0 and unmatched_notes == 0
+
+
+def test_a_chord_takes_the_duration_of_the_notehead_that_saw_the_stem():
+    """Only the notehead at a stem's end can see the flag or beam that
+    shortens the chord; the inner members read a plain quarter and would
+    outvote it."""
+    events = [
+        # the notehead at the stem's end: a quarter head with one beam level
+        _note_event(100.0, 8, y=60.0, stem="up", stem_id="A", flags=1),
+        _note_event(100.0, 4, y=70.0, stem="up", stem_id="A"),
+        _note_event(100.0, 4, y=80.0, stem="up", stem_id="A"),
+    ]
+    cols = [_col(100.0, (1, "7"), (2, "8"), (3, "5"))]
+    voices, _, _, _ = _measure(cols, events)
+    assert [(c, d) for c, d, _n in voices[0]] == [(8, 0)]
+
+
+def test_a_chord_with_no_stem_found_is_not_mistaken_for_two_voices():
+    """Some scores engrave chords whose stem the vector pass cannot see at
+    all. Stems are what two-voice writing is notated WITH, so an onset with
+    no stem evidence is a chord - splitting it by pitch invented a second
+    voice out of one chord and left both halves short."""
+    events = [_note_event(100.0, 4, y=y) for y in (60.0, 70.0, 80.0, 95.0)]
+    cols = [_col(100.0, (2, "5"), (3, "5"), (4, "5"), (5, "8"))]
+    voices, _, _, _ = _measure(cols, events, budget=4.0)
+    assert len(voices) == 1, voices
+    assert len(voices[0]) == 1, "one chord, one beat"
+    assert len(voices[0][0][2]) == 4
+
+
+def test_two_stems_the_same_way_up_at_one_onset_are_one_chord():
+    """Not three-voice writing - one chord whose stem came through the vector
+    pass as two separate strokes."""
+    events = [
+        _note_event(100.0, 4, y=60.0, stem="down", stem_id="A"),
+        _note_event(100.0, 4, y=75.0, stem="down", stem_id="B"),
+    ]
+    cols = [_col(100.0, (1, "7"), (3, "5"))]
+    voices, _, _, _ = _measure(cols, events, budget=3.0)
+    assert len(voices) == 1, voices
+    assert len(voices[0]) == 1
+
+
+def test_a_monophonic_bar_stays_one_voice_when_its_stems_flip():
+    """Single-voice writing flips stem direction with pitch around the middle
+    line, so direction alone would shred a melody crossing it into two
+    voices. Nothing sounds together here, so nothing is polyphonic."""
+    events = [
+        _note_event(100.0, 4, y=60.0, stem="down"),
+        _note_event(140.0, 4, y=130.0, stem="up"),
+        _note_event(180.0, 4, y=55.0, stem="down"),
+    ]
+    cols = [_col(100.0, (1, "5")), _col(140.0, (5, "3")), _col(180.0, (1, "7"))]
+    voices, _, _, inferred = _measure(cols, events, budget=3.0)
+    assert len(voices) == 1, voices
+    assert len(voices[0]) == 3
+    assert inferred == 0.0, "a monophonic bar is never padded with inferred rests"
+
+
+def test_a_whole_note_with_no_stem_joins_the_voice_below_the_melody():
+    """A whole note never takes a stem in any notation, so the only signal
+    left is where it sits relative to the voice that does have one."""
+    events = [_note_event(x, 4, y=60.0, stem="up") for x in (100.0, 140.0, 180.0, 220.0)]
+    events.append(_note_event(100.0, 1, y=130.0, kind="notehead_whole"))
+    cols = [_col(100.0, (1, "7"), (6, "3")), _col(140.0, (1, "8")),
+            _col(180.0, (1, "9")), _col(220.0, (1, "10"))]
+    voices, _, _, _ = _measure(cols, events, budget=4.0)
+    assert len(voices) == 2, voices
+    assert _quarters(voices[0]) == 4.0
+    assert _quarters(voices[1]) == 4.0
+    assert voices[1][0][2] == [(6, "3")], "the whole note is the lower voice"
+
+
+def test_a_silent_voice_is_padded_with_rests_so_it_fills_the_bar():
+    """This is what actually makes the arithmetic work: without it every
+    voice but the busiest reads as a short bar and drifts against it."""
+    events = [_note_event(100.0, 4, y=60.0, stem="up")]
+    events += [_note_event(x, 4, y=130.0, stem="down") for x in (100.0, 140.0, 180.0)]
+    cols = [_col(100.0, (1, "7"), (5, "3")), _col(140.0, (5, "5")), _col(180.0, (5, "7"))]
+    voices, _, _, inferred = _measure(cols, events, budget=3.0)
+    assert len(voices) == 2
+    assert _quarters(voices[0]) == 3.0
+    assert _quarters(voices[1]) == 3.0
+    assert inferred == 2.0, "the upper voice was silent for two of the three beats"
+    # the note sounds first, then the inferred silence - spelled as the one
+    # half rest that covers it, not two quarter rests
+    assert voices[0] == [(4, 0, [(1, "7")]), (2, 0, [])], voices[0]
+
+
+def test_a_voice_that_enters_late_is_padded_at_the_front():
+    events = [_note_event(180.0, 4, y=60.0, stem="up")]
+    events += [_note_event(x, 4, y=130.0, stem="down") for x in (100.0, 140.0, 180.0)]
+    cols = [_col(100.0, (5, "3")), _col(140.0, (5, "5")),
+            _col(180.0, (1, "7"), (5, "7"))]
+    voices, _, _, _ = _measure(cols, events, budget=3.0)
+    assert len(voices) == 2
+    assert _quarters(voices[0]) == 3.0
+    assert voices[0][0][2] == [], "silence first"
+    assert voices[0][-1][2] == [(1, "7")], "then the note it enters on"
+
+
+def test_rest_beats_for_fills_a_meter_exactly():
+    assert tabextract._rest_beats_for(3.0) == [(2, 0, []), (4, 0, [])]
+    assert tabextract._rest_beats_for(4.0) == [(1, 0, [])]
+    assert tabextract._rest_beats_for(1.5) == [(4, 0, []), (8, 0, [])]
+
+
+def test_an_empty_bar_is_filled_with_rests_that_add_up():
+    """A 3/4 bar's 3.0 quarters snap to a WHOLE rest, which is a third longer
+    than the bar - an empty bar has to be spelled with rests that sum to the
+    meter instead."""
+    tex = tabextract._build_alphatex(
+        "T", None, [], (3, 4), [(tabextract._rest_beats_for(3.0), (3, 4))])
+    body = tex.split("\n.\n", 1)[1].strip()
+    assert body == ":2 r :4 r |", body
+
+
+def test_concurrent_voices_are_emitted_with_the_voice_separator():
+    """alphaTex spells concurrent voices inside a bar with `\\voice`, which
+    only means that with `\\voicemode barwise` in the header - the default
+    reads it as "restart the staff for the next voice"."""
+    measures = [
+        ([[(4, 0, [(1, "7")])] * 3, [(8, 0, [(5, "3")])] * 6], (3, 4)),
+        ([[(4, 0, [(1, "7")])] * 3], (3, 4)),
+    ]
+    tex = tabextract._build_alphatex("T", None, [], (3, 4), measures)
+    head, body = tex.split("\n.\n", 1)
+    assert "\\voicemode barwise" in head
+    lines = body.strip().splitlines()
+    assert lines[0].count("\\voice") == 1, lines[0]
+    assert lines[1].count("\\voice") == 0, "a monophonic bar emits no second voice"
+
+
+def test_a_monophonic_score_does_not_declare_a_voice_mode():
+    """The directive only appears where it does something."""
+    tex = tabextract._build_alphatex(
+        "T", None, [], (3, 4), [([[(4, 0, [(1, "7")])] * 3], (3, 4))])
+    assert "\\voicemode" not in tex
+
+
+def test_bar_quarters_is_the_longest_voice_not_the_sum():
+    """Voices sound CONCURRENTLY. Summing them is exactly the mistake that
+    made a bar of two-voice writing read as double its meter."""
+    bar = [[(4, 0, [])] * 3, [(8, 0, [])] * 6]
+    assert tabextract._bar_quarters(bar) == 3.0
+    assert tabextract._overfull_bars([(bar, (3, 4))]) == (0, 1)
+    # a voice that really does overflow is still caught
+    over = [[(4, 0, [])] * 3, [(4, 0, [])] * 4]
+    assert tabextract._overfull_bars([(over, (3, 4))]) == (1, 1)
+
+
+# ---------------------------------------------------------------------------
+# Bar fullness on a real reference score
+# ---------------------------------------------------------------------------
+
+_DUR_TOKEN = re.compile(r"^:(\d+)$")
+
+
+def _emitted_voice_quarters(segment):
+    """Quarter notes in one emitted voice of one bar, read back out of the
+    alphaTex itself - so this measures the artifact that gets stored and
+    rendered, not an intermediate the emitter might not agree with."""
+    total = 0.0
+    dur = None
+    dots = 0
+    for tok in segment.split():
+        m = _DUR_TOKEN.match(tok)
+        if m:
+            if dur:
+                total += tabextract._beat_quarters(dur, dots)
+            dur, dots = int(m.group(1)), 0
+            continue
+        if "{dd}" in tok:
+            dots = 2
+        elif "{d}" in tok:
+            dots = 1
+    if dur:
+        total += tabextract._beat_quarters(dur, dots)
+    return total
+
+
+def _emitted_bars(alphatex):
+    """[(budget, [voice quarters, ...]), ...] for every emitted bar."""
+    header, body = alphatex.split("\n.\n", 1)
+    head = re.search(r"\\ts\s+(\d+)\s+(\d+)", header)
+    ts = (int(head.group(1)), int(head.group(2))) if head else (4, 4)
+    out = []
+    for line in body.strip().splitlines():
+        m = re.match(r"\s*\\ts\s+(\d+)\s+(\d+)\s*", line)
+        if m:
+            ts = (int(m.group(1)), int(m.group(2)))
+            line = line[m.end():]
+        bar = line.rstrip().rstrip("|").strip()
+        voices = [s.strip() for s in bar.split("\\voice")]
+        out.append((tabextract._measure_quarter_length(ts),
+                    [_emitted_voice_quarters(v) for v in voices]))
+    return out
+
+
+def test_reference_score_bars_mostly_add_up(zanarkand_pdf):
+    """To Zanarkand is two-voice fingerstyle writing throughout: a melody over
+    an independent bass line. Assembled into one voice per bar, 37 of its 50
+    bars held more than their meter (only 24% summed exactly, 72.5 quarters of
+    total error) with every individual duration decoded correctly. Separating
+    the voices is what fixes the arithmetic, so pin it: this is the metric the
+    feature exists to move.
+    """
+    result = tabextract.extract(zanarkand_pdf)
+    assert result.extractable
+    bars = _emitted_bars(result.alphatex)
+    assert len(bars) == 50, len(bars)
+
+    exact = sum(1 for budget, vs in bars
+                if all(abs(v - budget) < 1e-6 for v in vs))
+    overfull = sum(1 for budget, vs in bars if any(v > budget + 1e-6 for v in vs))
+    error = sum(abs(v - budget) for budget, vs in bars for v in vs)
+    multivoice = sum(1 for _b, vs in bars if len(vs) > 1)
+
+    assert exact >= 44, f"only {exact} of 50 bars sum exactly (was 12 before voices)"
+    assert overfull <= 6, f"{overfull} bars overfull (was 37 before voices)"
+    assert error <= 12.0, f"{error} quarters of error (was 72.5 before voices)"
+    assert multivoice >= 30, f"only {multivoice} bars came out as two voices"
+
+
+def test_reference_score_still_reports_the_bars_that_do_not_add_up(zanarkand_pdf):
+    """A much smaller number, but it must still be reported rather than
+    disappearing - the remaining bars really do play wrong."""
+    result = tabextract.extract(zanarkand_pdf)
+    fullness = [w for w in result.warnings if "hold more than their time signature" in w]
+    assert len(fullness) == 1, result.warnings
+    assert re.search(r"\b\d+ of 50 bar\(s\)", fullness[0]), fullness[0]
+    assert any("concurrent voices" in w for w in result.warnings)
 
 
 # ---------------------------------------------------------------------------

--- a/server/tests/test_tabextract.py
+++ b/server/tests/test_tabextract.py
@@ -742,6 +742,86 @@ def test_a_monophonic_score_does_not_declare_a_voice_mode():
     assert "\\voicemode" not in tex
 
 
+def test_an_onset_short_of_digits_does_not_eat_the_next_onsets_column():
+    """An onset can legitimately need two columns (engravers offset a bass tab
+    number a few points right of a treble one in the same chord), but the
+    search for the second one has to stay beside the first. Searching the full
+    notehead-to-digit window instead let an onset with more noteheads than its
+    own column had digits consume the NEXT onset's column - sounding those
+    frets a beat early and dropping the notes that column belonged to."""
+    events = [
+        _note_event(100.0, 4, y=60.0, stem="up"),
+        _note_event(100.0, 4, y=120.0, stem="down"),
+        _note_event(110.0, 4, y=122.0, stem="down"),
+    ]
+    cols = [_col(100.0, (1, "7")), _col(110.0, (5, "3"))]
+    voices, _, unmatched_notes, _ = _measure(cols, events, budget=3.0)
+    lower = [b for b in voices[1] if b[2]]
+    assert lower == [(4, 0, [(5, "3")])], voices
+    # and it is the SECOND beat of that voice, not the first
+    assert voices[1].index(lower[0]) == 1, voices[1]
+    assert unmatched_notes == 1, "the notehead with no digit is reported, not hidden"
+
+
+def test_one_stem_shared_across_two_onsets_is_not_one_chord():
+    """Sharing a stem is necessary but not sufficient to be one beat - the
+    noteheads also have to sound together. A notehead whose own stem was
+    missed can be threaded onto a neighbour's, and keying on the stem alone
+    welded two consecutive onsets into a chord positioned between them,
+    losing an onset and its duration."""
+    events = [
+        _note_event(100.0, 4, y=60.0, stem="up", stem_id="A"),
+        _note_event(106.0, 4, y=80.0, stem="up", stem_id="A"),
+        _note_event(140.0, 4, y=62.0, stem="up"),
+    ]
+    cols = [_col(100.0, (2, "5")), _col(106.0, (5, "3")), _col(140.0, (5, "7"))]
+    voices, _, _, _ = _measure(cols, events, budget=3.0)
+    assert len(voices) == 1, voices
+    assert len(voices[0]) == 3, "three onsets, three beats"
+    assert tabextract._bar_quarters(voices) == 3.0
+
+
+def test_a_rest_matching_no_onset_is_dropped_not_added_to_a_sounding_voice():
+    """A rest glyph further from every decoded onset than the merge tolerance
+    says nothing about which voice it belongs to. Adding it anyway put a beat
+    into a voice that was already sounding there, taking that voice over its
+    meter and pushing everything after it late."""
+    events = [_note_event(x, 4, y=60.0, stem="up") for x in (100.0, 140.0, 180.0, 220.0)]
+    events += [_note_event(x, 4, y=120.0, stem="down") for x in (100.0, 180.0)]
+    events += [_note_event(145.4, 4, y=62.0, rest=True)]  # 5.4pt from any onset
+    cols = [_col(100.0, (1, "7"), (5, "3")), _col(140.0, (1, "8")),
+            _col(180.0, (1, "9"), (5, "5")), _col(220.0, (1, "10"))]
+    voices, _, _, _ = _measure(cols, events, budget=4.0)
+    assert len(voices) == 2
+    assert _quarters(voices[0]) == 4.0, voices[0]
+    assert _quarters(voices[1]) == 4.0, voices[1]
+    assert [b[2] for b in voices[0]] == [[(1, "7")], [(1, "8")], [(1, "9")], [(1, "10")]]
+
+
+def test_a_voice_whose_notes_all_lost_their_digits_is_not_emitted():
+    """Padding a voice that decoded no notes at all filled a whole bar with
+    inferred silence: a phantom voice that counted as polyphony, overstated
+    how much rest was deduced from the meter, and wrote a meaningless
+    `\\voice :2 r :4 r` into the stored transcription."""
+    events = [
+        _note_event(100.0, 4, y=60.0, stem="up"),
+        _note_event(100.0, 4, y=120.0, stem="down"),
+    ]
+    cols = [_col(100.0, (1, "7"))]  # one digit for two noteheads
+    voices, _, unmatched_notes, inferred = _measure(cols, events, budget=3.0)
+    assert len(voices) == 1, voices
+    assert voices[0] == [(4, 0, [(1, "7")])]
+    assert inferred == 0.0, "no silence is inferred for a voice that never played"
+    assert unmatched_notes == 1
+
+
+def test_a_bar_of_nothing_but_rests_still_keeps_them():
+    """The phantom-voice filter must not throw away a genuinely silent bar."""
+    events = [_note_event(100.0, 4, rest=True)]
+    voices, _, _, _ = _measure([], events, budget=3.0)
+    assert voices == [[(4, 0, [])]], voices
+
+
 def test_bar_quarters_is_the_longest_voice_not_the_sum():
     """Voices sound CONCURRENTLY. Summing them is exactly the mistake that
     made a bar of two-voice writing read as double its meter."""

--- a/server/tools/tab_extract/verify_tex.mjs
+++ b/server/tools/tab_extract/verify_tex.mjs
@@ -12,12 +12,14 @@
 //
 // Each argument after the alphaTab path is either a .tex file or a
 // directory (all *.tex files directly inside it are checked). Prints one
-// JSON line per file: {file, ok, bars, beats, notes, dottedBeats,
+// JSON line per file: {file, ok, bars, beats, notes, dottedBeats, voices,
 // firstNoteMidi} or {file, ok: false, error}. Exits 1 if any file failed to
-// parse. dottedBeats and firstNoteMidi round out the same two things a
+// parse. dottedBeats, voices and firstNoteMidi round out the things a
 // syntax-only check can't catch: that a `{d}`/`{dd}` beat effect actually
-// produced a dotted beat rather than just parsing without error, and that
-// tuning was emitted in the string order alphaTex expects (a mirrored
+// produced a dotted beat rather than just parsing without error, that a
+// `\voice` separator really did land the beats after it in a SECOND
+// concurrent voice (voices counts more than one per bar only if it did), and
+// that tuning was emitted in the string order alphaTex expects (a mirrored
 // \tuning line parses fine but gives every note the wrong pitch).
 //
 // Example (from this directory, against the web project's own alphaTab):
@@ -58,13 +60,25 @@ async function main() {
             importer.logErrors = false;
             importer.initFromString(tex, new Settings());
             const score = importer.readScore();
-            let bars = 0, beats = 0, notes = 0, dottedBeats = 0;
+            let bars = 0, beats = 0, notes = 0, dottedBeats = 0, voices = 0;
             let firstNoteMidi = null;
             for (const track of score.tracks) {
                 for (const staff of track.staves) {
                     bars = Math.max(bars, staff.bars.length);
                     for (const bar of staff.bars) {
                         for (const voice of bar.voices) {
+                            // alphaTab gives EVERY bar as many voices as the
+                            // busiest bar on the staff has, padding the ones
+                            // a bar does not use with a single auto-inserted
+                            // rest. Those are the importer's own filler, not
+                            // beats the transcription emitted, so counting
+                            // them would put this over the emitted total by
+                            // one per unused voice. isEmpty marks exactly
+                            // that filler: a voice the transcription really
+                            // did write, even one holding only rests, comes
+                            // back isEmpty === false.
+                            if (voice.isEmpty) continue;
+                            voices += 1;
                             for (const beat of voice.beats) {
                                 beats += 1;
                                 if (beat.dots > 0) dottedBeats += 1;
@@ -77,7 +91,7 @@ async function main() {
                     }
                 }
             }
-            Object.assign(result, { ok: true, bars, beats, notes, dottedBeats, firstNoteMidi });
+            Object.assign(result, { ok: true, bars, beats, notes, dottedBeats, voices, firstNoteMidi });
         } catch (e) {
             anyFailed = true;
             Object.assign(result, { ok: false, error: String(e && e.stack ? e.stack : e) });


### PR DESCRIPTION
Closes #40.

Classical and fingerstyle guitar is polyphonic — a melody sounds *over* an independent bass line. The transcriber assembled every note on a staff into one sequence of beats, so a bar held the **sum** of its voices instead of its voices running concurrently: typically about double its meter, with every individual duration decoded correctly. Playback follows the bar, so timing drifted through most of a score.

## What changed

Each notehead is grouped with the others hanging off **its own engraved stem** (a chord is one beat), and where two stems genuinely sound at the same onset the bar is split into concurrent voices by **stem direction** — the signal engravers use for exactly this. Each voice is then filled out with rests so it accounts for the bar on its own, which is what actually makes the arithmetic work.

**Stem direction is deliberately not used on its own.** Single-voice writing also flips stems with pitch around the middle line, so splitting wherever direction changes would shred a melody crossing it into two voices at every crossing. **Simultaneity** is what distinguishes the two cases, because one voice never has two stems at one onset.

Three engraving details had to be handled for that to hold up:

- **A chord's inner noteheads sit part way *along* the shared stem**, far outside the tight end-window the duration pass uses (that window is what stops a neighbouring voice's stem being read for flags). They found no stem at all, so each became its own beat — and, at a shared onset, a phantom second voice. They now attach to the stem threaded through them, and a chord's duration is recomposed from all its members, since only the notehead at the stem's end can see the flag or beam.
- **A notehead whose stem is not found at all joins whatever else sounds at its onset.** Stems are what two-voice writing is notated *with*, so an onset carrying no stem evidence is a chord, not two voices. Some scores in the library engrave chords whose stem the vector pass cannot see; splitting those by pitch invented a voice out of one chord and left both halves short.
- **Two simultaneous notes in different voices are two tab digits on different strings — which is also exactly what a chord looks like.** The split cannot be read from the tab at all, so it is read from the notation: noteheads ordered by *pitch* against digits ordered by *string* (string 1 being the highest-pitched). That puts each voice's note on the string the engraver wrote it on whether the onset is one chord or two voices.

A whole note never takes a stem in any notation, so it is placed by where it sits relative to the voices that do have one. Half notes now have their stem looked up for direction only (never for a flag they cannot carry) — a lower voice in this repertoire is very often written in half notes and had no voice signal at all before.

## alphaTex syntax

Concurrent voices are separated by `\voice` **inside** the bar, which requires `\voicemode barwise` in the header. alphaTex's default (`staffwise`) reads `\voice` as "start the whole staff again for the next voice", so everything after the first separator would have become bar 1 onwards of voice 2. Verified against the installed renderer (alphaTab 1.8.4) rather than assumed. The directive is only emitted when a score actually has a multi-voice bar.

## Results

Bar arithmetic, measured through the emitted transcription. `exact` = every emitted voice sums exactly to its meter; `error` = total |voice quarters − budget|.

| File | exact before | exact after | error before | error after |
|---|---|---|---|---|
| Score A | 12/50 (24.0%) | **46/50 (92.0%)** | 72.50q | **6.00q** |
| Score B | 4/35 (11.4%) | **28/35 (80.0%)** | 51.50q | **15.50q** |
| Score C | 8/69 (11.6%) | **25/69 (36.2%)** | 178.50q | **74.50q** |
| Score D | 3/20 (15.0%) | **7/20 (35.0%)** | 32.00q | **15.50q** |
| Score E | 7/17 (41.2%) | **12/17 (70.6%)** | 32.00q | **8.00q** |
| Score F | 1/27 (3.7%) | **17/27 (63.0%)** | 75.50q | **15.75q** |
| Score G | 13/39 (33.3%) | **21/39 (53.8%)** | 30.75q | **13.50q** |

Whole library — 297 files, **291 extractable and 0 crashes, both unchanged**:

| | before | after |
|---|---|---|
| bars summing exactly | 1814 / 10689 (17.0%) | **7916 / 10689 (74.1%)** |
| overfull bars | 8017 | **2177** |
| total absolute error | 18707.06q | **3855.44q** |
| bars emitted as two voices | 0 | 7793 |

All 287 emitted transcriptions were re-parsed with the installed renderer: every one parses, and the renderer reports 7726 bars carrying more than one sounding voice — i.e. the `\voice` separators really land their beats in a second concurrent voice rather than merely parsing.

## What this does not fix

Tuplets, tie detection and time-signature calibration are unchanged and out of scope. Two of the residuals are worth naming because they now dominate:

- **Score C** is the weakest file above, and its residual is almost entirely *not* a voice problem: 53 of its overfull voices are over by exactly 1.0 quarter, which is a whole note measured against a 3/4 budget. The score prints 4/4, then 5/4, then 4/4; the decoder reads a change to 3/4 and misses the return. That is a time-signature bug.
- **Score A bar 10** is one of its 3 remaining overfull bars: the melody's third note is a flagged eighth in the score and decodes as a quarter, so that voice holds 3.5 quarters. A missed flag, not a missed voice.

Because a voice that is silent for part of a bar gets padded, a bar can no longer come out *underfull* in a multi-voice bar — so the honest comparison is the overfull count and the overfull error, and those move the same way (over-error 436.25q → 116.25q on the seven files above). The total quarters of rest that were deduced from the meter rather than read from a printed rest is reported as its own warning, so padded silence can be told from decoded silence.

`_overfull_bars` and the bars-that-do-not-add-up warning both stay, now reporting a much smaller number, and the warning names the causes that remain rather than blaming merged voices for all of them.

## Verification

- **Rendered and compared by eye.** Page 1 of Score A against the emitted transcription rendered by alphaTab: the melody lines up with the top voice on the high strings and the accompaniment with the lower voice on the low strings, bar for bar, including the bars where the two share an onset and their digits had to be split between the voices.
- **Tests** for the assignment rules — stem-up/stem-down split, a shared onset's digits splitting by pitch, chords staying one beat (with a stem, and with no stem found), same-direction stems folding into one chord, monophonic bars with flipping stems staying single-voice, whole-note placement, rest insertion front and back — plus a regression test pinning bar fullness on the reference file, and unit tests for reading a stem's direction from which end overhangs its noteheads.
- `server/tools/tab_extract/verify_tex.mjs` now skips the voices alphaTab pads unused bars with, so its beat count is what the transcription emitted; it also reports a voice count, and the round-trip test asserts more sounding voices than bars.
- Full suite in a clean container with the library mounted: **102 passed**.
