### PR TITLE
Emit MusicXML and document the tab profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,12 +31,16 @@ them.
 - **Tab out of a PDF** — engraved guitar PDFs carry their tab as real text and
   their rhythm in the music font's own glyphs, so Fermata reads both directly
   instead of guessing at pixels, and renders the result as a playable,
-  editable staff beside the original page. Fret numbers, strings and chords
-  come out reliably; how much of the rhythm survives depends on the engraving,
-  and whatever stayed uncertain is listed with the staff rather than hidden.
-  Music written in two voices is still flattened into one, so bars in
-  polyphonic pieces frequently do not add up yet — the count is reported.
-  Scanned PDFs have nothing to read and are not transcribed.
+  editable staff beside the original page. The transcription is written as
+  **MusicXML**, so it opens in other notation software rather than only here —
+  see [the tab profile](docs/musicxml-tab-profile.md) for exactly what is
+  written. Fret numbers, strings and chords come out reliably; how much of the
+  rhythm survives depends on the engraving, and whatever stayed uncertain is
+  listed with the staff rather than hidden. Bars whose voices the engraved
+  stems do not separate still do not add up — that is now a stated conformance
+  rule of the profile, so any MusicXML tool finds those bars too, and the count
+  is reported either way. Scanned PDFs have nothing to read and are not
+  transcribed.
 - **Practice tracking** — a session timer per piece, with recently-practised
   and neglected views so the library reflects what you are actually working on.
 - **Gig mode** — fullscreen, screen kept awake, oversized tap targets and
@@ -87,11 +91,24 @@ npm install
 npm run dev
 ```
 
+Tests:
+
+```bash
+cd server
+pip install -e ".[dev]"
+python -m pytest -q
+```
+
+Tests that need real sheet music read it from `FERMATA_TEST_LIBRARY` and skip
+when it is unset. Setting `FERMATA_MUSICXML_XSD` to a local copy of the
+MusicXML 4.0 schema additionally validates the emitted transcriptions against
+it — see [the tab profile](docs/musicxml-tab-profile.md#checking-a-file).
+
 ## Formats
 
 | Format | How it reads |
 | --- | --- |
-| PDF, engraved with a tab staff | Practice reader, plus transcription to a playable staff you can view beside the page |
+| PDF, engraved with a tab staff | Practice reader, plus transcription to MusicXML — a playable staff beside the page, and a file other notation software reads ([profile](docs/musicxml-tab-profile.md)) |
 | PDF, engraved without tab | Practice reader; nothing to transcribe from |
 | PDF, scanned | Practice reader only — a scan holds no text or glyphs to read |
 | MusicXML (`.musicxml`, `.mxl`) | Interactive: notation / tab / both, audio, full fidelity |
@@ -104,9 +121,9 @@ demo*) if your library is PDF-only so far.
 
 ## Roadmap
 
-- **Separating voices when transcribing** — the largest gap between a
-  transcription and a score you could practise from, and the reason bars in
-  polyphonic pieces overfill today
+- **Tuplets and ties when transcribing** — the largest remaining gap between a
+  transcription and a score you could practise from, and the reason bars still
+  overfill once voices have been separated
 - **Score creation and editing** — build a staff from scratch in the browser,
   instrument-agnostic with first-class guitar tablature support
 - **More import formats** — MIDI and plain-text tab in particular, since those

--- a/docs/examples/monophonic.musicxml
+++ b/docs/examples/monophonic.musicxml
@@ -1,0 +1,139 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.musicxml.org/xsd/musicxml.xsd">
+  <work>
+    <work-title>Monophonic example</work-title>
+  </work>
+  <identification>
+    <encoding>
+      <software>Fermata</software>
+      <encoding-date>2026-08-19</encoding-date>
+    </encoding>
+  </identification>
+  <part-list>
+    <score-part id="P1">
+      <part-name>Guitar</part-name>
+      <score-instrument id="P1-I1">
+        <instrument-name>Guitar</instrument-name>
+      </score-instrument>
+      <midi-instrument id="P1-I1">
+        <midi-channel>1</midi-channel>
+        <midi-program>25</midi-program>
+      </midi-instrument>
+    </score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>480</divisions>
+        <key>
+          <fifths>0</fifths>
+        </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+        </time>
+        <clef>
+          <sign>TAB</sign>
+          <line>5</line>
+        </clef>
+        <staff-details>
+          <staff-lines>6</staff-lines>
+          <staff-tuning line="1">
+            <tuning-step>E</tuning-step>
+            <tuning-octave>2</tuning-octave>
+          </staff-tuning>
+          <staff-tuning line="2">
+            <tuning-step>A</tuning-step>
+            <tuning-octave>2</tuning-octave>
+          </staff-tuning>
+          <staff-tuning line="3">
+            <tuning-step>D</tuning-step>
+            <tuning-octave>3</tuning-octave>
+          </staff-tuning>
+          <staff-tuning line="4">
+            <tuning-step>G</tuning-step>
+            <tuning-octave>3</tuning-octave>
+          </staff-tuning>
+          <staff-tuning line="5">
+            <tuning-step>B</tuning-step>
+            <tuning-octave>3</tuning-octave>
+          </staff-tuning>
+          <staff-tuning line="6">
+            <tuning-step>E</tuning-step>
+            <tuning-octave>4</tuning-octave>
+          </staff-tuning>
+        </staff-details>
+      </attributes>
+      <direction placement="above">
+        <direction-type>
+          <metronome>
+            <beat-unit>quarter</beat-unit>
+            <per-minute>80</per-minute>
+          </metronome>
+        </direction-type>
+        <sound tempo="80" />
+      </direction>
+      <note>
+        <pitch>
+          <step>E</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>480</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <notations>
+          <technical>
+            <string>1</string>
+            <fret>0</fret>
+          </technical>
+        </notations>
+      </note>
+      <note>
+        <pitch>
+          <step>C</step>
+          <alter>1</alter>
+          <octave>4</octave>
+        </pitch>
+        <duration>480</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <notations>
+          <technical>
+            <string>2</string>
+            <fret>2</fret>
+          </technical>
+        </notations>
+      </note>
+      <note>
+        <pitch>
+          <step>A</step>
+          <octave>3</octave>
+        </pitch>
+        <duration>480</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <notations>
+          <technical>
+            <string>3</string>
+            <fret>2</fret>
+          </technical>
+        </notations>
+      </note>
+      <note>
+        <pitch>
+          <step>G</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>480</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <notations>
+          <technical>
+            <string>1</string>
+            <fret>3</fret>
+          </technical>
+        </notations>
+      </note>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/examples/two-voice.musicxml
+++ b/docs/examples/two-voice.musicxml
@@ -1,0 +1,134 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.musicxml.org/xsd/musicxml.xsd">
+  <work>
+    <work-title>Two-voice example</work-title>
+  </work>
+  <identification>
+    <encoding>
+      <software>Fermata</software>
+      <encoding-date>2026-08-19</encoding-date>
+    </encoding>
+  </identification>
+  <part-list>
+    <score-part id="P1">
+      <part-name>Guitar</part-name>
+      <score-instrument id="P1-I1">
+        <instrument-name>Guitar</instrument-name>
+      </score-instrument>
+      <midi-instrument id="P1-I1">
+        <midi-channel>1</midi-channel>
+        <midi-program>25</midi-program>
+      </midi-instrument>
+    </score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>480</divisions>
+        <key>
+          <fifths>0</fifths>
+        </key>
+        <time>
+          <beats>3</beats>
+          <beat-type>4</beat-type>
+        </time>
+        <clef>
+          <sign>TAB</sign>
+          <line>5</line>
+        </clef>
+        <staff-details>
+          <staff-lines>6</staff-lines>
+          <staff-tuning line="1">
+            <tuning-step>E</tuning-step>
+            <tuning-octave>2</tuning-octave>
+          </staff-tuning>
+          <staff-tuning line="2">
+            <tuning-step>A</tuning-step>
+            <tuning-octave>2</tuning-octave>
+          </staff-tuning>
+          <staff-tuning line="3">
+            <tuning-step>D</tuning-step>
+            <tuning-octave>3</tuning-octave>
+          </staff-tuning>
+          <staff-tuning line="4">
+            <tuning-step>G</tuning-step>
+            <tuning-octave>3</tuning-octave>
+          </staff-tuning>
+          <staff-tuning line="5">
+            <tuning-step>B</tuning-step>
+            <tuning-octave>3</tuning-octave>
+          </staff-tuning>
+          <staff-tuning line="6">
+            <tuning-step>E</tuning-step>
+            <tuning-octave>4</tuning-octave>
+          </staff-tuning>
+        </staff-details>
+      </attributes>
+      <note>
+        <pitch>
+          <step>E</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>480</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <notations>
+          <technical>
+            <string>1</string>
+            <fret>0</fret>
+          </technical>
+        </notations>
+      </note>
+      <note>
+        <pitch>
+          <step>D</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>480</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <notations>
+          <technical>
+            <string>2</string>
+            <fret>3</fret>
+          </technical>
+        </notations>
+      </note>
+      <note>
+        <pitch>
+          <step>F</step>
+          <alter>1</alter>
+          <octave>4</octave>
+        </pitch>
+        <duration>480</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <notations>
+          <technical>
+            <string>1</string>
+            <fret>2</fret>
+          </technical>
+        </notations>
+      </note>
+      <backup>
+        <duration>1440</duration>
+      </backup>
+      <note>
+        <pitch>
+          <step>A</step>
+          <octave>2</octave>
+        </pitch>
+        <duration>1440</duration>
+        <voice>2</voice>
+        <type>half</type>
+        <dot />
+        <notations>
+          <technical>
+            <string>5</string>
+            <fret>0</fret>
+          </technical>
+        </notations>
+      </note>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/musicxml-tab-profile.md
+++ b/docs/musicxml-tab-profile.md
@@ -366,9 +366,14 @@ six positions either way — and both halves of the tie-break earn their place:
 
 **Where this profile guesses, and what it costs.** Two honest limitations:
 
-1. In a key with five or more accidentals, the nearest-position rule can pick a
-   chromatic spelling an engraver would not have — B sharp rather than C
-   natural in B major. It is the right pitch, spelled unusually.
+1. From **four** accidentals up, the nearest-position rule can pick a chromatic
+   spelling an engraver would not have. E major spells F natural as E sharp; A
+   flat major spells B natural as C flat, which also moves the printed octave,
+   since C flat 5 and B natural 4 are the same pitch. B major spells C natural
+   as B sharp. Three accidentals or fewer never produce one. The pitch is
+   correct in every case; only the spelling is unusual, so a reader that
+   derives pitch from `<pitch>` is unaffected and one that renders accidentals
+   literally will show something a human would have written differently.
 2. A producer that cannot read the key signature at all should write
    `<fifths>0</fifths>`, which is what MusicXML means by no key signature, and
    spell accordingly.
@@ -677,8 +682,17 @@ voice and note counts along with the first note's MIDI value, string and fret.
 **What Fermata reports about its own transcriptions.** A transcription's
 warnings and confidence live on the transcription record and in the API
 response, not in the MusicXML — the emitted file is an ordinary score with
-nothing unusual in it. Those warnings include how many measures fail Rule 8, in
-each direction, and how many notes were unwritable under Rule 11.
+nothing unusual in it. The warnings say how many measures fail Rule 8, in each
+direction, and how many notes were unwritable under Rule 11. The same Rule 8
+counts are also returned as numbers — `bars_overfull`, `bars_short`,
+`bars_defective` and `bars_measured` — so a consumer can compare them against
+what its own MusicXML tooling makes of the file.
+
+`bars_defective` counts a measure once whichever way it is wrong. A measure
+with two voices can have one over its meter and the other under it, so
+`bars_overfull + bars_short` double-counts such a measure and can exceed
+`bars_measured`; `bars_defective` is the figure to compare against another
+tool's count, and the one the reported confidence is derived from.
 
 ## Out of scope
 

--- a/docs/musicxml-tab-profile.md
+++ b/docs/musicxml-tab-profile.md
@@ -1,0 +1,740 @@
+# A MusicXML profile for guitar tablature
+
+This document describes how Fermata writes guitar tablature as MusicXML, in
+enough detail that another program can produce files Fermata reads and read
+files Fermata writes.
+
+It is a **profile**, not a format. Every construct used here is defined by
+[MusicXML 4.0](https://www.w3.org/2021/06/musicxml40/); nothing is invented,
+nothing is namespaced into a private extension, and a file that follows this
+profile is an ordinary MusicXML file that opens in any application supporting
+tablature. The profile exists because the specification is deliberately
+permissive: the same tab bar can be encoded several equally valid ways, and two
+programs that each read MusicXML correctly can still fail to agree. Pinning
+down one encoding is what makes interoperation predictable.
+
+The rules below are numbered so they can be cited. They are stated as
+requirements on a **conforming file**. Where a rule goes beyond what MusicXML
+itself requires, that is said explicitly — the specification is silent on
+several things this profile has to decide.
+
+## Contents
+
+- [Scope](#scope)
+- [Conformance rules](#conformance-rules)
+  - [Document form](#document-form-rules-1-3)
+  - [Tab staff description](#tab-staff-description-rules-4-5)
+  - [Voices](#voices-rules-6-8)
+  - [Fret, string and pitch](#fret-string-and-pitch-rules-9-13)
+- [Example 1: one monophonic bar](#example-1-one-monophonic-bar)
+- [Example 2: two voices in one bar](#example-2-two-voices-in-one-bar)
+- [Checking a file](#checking-a-file)
+- [Out of scope](#out-of-scope)
+
+## Scope
+
+The profile covers what is needed to represent a fretted-string part read from
+an engraved tab score: the staff and its tuning, barlines and meter, note
+durations including augmentation dots, rests, chords, concurrent voices, and
+the fret, string and sounding pitch of every note.
+
+It covers those things because they are the ones whose encoding is either
+ambiguous or easy to get subtly wrong — string numbering above all, which runs
+opposite to staff-line numbering and produces a file that validates cleanly
+while placing every note on the wrong string.
+
+It does not cover playing techniques whose encoding is settled but whose
+rendering varies widely between applications, nor anything a tab-reading
+extractor cannot determine. Those are listed under [Out of
+scope](#out-of-scope) rather than left as an implied promise.
+
+## Conformance rules
+
+### Document form (Rules 1–3)
+
+**Rule 1.** A conforming file is a `score-partwise` document with
+`version="4.0"`, encoded UTF-8, and carries **no DOCTYPE**.
+
+Omitting the DOCTYPE is a deliberate departure from the form the MusicXML 4.0
+tutorial shows. Three reasons, all practical:
+
+- The MusicXML DTDs are deprecated as of version 4.0 in favour of the XSD.
+- The public identifier's system URL,
+  `http://www.musicxml.org/dtds/partwise.dtd`, no longer resolves. A parser
+  configured to fetch external DTDs fails outright on a file that names it.
+- An external DTD reference is an XXE and denial-of-service surface, so many
+  XML parsers refuse such a document by default rather than fetching it.
+
+A `DOCTYPE` therefore costs interoperability instead of buying it. A conforming
+**reader**, on the other hand, must tolerate one: a great many real MusicXML
+files in circulation carry it, and they are otherwise fine. Ignore the DTD
+rather than resolving it.
+
+Declaring the schema location is optional and inert for non-validating readers:
+
+```xml
+<score-partwise version="4.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:noNamespaceSchemaLocation="http://www.musicxml.org/xsd/musicxml.xsd">
+```
+
+**Rule 2.** `<divisions>` is declared once, in the first measure's
+`<attributes>`, as a positive integer, and every `<duration>` and `<backup>`
+duration in the file is an exact integer multiple of the note values in use.
+No measure re-declares it.
+
+`<divisions>` is the number of divisions per quarter note. Its value has to be
+chosen so that no duration in the file needs a fraction, because that is what
+lets a consumer check [Rule 8](#voices-rules-6-8) with integer arithmetic
+instead of comparing floating-point sums. The tightest case in this profile's
+duration vocabulary is a double-dotted 32nd note — an eighth of a quarter
+times 7/4, so 7/32 of a quarter — which makes 32 the smallest workable value.
+
+Fermata writes **480**. It is a common choice in files produced by notation
+software, so the output looks ordinary; it also divides by 3 and 5, which
+leaves room for tuplets without a later change of divisions. The specification
+notes that a value above 16383 costs Standard MIDI 1.0 compatibility, so stay
+below that.
+
+A conforming file may use any value satisfying the rule. A conforming reader
+must read the declared value rather than assuming one.
+
+**Rule 3.** The file contains exactly one `<part>`, declared by exactly one
+`<score-part>` in `<part-list>`, with matching `id` attributes. Measures are
+numbered from 1, consecutively, without gaps.
+
+`<part-name>` is required by the schema. `<score-instrument>` and
+`<midi-instrument>` are optional; Fermata writes both, with MIDI program 25
+(General MIDI *Acoustic Guitar (nylon)*), so that a file plays with a
+plausible timbre rather than a default piano. A reader must not require them.
+
+### Tab staff description (Rules 4–5)
+
+**Rule 4.** The first measure's `<attributes>` declares, in this order:
+`<divisions>`, `<key>`, `<time>`, `<clef>` with `<sign>TAB</sign>`, and
+`<staff-details>` containing `<staff-lines>` and one `<staff-tuning>` per
+string. A later measure carries an `<attributes>` element only where the meter
+changes, and then only a `<time>`.
+
+The order is not a style preference. `<attributes>`, `<note>`,
+`<staff-details>` and `<staff-tuning>` are all `xs:sequence` in the schema, so
+each has exactly one legal child order and any other fails validation. The
+sequences that matter here:
+
+| Element | Child order |
+|---|---|
+| `<attributes>` | `divisions`, `key`, `time`, `staves`, `part-symbol`, `instruments`, `clef`, `staff-details`, … |
+| `<staff-details>` | `staff-type`, `staff-lines`, `line-detail`\*, `staff-tuning`\*, `capo`, `staff-size` |
+| `<staff-tuning>` | `tuning-step`, `tuning-alter`?, `tuning-octave` |
+| `<note>` (normal) | `chord`?, (`pitch`\|`unpitched`\|`rest`), `duration`, `tie`\*, `instrument`\*, `footnote`?, `level`?, `voice`?, `type`?, `dot`\*, `accidental`?, `time-modification`?, `stem`?, `notehead`?, `notehead-text`?, `staff`?, `beam`\*, `notations`\*, … |
+
+Two consequences that catch people out: `<voice>` comes **before** `<type>`,
+and `<clef>` comes **before** `<staff-details>`. Both orders read as unnatural
+and both are mandatory.
+
+`<notations>` and `<technical>`, by contrast, are `xs:choice` with unbounded
+repetition, so their children may appear in any order. `<string>` before
+`<fret>` and `<fret>` before `<string>` are both valid.
+
+`<clef><line>` is optional for a TAB sign — the specification says line numbers
+"are only needed with the G, F, and C signs in order to position a pitch
+correctly on the staff". The specification's own tablature example nonetheless
+writes `<line>5</line>`, and this profile follows it rather than inventing a
+different value or leaving it out.
+
+**Rule 5.** In `<staff-tuning>`, the `line` attribute counts staff lines **from
+the bottom**: `line="1"` is the lowest-pitched string. `<capo>`, where present,
+appears after every `<staff-tuning>`, and the tunings are written as the open,
+non-capo values.
+
+This is the rule most likely to be got backwards, and the failure is silent —
+a file with the numbering mirrored validates against the schema and loads in
+every application, with every note on the wrong string.
+
+The reason it is easy to invert is that the two numbering schemes genuinely run
+in opposite directions, and both are normative. From the schema's own
+documentation:
+
+> The staff-line type indicates the line on a given staff. Staff lines are
+> numbered from bottom to top, with 1 being the bottom line on a staff.
+
+> The string-number type indicates a string number. Strings are numbered from
+> high to low, with 1 being the highest pitched full-length string.
+
+`<staff-tuning line=>` is a staff line, and `<string>` is a string number.
+Therefore:
+
+```
+line = staff-lines + 1 - string
+```
+
+For a six-line guitar staff: `line="1"` is the low E and string 6; `line="6"`
+is the high E and string 1. Standard tuning is written bottom-up as E2, A2, D3,
+G3, B3, E4 — see [Example 1](#example-1-one-monophonic-bar).
+
+Beware prose summaries of the tablature tutorial, some of which state the
+opposite. The schema's `staff-line` documentation and the tutorial's own code
+example agree with the rule above.
+
+`<capo>` "indicates at which fret a capo should be placed on a fretted
+instrument. This changes the open tuning of the strings specified by
+staff-tuning by the specified number of half-steps." So a capo does not alter
+the written tunings, and fret numbers stay relative to it:
+
+```
+sounding pitch = tuning + capo + fret
+```
+
+Fermata never writes `<capo>`, because it cannot detect a capo from an
+engraved score. The emitter supports it for other producers, and Fermata reads
+it.
+
+### Voices (Rules 6–8)
+
+**Rule 6.** Voices are written one complete voice at a time. Each voice after
+the first is preceded by a `<backup>` whose `<duration>` equals the total
+duration the preceding voice wrote, returning the writing position to the start
+of the measure. Voices are numbered with the strings `1`, `2`, … from 1,
+consecutively within a measure, in top-to-bottom order.
+
+MusicXML is silent on almost all of this, so most of Rule 6 is this profile's
+choice rather than the specification's requirement. What the specification does
+say:
+
+> The backup and forward elements are required to coordinate multiple voices in
+> one part, including music on multiple staves. […] Duration values should
+> always be positive, and should not cross measure boundaries or mid-measure
+> changes in the divisions value.
+
+> The duration element moves the musical position when used in backup elements,
+> forward elements, and note elements that do not contain a chord child
+> element.
+
+What it does **not** say: whether `<voice>` is scoped to the part or the staff,
+whether numbering starts at 1, or whether the values are numeric at all —
+`<voice>` is typed `xs:string`, so any string validates. This profile requires
+consecutive numeric strings from 1, part-scoped, because a reader has no other
+way to tell how many voices a measure has.
+
+**Rule 7.** The notes of a chord share one onset: the first carries no
+`<chord>`, every subsequent note carries `<chord/>` as its first child, and all
+of them carry the same `<duration>`, `<type>` and `<voice>`.
+
+Only the first note of a chord advances the position. From the specification:
+
+> The duration of a chord note does not move the musical position within a
+> measure. That is done by the duration of the first preceding note without a
+> chord element. Thus the duration of a chord note cannot be longer than the
+> preceding note.
+
+A four-note chord in 4/4 therefore contributes one beat, not four.
+
+**Rule 8.** In every measure, for every voice that appears in it, the sum of
+the durations of that voice's notes and rests — counting chord members once —
+equals the measure's duration, which is
+`divisions × 4 × beats ÷ beat-type`.
+
+This is the profile's central rule and the main reason for choosing MusicXML in
+the first place. **MusicXML does not require it.** There is no statement
+anywhere in the specification that a measure's contents must add up to its
+meter, and plenty of real files in which they do not. It is stated here as a
+requirement because it is the one property that makes a defective tab
+transcription *detectable by a tool nobody involved wrote*.
+
+A transcription derived from an engraved score can get individual durations
+right and still produce a bar that does not add up — an undetected tuplet, a
+flag the reader missed, or two voices that were flattened into one. In a
+bespoke text format, catching that needs bespoke arithmetic. Under Rule 8 it is
+a structural defect that any MusicXML implementation reports.
+
+The checking arithmetic is exactly:
+
+```
+measure duration = divisions * 4 * beats / beat-type
+```
+
+with `beats` and `beat-type` from the `<time>` in effect. The denominator
+matters: 3/4 and 6/8 are both three quarter notes' worth, and using the
+numerator alone gives a compound meter twice its true length.
+
+Two notes on what conformance means in practice:
+
+- A producer must not pad or trim a measure to satisfy Rule 8. Silently
+  inserting a rest to make the sum work hides the defect the rule exists to
+  expose. Fermata emits measures exactly as read and reports how many fail the
+  rule — see [Checking a file](#checking-a-file).
+- A reader should treat a Rule 8 violation as a diagnostic, not a parse error.
+  The file is still valid MusicXML and still largely playable; the affected
+  measures simply drift.
+
+### Fret, string and pitch (Rules 9–13)
+
+**Rule 9.** Every note that sounds carries
+`<notations><technical><string>` and `<fret>`. Frets count from 0 for an open
+string; strings count from 1 for the highest-pitched string. A `<rest>` carries
+neither.
+
+Both conventions are the specification's, verbatim:
+
+> Fret numbers start with 0 for an open string and 1 for the first fret.
+
+> String numbers start with 1 for the highest pitched full-length string.
+
+`<fret>` extends `xs:nonNegativeInteger`, so 0 is legal and a negative fret is
+not; `<string>` extends `string-number`, a restriction of `xs:positiveInteger`,
+so string numbers start at 1. A conforming file's string numbers are all within
+the instrument's string count, so that each resolves against a declared
+`<staff-tuning>`.
+
+**Rule 10.** Every note that sounds also carries `<pitch>`, and its pitch
+agrees with its string, fret, the declared tuning and any capo.
+
+The schema requires exactly one of `<pitch>`, `<unpitched>` or `<rest>` on
+every note; `<fret>` and `<string>` are under `<notations>` and do not
+substitute for it. The specification does not say which to use for tablature —
+the "always use `<unpitched>`" instruction applies to percussion clef, not TAB
+— but every note in its own tablature tutorial uses `<pitch>`, and a fretted
+note has determinate pitch. This profile requires `<pitch>`.
+
+Requiring the two to *agree* is the substantive half of the rule. Nothing in
+MusicXML forces a consumer to derive pitch from string, fret and tuning, and
+nothing forces a producer to keep them consistent, so a file can state one
+pitch in `<pitch>` and imply another in `<technical>`. A conforming file does
+not: a reader may use whichever it prefers and get the same answer.
+
+**Rule 11.** A note's pitch is one `<pitch>` can express. MusicXML's `octave`
+type is an integer from 0 to 9, which bounds pitch to roughly MIDI 12–131.
+
+This sounds like a formality and is not. Fret numbers read from an engraved PDF
+are occasionally not fret numbers: two adjacent single-digit frets that the
+source rendered as one text span arrive as, say, 78, and 78 semitones above a
+string is past the top of the range. Writing it produces an `<octave>` of 10,
+which fails validation and makes the **entire document** unreadable to a
+validating consumer — a far worse outcome than one missing note.
+
+A producer that cannot represent a note must not write it as some other pitch.
+Fermata omits the note, keeps its beat in place as a rest of the same duration
+so that Rule 8 still holds for the measure, and reports the count.
+
+**Rule 12.** Enharmonic spelling — the choice between F sharp and G flat for
+the same sounding pitch — is determined by the key signature in
+`<attributes><key><fifths>`, resolved on the line of fifths as described below.
+
+String, fret and tuning give an exact MIDI number; they say nothing about how
+to spell it, and MusicXML wants `<step>`, `<alter>` and `<octave>`. The key
+signature is what decides.
+
+On the line of fifths, a key *is* a position. The seven diatonic notes of a key
+with `fifths` accidentals occupy positions `fifths-1` through `fifths+5`, so
+the key's centre is at `fifths+2`. C major (`fifths` 0) centres on 2, and its
+positions −1 to 5 are exactly F C G D A E B. Position *n* has:
+
+```
+step  = "FCGDAEB"[(n + 1) mod 7]
+alter = floor((n + 1) / 7)
+pitch class = (7n) mod 12
+```
+
+Each pitch class's spellings lie 12 positions apart (twelve fifths is seven
+octaves), so at most two fall within the single-accidental range −8 (F flat) to
+12 (B sharp), and the **nearer one to the key's centre** is chosen. In C major,
+position 7 (C sharp) is five steps from the centre against D flat's seven, so a
+chromatic C sharp is spelled sharp; E flat, at five against D sharp's seven, is
+spelled flat.
+
+The octave follows from the spelling, not from the MIDI number alone — MIDI 60
+spelled B sharp is octave 3, not 4:
+
+```
+octave = floor((midi - alter - semitone(step)) / 12) - 1
+```
+
+Every note *in* the key is spelled unambiguously by this rule, in every key: a
+key's own seven notes sit within three positions of its centre and their
+enharmonic partners twelve further out, so distance always decides them.
+
+**Rule 13.** Where two spellings are equally distant from the key's centre, the
+one needing no accidental wins; failing that, the flat.
+
+A tie occurs for exactly one pitch class per key — the tritone from the centre,
+six positions either way — and both halves of the tie-break earn their place:
+
+- In C major the tied pair is A flat against G sharp. Both need an accidental,
+  so the flat wins, which is the conventional reading.
+- In A flat major it is E against F flat. Preferring the plain letter is what
+  keeps an ordinary E natural from being written F flat.
+
+**Where this profile guesses, and what it costs.** Two honest limitations:
+
+1. In a key with five or more accidentals, the nearest-position rule can pick a
+   chromatic spelling an engraver would not have — B sharp rather than C
+   natural in B major. It is the right pitch, spelled unusually.
+2. A producer that cannot read the key signature at all should write
+   `<fifths>0</fifths>`, which is what MusicXML means by no key signature, and
+   spell accordingly.
+
+Both cost only how accidentals are written. The sounding pitch, the fret and
+the string are unaffected by the key, so a wrong or missing key signature never
+makes a note wrong — only oddly spelled. That asymmetry is why this profile
+picks a documented default instead of recording per-note uncertainty.
+
+## Example 1: one monophonic bar
+
+One bar of 4/4 at 80 bpm in standard tuning: open first string (E4), second
+string second fret (C sharp 4), third string second fret (A3), first string
+third fret (G4). This file is published as
+[`docs/examples/monophonic.musicxml`](examples/monophonic.musicxml) and is
+validated by the test suite.
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.musicxml.org/xsd/musicxml.xsd">
+  <work>
+    <work-title>Monophonic example</work-title>
+  </work>
+  <identification>
+    <encoding>
+      <software>Fermata</software>
+      <encoding-date>2026-08-19</encoding-date>
+    </encoding>
+  </identification>
+  <part-list>
+    <score-part id="P1">
+      <part-name>Guitar</part-name>
+      <score-instrument id="P1-I1">
+        <instrument-name>Guitar</instrument-name>
+      </score-instrument>
+      <midi-instrument id="P1-I1">
+        <midi-channel>1</midi-channel>
+        <midi-program>25</midi-program>
+      </midi-instrument>
+    </score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>480</divisions>
+        <key>
+          <fifths>0</fifths>
+        </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+        </time>
+        <clef>
+          <sign>TAB</sign>
+          <line>5</line>
+        </clef>
+        <staff-details>
+          <staff-lines>6</staff-lines>
+          <staff-tuning line="1">
+            <tuning-step>E</tuning-step>
+            <tuning-octave>2</tuning-octave>
+          </staff-tuning>
+          <staff-tuning line="2">
+            <tuning-step>A</tuning-step>
+            <tuning-octave>2</tuning-octave>
+          </staff-tuning>
+          <staff-tuning line="3">
+            <tuning-step>D</tuning-step>
+            <tuning-octave>3</tuning-octave>
+          </staff-tuning>
+          <staff-tuning line="4">
+            <tuning-step>G</tuning-step>
+            <tuning-octave>3</tuning-octave>
+          </staff-tuning>
+          <staff-tuning line="5">
+            <tuning-step>B</tuning-step>
+            <tuning-octave>3</tuning-octave>
+          </staff-tuning>
+          <staff-tuning line="6">
+            <tuning-step>E</tuning-step>
+            <tuning-octave>4</tuning-octave>
+          </staff-tuning>
+        </staff-details>
+      </attributes>
+      <direction placement="above">
+        <direction-type>
+          <metronome>
+            <beat-unit>quarter</beat-unit>
+            <per-minute>80</per-minute>
+          </metronome>
+        </direction-type>
+        <sound tempo="80" />
+      </direction>
+      <note>
+        <pitch>
+          <step>E</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>480</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <notations>
+          <technical>
+            <string>1</string>
+            <fret>0</fret>
+          </technical>
+        </notations>
+      </note>
+      <note>
+        <pitch>
+          <step>C</step>
+          <alter>1</alter>
+          <octave>4</octave>
+        </pitch>
+        <duration>480</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <notations>
+          <technical>
+            <string>2</string>
+            <fret>2</fret>
+          </technical>
+        </notations>
+      </note>
+      <note>
+        <pitch>
+          <step>A</step>
+          <octave>3</octave>
+        </pitch>
+        <duration>480</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <notations>
+          <technical>
+            <string>3</string>
+            <fret>2</fret>
+          </technical>
+        </notations>
+      </note>
+      <note>
+        <pitch>
+          <step>G</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>480</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <notations>
+          <technical>
+            <string>1</string>
+            <fret>3</fret>
+          </technical>
+        </notations>
+      </note>
+    </measure>
+  </part>
+</score-partwise>
+```
+
+Rule 8 checks out: the measure duration is `480 × 4 × 4 ÷ 4 = 1920`, and voice
+1 holds four notes of 480 each.
+
+The tempo direction is optional; a file with no tempo simply omits it. The
+`<metronome>` is what gets engraved and `<sound tempo=>` is what a player
+reads, so both are written.
+
+## Example 2: two voices in one bar
+
+One bar of 3/4 in standard tuning. The upper voice plays three quarter notes —
+E4, D4, F sharp 4 — over a lower voice holding one dotted half note, open fifth
+string (A2). The complete file is published as
+[`docs/examples/two-voice.musicxml`](examples/two-voice.musicxml); the header,
+`<part-list>` and `<staff-details>` are identical to Example 1 apart from the
+meter, so only the measure is shown here.
+
+```xml
+<measure number="1">
+  <attributes>
+    <divisions>480</divisions>
+    <key>
+      <fifths>0</fifths>
+    </key>
+    <time>
+      <beats>3</beats>
+      <beat-type>4</beat-type>
+    </time>
+    <clef>
+      <sign>TAB</sign>
+      <line>5</line>
+    </clef>
+    <staff-details>
+      <staff-lines>6</staff-lines>
+      <!-- six <staff-tuning> elements, exactly as in Example 1 -->
+    </staff-details>
+  </attributes>
+  <note>
+    <pitch>
+      <step>E</step>
+      <octave>4</octave>
+    </pitch>
+    <duration>480</duration>
+    <voice>1</voice>
+    <type>quarter</type>
+    <notations>
+      <technical>
+        <string>1</string>
+        <fret>0</fret>
+      </technical>
+    </notations>
+  </note>
+  <note>
+    <pitch>
+      <step>D</step>
+      <octave>4</octave>
+    </pitch>
+    <duration>480</duration>
+    <voice>1</voice>
+    <type>quarter</type>
+    <notations>
+      <technical>
+        <string>2</string>
+        <fret>3</fret>
+      </technical>
+    </notations>
+  </note>
+  <note>
+    <pitch>
+      <step>F</step>
+      <alter>1</alter>
+      <octave>4</octave>
+    </pitch>
+    <duration>480</duration>
+    <voice>1</voice>
+    <type>quarter</type>
+    <notations>
+      <technical>
+        <string>1</string>
+        <fret>2</fret>
+      </technical>
+    </notations>
+  </note>
+  <backup>
+    <duration>1440</duration>
+  </backup>
+  <note>
+    <pitch>
+      <step>A</step>
+      <octave>2</octave>
+    </pitch>
+    <duration>1440</duration>
+    <voice>2</voice>
+    <type>half</type>
+    <dot />
+    <notations>
+      <technical>
+        <string>5</string>
+        <fret>0</fret>
+      </technical>
+    </notations>
+  </note>
+</measure>
+```
+
+The things to note:
+
+- The measure duration is `480 × 4 × 3 ÷ 4 = 1440`. Voice 1 holds three notes
+  of 480; voice 2 holds one of 1440. Both sum to 1440, so Rule 8 holds.
+- The `<backup>` duration is 1440 — the whole of what voice 1 wrote — which
+  returns the position to the start of the measure for voice 2 to begin.
+- Voice 2's note is a dotted half: `<type>half</type>` plus one `<dot/>`, with
+  `<duration>` 1440 rather than 960. The `<type>` and `<dot>` describe how it
+  is written; `<duration>` is what sounds, and the two must agree.
+- Fret 2 on string 1 is F sharp 4 — spelled sharp, not G flat, by Rule 12: in C
+  major, F sharp is nearer the key's centre on the line of fifths.
+
+## Checking a file
+
+Fermata's own output is checked three ways, and any implementation of this
+profile can be checked the same way.
+
+**Schema validation.** Validate against the MusicXML 4.0 XSD, available from
+the [w3c/musicxml](https://github.com/w3c/musicxml) repository. The schema's
+`xs:import` elements name remote URLs for `xml.xsd` and `xlink.xsd`; download
+those alongside it and repoint the `schemaLocation` attributes locally, or
+validation will fail with an unrelated complaint about the `xml:lang`
+attribute. Fermata's test suite validates its examples when
+`FERMATA_MUSICXML_XSD` points at such a copy.
+
+Schema validation catches every child-order mistake in [Rule
+4](#tab-staff-description-rules-4-5) and every out-of-range value in [Rule
+11](#fret-string-and-pitch-rules-9-13). It cannot catch a mirrored string
+numbering or a Rule 8 violation, because both produce perfectly valid XML.
+
+**Measure arithmetic.** Rule 8 is checkable by any MusicXML implementation.
+[music21](https://www.music21.org/) reports it directly: parse the file, and for
+each measure compare each voice's summed `duration.quarterLength` against the
+measure's `barDuration.quarterLength`.
+
+**Round-trip through a renderer.** Loading the file in an application that
+reads tablature is what catches a mirrored string numbering, since the notes
+come back on the wrong strings while everything else looks correct. Fermata
+uses [alphaTab](https://alphatab.net/) for this, via
+`server/tools/tab_extract/verify_musicxml.mjs`, which reports each file's bar,
+voice and note counts along with the first note's MIDI value, string and fret.
+
+**What Fermata reports about its own transcriptions.** A transcription's
+warnings and confidence live on the transcription record and in the API
+response, not in the MusicXML — the emitted file is an ordinary score with
+nothing unusual in it. Those warnings include how many measures fail Rule 8, in
+each direction, and how many notes were unwritable under Rule 11.
+
+## Out of scope
+
+An honest scope statement is more useful than an aspirational one. The
+following are **not** covered by this profile. Some are MusicXML features this
+profile simply does not use; others are things Fermata cannot determine from an
+engraved score. A conforming file does not contain them, and a conforming
+reader need not expect them.
+
+**Techniques whose encoding is settled but whose rendering is not.** MusicXML
+defines all of these under `<technical>`; applications differ enough in how
+faithfully they render and play them that pinning down an encoding here would
+promise more interoperability than exists.
+
+- Bends and bend contours (`<bend>`, `<bend-alter>`, `<pre-bend>`,
+  `<release>`). Bend *shape* in particular renders very differently between
+  applications.
+- Tapping (`<tap>`), hammer-ons and pull-offs (`<hammer-on>`, `<pull-off>`),
+  slides (`<slide>`) and glissandi.
+- Harmonics (`<harmonic>`), whether natural or artificial.
+- Vibrato, tremolo, palm muting, `<open-string>`, `<thumb-position>`,
+  `<golpe>`, `<fingernails>`.
+- Left-hand fingering and right-hand plucking indications (`<fingering>`,
+  `<pluck>`).
+
+**Rhythm and structure this profile does not model.**
+
+- Tuplets (`<time-modification>`, `<tuplet>`). This is why Rule 2's divisions
+  value is chosen to divide by 3 — so adding them later does not require
+  changing it.
+- Ties (`<tie>`, `<tied>`) and slurs.
+- Grace notes, which the schema handles as a separate `<note>` branch with no
+  `<duration>` at all.
+- Repeats, codas, segnos, multiple endings, and any other structural
+  navigation.
+- Beaming (`<beam>`). Readers group notes into beams themselves.
+- Note values shorter than a 32nd, and more than two augmentation dots.
+
+**Score-level things.**
+
+- More than one part, more than one staff per part, and a tab staff paired with
+  its own standard-notation staff in the same part. MusicXML supports the last
+  of these with `<staff-type>alternate</staff-type>`; this profile writes the
+  tab staff alone.
+- Printed accidentals. `<accidental>` is the accidental an engraver *drew*,
+  which is a display decision — courtesy accidentals, cautionary parentheses —
+  distinct from `<alter>`, which is the pitch. This profile writes `<alter>`
+  and omits `<accidental>`, leaving the reader to decide what to print from the
+  pitch and the key signature.
+- Layout: `default-x`, `default-y`, `<print>`, `<defaults>`, page and system
+  breaks. Nothing here positions anything.
+- Lyrics, chord symbols (`<harmony>`), dynamics, articulations, fermatas,
+  arpeggios and ornaments.
+- Key changes part-way through a score. The meter is tracked as a timeline and
+  a change is written where it happens; the key is a single document-level
+  value, because it affects only enharmonic spelling and a later change costs
+  some oddly-spelled accidentals rather than any wrong pitch.
+- Capo detection. `<capo>` is supported on both sides but Fermata never writes
+  it, having no way to read a capo off an engraved score.

--- a/server/fermata/api.py
+++ b/server/fermata/api.py
@@ -418,6 +418,12 @@ def transcribe(score_id: int, body: TranscribeIn | None = Body(default=None)):
     d["time_signature_source"] = result.time_signature_source
     d["key_fifths"] = result.key_fifths
     d["key_signature_source"] = result.key_signature_source
+    # Rule 8 conformance as data, not only as prose in the warning list, so a
+    # caller can compare it against what its own MusicXML tooling reports.
+    d["bars_overfull"] = result.bars_overfull
+    d["bars_short"] = result.bars_short
+    d["bars_defective"] = result.bars_defective
+    d["bars_measured"] = result.bars_measured
     return d
 
 
@@ -432,16 +438,19 @@ class TranscriptionEditIn(BaseModel):
 
 
 def _sniff_transcription_format(content: str) -> str:
-    """Which format an edited transcription is written in, from the content.
+    """Which format an edited transcription is written in, read off the content.
 
-    Unambiguous in practice: a MusicXML document opens with an XML declaration
-    or its root element, and alphaTex has no form in which it can begin with
-    a '<'.
+    This is the only thing that decides an edit's format, because the format of
+    the row being edited says nothing about what was typed into it: pasting
+    alphaTex over a MusicXML transcription used to store it as MusicXML, and
+    the viewer then handed it to the MusicXML loader and rendered nothing.
+
+    The test is that the content begins with '<'. Every MusicXML document does,
+    whether it opens with an XML declaration, a DOCTYPE, a comment or its root
+    element, and alphaTex has no form in which it can - metadata lines begin
+    with a backslash, beats with a colon or a fret number.
     """
-    head = content.lstrip()[:200]
-    if head.startswith("<?xml") or head.startswith("<score-partwise") or head.startswith("<!DOCTYPE"):
-        return "musicxml"
-    return "alphatex"
+    return "musicxml" if content.lstrip().startswith("<") else "alphatex"
 
 
 @router.put("/scores/{score_id}/transcription")

--- a/server/fermata/api.py
+++ b/server/fermata/api.py
@@ -18,7 +18,16 @@ router = APIRouter(prefix="/api")
 
 VALID_KINDS = {"notation", "tab", "both", "unknown"}
 VALID_PRACTICED = {"recent", "neglected"}
-MAX_TRANSCRIPTION_CHARS = 2_000_000
+# MusicXML is a good deal more verbose than alphaTex for the same music: across
+# the sampled library it runs about 44x the characters, and the longest score
+# comes out around 660 KB. This leaves room for a compilation several times
+# longer than anything in that sample.
+MAX_TRANSCRIPTION_CHARS = 8_000_000
+
+# The format a new extraction is stored in. Rows carry their own format, so
+# this changing does not invalidate what is already stored - see transcribe().
+TRANSCRIPTION_FORMAT = "musicxml"
+VALID_TRANSCRIPTION_FORMATS = {"musicxml", "alphatex"}
 
 
 def _score_row(conn, score_id: int):
@@ -372,15 +381,25 @@ def transcribe(score_id: int, body: TranscribeIn | None = Body(default=None)):
 
     # Only ever writes the source='extracted' row (see unique index on
     # (score_id, source) in db.py) - a source='edited' row is untouched.
+    #
+    # MusicXML REPLACES alphaTex as the stored format rather than sitting
+    # beside it: the unique index is (score_id, source) with no format in it,
+    # so two extracted rows in different formats could not coexist anyway, and
+    # a canonical output that is only sometimes canonical is not one. The
+    # `format` column is what makes the swap safe without a data migration -
+    # it is read back and dispatched on (see the web TabViewer), so rows
+    # written before this change keep rendering as the alphaTex they are, and
+    # a hand-edited row stays in whichever format it was edited in until its
+    # author edits it again.
     confidence_json = json.dumps({"warnings": result.warnings, "confidence": result.confidence})
     with tx() as tx_conn:
         tx_conn.execute(
             """INSERT INTO transcriptions(score_id, format, content, source, confidence, updated_at)
-               VALUES (?, 'alphatex', ?, 'extracted', ?, datetime('now'))
+               VALUES (?, ?, ?, 'extracted', ?, datetime('now'))
                ON CONFLICT(score_id, source) DO UPDATE SET
-                   content = excluded.content, confidence = excluded.confidence,
-                   updated_at = datetime('now')""",
-            (score_id, result.alphatex, confidence_json),
+                   format = excluded.format, content = excluded.content,
+                   confidence = excluded.confidence, updated_at = datetime('now')""",
+            (score_id, TRANSCRIPTION_FORMAT, result.musicxml, confidence_json),
         )
 
     conn = connect()
@@ -397,23 +416,49 @@ def transcribe(score_id: int, body: TranscribeIn | None = Body(default=None)):
     d["tuning_label"] = result.tuning_label
     d["time_signature"] = list(result.time_signature) if result.time_signature else None
     d["time_signature_source"] = result.time_signature_source
+    d["key_fifths"] = result.key_fifths
+    d["key_signature_source"] = result.key_signature_source
     return d
 
 
 class TranscriptionEditIn(BaseModel):
     content: str = Field(min_length=1, max_length=MAX_TRANSCRIPTION_CHARS)
+    # Optional because the stored format changed once and could again: a
+    # client that knows what it edited should say so, and one that does not
+    # gets the answer sniffed from the content rather than assumed. Storing
+    # the wrong format here is not a cosmetic mistake - the renderer dispatches
+    # on it, so a MusicXML document labelled alphatex fails to load at all.
+    format: str | None = None
+
+
+def _sniff_transcription_format(content: str) -> str:
+    """Which format an edited transcription is written in, from the content.
+
+    Unambiguous in practice: a MusicXML document opens with an XML declaration
+    or its root element, and alphaTex has no form in which it can begin with
+    a '<'.
+    """
+    head = content.lstrip()[:200]
+    if head.startswith("<?xml") or head.startswith("<score-partwise") or head.startswith("<!DOCTYPE"):
+        return "musicxml"
+    return "alphatex"
 
 
 @router.put("/scores/{score_id}/transcription")
 def save_transcription(score_id: int, body: TranscriptionEditIn):
+    fmt = body.format or _sniff_transcription_format(body.content)
+    if fmt not in VALID_TRANSCRIPTION_FORMATS:
+        raise HTTPException(
+            422, f"format must be one of {sorted(VALID_TRANSCRIPTION_FORMATS)}")
     with tx() as conn:
         _score_row(conn, score_id)
         conn.execute(
             """INSERT INTO transcriptions(score_id, format, content, source, updated_at)
-               VALUES (?, 'alphatex', ?, 'edited', datetime('now'))
+               VALUES (?, ?, ?, 'edited', datetime('now'))
                ON CONFLICT(score_id, source) DO UPDATE SET
-                   content = excluded.content, updated_at = datetime('now')""",
-            (score_id, body.content),
+                   format = excluded.format, content = excluded.content,
+                   updated_at = datetime('now')""",
+            (score_id, fmt, body.content),
         )
     conn = connect()
     row = conn.execute(

--- a/server/fermata/glyph_rhythm.py
+++ b/server/fermata/glyph_rhythm.py
@@ -1544,3 +1544,89 @@ def decode_time_signature(page, staff_top, staff_bottom, staff_x0, spacing=None)
               if staff_top - tol.spacing <= e.yc <= staff_bottom + tol.spacing
               and staff_x0 - tol.drawing_x_pad <= e.x0 <= staff_x0 + lead]
     return _signature_from_window(window, mid)
+
+
+# ---------------------------------------------------------------------------
+# Key signature
+# ---------------------------------------------------------------------------
+
+# The accidental glyphs a key signature is built from. The parenthesised
+# variants are cautionary accidentals printed over a note and are never part
+# of one.
+KEY_ACCIDENTAL_CATS = {"sharp": 1, "flat": -1}
+# What ENDS the key signature: the printed meter. Both the digit form and the
+# common/cut-time symbols count.
+_METER_CATS = set(DIGIT_CATS) | {"common_time", "cut_time"}
+# How far into the staff the clef + up to seven accidentals + the meter
+# reach. Wider than decode_time_signature's own lead window, because a
+# seven-accidental signature pushes the meter further right than the 8.8
+# spacings that window allows for.
+_KEY_LEAD_SPACINGS = 20.0
+# A key signature holds at most seven accidentals (C flat major / C sharp
+# major). More than that in the leading window is not a key signature.
+_MAX_KEY_ACCIDENTALS = 7
+
+
+def decode_key_signature(page, staff_top, staff_bottom, staff_x0, spacing=None):
+    """The key signature printed at the START of this staff, as a MusicXML
+    `fifths` count (positive for sharps, negative for flats), or (None, why).
+
+    Only ever read from a staff that also prints its METER, and only from the
+    accidentals engraved to the LEFT of that meter. That restriction is what
+    makes the reading safe rather than merely plausible: an accidental
+    applying to a single note is engraved immediately before its notehead,
+    which puts it to the RIGHT of the meter, while a key signature is always
+    between the clef and the meter. Without the meter as a right-hand
+    boundary, a piece in C major whose first note happens to be an F sharp
+    reads as G major.
+
+    Engravers print the meter once, at the start of the piece and again only
+    where it changes, but reprint the key signature on every system - so in
+    practice this answers on the first system and declines on the rest, which
+    is all a document-level key needs.
+
+    A wrong answer here costs nothing but an odd enharmonic spelling: fret,
+    string and sounding pitch are computed from the tuning and are unaffected
+    by the key (see musicxml.spell_pitch). That asymmetry is why declining
+    is cheap and why the default when nothing is found is plain `fifths` 0.
+    """
+    tol = _Tol(spacing if spacing else (staff_bottom - staff_top) / 4.0)
+    glyphs = extract_glyph_events(page)
+    if not glyphs.events:
+        return None, "no music glyphs found"
+
+    lead = tol.spacing * _KEY_LEAD_SPACINGS
+    band = [e for e in glyphs.events
+            if staff_top - tol.spacing <= e.yc <= staff_bottom + tol.spacing
+            and staff_x0 - tol.drawing_x_pad <= e.x0 <= staff_x0 + lead]
+    if not band:
+        return None, "no music glyphs at the start of this staff"
+
+    meter_xs = [e.x0 for e in band if e.category in _METER_CATS]
+    if not meter_xs:
+        return None, (
+            "no meter is printed at the start of this staff, so there is no boundary "
+            "separating a key signature from an accidental on the first note"
+        )
+    meter_x0 = min(meter_xs)
+
+    # Right of the clef, left of the meter.
+    clef_xs = [e.x1 for e in band if e.category == "clef"]
+    left = max(clef_xs) if clef_xs else (staff_x0 - tol.drawing_x_pad)
+
+    run = [e for e in band
+           if e.category in KEY_ACCIDENTAL_CATS and left <= e.x0 < meter_x0]
+    if not run:
+        return 0, "no accidentals between the clef and the meter"
+
+    signs = {KEY_ACCIDENTAL_CATS[e.category] for e in run}
+    if len(signs) > 1:
+        return None, "both sharps and flats between the clef and the meter"
+    if len(run) > _MAX_KEY_ACCIDENTALS:
+        return None, (
+            f"{len(run)} accidentals between the clef and the meter - more than a key "
+            "signature can hold"
+        )
+    return signs.pop() * len(run), (
+        f"{len(run)} accidental glyph(s) between the clef and the printed meter"
+    )

--- a/server/fermata/glyph_rhythm.py
+++ b/server/fermata/glyph_rhythm.py
@@ -1468,6 +1468,63 @@ def _cluster_span(cluster):
     return min(e.x0 for e in cluster), max(e.x1 for e in cluster)
 
 
+_METER_SYMBOL_CATS = ("common_time", "cut_time")
+
+
+def _stacked_digit_pairs(window, mid):
+    """Numerator/denominator digit-run pairs in this window: runs above and
+    below `mid` whose x-spans OVERLAP. Returns (pairs, why_not), pairs sorted
+    widest overlap first.
+
+    Overlapping x is what makes two digits a METER rather than two unrelated
+    numerals, and it is the only structural test available - which is why both
+    readers of a printed meter share this one function.
+    _signature_from_window needs the meter's VALUE; _meter_left_edge, for
+    decode_key_signature, needs only its POSITION. Neither may treat a LONE
+    digit as a meter: the small 8 of an octave-transposing treble clef is a
+    digit glyph engraved at the clef, and it is routine in guitar notation.
+    """
+    digits = [e for e in window if e.category in DIGIT_CATS]
+    if len(digits) < 2:
+        return [], f"only {len(digits)} time-signature digit glyph(s) found"
+
+    num_digits = [e for e in digits if e.yc < mid]
+    den_digits = [e for e in digits if e.yc >= mid]
+    if not num_digits or not den_digits:
+        return [], "digit glyphs found but not split across a numerator/denominator band"
+
+    pairs = []
+    for nc in _group_digit_clusters(num_digits):
+        n0, n1 = _cluster_span(nc)
+        for dc in _group_digit_clusters(den_digits):
+            d0, d1 = _cluster_span(dc)
+            overlap = min(n1, d1) - max(n0, d0)
+            if overlap > 0:
+                pairs.append((overlap, nc, dc))
+    if not pairs:
+        return [], "digit glyphs found but numerator/denominator x-spans don't align"
+
+    pairs.sort(key=lambda t: -t[0])
+    return pairs, None
+
+
+def _meter_left_edge(window, mid):
+    """The x of the leftmost printed meter in this window, or (None, why).
+
+    A meter is a common/cut-time symbol, or a numerator digit run stacked over
+    a denominator run - see _stacked_digit_pairs for why a lone digit is not
+    one. Used as the right-hand boundary of the key signature, where getting
+    it too far left silently empties the key signature instead of failing.
+    """
+    edges = [e.x0 for e in window if e.category in _METER_SYMBOL_CATS]
+    pairs, why_not = _stacked_digit_pairs(window, mid)
+    for _overlap, nc, dc in pairs:
+        edges.append(min(_cluster_span(nc)[0], _cluster_span(dc)[0]))
+    if not edges:
+        return None, why_not or "no common-time symbol and no stacked meter digits"
+    return min(edges), None
+
+
 def _signature_from_window(window, mid):
     """Resolve one x-window of glyphs into a time signature, or (None, why)."""
     for e in window:
@@ -1476,36 +1533,16 @@ def _signature_from_window(window, mid):
         if e.category == "cut_time":
             return (2, 2), "cut_time symbol"
 
-    digits = [e for e in window if e.category in DIGIT_CATS]
-    if len(digits) < 2:
-        return None, f"only {len(digits)} time-signature digit glyph(s) found"
-
-    num_digits = [e for e in digits if e.yc < mid]
-    den_digits = [e for e in digits if e.yc >= mid]
-    if not num_digits or not den_digits:
-        return None, "digit glyphs found but not split across a numerator/denominator band"
-
-    num_clusters = _group_digit_clusters(num_digits)
-    den_clusters = _group_digit_clusters(den_digits)
-
-    # A real time signature stacks its numerator and denominator digit runs
-    # at the same x column - pick the numerator/denominator cluster pair
-    # whose x-spans overlap most, and require that match to be unambiguous
-    # (no near-tied second-best pair using a DIFFERENT cluster) before
-    # trusting it. If nothing lines up cleanly, report "not detected"
-    # rather than ever returning a confidently-wrong guess.
-    pairs = []
-    for nc in num_clusters:
-        n0, n1 = _cluster_span(nc)
-        for dc in den_clusters:
-            d0, d1 = _cluster_span(dc)
-            overlap = min(n1, d1) - max(n0, d0)
-            if overlap > 0:
-                pairs.append((overlap, nc, dc))
+    # A real time signature stacks its numerator and denominator digit runs at
+    # the same x column - take the pair whose x-spans overlap most, and require
+    # that match to be unambiguous (no near-tied second-best pair using a
+    # DIFFERENT cluster) before trusting it. If nothing lines up cleanly,
+    # report "not detected" rather than ever returning a confidently-wrong
+    # guess.
+    pairs, why_not = _stacked_digit_pairs(window, mid)
     if not pairs:
-        return None, "digit glyphs found but numerator/denominator x-spans don't align"
+        return None, why_not
 
-    pairs.sort(key=lambda t: -t[0])
     best_overlap, best_nc, best_dc = pairs[0]
     for overlap, nc, dc in pairs[1:]:
         if overlap > best_overlap * 0.6 and (nc is not best_nc or dc is not best_dc):
@@ -1554,9 +1591,6 @@ def decode_time_signature(page, staff_top, staff_bottom, staff_x0, spacing=None)
 # variants are cautionary accidentals printed over a note and are never part
 # of one.
 KEY_ACCIDENTAL_CATS = {"sharp": 1, "flat": -1}
-# What ENDS the key signature: the printed meter. Both the digit form and the
-# common/cut-time symbols count.
-_METER_CATS = set(DIGIT_CATS) | {"common_time", "cut_time"}
 # How far into the staff the clef + up to seven accidentals + the meter
 # reach. Wider than decode_time_signature's own lead window, because a
 # seven-accidental signature pushes the meter further right than the 8.8
@@ -1580,6 +1614,16 @@ def decode_key_signature(page, staff_top, staff_bottom, staff_x0, spacing=None):
     boundary, a piece in C major whose first note happens to be an F sharp
     reads as G major.
 
+    "Meter" here means a real one - a common/cut-time symbol, or a numerator
+    digit run stacked over a denominator run (_meter_left_edge). Accepting any
+    digit as the boundary is not good enough, and fails in the one direction
+    that cannot be noticed: the small 8 of an octave-transposing treble clef is
+    a digit glyph engraved AT the clef, so it collapses the window to nothing,
+    the accidental run comes out empty, and the function returns a confident 0.
+    A piece in E major would be spelled as C major and reported as decoded. The
+    same goes for any stray numeral between two accidentals, which would
+    truncate the run and read four sharps as two.
+
     Engravers print the meter once, at the start of the piece and again only
     where it changes, but reprint the key signature on every system - so in
     practice this answers on the first system and declines on the rest, which
@@ -1602,17 +1646,28 @@ def decode_key_signature(page, staff_top, staff_bottom, staff_x0, spacing=None):
     if not band:
         return None, "no music glyphs at the start of this staff"
 
-    meter_xs = [e.x0 for e in band if e.category in _METER_CATS]
-    if not meter_xs:
+    mid = (staff_top + staff_bottom) / 2
+    meter_x0, why_no_meter = _meter_left_edge(band, mid)
+    if meter_x0 is None:
         return None, (
             "no meter is printed at the start of this staff, so there is no boundary "
-            "separating a key signature from an accidental on the first note"
+            f"separating a key signature from an accidental on the first note ({why_no_meter})"
         )
-    meter_x0 = min(meter_xs)
 
-    # Right of the clef, left of the meter.
-    clef_xs = [e.x1 for e in band if e.category == "clef"]
-    left = max(clef_xs) if clef_xs else (staff_x0 - tol.drawing_x_pad)
+    # Right of the clef, left of the meter. The LEFTMOST clef's right edge: a
+    # courtesy clef further along the system would otherwise push the window's
+    # left wall past the accidentals and empty it.
+    clefs = [e for e in band if e.category == "clef"]
+    left = min(clefs, key=lambda e: e.x0).x1 if clefs else (staff_x0 - tol.drawing_x_pad)
+
+    if meter_x0 <= left:
+        # A degenerate window has no accidentals in it for the same reason an
+        # empty key signature does, and the two must not be confused - "no
+        # sharps or flats" is an answer, "I could not look" is not.
+        return None, (
+            "the printed meter is not to the right of the clef, so no key-signature "
+            "window can be established on this staff"
+        )
 
     run = [e for e in band
            if e.category in KEY_ACCIDENTAL_CATS and left <= e.x0 < meter_x0]

--- a/server/fermata/musicxml.py
+++ b/server/fermata/musicxml.py
@@ -148,10 +148,13 @@ def spell_pitch(midi: int, fifths: int = 0) -> tuple[str, int, int]:
     Diatonic notes are never affected by the tie-break: a key's own seven
     notes sit within three positions of its centre and their enharmonic
     partners twelve further out, so distance alone always decides them. Only
-    chromatic notes are ever in question, and in a key with five or more
-    accidentals the nearest-position rule can pick a spelling an engraver
-    would not have chosen (B sharp rather than C natural in B major). It is
-    the right pitch either way - see the module docstring.
+    chromatic notes are ever in question, and from FOUR accidentals up the
+    nearest-position rule can pick a spelling an engraver would not have
+    chosen. E major spells F natural as E sharp, and A flat major spells B
+    natural as C flat - which also moves the printed octave, since C flat 5
+    and B natural 4 are the same pitch. Three accidentals or fewer never
+    produce one. It is the right pitch either way, only oddly written - see
+    the module docstring.
 
     The octave follows from the spelling rather than from the MIDI number
     alone, so MIDI 60 spelled as B sharp is octave 3, not 4.
@@ -215,10 +218,16 @@ def is_representable(midi: int, fifths: int = 0) -> bool:
     return MIN_OCTAVE <= spell_pitch(midi, fifths)[2] <= MAX_OCTAVE
 
 
-def unrepresentable_notes(measures, tuning, capo=0, fifths=0) -> int:
+def unrepresentable_notes(measures, tuning, fifths=0, capo=None) -> int:
     """How many notes in these measures have no writable `<pitch>`, and so are
     replaced in the emitted score - see build(). Counted from the same
-    predicate the emitter applies, so the report and the file agree."""
+    predicate the emitter applies, so the report and the file agree.
+
+    `fifths` and `capo` mirror build()'s own parameters, in the same order and
+    with the same defaults: both shift which notes are representable at the
+    octave boundary, so a caller that passes one to build() and not to this
+    would get a count that quietly disagrees with the file.
+    """
     tuning = list(tuning) if tuning else []
     if not tuning:
         return 0

--- a/server/fermata/musicxml.py
+++ b/server/fermata/musicxml.py
@@ -1,0 +1,499 @@
+"""MusicXML emission for extracted guitar tablature.
+
+This writes ordinary MusicXML 4.0 - no private elements, no container of our
+own - following the profile documented in docs/musicxml-tab-profile.md. The
+profile exists because MusicXML leaves a good deal of latitude and a tab
+score can be spelled several equally valid ways; pinning one down is what
+lets another program produce files this reads, and read files this writes.
+Rule numbers in the comments below are that document's.
+
+Everything a tab staff needs is already in the specification: `<staff-details>`
+carries `<staff-lines>` and one `<staff-tuning>` per string, and each note
+carries `<notations><technical><string>` and `<fret>`. Per the schema's own
+documentation, "Fret numbers start with 0 for an open string" and "String
+numbers start with 1 for the highest pitched full-length string" - the latter
+being the convention tabextract._Staff.string_for_y already uses.
+
+STRING NUMBER vs STAFF LINE is the one place two numbering schemes run
+opposite each other, and getting it backwards mirrors every note onto the
+wrong string while still validating. The schema's `staff-line` type says
+"Staff lines are numbered from bottom to top, with 1 being the bottom line on
+a staff", and `<staff-tuning line=>` is a staff line - so line 1 is the
+LOWEST-pitched string, while `<string>` 1 is the HIGHEST-pitched. On a
+six-line staff, line = 7 - string. Fermata's `tuning` lists are ordered
+lowest string first, so tuning[i] is line i+1 and no reversal appears here,
+even though the alphaTex emitter needs one.
+
+CHILD ORDER MATTERS. `<attributes>`, `<note>`, `<staff-details>` and
+`<staff-tuning>` are xs:sequence in the schema, so their children have one
+legal order and anything else fails validation outright. The order used below
+is the schema's; see _append_note and _append_attributes. (`<notations>` and
+`<technical>` are xs:choice and their contents may be in any order.)
+
+PITCH. A tab note's sounding pitch is exact: string plus fret plus tuning is
+a MIDI number with nothing inferred. Turning that into MusicXML's
+`<step>`/`<alter>`/`<octave>` is the only genuinely under-determined step,
+because F sharp and G flat are the same MIDI number and the key signature is
+what decides between them. spell_pitch() resolves it on the line of fifths -
+see its docstring - from a key signature read off the score's own engraved
+accidentals (glyph_rhythm.decode_key_signature), defaulting to no accidentals
+where that cannot be read. A wrong key costs an odd enharmonic spelling and
+nothing else: the sounding pitch, the fret and the string are unaffected, so
+this never makes a note WRONG, only oddly spelled.
+"""
+
+from __future__ import annotations
+
+import re
+import xml.etree.ElementTree as ET
+from datetime import date
+
+# Divisions per quarter note (Rule 2). Every duration this emitter can
+# produce has to come out an integer number of divisions, or the arithmetic a
+# consumer does to check Rule 8 stops being exact. The tightest case in
+# tabextract's vocabulary is a double-dotted 32nd - an eighth of a quarter
+# times 7/4, i.e. 7/32 of a quarter - so 32 is the smallest workable value.
+# 480 is used instead because it is what notation programs commonly write, so
+# the files look ordinary, and because it also divides by 3 and 5, leaving
+# room for the tuplets this profile does not yet cover without having to
+# change divisions. The schema's own guidance caps it: "If maximum
+# compatibility with Standard MIDI 1.0 files is important, do not have the
+# divisions value exceed 16383."
+DIVISIONS = 480
+
+# tabextract's duration codes (a code is the note value's denominator: 4 is a
+# quarter) to MusicXML `<type>` names.
+TYPE_NAMES = {
+    1: "whole",
+    2: "half",
+    4: "quarter",
+    8: "eighth",
+    16: "16th",
+    32: "32nd",
+}
+
+# Augmentation dots multiply a note's written value by these.
+_DOT_FACTORS = (1.0, 1.5, 1.75)
+
+# General MIDI program 25 is Acoustic Guitar (nylon). MusicXML numbers
+# programs from 1, so this is the value as written.
+_MIDI_PROGRAM_NYLON_GUITAR = 25
+
+_STEP_SEMITONES = {"C": 0, "D": 2, "E": 4, "F": 5, "G": 7, "A": 9, "B": 11}
+
+# The line of fifths, as note LETTERS at seven consecutive positions.
+# Position n has letter _FIFTHS_LETTERS[(n + 1) % 7] and alter (n + 1) // 7,
+# so position -1 is F, 0 is C, 5 is B, 6 is F sharp and -2 is B flat.
+_FIFTHS_LETTERS = ("F", "C", "G", "D", "A", "E", "B")
+
+# The spellings spell_pitch will consider, as line-of-fifths positions: F flat
+# (-8) through B sharp (12). That is exactly the single-accidental range -
+# every one of the twelve pitch classes has at least one spelling inside it,
+# and none of them is a double sharp or double flat, so no note ever comes out
+# spelled with an accidental a guitarist would not expect.
+_FIFTHS_MIN = -8
+_FIFTHS_MAX = 12
+
+_PITCH_NAME_RE = re.compile(r"^([A-Ga-g])(#{1,2}|b{1,2}|)(-?\d+)$")
+
+# MusicXML's `positive-divisions` type excludes zero, so a beat that resolved
+# to no duration at all cannot be written as <duration>0</duration> - it has
+# to be left out entirely. See build().
+_MIN_DURATION = 1
+
+# MusicXML's `octave` type is an integer from 0 to 9, so <pitch> simply cannot
+# express anything outside roughly MIDI 12 to 131. That matters here because a
+# fret number is not always a real fret: two adjacent single-digit frets that
+# the PDF rendered as one text span come through as e.g. 78, and 78 semitones
+# above a string puts the note past the top of the range. Such a note is
+# already known-bad - tabextract counts frets above _MAX_SANE_FRET and warns
+# about them - and writing it anyway makes the whole document fail validation,
+# which is a far worse outcome than one missing note. See is_representable.
+MIN_OCTAVE = 0
+MAX_OCTAVE = 9
+
+
+def _fifths_position(n: int) -> tuple[str, int]:
+    """The (step, alter) at position n on the line of fifths."""
+    return _FIFTHS_LETTERS[(n + 1) % 7], (n + 1) // 7
+
+
+def spell_pitch(midi: int, fifths: int = 0) -> tuple[str, int, int]:
+    """Spell a MIDI note number as MusicXML (step, alter, octave).
+
+    The MIDI number is exact; which of its enharmonic spellings to write is
+    not, and the key signature is what settles it. Both are handled on the
+    line of fifths, where a key signature IS a position: the diatonic notes of
+    a key with `fifths` accidentals occupy positions fifths-1 through
+    fifths+5, so the key's centre sits at fifths+2. C major (fifths 0) centres
+    on 2, and its seven positions -1..5 are exactly F C G D A E B.
+
+    Each pitch class's spellings are 12 positions apart on that line (twelve
+    fifths is seven octaves), so at most two of them fall in the
+    single-accidental range considered here, and the one nearer the key's
+    centre is the one an engraver writes. In C major, position 7 (C sharp) is
+    five steps from the centre against D flat's seven, which is why a
+    chromatic C sharp is spelled sharp; E flat, at five against D sharp's
+    seven, is spelled flat.
+
+    A tie happens for exactly one pitch class per key - the one a tritone from
+    the key's centre, six positions either way - and is broken first toward
+    the spelling that needs NO accidental, then toward the flat. Both halves
+    matter: in C major the tied pair is A flat against G sharp, both accented,
+    and the flat is the conventional reading; in A flat major it is E against
+    F flat, and preferring the plain letter is what keeps a perfectly ordinary
+    E natural from being written F flat. That two-step tie-break is Rule 13's
+    documented default.
+
+    Diatonic notes are never affected by the tie-break: a key's own seven
+    notes sit within three positions of its centre and their enharmonic
+    partners twelve further out, so distance alone always decides them. Only
+    chromatic notes are ever in question, and in a key with five or more
+    accidentals the nearest-position rule can pick a spelling an engraver
+    would not have chosen (B sharp rather than C natural in B major). It is
+    the right pitch either way - see the module docstring.
+
+    The octave follows from the spelling rather than from the MIDI number
+    alone, so MIDI 60 spelled as B sharp is octave 3, not 4.
+    """
+    pitch_class = midi % 12
+    centre = fifths + 2
+    best = None
+    for n in range(_FIFTHS_MIN, _FIFTHS_MAX + 1):
+        if (7 * n) % 12 != pitch_class:
+            continue
+        rank = (abs(n - centre), abs(_fifths_position(n)[1]), n)
+        if best is None or rank < best:
+            best = rank
+    step, alter = _fifths_position(best[-1])
+    octave = (midi - alter - _STEP_SEMITONES[step]) // 12 - 1
+    return step, alter, octave
+
+
+def parse_pitch_name(name) -> tuple[str, int, int]:
+    """A tuning entry like "E2", "F#2" or "Eb3" as (step, alter, octave)."""
+    m = _PITCH_NAME_RE.match(str(name).strip())
+    if not m:
+        raise ValueError(f"not a pitch name: {name!r}")
+    accidentals = m.group(2)
+    alter = len(accidentals) if accidentals.startswith("#") else -len(accidentals)
+    return m.group(1).upper(), alter, int(m.group(3))
+
+
+def pitch_midi(step: str, alter: int, octave: int) -> int:
+    return 12 * (octave + 1) + _STEP_SEMITONES[step] + alter
+
+
+def tuning_midi(name) -> int:
+    return pitch_midi(*parse_pitch_name(name))
+
+
+def open_string_midi(tuning, string: int, capo: int = 0) -> int:
+    """The sounding pitch of an open string, by MusicXML string number.
+
+    `tuning` is ordered lowest string first (tabextract.DEFAULT_TUNING), and
+    string numbers run the other way - string 1 is the highest-pitched - so
+    string n is tuning[len(tuning) - n].
+
+    `<staff-tuning>` records "the open, non-capo tuning", and `<capo>`
+    "changes the open tuning of the strings specified by staff-tuning by the
+    specified number of half-steps" - so a capo raises the sounding pitch
+    without altering the written tuning, and fret numbers stay relative to it.
+    """
+    if not 1 <= string <= len(tuning):
+        raise ValueError(f"string {string} is not on a {len(tuning)}-string instrument")
+    return tuning_midi(tuning[len(tuning) - string]) + (capo or 0)
+
+
+def is_representable(midi: int, fifths: int = 0) -> bool:
+    """Whether `<pitch>` can express this note at all (Rule 11).
+
+    Checked on the spelling rather than on the MIDI number, because the octave
+    is a property of the spelling: MIDI 131 is B9 and representable, while the
+    same pitch spelled C flat would be octave 10 and not.
+    """
+    return MIN_OCTAVE <= spell_pitch(midi, fifths)[2] <= MAX_OCTAVE
+
+
+def unrepresentable_notes(measures, tuning, capo=0, fifths=0) -> int:
+    """How many notes in these measures have no writable `<pitch>`, and so are
+    replaced in the emitted score - see build(). Counted from the same
+    predicate the emitter applies, so the report and the file agree."""
+    tuning = list(tuning) if tuning else []
+    if not tuning:
+        return 0
+    count = 0
+    for measure_in in measures:
+        beats_in, _ts = _split_measure(measure_in, None)
+        for voice in voices_of(beats_in):
+            for _code, _dots, notes in voice:
+                for string, fret in notes or ():
+                    string, fret = int(string), int(fret)
+                    if not 1 <= string <= len(tuning):
+                        count += 1
+                        continue
+                    midi = open_string_midi(tuning, string, capo) + fret
+                    if not is_representable(midi, fifths):
+                        count += 1
+    return count
+
+
+def beat_divisions(duration_code: int, dots: int = 0) -> int:
+    """One beat's length in divisions. An integer by construction, provided
+    duration_code is in TYPE_NAMES - see DIVISIONS."""
+    if not duration_code:
+        return 0
+    factor = _DOT_FACTORS[min(max(dots, 0), len(_DOT_FACTORS) - 1)]
+    return round(DIVISIONS * 4 * factor / duration_code)
+
+
+def measure_divisions(ts) -> int:
+    """One measure's length in divisions for this meter. 3/4 and 6/8 both come
+    to three quarters' worth, so the denominator has to be honoured - the
+    numerator alone would give a compound meter twice its true length."""
+    num, den = ts
+    return round(DIVISIONS * 4 * num / den)
+
+
+def voices_of(beats):
+    """A measure's beats as a list of voices, accepting a flat list of beats as
+    the one-voice case - the same shape tabextract._build_alphatex takes."""
+    if not beats:
+        return []
+    return list(beats) if isinstance(beats[0], list) else [beats]
+
+
+def voice_durations(beats) -> list[int]:
+    """Each voice's total length in divisions, in voice order. This is the
+    left-hand side of Rule 8, computed from the beats model rather than from
+    emitted XML, so a caller can report on a transcription without parsing its
+    own output back in."""
+    return [sum(beat_divisions(code, dots) for code, dots, _notes in voice)
+            for voice in voices_of(beats)]
+
+
+def _sub(parent, tag, text=None, **attrib):
+    el = ET.SubElement(parent, tag, {k: str(v) for k, v in attrib.items()})
+    if text is not None:
+        el.text = str(text)
+    return el
+
+
+def _append_note(measure, duration, type_name, dots, voice, string=None,
+                 fret=None, midi=None, fifths=0, chord=False):
+    """One `<note>`. The schema's sequence for a normal note is: chord?,
+    (pitch|unpitched|rest), duration, tie*, instrument*, footnote?, level?,
+    voice?, type?, dot*, accidental?, ..., notations* - so voice comes BEFORE
+    type, and notations last. A rest is the same shape with `<rest/>` in
+    place of `<pitch>` and no `<notations>`.
+    """
+    note = _sub(measure, "note")
+    if string is None:
+        _sub(note, "rest")
+    else:
+        if chord:
+            _sub(note, "chord")
+        step, alter, octave = spell_pitch(midi, fifths)
+        pitch = _sub(note, "pitch")
+        _sub(pitch, "step", step)
+        # <alter> is omitted rather than written as 0: both are legal, and
+        # leaving it out is what notation programs write for a natural.
+        if alter:
+            _sub(pitch, "alter", alter)
+        _sub(pitch, "octave", octave)
+    _sub(note, "duration", duration)
+    _sub(note, "voice", voice)
+    if type_name:
+        _sub(note, "type", type_name)
+    for _ in range(dots):
+        _sub(note, "dot")
+    if string is not None:
+        notations = _sub(note, "notations")
+        technical = _sub(notations, "technical")
+        _sub(technical, "string", string)
+        _sub(technical, "fret", fret)
+
+
+def _append_attributes(measure, ts, fifths, tuning, capo, opening):
+    """`<attributes>` in the schema's order: divisions, key, time, staves,
+    part-symbol, instruments, clef, staff-details. Only the opening measure
+    declares divisions, key, clef and tuning; a later measure carries nothing
+    but a new `<time>`, which is what a meter change is.
+    """
+    attributes = _sub(measure, "attributes")
+    if opening:
+        _sub(attributes, "divisions", DIVISIONS)
+        key = _sub(attributes, "key")
+        _sub(key, "fifths", fifths)
+    if ts:
+        time = _sub(attributes, "time")
+        _sub(time, "beats", ts[0])
+        _sub(time, "beat-type", ts[1])
+    if opening:
+        clef = _sub(attributes, "clef")
+        _sub(clef, "sign", "TAB")
+        # <line> is optional for a TAB sign ("only needed with the G, F, and C
+        # signs in order to position a pitch correctly"), but the spec's own
+        # tablature example writes 5, so emit that rather than invent one.
+        _sub(clef, "line", 5)
+        details = _sub(attributes, "staff-details")
+        # staff-details' sequence is staff-type?, staff-lines, staff-tuning*,
+        # capo?, staff-size? - capo after the tunings, not before.
+        _sub(details, "staff-lines", len(tuning))
+        for index, name in enumerate(tuning):
+            step, alter, octave = parse_pitch_name(name)
+            st = _sub(details, "staff-tuning", line=index + 1)
+            _sub(st, "tuning-step", step)
+            if alter:
+                _sub(st, "tuning-alter", alter)
+            _sub(st, "tuning-octave", octave)
+        if capo:
+            _sub(details, "capo", capo)
+    return attributes
+
+
+def _append_tempo(measure, tempo):
+    direction = _sub(measure, "direction", placement="above")
+    dtype = _sub(direction, "direction-type")
+    metronome = _sub(dtype, "metronome")
+    _sub(metronome, "beat-unit", "quarter")
+    _sub(metronome, "per-minute", tempo)
+    # <sound> is what a player reads; the <metronome> above it is what gets
+    # engraved. Both, so the file looks right and plays right.
+    _sub(direction, "sound", tempo=tempo)
+
+
+def _append_part_list(root, part_id, part_name):
+    """score-part's sequence puts part-name first, then score-instrument, then
+    midi-instrument - whose id must reference the score-instrument's."""
+    part_list = _sub(root, "part-list")
+    score_part = _sub(part_list, "score-part", id=part_id)
+    _sub(score_part, "part-name", part_name)
+    instrument_id = f"{part_id}-I1"
+    instrument = _sub(score_part, "score-instrument", id=instrument_id)
+    _sub(instrument, "instrument-name", part_name)
+    midi = _sub(score_part, "midi-instrument", id=instrument_id)
+    _sub(midi, "midi-channel", 1)
+    _sub(midi, "midi-program", _MIDI_PROGRAM_NYLON_GUITAR)
+
+
+def _split_measure(measure_in, in_effect):
+    """One entry of `measures` as (beats, meter). A bare list of beats - what a
+    caller with no per-measure meter to carry hands over - keeps whatever
+    meter is already in effect."""
+    if measure_in and isinstance(measure_in, tuple) and len(measure_in) == 2:
+        beats_in, measure_ts = measure_in
+    else:
+        beats_in, measure_ts = measure_in, None
+    return beats_in, tuple(measure_ts) if measure_ts else in_effect
+
+
+def build(title, tempo, tuning, ts, measures, fifths=0, capo=None,
+          part_name="Guitar", encoding_date=None):
+    """Emit one tab part as a MusicXML 4.0 `score-partwise` document.
+
+    `measures` is a list of (beats, measure_ts) pairs - or bare beats lists,
+    for a caller with no per-measure meter to carry - where beats is a list of
+    VOICES and each voice a list of (duration_code, dots, notes), notes being
+    a list of (string, fret). That is exactly what tabextract produces and
+    what _build_alphatex consumes, so the two emitters stay interchangeable.
+
+    Voices are written one after another, each after the first preceded by a
+    `<backup>` returning the writing position to the start of the measure
+    (Rule 6), and numbered from 1 in the order given - which tabextract orders
+    top voice first.
+
+    What this deliberately does NOT do is adjust anything to make the
+    arithmetic work. A measure whose voices do not sum to its meter is written
+    exactly as extracted, so it fails Rule 8 and any MusicXML tool will say
+    so. Padding it here would hide a defect the extractor already counts and
+    reports, and the whole point of emitting a standard format is that
+    somebody else's tool can find those.
+
+    The one thing it does refuse to write is a pitch MusicXML has no way to
+    express - see is_representable, and unrepresentable_notes for the count a
+    caller should report.
+
+    No DOCTYPE is written. The MusicXML DTDs are deprecated as of version 4.0,
+    the public DTD URL no longer resolves, and secure-by-default XML parsers
+    refuse a document that carries an external DTD reference at all - so a
+    DOCTYPE line costs interoperability instead of buying it. The
+    xsi:noNamespaceSchemaLocation hint below is the current self-describing
+    form and is inert for readers that do not validate.
+    """
+    tuning = list(tuning) if tuning else []
+    if not tuning:
+        raise ValueError("a tab part needs a tuning: one entry per string, lowest first")
+    part_id = "P1"
+
+    root = ET.Element("score-partwise", {
+        "version": "4.0",
+        "xmlns:xsi": "http://www.w3.org/2001/XMLSchema-instance",
+        "xsi:noNamespaceSchemaLocation": "http://www.musicxml.org/xsd/musicxml.xsd",
+    })
+    # score-partwise' header is a sequence: work?, movement-number?,
+    # movement-title?, identification?, defaults?, credit*, part-list.
+    if title:
+        work = _sub(root, "work")
+        _sub(work, "work-title", title)
+    identification = _sub(root, "identification")
+    encoding = _sub(identification, "encoding")
+    _sub(encoding, "software", "Fermata")
+    _sub(encoding, "encoding-date", encoding_date or date.today().isoformat())
+    _append_part_list(root, part_id, part_name)
+
+    part = _sub(root, "part", id=part_id)
+    in_effect = tuple(ts) if ts else None
+    for index, measure_in in enumerate(measures):
+        beats_in, measure_ts = _split_measure(measure_in, in_effect)
+        measure = _sub(part, "measure", number=index + 1)
+        opening = index == 0
+        if opening or measure_ts != in_effect:
+            _append_attributes(measure, measure_ts, fifths, tuning, capo, opening)
+            in_effect = measure_ts
+        if opening and tempo:
+            _append_tempo(measure, tempo)
+
+        written = 0
+        for voice_number, voice in enumerate(voices_of(beats_in), start=1):
+            if voice_number > 1 and written:
+                backup = _sub(measure, "backup")
+                _sub(backup, "duration", written)
+            written = 0
+            for duration_code, dots, notes in voice:
+                duration = beat_divisions(duration_code, dots)
+                if duration < _MIN_DURATION:
+                    # <duration> is positive-divisions, so there is no way to
+                    # write a zero-length beat. Nothing sounds for no time
+                    # either, so dropping it loses nothing.
+                    continue
+                type_name = TYPE_NAMES.get(duration_code)
+                dot_count = min(max(dots, 0), len(_DOT_FACTORS) - 1)
+                # Notes whose pitch `<pitch>` cannot express are left out
+                # (Rule 11). A beat that loses ALL of its notes that way still
+                # keeps its place, as a rest of the same length: dropping the
+                # beat outright would shorten its voice and break Rule 8 for
+                # the whole measure, which turns one unwritable note into a
+                # measure that reads as defective.
+                writable = []
+                for string, fret in notes or ():
+                    string, fret = int(string), int(fret)
+                    if not 1 <= string <= len(tuning):
+                        continue
+                    midi = open_string_midi(tuning, string, capo) + fret
+                    if is_representable(midi, fifths):
+                        writable.append((string, fret, midi))
+                if not writable:
+                    _append_note(measure, duration, type_name, dot_count, voice_number)
+                else:
+                    for position, (string, fret, midi) in enumerate(writable):
+                        _append_note(
+                            measure, duration, type_name, dot_count, voice_number,
+                            string=string, fret=fret, midi=midi,
+                            fifths=fifths, chord=position > 0,
+                        )
+                written += duration
+
+    ET.indent(root, space="  ")
+    body = ET.tostring(root, encoding="unicode")
+    return f'<?xml version="1.0" encoding="UTF-8"?>\n{body}\n'

--- a/server/fermata/tabextract.py
+++ b/server/fermata/tabextract.py
@@ -68,9 +68,18 @@ splitting on direction wherever it changes would shred a monophonic melody
 into two voices at every crossing. Simultaneity is what distinguishes the
 two, because one voice never has two stems at one onset.
 
+OUTPUT: the canonical format is MusicXML (see musicxml.py and the profile in
+docs/musicxml-tab-profile.md), with the same music also emitted as alphaTex
+for the transcription editor to work in. The measure arithmetic that used to
+be checkable only by a script written here is a conformance rule of that
+profile - every sounding voice's durations sum to the measure's duration - so
+any MusicXML tool can now find a bar that does not add up. _bar_conformance
+counts them from the same beats model the emitters read, in both directions,
+and nothing is padded or trimmed to make the sums come out.
+
 KNOWN LIMITATIONS, deliberately not modeled: tuplets, ties, and any bar
 whose voices the stems do not separate. Bars that still do not add up are
-counted and reported (see _overfull_bars) rather than smoothed over.
+counted and reported (see _bar_conformance) rather than smoothed over.
 """
 
 from __future__ import annotations
@@ -84,6 +93,7 @@ from pathlib import Path
 import fitz  # PyMuPDF
 
 from . import glyph_rhythm as glyph
+from . import musicxml as mxl
 
 DEFAULT_TUNING = ["E2", "A2", "D3", "G3", "B3", "E4"]
 DROP_D_TUNING = ["D2", "A2", "D3", "G3", "B3", "E4"]
@@ -97,6 +107,11 @@ _PLAIN_DURATIONS = [(4.0, 1), (2.0, 2), (1.0, 4), (0.5, 8), (0.25, 16), (0.125, 
 class ExtractionResult:
     extractable: bool
     reason: str | None = None
+    # The canonical output: a MusicXML 4.0 score-partwise document following
+    # the profile in docs/musicxml-tab-profile.md. `alphatex` is the same
+    # music in the renderer's own text format, kept because it is what the
+    # transcription editor is comfortable to hand-edit in.
+    musicxml: str | None = None
     alphatex: str | None = None
     title: str | None = None
     tempo: int | None = None
@@ -104,6 +119,11 @@ class ExtractionResult:
     tuning_label: str | None = None
     time_signature: tuple[int, int] | None = None
     time_signature_source: str = "not detected"
+    # MusicXML's `fifths`: positive for sharps, negative for flats. Only ever
+    # used to choose between enharmonic spellings of the same sounding pitch
+    # (see musicxml.spell_pitch), so 0 is a safe default rather than a claim.
+    key_fifths: int = 0
+    key_signature_source: str = "not detected"
     bars: int = 0
     beats: int = 0
     notes: int = 0
@@ -124,6 +144,7 @@ class ExtractionResult:
         return {
             "extractable": self.extractable,
             "reason": self.reason,
+            "musicxml": self.musicxml,
             "alphatex": self.alphatex,
             "title": self.title,
             "tempo": self.tempo,
@@ -131,6 +152,8 @@ class ExtractionResult:
             "tuning_label": self.tuning_label,
             "time_signature": list(self.time_signature) if self.time_signature else None,
             "time_signature_source": self.time_signature_source,
+            "key_fifths": self.key_fifths,
+            "key_signature_source": self.key_signature_source,
             "bars": self.bars,
             "beats": self.beats,
             "notes": self.notes,
@@ -1388,36 +1411,66 @@ def _voices_of(beats):
     return list(beats) if isinstance(beats[0], list) else [beats]
 
 
+def _voice_quarters(beats) -> list[float]:
+    """Each voice's total length in quarter notes, in voice order - the
+    quantity both _bar_quarters and _bar_conformance are about."""
+    return [sum(_beat_quarters(code, dots) for code, dots, _n in v)
+            for v in _voices_of(beats)]
+
+
 def _bar_quarters(beats) -> float:
     """The longest voice in this bar, in quarter notes. Voices sound
     CONCURRENTLY, so a bar is as long as its longest voice - not the sum of
     them, which is exactly the mistake that made a bar of two-voice writing
     read as double its meter."""
-    return max((sum(_beat_quarters(code, dots) for code, dots, _n in v)
-                for v in _voices_of(beats)), default=0.0)
+    return max(_voice_quarters(beats), default=0.0)
 
 
-def _overfull_bars(measures) -> tuple[int, int]:
-    """Count bars where some voice holds more than its time signature allows.
+def _bar_conformance(measures) -> tuple[int, int, int]:
+    """Count bars whose voices do not add up, in each direction: returns
+    (overfull, short, counted).
 
-    A bar is counted once however many of its voices overflow: it is the bar
-    that plays wrong. Undetected tuplets, a flag the decoder missed, and two
-    voices the stems did not separate all land here, so this stays measured
-    separately from how the durations were obtained - every individual
-    reading can be right while the bar is still not.
+    This is exactly the MusicXML profile's Rule 8 - every sounding voice's
+    durations sum to the measure's duration - measured on the beats model
+    rather than on emitted XML, so the numbers are available whichever format
+    is being written. A bar is counted once however many of its voices are
+    wrong: it is the bar that plays wrong. Undetected tuplets, a flag the
+    decoder missed, and two voices the stems did not separate all land in the
+    overfull count, so this stays measured separately from how the durations
+    were obtained - every individual reading can be right while the bar as a
+    whole is not.
+
+    OVERFULL uses the longest voice and SHORT the shortest, which between them
+    is the same thing as "some voice differs from the meter". Nothing here
+    corrects anything: a bar that does not add up is emitted as it was read,
+    counted, and reported.
     """
     overfull = 0
+    short = 0
     counted = 0
     for beats, ts in measures:
         if not ts:
             continue
         counted += 1
-        if _bar_quarters(beats) > _measure_quarter_length(ts) + 1e-6:
+        budget = _measure_quarter_length(ts)
+        voices = _voice_quarters(beats)
+        if not voices:
+            continue
+        if max(voices) > budget + 1e-6:
             overfull += 1
+        if min(voices) < budget - 1e-6:
+            short += 1
+    return overfull, short, counted
+
+
+def _overfull_bars(measures) -> tuple[int, int]:
+    """Bars holding MORE than their time signature allows, and how many bars
+    were checked - see _bar_conformance."""
+    overfull, _short, counted = _bar_conformance(measures)
     return overfull, counted
 
 
-def _rhythm_report(counts, details, overfull=0, bars=0):
+def _rhythm_report(counts, details, overfull=0, bars=0, short=0):
     """Derive the document's rhythm warnings and confidence string from the
     collected per-staff provenances - the single place that decides both, so
     they cannot drift out of step with each other or with the measure loop.
@@ -1486,6 +1539,13 @@ def _rhythm_report(counts, details, overfull=0, bars=0):
                 "low overall - individual durations were read from the score's own engraving, but "
                 f"{overfull} of {bars} bar(s) do not add up to their time signature"
             )
+    if bars and short:
+        warnings.append(
+            f"{short} of {bars} bar(s) hold less than their time signature allows - a note whose "
+            "duration was read short, or one dropped for want of a fret number, leaves the bar "
+            "with a gap at the end. The emitted score says so rather than padding it out, so any "
+            "MusicXML tool will report those bars too"
+        )
 
     # Surface the concrete per-staff reasons behind any downgrade, capped so
     # a long score can't turn the warning list into a wall of text.
@@ -1728,6 +1788,29 @@ def _build_time_signature_timeline(pages_with_tab):
     return timeline, reasons
 
 
+def _detect_key_signature(pages_with_tab) -> tuple[int, str, str | None]:
+    """The score's key signature as a MusicXML `fifths` count, plus how it was
+    obtained and, where it was not, the decoder's reason.
+
+    Read as ONE document-level value from the first notation staff that yields
+    one, rather than as a timeline the way the meter is. The key is used for
+    nothing but choosing between enharmonic spellings of the same sounding
+    pitch, so a key change part-way through a score costs a handful of
+    oddly-spelled accidentals in the later sections and no wrong notes at all
+    - not worth carrying a second timeline for. Where nothing can be read, 0
+    is used, which is what MusicXML means by "no key signature".
+    """
+    reason = None
+    for _page_idx, page, _tab_staves, std_staves in pages_with_tab:
+        for s in std_staves:
+            fifths, why = glyph.decode_key_signature(page, s.top, s.bottom, s.x0, s.spacing)
+            if fifths is not None:
+                return fifths, "glyph-decoded", None
+            if reason is None:
+                reason = why
+    return 0, "not detected (assumed no key signature)", reason
+
+
 def _extract(doc, pdf_path, time_signature: tuple[int, int] | None) -> ExtractionResult:
     if doc.page_count == 0:
         return ExtractionResult(extractable=False, reason="pdf has no pages")
@@ -1841,6 +1924,12 @@ def _extract(doc, pdf_path, time_signature: tuple[int, int] | None) -> Extractio
         # generic "assumed 4/4".
         for reason in list(dict.fromkeys(ts_reasons))[:3]:
             warnings.append(f"time signature: {reason}")
+
+    # The key signature, for enharmonic spelling only - see
+    # _detect_key_signature and musicxml.spell_pitch.
+    key_fifths, key_source, key_reason = _detect_key_signature(pages_with_tab)
+    if key_reason:
+        warnings.append(f"key signature: {key_reason} - notes are spelled as if there were none")
 
     if len(ts_timeline) > 1:
         changes = ", ".join(f"{n}/{d}" for _, _, (n, d) in ts_timeline[:6])
@@ -1972,9 +2061,9 @@ def _extract(doc, pdf_path, time_signature: tuple[int, int] | None) -> Extractio
 
     # Rhythm warnings and confidence: derived once, from what the staves
     # actually resolved to.
-    overfull_bars, counted_bars = _overfull_bars(all_measures)
+    overfull_bars, short_bars, counted_bars = _bar_conformance(all_measures)
     rhythm_warnings, rhythm_confidence = _rhythm_report(
-        prov_counts, prov_details, overfull_bars, counted_bars
+        prov_counts, prov_details, overfull_bars, counted_bars, short_bars
     )
     warnings.extend(rhythm_warnings)
     # Font-level problems that weren't already the reason a staff degraded
@@ -2024,6 +2113,17 @@ def _extract(doc, pdf_path, time_signature: tuple[int, int] | None) -> Extractio
             "from the PDF's own text (not from a merge) - likely two adjacent notes rendered as "
             "one text span in the source - treat those frets as low confidence"
         )
+    # A fret that high can put a note past the top of MusicXML's octave range,
+    # which no <pitch> element can express. Those are left out of the emitted
+    # score (their beat keeps its place as a rest, so the bar still adds up)
+    # and said so here rather than quietly written as some other pitch.
+    unwritable = mxl.unrepresentable_notes(all_measures, tuning, fifths=key_fifths)
+    if unwritable:
+        warnings.append(
+            f"{unwritable} note(s) sit outside the range a MusicXML pitch can express - an "
+            "impossible fret number puts them there - and are emitted as a rest of the same "
+            "length rather than as a note at some other pitch"
+        )
 
     if not all_measures:
         return ExtractionResult(
@@ -2041,6 +2141,7 @@ def _extract(doc, pdf_path, time_signature: tuple[int, int] | None) -> Extractio
 
     title = Path(pdf_path).stem
     alphatex = _build_alphatex(title, tempo, tuning, ts, all_measures)
+    musicxml = mxl.build(title, tempo, tuning, ts, all_measures, fifths=key_fifths)
     beats_total = sum(len(v) for beats, _ in all_measures for v in _voices_of(beats))
     notes_total = sum(len(notes) for beats, _ in all_measures
                       for v in _voices_of(beats) for _, _, notes in v)
@@ -2060,10 +2161,21 @@ def _extract(doc, pdf_path, time_signature: tuple[int, int] | None) -> Extractio
         "frets": "high - read directly from vector text spans positioned against detected tab staff lines",
         "rhythm": rhythm_confidence,
         "time_signature": ts_confidence,
+        # The key decides between enharmonic spellings of the same sounding
+        # pitch and nothing else, so even a wrong reading here cannot make a
+        # note wrong - only oddly written.
+        "key_signature": (
+            "high - read from the accidentals engraved between the clef and the meter; affects "
+            "enharmonic spelling only"
+            if key_source == "glyph-decoded" else
+            "not detected - notes are spelled as if there were no key signature, which affects "
+            "how accidentals are written and not which pitches sound"
+        ),
     }
 
     return ExtractionResult(
         extractable=True,
+        musicxml=musicxml,
         alphatex=alphatex,
         title=title,
         tempo=tempo,
@@ -2071,6 +2183,8 @@ def _extract(doc, pdf_path, time_signature: tuple[int, int] | None) -> Extractio
         tuning_label=tuning_label,
         time_signature=ts,
         time_signature_source=ts_source,
+        key_fifths=key_fifths,
+        key_signature_source=key_source,
         bars=len(all_measures),
         beats=beats_total,
         notes=notes_total,

--- a/server/fermata/tabextract.py
+++ b/server/fermata/tabextract.py
@@ -89,6 +89,7 @@ import collections
 import re
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import NamedTuple
 
 import fitz  # PyMuPDF
 
@@ -127,6 +128,15 @@ class ExtractionResult:
     bars: int = 0
     beats: int = 0
     notes: int = 0
+    # How many bars fail the MusicXML profile's Rule 8, and how - the same
+    # numbers the warnings state in prose, as data. `bars_defective` counts a
+    # bar once whichever way it is wrong, so it is the one to compare against
+    # what an independent MusicXML tool reports; overfull + short double-counts
+    # a bar that is wrong in both directions at once. See _bar_conformance.
+    bars_overfull: int = 0
+    bars_short: int = 0
+    bars_defective: int = 0
+    bars_measured: int = 0
     # Total tab / standard staff systems found across the whole document
     # (summed across pages) - same definition analyze() uses, not a
     # per-page maximum.
@@ -157,6 +167,10 @@ class ExtractionResult:
             "bars": self.bars,
             "beats": self.beats,
             "notes": self.notes,
+            "bars_overfull": self.bars_overfull,
+            "bars_short": self.bars_short,
+            "bars_defective": self.bars_defective,
+            "bars_measured": self.bars_measured,
             "tab_staff_count": self.tab_staff_count,
             "standard_staff_count": self.standard_staff_count,
             "pages_processed": self.pages_processed,
@@ -1426,9 +1440,24 @@ def _bar_quarters(beats) -> float:
     return max(_voice_quarters(beats), default=0.0)
 
 
-def _bar_conformance(measures) -> tuple[int, int, int]:
-    """Count bars whose voices do not add up, in each direction: returns
-    (overfull, short, counted).
+class _BarConformance(NamedTuple):
+    """How many bars fail the MusicXML profile's Rule 8, and how.
+
+    `defective` counts a bar once whichever way it is wrong - a polyphonic bar
+    can have one voice over its meter and another under it, so overfull + short
+    would count that bar twice and can exceed `counted`. Rule 8 treats both
+    directions as defective, so `defective` is what the reported confidence is
+    derived from.
+    """
+
+    overfull: int
+    short: int
+    defective: int
+    counted: int
+
+
+def _bar_conformance(measures) -> _BarConformance:
+    """Count bars whose voices do not add up, in each direction.
 
     This is exactly the MusicXML profile's Rule 8 - every sounding voice's
     durations sum to the measure's duration - measured on the beats model
@@ -1447,6 +1476,7 @@ def _bar_conformance(measures) -> tuple[int, int, int]:
     """
     overfull = 0
     short = 0
+    defective = 0
     counted = 0
     for beats, ts in measures:
         if not ts:
@@ -1456,28 +1486,33 @@ def _bar_conformance(measures) -> tuple[int, int, int]:
         voices = _voice_quarters(beats)
         if not voices:
             continue
-        if max(voices) > budget + 1e-6:
-            overfull += 1
-        if min(voices) < budget - 1e-6:
-            short += 1
-    return overfull, short, counted
+        over = max(voices) > budget + 1e-6
+        under = min(voices) < budget - 1e-6
+        overfull += over
+        short += under
+        defective += over or under
+    return _BarConformance(overfull, short, defective, counted)
 
 
 def _overfull_bars(measures) -> tuple[int, int]:
     """Bars holding MORE than their time signature allows, and how many bars
     were checked - see _bar_conformance."""
-    overfull, _short, counted = _bar_conformance(measures)
-    return overfull, counted
+    bars = _bar_conformance(measures)
+    return bars.overfull, bars.counted
 
 
-def _rhythm_report(counts, details, overfull=0, bars=0, short=0):
+def _rhythm_report(counts, details, conformance=None):
     """Derive the document's rhythm warnings and confidence string from the
     collected per-staff provenances - the single place that decides both, so
     they cannot drift out of step with each other or with the measure loop.
 
     `counts` is a Counter over the PROV_* values; `details` maps each
     provenance to the distinct per-staff explanations collected for it.
+    `conformance` is a _BarConformance, or None where no bars were measured.
     """
+    conformance = conformance or _BarConformance(0, 0, 0, 0)
+    overfull, short = conformance.overfull, conformance.short
+    defective, bars = conformance.defective, conformance.counted
     glyphs = counts.get(PROV_GLYPHS, 0)
     degraded = counts.get(PROV_GLYPHS_DEGRADED, 0)
     spacing = counts.get(PROV_SPACING, 0)
@@ -1525,7 +1560,6 @@ def _rhythm_report(counts, details, overfull=0, bars=0, short=0):
     # confident reading of every notehead still produces a wrong bar when its
     # voices don't come apart, and playback follows the bar.
     if bars and overfull:
-        share = overfull / bars
         warnings.append(
             f"{overfull} of {bars} bar(s) hold more than their time signature allows. Music "
             "written in two voices (a melody over a separate bass line) is separated into "
@@ -1534,17 +1568,23 @@ def _rhythm_report(counts, details, overfull=0, bars=0, short=0):
             "lands here too - the notes and their individual durations can still be right while "
             "the bar as a whole is not, so playback timing will drift in those bars"
         )
-        if share >= 0.25:
-            confidence = (
-                "low overall - individual durations were read from the score's own engraving, but "
-                f"{overfull} of {bars} bar(s) do not add up to their time signature"
-            )
     if bars and short:
         warnings.append(
             f"{short} of {bars} bar(s) hold less than their time signature allows - a note whose "
             "duration was read short, or one dropped for want of a fret number, leaves the bar "
             "with a gap at the end. The emitted score says so rather than padding it out, so any "
             "MusicXML tool will report those bars too"
+        )
+    # The downgrade is driven by bars that fail Rule 8 in EITHER direction. A
+    # score whose bars are mostly SHORT because notes were dropped is just as
+    # unplayable as one whose bars overflow, and reporting "high - decoded
+    # directly from the ... engraving" over a warning list saying most bars do
+    # not add up is exactly the kind of confident-but-wrong claim the rest of
+    # this module exists to avoid.
+    if bars and defective / bars >= 0.25:
+        confidence = (
+            "low overall - individual durations were read from the score's own engraving, but "
+            f"{defective} of {bars} bar(s) do not add up to their time signature"
         )
 
     # Surface the concrete per-staff reasons behind any downgrade, capped so
@@ -2061,9 +2101,9 @@ def _extract(doc, pdf_path, time_signature: tuple[int, int] | None) -> Extractio
 
     # Rhythm warnings and confidence: derived once, from what the staves
     # actually resolved to.
-    overfull_bars, short_bars, counted_bars = _bar_conformance(all_measures)
+    conformance = _bar_conformance(all_measures)
     rhythm_warnings, rhythm_confidence = _rhythm_report(
-        prov_counts, prov_details, overfull_bars, counted_bars, short_bars
+        prov_counts, prov_details, conformance
     )
     warnings.extend(rhythm_warnings)
     # Font-level problems that weren't already the reason a staff degraded
@@ -2143,8 +2183,13 @@ def _extract(doc, pdf_path, time_signature: tuple[int, int] | None) -> Extractio
     alphatex = _build_alphatex(title, tempo, tuning, ts, all_measures)
     musicxml = mxl.build(title, tempo, tuning, ts, all_measures, fifths=key_fifths)
     beats_total = sum(len(v) for beats, _ in all_measures for v in _voices_of(beats))
+    # What the emitted score actually HOLDS, not what was read off the page:
+    # `unwritable` notes have no expressible pitch and are left out of the
+    # MusicXML (their beat stays, as a rest, so beats_total is unaffected).
+    # Reporting the pre-emission figure made `notes` larger than the canonical
+    # output it is reported beside.
     notes_total = sum(len(notes) for beats, _ in all_measures
-                      for v in _voices_of(beats) for _, _, notes in v)
+                      for v in _voices_of(beats) for _, _, notes in v) - unwritable
 
     ts_confidence = {
         "manual override": "n/a - caller supplied",
@@ -2188,6 +2233,10 @@ def _extract(doc, pdf_path, time_signature: tuple[int, int] | None) -> Extractio
         bars=len(all_measures),
         beats=beats_total,
         notes=notes_total,
+        bars_overfull=conformance.overfull,
+        bars_short=conformance.short,
+        bars_defective=conformance.defective,
+        bars_measured=conformance.counted,
         tab_staff_count=tab_count,
         standard_staff_count=std_count,
         pages_processed=len(pages_with_tab),

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -20,6 +20,12 @@ dependencies = [
 dev = [
     "pytest>=8.0",
     "httpx>=0.27",
+    # Validating emitted MusicXML against the real MusicXML 4.0 XSD, which
+    # needs a schema-aware parser - the standard library has none. The
+    # validation test skips unless FERMATA_MUSICXML_XSD points at a schema, so
+    # this is what makes running it possible rather than what triggers it.
+    # See docs/musicxml-tab-profile.md#checking-a-file.
+    "lxml>=5.0",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/server/tests/test_glyph_rhythm.py
+++ b/server/tests/test_glyph_rhythm.py
@@ -519,3 +519,139 @@ def test_a_seconds_chord_keeps_its_stem_despite_one_displaced_notehead():
                _note(57.0, 100.0, "c")]  # the displaced one, right of the stem
     G._assign_stem_directions(members, {"c": stem})
     assert [m.stem_dir for m in members] == ["up", "up", "up"]
+
+
+# ---------------------------------------------------------------------------
+# Key signature
+# ---------------------------------------------------------------------------
+
+# One synthetic notation staff: five lines 5pt apart, top 200, bottom 220,
+# middle 210. A clef at x 50-66, then the key signature, then the meter.
+_KS_TOP, _KS_BOTTOM, _KS_MID = 200.0, 220.0, 210.0
+
+
+def _ks_clef(x0=50.0):
+    return _ev("clef", x0, 200.0, x0 + 16.0, 220.0)
+
+
+def _ks_meter(x0=110.0):
+    """A stacked 4/4: numerator above the middle line, denominator below, at
+    the same x."""
+    return [
+        _ev("digit4", x0, 200.0, x0 + 7.0, 209.0),
+        _ev("digit4", x0, 211.0, x0 + 7.0, 220.0),
+    ]
+
+
+def _ks_sharps(count, x0=70.0, step=7.0):
+    return [_ev("sharp", x0 + i * step, 203.0, x0 + i * step + 5.0, 213.0)
+            for i in range(count)]
+
+
+def _decode_ks(events, monkeypatch):
+    """Run decode_key_signature over a synthetic glyph set."""
+    page = object()
+    monkeypatch.setattr(
+        G, "extract_glyph_events",
+        lambda _page: G.PageGlyphs(list(events), {"Opus": []}, [], []))
+    return G.decode_key_signature(page, _KS_TOP, _KS_BOTTOM, 48.0, 5.0)
+
+
+def test_key_signature_reads_the_accidentals_between_clef_and_meter(monkeypatch):
+    events = [_ks_clef()] + _ks_sharps(4) + _ks_meter()
+    fifths, why = _decode_ks(events, monkeypatch)
+    assert fifths == 4
+    assert "4 accidental glyph" in why
+
+
+def test_key_signature_counts_flats_as_negative_fifths(monkeypatch):
+    flats = [_ev("flat", 70.0 + i * 7.0, 203.0, 75.0 + i * 7.0, 213.0) for i in range(3)]
+    events = [_ks_clef()] + flats + _ks_meter()
+    fifths, _why = _decode_ks(events, monkeypatch)
+    assert fifths == -3
+
+
+def test_an_octave_transposing_clef_digit_is_not_a_meter_boundary(monkeypatch):
+    """The regression this guard exists for. An octave-transposing treble clef
+    - routine in guitar notation - carries a small 8 below the staff, which is
+    a digit glyph sitting AT the clef, left of the key signature. Treating any
+    digit as the meter collapsed the window to nothing, so the accidental run
+    came out empty and the reader returned a confident 0: a piece in E major
+    silently spelled as C major and reported as glyph-decoded, high
+    confidence. Only a stacked numerator/denominator pair is a meter."""
+    transposing_8 = _ev("digit8", 54.0, 221.0, 60.0, 229.0)  # under the clef
+    events = [_ks_clef(), transposing_8] + _ks_sharps(4) + _ks_meter()
+    fifths, why = _decode_ks(events, monkeypatch)
+    assert fifths == 4, f"transposing clef digit swallowed the key signature: {why}"
+
+
+def test_a_stray_numeral_between_accidentals_does_not_truncate_the_run(monkeypatch):
+    """Same failure in a different disguise: a lone digit part-way through the
+    key signature used to end it, reading four sharps as two."""
+    stray = _ev("digit3", 83.0, 221.0, 88.0, 229.0)
+    events = [_ks_clef(), stray] + _ks_sharps(4) + _ks_meter()
+    fifths, _why = _decode_ks(events, monkeypatch)
+    assert fifths == 4
+
+
+def test_no_printed_meter_declines_rather_than_answering_zero(monkeypatch):
+    """Without the meter as a right-hand boundary there is nothing separating a
+    key signature from an accidental on the first note, so the honest answer is
+    "not detected" - not C major."""
+    events = [_ks_clef()] + _ks_sharps(1)
+    fifths, why = _decode_ks(events, monkeypatch)
+    assert fifths is None
+    assert "no meter is printed" in why
+
+
+def test_a_lone_meter_digit_is_not_enough_to_establish_the_window(monkeypatch):
+    events = [_ks_clef()] + _ks_sharps(2) + [_ev("digit4", 110.0, 200.0, 117.0, 209.0)]
+    fifths, why = _decode_ks(events, monkeypatch)
+    assert fifths is None
+    assert "no meter is printed" in why
+
+
+def test_a_common_time_symbol_is_a_valid_meter_boundary(monkeypatch):
+    events = [_ks_clef()] + _ks_sharps(2) + [_ev("common_time", 110.0, 203.0, 118.0, 217.0)]
+    fifths, _why = _decode_ks(events, monkeypatch)
+    assert fifths == 2
+
+
+def test_an_empty_key_signature_is_zero_not_a_failure(monkeypatch):
+    """C major and A minor really do print no accidentals, and once the window
+    is established that is an answer rather than a miss."""
+    events = [_ks_clef()] + _ks_meter()
+    fifths, why = _decode_ks(events, monkeypatch)
+    assert fifths == 0
+    assert "no accidentals" in why
+
+
+def test_a_meter_left_of_the_clef_declines_instead_of_reading_zero(monkeypatch):
+    """A degenerate window holds no accidentals for the same reason an empty
+    key signature does. The two must not come back as the same answer."""
+    events = [_ks_clef(x0=90.0)] + _ks_sharps(2, x0=70.0) + _ks_meter(x0=50.0)
+    fifths, why = _decode_ks(events, monkeypatch)
+    assert fifths is None
+    assert "not to the right of the clef" in why
+
+
+def test_mixed_sharps_and_flats_are_not_a_key_signature(monkeypatch):
+    events = ([_ks_clef()] + _ks_sharps(1)
+              + [_ev("flat", 80.0, 203.0, 85.0, 213.0)] + _ks_meter())
+    fifths, why = _decode_ks(events, monkeypatch)
+    assert fifths is None
+    assert "both sharps and flats" in why
+
+
+def test_more_accidentals_than_a_key_signature_can_hold_is_declined(monkeypatch):
+    events = [_ks_clef()] + _ks_sharps(8, x0=70.0, step=4.0) + _ks_meter()
+    fifths, why = _decode_ks(events, monkeypatch)
+    assert fifths is None
+    assert "more than a key signature can hold" in why
+
+
+def test_meter_left_edge_takes_the_leftmost_stacked_pair():
+    window = _ks_meter(x0=110.0) + _ks_meter(x0=200.0)
+    edge, why = G._meter_left_edge(window, _KS_MID)
+    assert edge == 110.0
+    assert why is None

--- a/server/tests/test_musicxml.py
+++ b/server/tests/test_musicxml.py
@@ -1,0 +1,570 @@
+"""Tests for the MusicXML emitter and the profile's conformance rules.
+
+These read the emitted document back with a parser rather than matching
+substrings, because the things that go wrong in MusicXML are structural: a
+child in the wrong place still looks right in a diff and fails validation, and
+a mirrored string numbering is invisible in the text but puts every note on
+the wrong string.
+
+Nothing here needs a sheet music library, so it all runs in CI. Validation
+against the real MusicXML 4.0 schema is a separate step and is skipped unless
+FERMATA_MUSICXML_XSD points at a copy of it - see test_validates_against_xsd.
+That is why the child ORDER of every xs:sequence element is asserted directly
+here as well: those assertions are what the schema would have caught, and they
+run whether or not a schema is to hand.
+"""
+
+import os
+import xml.etree.ElementTree as ET
+
+import pytest
+
+from fermata import musicxml, tabextract
+
+DEFAULT_TUNING = tabextract.DEFAULT_TUNING
+DROP_D = tabextract.DROP_D_TUNING
+
+
+def _one_bar(beats, ts=(4, 4), **kwargs):
+    return musicxml.build("T", None, DEFAULT_TUNING, ts, [(beats, ts)], **kwargs)
+
+
+def _root(xml: str):
+    return ET.fromstring(xml)
+
+
+def _notes(root):
+    return root.findall("./part/measure/note")
+
+
+# ---------------------------------------------------------------------------
+# Rules 1-5: document form and required structure
+# ---------------------------------------------------------------------------
+
+
+def test_document_is_score_partwise_version_4():
+    root = _root(_one_bar([[(4, 0, [(1, 0)])]]))
+    assert root.tag == "score-partwise"
+    assert root.get("version") == "4.0"
+
+
+def test_no_doctype_is_emitted():
+    """The MusicXML DTDs are deprecated as of 4.0, the public DTD URL no longer
+    resolves, and secure-by-default XML parsers refuse a document carrying an
+    external DTD reference at all - so a DOCTYPE costs interoperability."""
+    xml = _one_bar([[(4, 0, [(1, 0)])]])
+    assert "<!DOCTYPE" not in xml
+    assert xml.startswith('<?xml version="1.0" encoding="UTF-8"?>')
+
+
+def test_part_list_declares_the_part_the_music_is_in():
+    root = _root(_one_bar([[(4, 0, [(1, 0)])]]))
+    declared = [sp.get("id") for sp in root.findall("./part-list/score-part")]
+    assert declared == ["P1"]
+    assert [p.get("id") for p in root.findall("./part")] == ["P1"]
+    # midi-instrument must reference a score-instrument that exists
+    instruments = {si.get("id") for si in root.findall("./part-list/score-part/score-instrument")}
+    for midi in root.findall("./part-list/score-part/midi-instrument"):
+        assert midi.get("id") in instruments
+
+
+def test_attributes_children_are_in_schema_order():
+    """<attributes> is an xs:sequence, so anything but this order is invalid
+    however sensible it reads."""
+    root = _root(_one_bar([[(4, 0, [(1, 0)])]]))
+    attributes = root.find("./part/measure/attributes")
+    order = [child.tag for child in attributes]
+    assert order == ["divisions", "key", "time", "clef", "staff-details"]
+
+
+def test_note_children_are_in_schema_order():
+    """A normal note's sequence is chord?, pitch, duration, ..., voice, type,
+    dot*, ..., notations - voice BEFORE type, notations last."""
+    root = _root(_one_bar([[(4, 1, [(1, 0), (2, 2)])]]))
+    first, second = _notes(root)
+    assert [c.tag for c in first] == [
+        "pitch", "duration", "voice", "type", "dot", "notations"]
+    # the second note of a chord leads with <chord/>
+    assert [c.tag for c in second] == [
+        "chord", "pitch", "duration", "voice", "type", "dot", "notations"]
+
+
+def test_rest_is_a_note_with_rest_in_place_of_pitch():
+    root = _root(_one_bar([[(4, 0, [])]]))
+    (rest,) = _notes(root)
+    assert [c.tag for c in rest] == ["rest", "duration", "voice", "type"]
+
+
+def test_staff_details_declares_six_lines_and_one_tuning_per_string():
+    root = _root(_one_bar([[(4, 0, [(1, 0)])]]))
+    details = root.find("./part/measure/attributes/staff-details")
+    assert details.findtext("staff-lines") == "6"
+    tunings = details.findall("staff-tuning")
+    assert len(tunings) == 6
+    assert [t.tag for t in details] == ["staff-lines"] + ["staff-tuning"] * 6
+
+
+def test_staff_tuning_line_1_is_the_lowest_string_not_the_highest():
+    """The single most consequential detail in the profile. MusicXML numbers
+    staff LINES from the bottom and STRINGS from the top, so line 1 is the low
+    E and line 6 the high E. Getting it backwards still validates and still
+    loads - it just mirrors every note onto the wrong string."""
+    root = _root(_one_bar([[(4, 0, [(1, 0)])]]))
+    details = root.find("./part/measure/attributes/staff-details")
+    by_line = {
+        t.get("line"): (t.findtext("tuning-step"), t.findtext("tuning-octave"))
+        for t in details.findall("staff-tuning")
+    }
+    assert by_line["1"] == ("E", "2")  # bottom line, string 6, low E
+    assert by_line["2"] == ("A", "2")
+    assert by_line["3"] == ("D", "3")
+    assert by_line["4"] == ("G", "3")
+    assert by_line["5"] == ("B", "3")
+    assert by_line["6"] == ("E", "4")  # top line, string 1, high E
+
+
+def test_drop_d_tuning_lowers_only_the_bottom_line():
+    root = _root(musicxml.build("T", None, DROP_D, (4, 4), [([[(4, 0, [(6, 0)])]], (4, 4))]))
+    details = root.find("./part/measure/attributes/staff-details")
+    tunings = details.findall("staff-tuning")
+    assert (tunings[0].findtext("tuning-step"), tunings[0].findtext("tuning-octave")) == ("D", "2")
+    assert (tunings[5].findtext("tuning-step"), tunings[5].findtext("tuning-octave")) == ("E", "4")
+    # and the open sixth string sounds D2, not E2
+    (note,) = _notes(root)
+    assert note.find("pitch/step").text == "D"
+    assert note.find("pitch/octave").text == "2"
+
+
+def test_tab_clef_is_declared():
+    root = _root(_one_bar([[(4, 0, [(1, 0)])]]))
+    clef = root.find("./part/measure/attributes/clef")
+    assert clef.findtext("sign") == "TAB"
+
+
+def test_every_note_carries_a_string_and_a_fret():
+    beats = [[(8, 0, [(1, 0), (3, 5)]), (8, 0, []), (4, 0, [(6, 12)])]]
+    root = _root(_one_bar(beats))
+    pitched = [n for n in _notes(root) if n.find("rest") is None]
+    assert len(pitched) == 3
+    for note in pitched:
+        technical = note.find("notations/technical")
+        assert technical.findtext("string") is not None
+        assert technical.findtext("fret") is not None
+    # a rest carries neither - there is no string it is not being played on
+    rests = [n for n in _notes(root) if n.find("rest") is not None]
+    assert rests and all(n.find("notations") is None for n in rests)
+
+
+def test_capo_follows_the_tunings_and_raises_the_sounding_pitch():
+    """staff-details' sequence puts capo AFTER every staff-tuning, and the
+    spec defines the tunings as the open, non-capo values - so a capo shows up
+    as an offset, not as rewritten tunings."""
+    root = _root(_one_bar([[(4, 0, [(1, 0)])]], capo=2))
+    details = root.find("./part/measure/attributes/staff-details")
+    assert [c.tag for c in details][-1] == "capo"
+    assert details.findtext("capo") == "2"
+    assert details.findall("staff-tuning")[5].findtext("tuning-step") == "E"
+    (note,) = _notes(root)
+    # open first string, capo at the second fret: F sharp 4, not E4
+    assert note.findtext("pitch/step") == "F"
+    assert note.findtext("pitch/alter") == "1"
+    assert note.findtext("pitch/octave") == "4"
+
+
+# ---------------------------------------------------------------------------
+# Rule 2: divisions
+# ---------------------------------------------------------------------------
+
+
+def test_divisions_makes_every_duration_an_integer():
+    """The point of the chosen divisions value: no duration in the emitter's
+    vocabulary needs a fraction, so a consumer checking Rule 8 does integer
+    arithmetic."""
+    for code in musicxml.TYPE_NAMES:
+        for dots in (0, 1, 2):
+            value = musicxml.beat_divisions(code, dots)
+            assert value == int(value)
+            assert value > 0
+
+
+def test_the_tightest_duration_is_the_double_dotted_thirty_second():
+    # 1/8 of a quarter times 7/4 = 7/32 of a quarter; at 480 divisions that
+    # is 105, and it is the value that decides the minimum for DIVISIONS.
+    assert musicxml.beat_divisions(32, 2) == 105
+    assert musicxml.beat_divisions(4, 0) == musicxml.DIVISIONS
+
+
+def test_measure_divisions_honours_the_denominator():
+    # 6/8 and 3/4 are both three quarters' worth
+    assert musicxml.measure_divisions((6, 8)) == musicxml.measure_divisions((3, 4))
+    assert musicxml.measure_divisions((4, 4)) == 4 * musicxml.DIVISIONS
+
+
+def test_divisions_is_declared_once_and_time_again_only_on_a_change():
+    measures = [
+        ([[(4, 0, [(1, 0)])] * 4], (4, 4)),
+        ([[(4, 0, [(1, 0)])] * 4], (4, 4)),
+        ([[(4, 0, [(1, 0)])] * 3], (3, 4)),
+    ]
+    root = _root(musicxml.build("T", None, DEFAULT_TUNING, (4, 4), measures))
+    bars = root.findall("./part/measure")
+    assert len(bars) == 3
+    assert len(root.findall("./part/measure/attributes/divisions")) == 1
+    assert bars[1].find("attributes") is None
+    # the meter change re-declares <time> and nothing else
+    changed = bars[2].find("attributes")
+    assert [c.tag for c in changed] == ["time"]
+    assert changed.findtext("time/beats") == "3"
+
+
+# ---------------------------------------------------------------------------
+# Rules 6-8: voices, backup, and the sum invariant
+# ---------------------------------------------------------------------------
+
+
+def _voice_sums(measure):
+    """Total duration written per voice, the way an independent consumer would
+    read it: a note's duration advances its voice unless it is a chord member,
+    and <backup> rewinds."""
+    sums = {}
+    for child in measure:
+        if child.tag == "backup":
+            continue
+        if child.tag != "note":
+            continue
+        if child.find("chord") is not None:
+            continue
+        voice = child.findtext("voice")
+        sums[voice] = sums.get(voice, 0) + int(child.findtext("duration"))
+    return sums
+
+
+def test_voices_are_numbered_from_one_in_order():
+    beats = [
+        [(4, 0, [(1, 0)]), (4, 0, [(1, 2)]), (4, 0, [(1, 3)])],
+        [(2, 1, [(5, 0)])],
+    ]
+    root = _root(_one_bar(beats, ts=(3, 4)))
+    voices = [n.findtext("voice") for n in _notes(root)]
+    assert set(voices) == {"1", "2"}
+    # voice 1 is written first, in full, before voice 2 starts
+    assert voices == ["1", "1", "1", "2"]
+
+
+def test_backup_returns_to_the_start_of_the_measure():
+    beats = [
+        [(4, 0, [(1, 0)]), (4, 0, [(1, 2)]), (4, 0, [(1, 3)])],
+        [(2, 1, [(5, 0)])],
+    ]
+    root = _root(_one_bar(beats, ts=(3, 4)))
+    measure = root.find("./part/measure")
+    (backup,) = measure.findall("backup")
+    assert int(backup.findtext("duration")) == 3 * musicxml.DIVISIONS
+
+
+def test_a_monophonic_measure_needs_no_backup():
+    root = _root(_one_bar([[(4, 0, [(1, 0)])] * 4]))
+    assert root.findall("./part/measure/backup") == []
+
+
+def test_both_voices_sum_to_the_measure_duration():
+    beats = [
+        [(4, 0, [(1, 0)]), (4, 0, [(1, 2)]), (4, 0, [(1, 3)])],
+        [(2, 1, [(5, 0)])],
+    ]
+    root = _root(_one_bar(beats, ts=(3, 4)))
+    expected = musicxml.measure_divisions((3, 4))
+    assert _voice_sums(root.find("./part/measure")) == {"1": expected, "2": expected}
+
+
+def test_a_chord_does_not_advance_the_voice():
+    """Every note of a chord carries the same duration, but only the first one
+    moves the position - so a four-note chord in 4/4 still fills one beat."""
+    beats = [[(4, 0, [(6, 0), (5, 2), (4, 2), (3, 1)])] + [(4, 0, [(1, 0)])] * 3]
+    root = _root(_one_bar(beats))
+    measure = root.find("./part/measure")
+    assert len(_notes(root)) == 7
+    assert _voice_sums(measure) == {"1": musicxml.measure_divisions((4, 4))}
+
+
+def test_an_overfull_bar_is_emitted_as_read_not_padded_or_trimmed():
+    """The emitter must not make the arithmetic come out. A bar that does not
+    add up is a defect the extractor already counts, and emitting a standard
+    format is what lets somebody else's tool find it - silently fixing it here
+    would destroy exactly that."""
+    over = [[(4, 0, [(1, 0)])] * 5]  # five quarters in a 4/4 bar
+    root = _root(_one_bar(over))
+    assert _voice_sums(root.find("./part/measure")) == {"1": 5 * musicxml.DIVISIONS}
+    short = [[(4, 0, [(1, 0)])] * 2]
+    root = _root(_one_bar(short))
+    assert _voice_sums(root.find("./part/measure")) == {"1": 2 * musicxml.DIVISIONS}
+
+
+def test_voice_durations_reports_the_same_totals_the_xml_carries():
+    """voice_durations() is what the extractor reports Rule 8 from, so it has
+    to agree with what a consumer reads out of the emitted document."""
+    beats = [
+        [(4, 0, [(1, 0)]), (4, 0, [(1, 2)]), (4, 0, [(1, 3)])],
+        [(2, 1, [(5, 0)])],
+    ]
+    root = _root(_one_bar(beats, ts=(3, 4)))
+    from_model = musicxml.voice_durations(beats)
+    from_xml = _voice_sums(root.find("./part/measure"))
+    assert sorted(from_model) == sorted(from_xml.values())
+
+
+# ---------------------------------------------------------------------------
+# Rules 9-13: fret, string and pitch
+# ---------------------------------------------------------------------------
+
+
+def test_open_strings_sound_their_tuning():
+    for string, expected in enumerate(reversed(DEFAULT_TUNING), start=1):
+        midi = musicxml.open_string_midi(DEFAULT_TUNING, string)
+        assert midi == musicxml.tuning_midi(expected)
+    assert musicxml.open_string_midi(DEFAULT_TUNING, 6) == 40  # low E2
+    assert musicxml.open_string_midi(DEFAULT_TUNING, 1) == 64  # high E4
+
+
+def test_a_fret_raises_the_open_string_by_that_many_semitones():
+    root = _root(_one_bar([[(4, 0, [(3, 2)])]]))
+    (note,) = _notes(root)
+    # third string is G3 (MIDI 55); the second fret is A3
+    assert note.findtext("pitch/step") == "A"
+    assert note.findtext("pitch/octave") == "3"
+    assert note.find("pitch/alter") is None
+
+
+@pytest.mark.parametrize("string,fret,midi", [
+    (1, 0, 64), (1, 12, 76), (2, 0, 59), (3, 0, 55),
+    (4, 0, 50), (5, 0, 45), (6, 0, 40), (6, 3, 43),
+])
+def test_emitted_pitch_matches_the_computed_midi_number(string, fret, midi):
+    root = _root(_one_bar([[(4, 0, [(string, fret)])]]))
+    (note,) = _notes(root)
+    step = note.findtext("pitch/step")
+    alter = int(note.findtext("pitch/alter") or 0)
+    octave = int(note.findtext("pitch/octave"))
+    assert musicxml.pitch_midi(step, alter, octave) == midi
+
+
+def test_spelling_round_trips_for_every_pitch_and_every_key():
+    """A spelling that does not resolve back to the MIDI number it came from
+    is a wrong note, not a stylistic choice."""
+    for fifths in range(-7, 8):
+        for midi in range(0, 128):
+            step, alter, octave = musicxml.spell_pitch(midi, fifths)
+            assert musicxml.pitch_midi(step, alter, octave) == midi
+            # never a double sharp or double flat
+            assert -1 <= alter <= 1
+
+
+@pytest.mark.parametrize("fifths,scale", [
+    (0, ["C", "D", "E", "F", "G", "A", "B"]),
+    (1, ["G", "A", "B", "C", "D", "E", "F#"]),
+    (2, ["D", "E", "F#", "G", "A", "B", "C#"]),
+    (4, ["E", "F#", "G#", "A", "B", "C#", "D#"]),
+    (7, ["C#", "D#", "E#", "F#", "G#", "A#", "B#"]),
+    (-1, ["F", "G", "A", "Bb", "C", "D", "E"]),
+    (-3, ["Eb", "F", "G", "Ab", "Bb", "C", "D"]),
+    (-4, ["Ab", "Bb", "C", "Db", "Eb", "F", "G"]),
+    (-6, ["Gb", "Ab", "Bb", "Cb", "Db", "Eb", "F"]),
+])
+def test_every_note_of_a_key_is_spelled_the_way_the_key_spells_it(fifths, scale):
+    """The part of pitch spelling that is not a matter of taste: a note IN the
+    key has exactly one correct spelling, in every key."""
+    spelled = set()
+    for midi in range(60, 84):
+        step, alter, _octave = musicxml.spell_pitch(midi, fifths)
+        spelled.add(step + ("#" * alter if alter > 0 else "b" * -alter))
+    for name in scale:
+        assert name in spelled, f"{name} missing from {sorted(spelled)} at fifths={fifths}"
+
+
+def test_a_tied_spelling_prefers_the_plain_letter_then_the_flat():
+    # C major: A flat rather than G sharp - both need an accidental, so the
+    # flat wins.
+    assert musicxml.spell_pitch(68, 0)[:2] == ("A", -1)
+    # A flat major: E natural rather than F flat - the plain letter wins
+    # before the flat preference gets a say.
+    assert musicxml.spell_pitch(64, -4)[:2] == ("E", 0)
+
+
+def test_the_key_signature_is_written_once_as_fifths():
+    root = _root(_one_bar([[(4, 0, [(1, 0)])]], fifths=-3))
+    assert root.findtext("./part/measure/attributes/key/fifths") == "-3"
+    assert len(root.findall("./part/measure/attributes/key")) == 1
+
+
+def test_the_key_changes_spelling_but_never_the_sounding_pitch():
+    """Why a mis-read key signature is cheap: it moves the spelling and
+    nothing else."""
+    beats = [[(4, 0, [(2, 2)])]]  # second string, second fret: MIDI 61
+    sharp = _root(_one_bar(beats, fifths=2))
+    flat = _root(_one_bar(beats, fifths=-4))
+    (a,) = _notes(sharp)
+    (b,) = _notes(flat)
+    assert (a.findtext("pitch/step"), a.findtext("pitch/alter")) == ("C", "1")
+    assert (b.findtext("pitch/step"), b.findtext("pitch/alter")) == ("D", "-1")
+    for note in (a, b):
+        step = note.findtext("pitch/step")
+        alter = int(note.findtext("pitch/alter"))
+        assert musicxml.pitch_midi(step, alter, int(note.findtext("pitch/octave"))) == 61
+        assert note.findtext("notations/technical/string") == "2"
+        assert note.findtext("notations/technical/fret") == "2"
+
+
+# ---------------------------------------------------------------------------
+# Odds and ends the emitter must not get wrong
+# ---------------------------------------------------------------------------
+
+
+def test_a_hostile_title_is_escaped_not_injected():
+    title = 'A & B <script>"x"</script>'
+    xml = musicxml.build(title, None, DEFAULT_TUNING, (4, 4), [([[(4, 0, [(1, 0)])]], (4, 4))])
+    root = _root(xml)  # would raise if the title broke the document
+    assert root.findtext("./work/work-title") == title
+    assert "<script>" not in xml
+
+
+def test_tempo_is_emitted_both_for_engraving_and_for_playback():
+    root = _root(musicxml.build("T", 96, DEFAULT_TUNING, (4, 4), [([[(4, 0, [(1, 0)])]], (4, 4))]))
+    direction = root.find("./part/measure/direction")
+    assert direction.findtext("direction-type/metronome/per-minute") == "96"
+    assert direction.find("sound").get("tempo") == "96"
+
+
+def test_no_tempo_means_no_direction_at_all():
+    root = _root(_one_bar([[(4, 0, [(1, 0)])]]))
+    assert root.findall("./part/measure/direction") == []
+
+
+def test_a_tuning_is_required():
+    with pytest.raises(ValueError):
+        musicxml.build("T", None, [], (4, 4), [([[(4, 0, [(1, 0)])]], (4, 4))])
+
+
+def test_a_bare_beats_list_is_accepted_as_the_one_voice_case():
+    """The shape _build_alphatex accepts, so callers can hand either emitter
+    the same measures."""
+    xml = musicxml.build("T", None, DEFAULT_TUNING, (4, 4), [[(4, 0, [(1, 0)])]])
+    root = _root(xml)
+    assert [n.findtext("voice") for n in _notes(root)] == ["1"]
+
+
+def test_measures_are_numbered_from_one_consecutively():
+    measures = [([[(4, 0, [(1, 0)])]], (4, 4))] * 4
+    root = _root(musicxml.build("T", None, DEFAULT_TUNING, (4, 4), measures))
+    assert [m.get("number") for m in root.findall("./part/measure")] == ["1", "2", "3", "4"]
+
+
+# ---------------------------------------------------------------------------
+# Validation against the real schema
+# ---------------------------------------------------------------------------
+
+
+def _emitted_samples():
+    return {
+        "monophonic": musicxml.build(
+            "Monophonic", 80, DEFAULT_TUNING, (4, 4),
+            [([[(4, 0, [(1, 0)]), (4, 0, [(2, 2)]), (4, 0, [(3, 2)]), (4, 0, [(1, 3)])]], (4, 4))],
+            fifths=0),
+        "two-voice": musicxml.build(
+            "Two Voice", None, DEFAULT_TUNING, (3, 4),
+            [([[(4, 0, [(1, 0)]), (4, 0, [(2, 1)]), (4, 0, [(1, 3)])],
+               [(2, 1, [(5, 0)])]], (3, 4))],
+            fifths=1),
+        "everything": musicxml.build(
+            "Everything", 120, DROP_D, (4, 4), [
+                ([[(4, 0, [(6, 0), (5, 2), (4, 2)]), (8, 0, []), (8, 1, [(1, 5)]),
+                   (16, 0, [(2, 3)]), (32, 2, [(2, 5)])]], (4, 4)),
+                ([[(4, 0, [(1, 12)])], [(4, 0, [(6, 3)])]], (1, 4)),
+                ([[(2, 0, [(3, 0)])]], (2, 4)),
+            ], fifths=-2, capo=3),
+    }
+
+
+def test_every_sample_parses_as_xml():
+    for name, xml in _emitted_samples().items():
+        assert ET.fromstring(xml) is not None, name
+
+
+def test_validates_against_xsd():
+    """Validate against the real MusicXML 4.0 schema.
+
+    Skipped unless FERMATA_MUSICXML_XSD points at a local musicxml.xsd, so CI
+    stays hermetic - the schema's own xs:import elements name remote URLs, and
+    a test that silently depends on the network is worse than one that says it
+    was skipped. Point it at a copy whose imports resolve locally.
+    """
+    path = os.environ.get("FERMATA_MUSICXML_XSD")
+    if not path or not os.path.isfile(path):
+        pytest.skip("FERMATA_MUSICXML_XSD not set to a musicxml.xsd")
+    lxml_etree = pytest.importorskip("lxml.etree")
+    schema = lxml_etree.XMLSchema(lxml_etree.parse(path))
+    for name, xml in _emitted_samples().items():
+        doc = lxml_etree.fromstring(xml.encode("utf-8"))
+        if not schema.validate(doc):
+            errors = "; ".join(f"line {e.line}: {e.message}" for e in schema.error_log)
+            pytest.fail(f"{name} failed MusicXML 4.0 validation: {errors}")
+
+
+# ---------------------------------------------------------------------------
+# The examples the profile document publishes
+# ---------------------------------------------------------------------------
+
+
+def _example_paths():
+    """The example files the profile document publishes.
+
+    They live outside server/, so they are absent from a container image built
+    from the server directory alone. Callers skip in that case rather than
+    fail - the files are documentation, not part of the installed package.
+    """
+    import pathlib
+    root = pathlib.Path(__file__).resolve().parents[2] / "docs" / "examples"
+    if not root.is_dir():
+        pytest.skip("docs/examples is not present in this checkout")
+    return sorted(root.glob("*.musicxml"))
+
+
+def test_the_published_examples_exist_and_conform():
+    """docs/musicxml-tab-profile.md publishes these as reference files for
+    another implementation to compare against, so they have to keep passing the
+    rules the document states - an example that drifts out of conformance is
+    worse than no example."""
+    paths = _example_paths()
+    assert [p.name for p in paths] == ["monophonic.musicxml", "two-voice.musicxml"]
+    for path in paths:
+        root = ET.parse(path).getroot()
+        assert root.tag == "score-partwise"
+        assert root.get("version") == "4.0"
+        divisions = int(root.findtext("./part/measure/attributes/divisions"))
+        beats = int(root.findtext("./part/measure/attributes/time/beats"))
+        beat_type = int(root.findtext("./part/measure/attributes/time/beat-type"))
+        expected = round(divisions * 4 * beats / beat_type)
+        for measure in root.findall("./part/measure"):
+            sums = _voice_sums(measure)
+            assert sums, path.name
+            for voice, total in sums.items():
+                assert total == expected, f"{path.name} voice {voice}: {total} != {expected}"
+        for note in root.findall("./part/measure/note"):
+            if note.find("rest") is not None:
+                continue
+            assert note.findtext("notations/technical/string") is not None, path.name
+            assert note.findtext("notations/technical/fret") is not None, path.name
+            octave = int(note.findtext("pitch/octave"))
+            assert musicxml.MIN_OCTAVE <= octave <= musicxml.MAX_OCTAVE
+
+
+def test_the_published_examples_validate_against_xsd():
+    path = os.environ.get("FERMATA_MUSICXML_XSD")
+    if not path or not os.path.isfile(path):
+        pytest.skip("FERMATA_MUSICXML_XSD not set to a musicxml.xsd")
+    lxml_etree = pytest.importorskip("lxml.etree")
+    schema = lxml_etree.XMLSchema(lxml_etree.parse(path))
+    for example in _example_paths():
+        doc = lxml_etree.parse(str(example))
+        if not schema.validate(doc):
+            errors = "; ".join(f"line {e.line}: {e.message}" for e in schema.error_log)
+            pytest.fail(f"{example.name} failed MusicXML 4.0 validation: {errors}")

--- a/server/tests/test_tabextract.py
+++ b/server/tests/test_tabextract.py
@@ -1154,3 +1154,102 @@ def test_calibrated_maestro_still_decodes(zanarkand_pdf):
     assert "own engraving" in result.confidence["rhythm"]
     assert result.time_signature_source == "glyph-decoded"
     assert not any("NOT the calibrated Maestro subset" in w for w in result.warnings)
+
+
+# ---------------------------------------------------------------------------
+# MusicXML as the canonical output
+# ---------------------------------------------------------------------------
+
+
+def test_bar_conformance_counts_both_directions():
+    """The MusicXML profile's Rule 8 measured on the beats model. A bar can be
+    wrong in either direction and both have to be visible - only the overfull
+    count existed before, so a bar with a note missing from it looked clean."""
+    exact = [[(4, 0, [(1, 0)])] * 3]
+    over = [[(4, 0, [(1, 0)])] * 4]
+    short = [[(4, 0, [(1, 0)])] * 2]
+    assert tabextract._bar_conformance([(exact, (3, 4))]) == (0, 0, 1)
+    assert tabextract._bar_conformance([(over, (3, 4))]) == (1, 0, 1)
+    assert tabextract._bar_conformance([(short, (3, 4))]) == (0, 1, 1)
+    # a bar is counted once per direction however many voices are wrong
+    both = [[(4, 0, [(1, 0)])] * 4, [(4, 0, [(2, 0)])] * 2]
+    assert tabextract._bar_conformance([(both, (3, 4))]) == (1, 1, 1)
+    # _overfull_bars keeps its old shape for the callers that want just that
+    assert tabextract._overfull_bars([(over, (3, 4))]) == (1, 1)
+
+
+def test_short_bars_are_reported_not_padded():
+    short = [([[(4, 0, [(1, 0)])] * 2], (3, 4))]
+    warnings, _confidence = tabextract._rhythm_report(
+        collections.Counter({tabextract.PROV_GLYPHS: 1}), {},
+        overfull=0, bars=1, short=1)
+    assert any("hold less than their time signature" in w for w in warnings)
+    # and the emitted score really does carry the short bar as-is
+    from fermata import musicxml
+    assert musicxml.voice_durations(short[0][0]) == [2 * musicxml.DIVISIONS]
+
+
+def test_extract_emits_musicxml_alongside_alphatex(zanarkand_pdf):
+    """Both emitters read the same measures, so their note counts must agree -
+    a MusicXML document holding a different number of notes than the alphaTex
+    for the same score means one of them is dropping beats."""
+    import xml.etree.ElementTree as ET
+
+    result = tabextract.extract(zanarkand_pdf)
+    assert result.musicxml is not None
+    root = ET.fromstring(result.musicxml)
+    assert root.tag == "score-partwise"
+    assert len(root.findall("./part/measure")) == result.bars
+    pitched = [n for n in root.findall("./part/measure/note") if n.find("rest") is None]
+    assert len(pitched) == result.notes
+
+
+def test_extract_decodes_the_key_signature(zanarkand_pdf):
+    result = tabextract.extract(zanarkand_pdf)
+    assert result.key_signature_source == "glyph-decoded"
+    assert -7 <= result.key_fifths <= 7
+    assert "high" in result.confidence["key_signature"]
+
+
+def test_an_impossible_fret_becomes_a_rest_and_the_bar_still_adds_up(tmp_path):
+    """A fret read off a two-digit text span can be nonsense (78, 79 - two
+    adjacent notes rendered as one span), and 78 semitones above a string is
+    past the top of MusicXML's octave range. Writing it anyway made the whole
+    document fail schema validation, which is far worse than one missing note,
+    so the note is dropped - but its beat keeps its place as a rest, or the
+    measure would stop adding up because of it."""
+    import xml.etree.ElementTree as ET
+
+    from fermata import musicxml
+
+    beats = [[(4, 0, [(1, 78)]), (4, 0, [(1, 0)]), (4, 0, [(1, 2)]), (4, 0, [(1, 3)])]]
+    measures = [(beats, (4, 4))]
+    assert musicxml.unrepresentable_notes(measures, tabextract.DEFAULT_TUNING) == 1
+    xml = musicxml.build("T", None, tabextract.DEFAULT_TUNING, (4, 4), measures)
+    root = ET.fromstring(xml)
+    notes = root.findall("./part/measure/note")
+    assert len(notes) == 4
+    assert notes[0].find("rest") is not None
+    assert notes[0].findtext("duration") == str(musicxml.DIVISIONS)
+    # no octave outside what MusicXML can express reached the document
+    for octave in root.findall(".//pitch/octave"):
+        assert musicxml.MIN_OCTAVE <= int(octave.text) <= musicxml.MAX_OCTAVE
+    # and the bar still sums to its meter
+    total = sum(int(n.findtext("duration")) for n in notes if n.find("chord") is None)
+    assert total == musicxml.measure_divisions((4, 4))
+
+
+def test_a_chord_with_one_impossible_fret_keeps_its_other_notes():
+    import xml.etree.ElementTree as ET
+
+    from fermata import musicxml
+
+    beats = [[(4, 0, [(1, 78), (3, 2), (5, 0)])]]
+    xml = musicxml.build("T", None, tabextract.DEFAULT_TUNING, (4, 4), [(beats, (4, 4))])
+    root = ET.fromstring(xml)
+    notes = root.findall("./part/measure/note")
+    assert len(notes) == 2
+    # the surviving notes re-form a chord: the first leads, the second follows
+    assert notes[0].find("chord") is None
+    assert notes[1].find("chord") is not None
+    assert [n.findtext("notations/technical/fret") for n in notes] == ["2", "0"]

--- a/server/tests/test_tabextract.py
+++ b/server/tests/test_tabextract.py
@@ -1007,14 +1007,16 @@ def test_overfull_bars_are_reported_and_cap_the_confidence():
     wrong, because merged voices overfill it. That must not read as high
     confidence, and the count must reach the user."""
     all_glyph = collections.Counter({tabextract.PROV_GLYPHS: 5})
-    w, c = tabextract._rhythm_report(all_glyph, {}, overfull=37, bars=50)
+    w, c = tabextract._rhythm_report(
+        all_glyph, {}, tabextract._BarConformance(37, 0, 37, 50))
     assert any("37 of 50 bar(s) hold more than their time signature" in x for x in w)
     assert any("two voices" in x for x in w)
     assert not c.startswith("high")
     assert "37 of 50" in c
 
     # A stray overfull bar is worth reporting but shouldn't condemn the score.
-    w2, c2 = tabextract._rhythm_report(all_glyph, {}, overfull=1, bars=50)
+    w2, c2 = tabextract._rhythm_report(
+        all_glyph, {}, tabextract._BarConformance(1, 0, 1, 50))
     assert any("1 of 50 bar(s) hold more" in x for x in w2)
     assert c2.startswith("high")
 
@@ -1164,16 +1166,20 @@ def test_calibrated_maestro_still_decodes(zanarkand_pdf):
 def test_bar_conformance_counts_both_directions():
     """The MusicXML profile's Rule 8 measured on the beats model. A bar can be
     wrong in either direction and both have to be visible - only the overfull
-    count existed before, so a bar with a note missing from it looked clean."""
+    count existed before, so a bar with a note missing from it looked clean.
+
+    The fields are (overfull, short, defective, counted)."""
     exact = [[(4, 0, [(1, 0)])] * 3]
     over = [[(4, 0, [(1, 0)])] * 4]
     short = [[(4, 0, [(1, 0)])] * 2]
-    assert tabextract._bar_conformance([(exact, (3, 4))]) == (0, 0, 1)
-    assert tabextract._bar_conformance([(over, (3, 4))]) == (1, 0, 1)
-    assert tabextract._bar_conformance([(short, (3, 4))]) == (0, 1, 1)
-    # a bar is counted once per direction however many voices are wrong
+    assert tabextract._bar_conformance([(exact, (3, 4))]) == (0, 0, 0, 1)
+    assert tabextract._bar_conformance([(over, (3, 4))]) == (1, 0, 1, 1)
+    assert tabextract._bar_conformance([(short, (3, 4))]) == (0, 1, 1, 1)
+    # A bar with one voice over its meter and another under it is wrong ONCE.
+    # overfull + short would count it twice and can exceed the bar count, which
+    # is why `defective` is a field of its own.
     both = [[(4, 0, [(1, 0)])] * 4, [(4, 0, [(2, 0)])] * 2]
-    assert tabextract._bar_conformance([(both, (3, 4))]) == (1, 1, 1)
+    assert tabextract._bar_conformance([(both, (3, 4))]) == (1, 1, 1, 1)
     # _overfull_bars keeps its old shape for the callers that want just that
     assert tabextract._overfull_bars([(over, (3, 4))]) == (1, 1)
 
@@ -1182,11 +1188,58 @@ def test_short_bars_are_reported_not_padded():
     short = [([[(4, 0, [(1, 0)])] * 2], (3, 4))]
     warnings, _confidence = tabextract._rhythm_report(
         collections.Counter({tabextract.PROV_GLYPHS: 1}), {},
-        overfull=0, bars=1, short=1)
+        tabextract._BarConformance(overfull=0, short=1, defective=1, counted=1))
     assert any("hold less than their time signature" in w for w in warnings)
     # and the emitted score really does carry the short bar as-is
     from fermata import musicxml
     assert musicxml.voice_durations(short[0][0]) == [2 * musicxml.DIVISIONS]
+
+
+def test_short_bars_downgrade_confidence_the_same_way_overfull_ones_do():
+    """Rule 8 treats both directions as defective, so the confidence string has
+    to as well. A score whose bars are mostly short because notes were dropped
+    used to report "high - decoded directly from the ... engraving" over a
+    warning list saying most of its bars do not add up."""
+    counts = collections.Counter({tabextract.PROV_GLYPHS: 1})
+    _w, high = tabextract._rhythm_report(
+        counts, {}, tabextract._BarConformance(0, 1, 1, 10))
+    assert high.startswith("high"), high
+
+    _w, low = tabextract._rhythm_report(
+        counts, {}, tabextract._BarConformance(0, 6, 6, 10))
+    assert low.startswith("low overall"), low
+    assert "6 of 10" in low
+
+    # and overfull still downgrades exactly as it did
+    _w, low_over = tabextract._rhythm_report(
+        counts, {}, tabextract._BarConformance(6, 0, 6, 10))
+    assert low_over.startswith("low overall"), low_over
+
+    # a bar wrong in both directions is one defective bar, not two - a 10-bar
+    # score with 2 such bars is 20% defective and must NOT be downgraded
+    _w, still_high = tabextract._rhythm_report(
+        counts, {}, tabextract._BarConformance(2, 2, 2, 10))
+    assert still_high.startswith("high"), still_high
+
+
+def test_reported_note_count_matches_what_the_musicxml_holds():
+    """`notes` is reported beside the MusicXML, so it has to be what the file
+    contains - not what came off the page before the emitter dropped the notes
+    it had no pitch for."""
+    import xml.etree.ElementTree as ET
+
+    from fermata import musicxml
+
+    beats = [[(4, 0, [(1, 78)]), (4, 0, [(1, 0)]), (4, 0, [(1, 2)]), (4, 0, [(1, 3)])]]
+    measures = [(beats, (4, 4))]
+    extracted = sum(len(n) for v in beats for _c, _d, n in v)
+    unwritable = musicxml.unrepresentable_notes(measures, tabextract.DEFAULT_TUNING)
+    root = ET.fromstring(
+        musicxml.build("T", None, tabextract.DEFAULT_TUNING, (4, 4), measures))
+    written = len([n for n in root.findall("./part/measure/note") if n.find("rest") is None])
+    assert extracted == 4
+    assert unwritable == 1
+    assert written == extracted - unwritable
 
 
 def test_extract_emits_musicxml_alongside_alphatex(zanarkand_pdf):
@@ -1253,3 +1306,37 @@ def test_a_chord_with_one_impossible_fret_keeps_its_other_notes():
     assert notes[0].find("chord") is None
     assert notes[1].find("chord") is not None
     assert [n.findtext("notations/technical/fret") for n in notes] == ["2", "0"]
+
+
+def test_reported_conformance_matches_the_emitted_measures(zanarkand_pdf):
+    """The Rule 8 counts are reported as data as well as prose, so they have to
+    agree with what a consumer reads out of the emitted document - which is the
+    whole argument for emitting a standard format."""
+    import xml.etree.ElementTree as ET
+
+    result = tabextract.extract(zanarkand_pdf)
+    root = ET.fromstring(result.musicxml)
+    assert result.bars_measured == result.bars
+
+    defective = 0
+    divisions = int(root.findtext("./part/measure/attributes/divisions"))
+    beats = beat_type = None
+    for measure in root.findall("./part/measure"):
+        time = measure.find("attributes/time")
+        if time is not None:
+            beats = int(time.findtext("beats"))
+            beat_type = int(time.findtext("beat-type"))
+        expected = round(divisions * 4 * beats / beat_type)
+        sums = {}
+        for note in measure.findall("note"):
+            if note.find("chord") is not None:
+                continue
+            voice = note.findtext("voice")
+            sums[voice] = sums.get(voice, 0) + int(note.findtext("duration"))
+        if any(total != expected for total in sums.values()):
+            defective += 1
+    assert defective == result.bars_defective
+    # a bar can be wrong in both directions at once, so these bound it rather
+    # than summing to it
+    assert result.bars_defective <= result.bars_overfull + result.bars_short
+    assert max(result.bars_overfull, result.bars_short) <= result.bars_defective

--- a/server/tests/test_transcription_api.py
+++ b/server/tests/test_transcription_api.py
@@ -158,3 +158,82 @@ def test_delete_transcription_404_when_none_exists(app_env, insert_score):
     with pytest.raises(HTTPException) as exc_info2:
         api.delete_transcription(score_id)
     assert exc_info2.value.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# The stored format
+# ---------------------------------------------------------------------------
+
+
+def test_extraction_is_stored_as_musicxml(app_env, zanarkand_pdf, monkeypatch, insert_score):
+    """MusicXML is the canonical stored format. The row carries its own format
+    rather than the reader assuming one, which is what lets this change land
+    without a data migration."""
+    import xml.etree.ElementTree as ET
+
+    monkeypatch.setattr(api, "LIBRARY_DIR", zanarkand_pdf.parent)
+    conn = db.connect()
+    score_id = insert_score(conn, zanarkand_pdf.name)
+
+    result = api.transcribe(score_id, body=None)
+    assert result["format"] == "musicxml"
+    root = ET.fromstring(result["content"])
+    assert root.tag == "score-partwise"
+    assert root.get("version") == "4.0"
+    assert result["key_signature_source"] == "glyph-decoded"
+
+    fetched = api.get_transcription(score_id)
+    assert fetched["format"] == "musicxml"
+    assert fetched["content"] == result["content"]
+
+
+def test_an_alphatex_edit_is_stored_and_returned_as_alphatex(
+    app_env, zanarkand_pdf, monkeypatch, insert_score
+):
+    """A row written in one format must keep saying so. The renderer dispatches
+    on it, so a hand edit relabelled musicxml would simply fail to load."""
+    monkeypatch.setattr(api, "LIBRARY_DIR", zanarkand_pdf.parent)
+    conn = db.connect()
+    score_id = insert_score(conn, zanarkand_pdf.name)
+    api.transcribe(score_id, body=None)
+
+    tex = '\title "hand edited"\n.\n:4 0.1 |'
+    edited = api.save_transcription(score_id, api.TranscriptionEditIn(content=tex))
+    assert edited["format"] == "alphatex"
+    assert api.get_transcription(score_id)["format"] == "alphatex"
+    # the extracted row underneath is untouched and still MusicXML
+    row = conn.execute(
+        "SELECT format FROM transcriptions WHERE score_id = ? AND source = 'extracted'",
+        (score_id,),
+    ).fetchone()
+    assert row["format"] == "musicxml"
+
+
+def test_an_edit_format_is_sniffed_when_the_client_does_not_say(app_env, insert_score):
+    """A client that does not send `format` gets it read off the content rather
+    than assumed, because assuming wrong makes the transcription unrenderable."""
+    conn = db.connect()
+    score_id = insert_score(conn, "x.pdf")
+    xml = '<?xml version="1.0" encoding="UTF-8"?>\n<score-partwise version="4.0"/>'
+    saved = api.save_transcription(score_id, api.TranscriptionEditIn(content=xml))
+    assert saved["format"] == "musicxml"
+    tex = ":4 0.1 |"
+    saved = api.save_transcription(score_id, api.TranscriptionEditIn(content=tex))
+    assert saved["format"] == "alphatex"
+
+
+def test_an_explicit_edit_format_wins_over_the_sniff(app_env, insert_score):
+    conn = db.connect()
+    score_id = insert_score(conn, "x.pdf")
+    saved = api.save_transcription(
+        score_id, api.TranscriptionEditIn(content=":4 0.1 |", format="musicxml"))
+    assert saved["format"] == "musicxml"
+
+
+def test_an_unknown_edit_format_is_rejected(app_env, insert_score):
+    conn = db.connect()
+    score_id = insert_score(conn, "x.pdf")
+    with pytest.raises(HTTPException) as exc_info:
+        api.save_transcription(
+            score_id, api.TranscriptionEditIn(content=":4 0.1 |", format="lilypond"))
+    assert exc_info.value.status_code == 422

--- a/server/tests/test_transcription_api.py
+++ b/server/tests/test_transcription_api.py
@@ -237,3 +237,46 @@ def test_an_unknown_edit_format_is_rejected(app_env, insert_score):
         api.save_transcription(
             score_id, api.TranscriptionEditIn(content=":4 0.1 |", format="lilypond"))
     assert exc_info.value.status_code == 422
+
+
+def test_pasting_alphatex_over_a_musicxml_row_stores_it_as_alphatex(
+    app_env, zanarkand_pdf, monkeypatch, insert_score
+):
+    """The format of an edit is decided by what was TYPED, not by the format of
+    the row it replaces. Storing the loaded row's format meant a user who
+    pasted alphaTex into the source editor of a MusicXML transcription got a
+    row labelled musicxml; the viewer dispatched on that label, handed alphaTex
+    to the MusicXML loader, and the staff never appeared."""
+    monkeypatch.setattr(api, "LIBRARY_DIR", zanarkand_pdf.parent)
+    conn = db.connect()
+    score_id = insert_score(conn, zanarkand_pdf.name)
+
+    extracted = api.transcribe(score_id, body=None)
+    assert extracted["format"] == "musicxml"
+
+    tex = '\title "hand edited"\n.\n:4 0.1 |'
+    saved = api.save_transcription(score_id, api.TranscriptionEditIn(content=tex))
+    assert saved["format"] == "alphatex"
+    assert api.get_transcription(score_id)["format"] == "alphatex"
+
+    # and the reverse: MusicXML pasted over an alphatex row
+    xml = '<?xml version="1.0"?>\n<score-partwise version="4.0"/>'
+    saved = api.save_transcription(score_id, api.TranscriptionEditIn(content=xml))
+    assert saved["format"] == "musicxml"
+
+
+@pytest.mark.parametrize("content,expected", [
+    ('<?xml version="1.0"?><score-partwise/>', "musicxml"),
+    ("<score-partwise version=\"4.0\"/>", "musicxml"),
+    ("<!DOCTYPE score-partwise><score-partwise/>", "musicxml"),
+    ("<!-- a comment first --><score-partwise/>", "musicxml"),
+    ("\n\n  <score-partwise/>", "musicxml"),
+    ('\title "x"\n.\n:4 0.1 |', "alphatex"),
+    (":4 0.1 |", "alphatex"),
+    ("\tempo 88\n.\n:8 3.4{d} |", "alphatex"),
+])
+def test_edit_format_is_read_off_the_content(content, expected):
+    """alphaTex has no form that begins with '<' - metadata lines begin with a
+    backslash and beats with a colon or a fret number - so the leading
+    character settles it."""
+    assert api._sniff_transcription_format(content) == expected

--- a/server/tools/tab_extract/verify_musicxml.mjs
+++ b/server/tools/tab_extract/verify_musicxml.mjs
@@ -1,0 +1,106 @@
+// Regression check for the MusicXML emitter: load a .musicxml file (or a
+// whole directory of them) with the SAME alphaTab loader the web player uses,
+// so a change that produces schema-valid but musically wrong output - a
+// mirrored string numbering, a <backup> that does not return to the start of
+// the measure, a voice alphaTab does not see as a voice - gets caught here
+// rather than surfacing later as a page that renders wrong. This cannot be
+// done from the Python test suite: it needs the real importer, not a
+// re-implementation of it.
+//
+// Usage:
+//   node verify_musicxml.mjs <path-to-alphaTab.mjs> <file-or-dir> [...more]
+//
+// Prints one JSON line per file: {file, ok, bars, voices, beats, notes,
+// dottedBeats, firstNoteMidi, firstNoteString, firstNoteFret, tuning} or
+// {file, ok: false, error}. Exits 1 if any file failed to load.
+//
+// firstNoteString/Fret and tuning are the ones that matter beyond "it
+// parsed": MusicXML numbers staff LINES from the bottom and STRINGS from the
+// top, so a file with the two confused still validates against the schema and
+// still loads here - but comes back with its notes on mirrored strings, which
+// is visible in these fields and nowhere else.
+//
+// Example (from this directory):
+//   node verify_musicxml.mjs ../../../web/node_modules/@coderline/alphatab/dist/alphaTab.mjs out
+import fs from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+async function main() {
+    const [alphaTabPath, ...targets] = process.argv.slice(2);
+    if (!alphaTabPath || targets.length === 0) {
+        console.error("usage: node verify_musicxml.mjs <alphaTab.mjs> <file-or-dir> [...]");
+        process.exit(2);
+    }
+
+    const files = [];
+    for (const target of targets) {
+        const st = fs.statSync(target);
+        if (st.isDirectory()) {
+            for (const name of fs.readdirSync(target)) {
+                if (name.endsWith(".musicxml") || name.endsWith(".xml")) {
+                    files.push(path.join(target, name));
+                }
+            }
+        } else {
+            files.push(target);
+        }
+    }
+
+    const mod = await import(pathToFileURL(path.resolve(alphaTabPath)).href);
+    const { ScoreLoader } = mod.importer;
+    const { Settings } = mod;
+
+    let anyFailed = false;
+    for (const file of files) {
+        const result = { file: path.basename(file) };
+        try {
+            const bytes = new Uint8Array(fs.readFileSync(file));
+            const score = ScoreLoader.loadScoreFromBytes(bytes, new Settings());
+            let bars = 0, voices = 0, beats = 0, notes = 0, dottedBeats = 0;
+            let firstNoteMidi = null, firstNoteString = null, firstNoteFret = null;
+            let tuning = null;
+            for (const track of score.tracks) {
+                for (const staff of track.staves) {
+                    bars = Math.max(bars, staff.bars.length);
+                    if (tuning === null && staff.tuning && staff.tuning.length) {
+                        tuning = Array.from(staff.tuning);
+                    }
+                    for (const bar of staff.bars) {
+                        for (const voice of bar.voices) {
+                            // alphaTab pads every bar out to the staff's
+                            // busiest voice count with an auto-inserted rest;
+                            // isEmpty marks exactly that filler, so skipping
+                            // it counts only voices the file really wrote.
+                            if (voice.isEmpty) continue;
+                            voices += 1;
+                            for (const beat of voice.beats) {
+                                beats += 1;
+                                if (beat.dots > 0) dottedBeats += 1;
+                                for (const note of beat.notes) {
+                                    notes += 1;
+                                    if (firstNoteMidi === null) {
+                                        firstNoteMidi = note.realValue;
+                                        firstNoteString = note.string;
+                                        firstNoteFret = note.fret;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            Object.assign(result, {
+                ok: true, bars, voices, beats, notes, dottedBeats,
+                firstNoteMidi, firstNoteString, firstNoteFret, tuning,
+            });
+        } catch (e) {
+            anyFailed = true;
+            Object.assign(result, { ok: false, error: String(e && e.stack ? e.stack : e) });
+        }
+        console.log(JSON.stringify(result));
+    }
+    if (anyFailed) process.exitCode = 1;
+}
+
+main();

--- a/web/src/lib/ScoreCompare.svelte
+++ b/web/src/lib/ScoreCompare.svelte
@@ -188,9 +188,11 @@
     saving = true;
     saveError = "";
     try {
-      const res = await api.saveTranscription(score.id, draft, transcription?.format);
+      const res = await api.saveTranscription(score.id, draft);
       // be defensive about what the endpoint actually echoes back - the
       // edit itself is the source of truth for content/source either way
+      // `res` carries the format the server read off the content, which is
+      // what the viewer dispatches on - so let it win over the loaded row's.
       transcription = { ...transcription, ...res, content: draft, source: "edited" };
       editorOpen = false;
     } catch (e) {

--- a/web/src/lib/ScoreCompare.svelte
+++ b/web/src/lib/ScoreCompare.svelte
@@ -188,7 +188,7 @@
     saving = true;
     saveError = "";
     try {
-      const res = await api.saveTranscription(score.id, draft);
+      const res = await api.saveTranscription(score.id, draft, transcription?.format);
       // be defensive about what the endpoint actually echoes back - the
       // edit itself is the source of truth for content/source either way
       transcription = { ...transcription, ...res, content: draft, source: "edited" };
@@ -259,7 +259,8 @@
           <h3>No staff transcription yet</h3>
           <p>
             Fermata can pull the guitar tab out of this PDF and render it as a playable,
-            editable staff. Fret and string extraction is accurate; how much of the rhythm
+            editable staff, saved as MusicXML so it opens in other notation software too.
+            Fret and string extraction is accurate; how much of the rhythm
             can be recovered depends on how the PDF was engraved, and anything left
             uncertain is listed alongside the finished staff. Check it against the PDF
             before trusting it.
@@ -302,7 +303,14 @@
         </div>
       {/if}
       <div class="staff-render">
-        <TabViewer tex={transcription.content} {gigMode} {onToggleGig} {practiceLabel} {onStopPractice} />
+        <TabViewer
+          tex={transcription.content}
+          format={transcription.format}
+          {gigMode}
+          {onToggleGig}
+          {practiceLabel}
+          {onStopPractice}
+        />
       </div>
     {/if}
   </div>
@@ -321,6 +329,12 @@
           <span class="source-badge" class:edited={transcription.source === "edited"}>
             {transcription.source === "edited" ? "edited" : "extracted"}
           </span>
+          <!-- the stored format, so "Edit source" says what you'd be editing -
+               transcriptions are MusicXML, but a row saved before that change,
+               or hand-edited in alphaTex, keeps its own format -->
+          {#if transcription.format}
+            <span class="source-badge">{transcription.format}</span>
+          {/if}
           <button class="ghost" onclick={() => (editorOpen ? (editorOpen = false) : openEditor())}>
             {editorOpen ? "Close editor" : "Edit source"}
           </button>

--- a/web/src/lib/TabViewer.svelte
+++ b/web/src/lib/TabViewer.svelte
@@ -7,6 +7,10 @@
     score = null,
     demo = false,
     tex = null,
+    // Which format `tex` holds. Transcriptions are stored as MusicXML, but a
+    // row written before that change - or hand-edited in alphaTex - carries
+    // its own format, so this is read from the row rather than assumed.
+    format = "alphatex",
     gigMode = false,
     onToggleGig = () => {},
     practiceLabel = null,
@@ -112,9 +116,15 @@
 
     if (demo) {
       at.tex(DEMO_TEX);
+    } else if (tex != null && format === "musicxml") {
+      // MusicXML goes through the same byte loader a file from the library
+      // uses - alphaTab detects the format from the content, so there is no
+      // separate MusicXML entry point. Re-runs whenever tex changes, so
+      // saving or reverting an edit re-renders.
+      at.load(new TextEncoder().encode(tex));
     } else if (tex != null) {
-      // caller supplies alphaTex directly (e.g. a rendered transcription) -
-      // re-runs whenever tex changes, so saving/reverting an edit re-renders
+      // caller supplies alphaTex directly - re-runs whenever tex changes, so
+      // saving/reverting an edit re-renders
       at.tex(tex);
     } else if (score) {
       fetch(api.fileUrl(score.id))

--- a/web/src/lib/api.js
+++ b/web/src/lib/api.js
@@ -69,11 +69,14 @@ export const api = {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(body ?? {}),
     }).then(j),
-  saveTranscription: (id, content) =>
+  // `format` says what the edited text actually is. The endpoint will sniff
+  // it when omitted, but the client already knows and the renderer dispatches
+  // on the stored value, so send it rather than rely on the guess.
+  saveTranscription: (id, content, format) =>
     fetch(`/api/scores/${id}/transcription`, {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ content }),
+      body: JSON.stringify({ content, format }),
     }).then(j),
   // deletes only the edited row, leaving the extracted one (if any) as the
   // real revert target; may 404 (nothing left) or 405 (not deployed yet)

--- a/web/src/lib/api.js
+++ b/web/src/lib/api.js
@@ -69,14 +69,18 @@ export const api = {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(body ?? {}),
     }).then(j),
-  // `format` says what the edited text actually is. The endpoint will sniff
-  // it when omitted, but the client already knows and the renderer dispatches
-  // on the stored value, so send it rather than rely on the guess.
-  saveTranscription: (id, content, format) =>
+  // No `format` is sent: what the user typed into the source editor decides
+  // it, not the format of the row they opened, and the server reads it off the
+  // content. Sending the loaded row's format stored a pasted alphaTex edit as
+  // musicxml, after which the viewer handed it to the MusicXML loader and the
+  // staff never appeared. Sniffing here as well would be a second copy of the
+  // rule with its own chance to disagree; the endpoint still accepts an
+  // explicit format for a client that genuinely knows.
+  saveTranscription: (id, content) =>
     fetch(`/api/scores/${id}/transcription`, {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ content, format }),
+      body: JSON.stringify({ content }),
     }).then(j),
   // deletes only the edited row, leaving the extracted one (if any) as the
   // real revert target; may 404 (nothing left) or 405 (not deployed yet)


### PR DESCRIPTION
Transcription emitted alphaTex, the renderer's own text format. Only this
project reads it, and its bar arithmetic could only be checked by a script
written here. MusicXML is the canonical output now, and the encoding is written
down as a profile — `docs/musicxml-tab-profile.md` — so another program can
produce and consume the same thing.

**It is a documented subset of MusicXML 4.0, not a new format.** No invented
elements, no container of our own, thirteen numbered conformance rules and two
examples that are validated by the test suite rather than typed out by hand.
MusicXML already specifies tablature — `<staff-details>` with `<staff-tuning>`
per string, `<technical><fret>` and `<string>` on the note — so the value is in
removing the ambiguity the specification deliberately leaves.

## The rules, in brief

| | |
| --- | --- |
| 1–3 | `score-partwise` 4.0, **no DOCTYPE**; `<divisions>` declared once and every duration an exact integer multiple of it; one part |
| 4–5 | Opening `<attributes>` in the schema's own order, with a TAB clef, `<staff-lines>` and one `<staff-tuning>` per string; **`line` counts staff lines from the bottom**, so `line = staff-lines + 1 - string`; `<capo>` after the tunings, tunings written un-capoed |
| 6–8 | Voices written one at a time, numbered from 1, each after the first preceded by a `<backup>` returning to the measure start; chord members carry `<chord/>` and do not advance the position; **every sounding voice's durations sum to the measure's duration** |
| 9–13 | `<fret>` and `<string>` on every sounding note, frets from 0 and strings from 1 for the highest; `<pitch>` present and consistent with string + fret + tuning + capo; pitch within what `<octave>` can express; spelling decided by the key signature on the line of fifths, ties to the plain letter then the flat |

Most of what can go wrong is element ordering — `<attributes>`, `<note>`,
`<staff-details>` and `<staff-tuning>` are all `xs:sequence`, so `<voice>`
before `<type>` and `<clef>` before `<staff-details>` are mandatory and read as
unnatural. Rule 5 is the one that fails *silently*: staff lines are numbered
from the bottom and strings from the top, and inverting them mirrors every note
onto the wrong string in a file that still validates and still loads. There is
a test named after it.

## Rule 8 is why this format

Every voice's durations must sum to its measure. **MusicXML does not require
that** — the document says so — and it is stated as a rule here because it is
the property that lets an independent tool find a defective transcription.

The overfull-bar count stops being a self-check. music21 reads 2948 defective
measures of 10689 across the library, which is *exactly* what the extractor
reports about itself; that agreement is now measured rather than assumed.
Under-full bars are counted too, which they were not before — a note dropped
for want of a fret number used to leave a bar looking clean.

Nothing is padded or trimmed to make the sums come out. A bar that does not add
up is emitted as it was read, because smoothing it over would hide the defect
the rule exists to expose.

## Pitch spelling

String, fret and tuning give an exact MIDI number; MusicXML wants `<step>`,
`<alter>` and `<octave>`, and only the key signature decides between F sharp
and G flat.

The key signature is now decoded from the accidentals the score engraves
**between the clef and its printed meter**. The meter is what makes the reading
safe: an accidental belonging to the first note sits to the *right* of it, so
without that boundary a piece in C major opening on an F sharp reads as G
major. Since engravers print the meter once and reprint the key on every
system, this answers on the first system and declines elsewhere, which is all a
document-level key needs. It resolves for 280 of 291 scores, and the values
look like guitar music — 97 with no accidentals, 91 with one sharp, then 34, 21
and 17 for two, three and four.

Spelling is settled on the line of fifths: of a pitch class's two
single-accidental spellings, take the one nearer the key's centre at
`fifths + 2`; on a tie prefer the spelling needing no accidental, then the
flat. Both halves of that tie-break earn their place — A flat rather than G
sharp in C major, and E natural rather than F flat in A flat major. Every note
of every key comes out spelled the way that key spells it (there is a test over
nine keys, and an exhaustive round-trip over all 128 pitches × 15 keys).

**What remains guessed**, stated in the document rather than annotated per
note: a chromatic note in a key of five or more accidentals can come out
unconventionally, B sharp rather than C natural in B major. It is the right
pitch, spelled oddly. And where no key can be read, `<fifths>0</fifths>`. Both
cost only how accidentals are written — the key never changes which pitch
sounds, which is why a documented default is the honest answer here instead of
a per-note uncertainty record.

## Three details worth flagging

- **No DOCTYPE.** The MusicXML DTDs are deprecated as of 4.0, the public DTD
  URL no longer resolves, and secure-by-default parsers refuse a document that
  references an external DTD at all. The line costs interoperability rather
  than buying it. Readers must still tolerate one, since plenty of real files
  carry it.
- **An impossible fret is not written as some other pitch.** A two-digit text
  span is occasionally two adjacent notes read as one, arriving as fret 78 — and
  78 semitones above a string is past the top of MusicXML's `<octave>` range.
  Writing it made five library files fail schema validation outright, which is
  far worse than one missing note. Such a note is omitted, its beat held open
  as a rest so the measure still satisfies Rule 8, and it is counted. **The XSD
  found this; no test written here would have.**
- **MusicXML replaces alphaTex as the stored format** rather than joining it —
  the unique index is `(score_id, source)` with no format in it, so two
  extracted rows could not coexist anyway. The `format` column is now read back
  and dispatched on instead of assumed, so rows written before this change keep
  rendering as the alphaTex they are and no data migration is needed. An edited
  row keeps the format it was edited in, and the guarantee that re-extraction
  never touches it is unchanged and still tested.

## Verification

Not self-consistency checks. Every claim below is from a tool this project did
not write.

| Check | Result |
| --- | --- |
| Real MusicXML 4.0 XSD (`lxml`) | **291/291 valid** |
| music21 parse | **291/291, no failures** |
| alphaTab (the renderer already shipped here) | **291/291 loaded** |
| Agreement between music21 and alphaTab | 10689 bars, 18295 voices, 96564 notes — identical |
| Rule 8, per music21 | 2948 of 10689 measures defective; extractor's own count agrees exactly, 0 mismatches over 291 files |

Library-wide: 297 PDFs, 291 converted, 0 errors, 6 not extractable (raster
scans and notation-only files, as before).

Tests: **176 passed, 0 skipped** in a clean container with the library mounted
and the real schema available — 56 of them new, covering child order for every
`xs:sequence` element, the string/line inversion, the Rule 8 arithmetic read
back out of the emitted XML, and pitch spelling. `pytest.importorskip` keeps
the schema step optional so CI stays hermetic; the ordering assertions are what
stand in for it there.

New: `server/tools/tab_extract/verify_musicxml.mjs`, alongside the existing
alphaTex one, which loads emitted files through the real alphaTab importer and
reports bars, voices, notes and the first note's MIDI value, string and fret.

## Deliberately out of scope

The document says this plainly rather than implying otherwise: bend contours,
tapping, hammer-ons, slides and harmonics, where implementation fidelity varies
too much to promise interoperability; tuplets, ties, grace notes, repeats and
beaming, which the extractor does not determine; printed `<accidental>`,
layout, lyrics and dynamics; multi-part and multi-staff scores; and mid-score
key changes. `<divisions>` is 480 partly so tuplets can be added later without
changing it.
