### PR TITLE
A rendering layer for the score view

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,11 @@ them.
   interactively and can be switched between standard notation, tablature, or
   both staves at once, with audio playback, adjustable speed, and a moving
   cursor. The built-in synthesizer also drives practice tools: drag-select a
-  passage on the score to loop it, plus metronome and count-in toggles.
+  passage on the score to loop it, plus metronome and count-in toggles. The
+  staff is themed to match the interface, lays itself out differently on a
+  phone, a tablet on a stand and a desktop, and can be drawn dark for
+  practising in the dark — see [how scores are rendered](docs/rendering.md) for
+  what the renderer does, what that layer adds, and why this renderer.
 - **Tab out of a PDF** — engraved guitar PDFs carry their tab as real text and
   their rhythm in the music font's own glyphs, so Fermata reads both directly
   instead of guessing at pixels, and renders the result as a playable,
@@ -90,6 +94,11 @@ cd web
 npm install
 npm run dev
 ```
+
+Everything to do with drawing a staff — appearance, responsive layout, and the
+renderer's quirks — lives in `web/src/lib/score-render.js`; components never
+touch the renderer directly. [docs/rendering.md](docs/rendering.md) explains
+that boundary and the decisions behind it.
 
 Tests:
 

--- a/docs/rendering.md
+++ b/docs/rendering.md
@@ -105,11 +105,40 @@ layout all flow through it. The view it returns exposes `setProfile`,
 ### Responsive layout
 
 The layer picks `layoutMode`, `barsPerRow` and `scale` from the width of the
-**score container** — not the window, because a side-by-side PDF comparison
+**scrolling stage** — not the window, because a side-by-side PDF comparison
 hands the staff half a desktop and half a desktop should lay out like the tablet
 it is that wide. Breakpoints are `PHONE_MAX_WIDTH` (620) and `TABLET_MAX_WIDTH`
-(1100), and the choice is re-applied from the renderer's own `resize` event, in
-the handler, so a viewport change costs one render rather than two.
+(1100).
+
+Two details of this are load-bearing and were both got wrong first time round.
+
+**The width comes from the stage, never from the host.** The host is also the
+renderer's own container, and in horizontal layout it grows to fit the score
+(see the quirks below) — so measuring it would feed the layout's output back
+into its input: a wide score reads as a wide screen, flips to the desktop tier,
+shrinks, reads as narrow, and oscillates. A `ResizeObserver` on the stage, whose
+width never depends on the layout chosen, is what drives the decision.
+
+**A tier change is a full render of the layer's own.** The renderer's answer to
+a width change is resize-*optimised* rather than a re-layout, and it is not
+enough:
+
+- it rebuilds the layout only when `layoutMode` itself changed;
+- otherwise it asks the layout to resize, and `HorizontalScreenLayout` declines
+  — `supportsResize` is `false` and `doResize()` is empty — so **nothing is
+  drawn at all**. Crossing 620px in the `stand` preset is horizontal to
+  horizontal with only a scale change, which is exactly this case;
+- and the vertical layouts regroup systems only when `barsPerRow` is auto.
+  `_resizeAndRenderScore` tests `getBarsPerSystem(0) > 0` against the *new*
+  value and, when set, keeps the grouping it already has and merely refits
+  widths — so phone (1 bar) to tablet (2 bars) would stay one stretched bar per
+  row.
+
+Relying on that path meant the layer could announce a new scale it had not
+drawn. It now renders the tier change itself, from a microtask so the renderer's
+new width is already assigned, and before the next paint so no intermediate
+state is visible. On a 360-bar score that render is 29–61 ms; on a normal one it
+is 1–4 ms.
 
 There are two presets, because the same width wants different answers depending
 on where the screen is:
@@ -145,10 +174,14 @@ Two themes: `parchment` (warm paper, dark ink) and `slate` (a dark staff for
 practising in the dark). The PDF reader has to invert a fixed page; a rendered
 staff can simply be drawn dark, which is what `slate` does.
 
-Values must stay in a form the renderer's colour parser accepts — hex, `rgb()`
-or `rgba()`. It answers `null` for anything else rather than raising, and a null
-colour draws as nothing at all, so the layer validates each token and falls back
-to a built-in default.
+Values must stay in a form the renderer's colour parser accepts: hex, or the
+**comma-separated** `rgb()`/`rgba()` form. It splits the function body on
+commas, so the modern space-separated syntax — `rgb(36 29 15)` — is not one of
+them; it parses to `null`, and a null colour draws as nothing at all. Some
+malformed input makes it throw instead. So the layer does not try to recognise
+the syntax itself: it hands each token to the parser, catches both answers, and
+falls back to a built-in default for anything the parser will not take. A
+mistyped token gives a readable staff, not an invisible one.
 
 **Exactly what the renderer exposes** — this is the whole surface:
 
@@ -181,6 +214,29 @@ to a built-in default.
   styled at all.
 - One hardcoded exception found in the source: a tab bend spanning more than one
   note is forced to the secondary colour regardless of voice.
+
+### Horizontal layout, and where the paper ends
+
+Two things the layer has to correct in horizontal layout, both of which are
+invisible in page layout and so easy to ship broken:
+
+- The renderer draws the whole score as one system, far wider than any sensible
+  card. Left alone, the staff scrolls off the paper onto the page background —
+  and with the parchment theme that is dark ink on a dark page, effectively
+  invisible. `slate` hides the problem, because its surface is close to the page
+  colour.
+- The renderer sizes its drawing surface from the total width it *reports*, but
+  draws partials wider than that and clips the excess with `overflow: hidden`.
+  On a real transcription that hid 53 of 316 glyphs — the last bar and the final
+  barline — with no scroll position that could reach them.
+
+So after a horizontal render the layer measures what was actually drawn and sets
+the host's width and the surface's overflow to match. Because the host is also
+the renderer's container, that width is cleared again before any render, or the
+renderer would measure the last score's width instead of the screen's. Partials
+arrive after the render reports itself finished — and more of them arrive as the
+score is scrolled — so the measurement follows a `MutationObserver` on the host
+rather than the render event.
 
 ### The branding override
 
@@ -223,13 +279,16 @@ scores, same machine:
 | --- | --- | --- |
 | First paint, navigation to first staff on screen | 267–403 ms | 504–621 ms |
 | First render, as the library reports it | 6.9–16 ms | 7.9–13.5 ms |
-| Re-render, library work | 0.3–1.6 ms | 0.2–0.6 ms |
-| Re-render, to pixels | 16–35 ms | 17–36 ms |
+| Profile switch, library work | 0.5–1.0 ms | 0.2–0.6 ms |
+| Profile switch, to pixels | 16–35 ms | 17–36 ms |
 
-The worker costs 130–260 ms of startup and buys nothing measurable back: layout
-of a 27 KB transcription is 12 ms, so it never gets close to a frame budget. On
-a much longer score main-thread layout would block briefly on load, and that is
-the trade this constant represents — one line to change if it ever bites.
+The worker costs 130–260 ms of startup and buys nothing measurable back. The
+cost it is meant to avoid is a main-thread stall on a long score, so that was
+measured too: a **360-bar** score renders in 69 ms of library work and 103 ms
+wall to first paint, a tier change re-renders in 29–61 ms, and the longest
+main-thread task across the whole run is **102 ms**, with none over 250 ms —
+because the renderer chunks the work into partials and only draws the ones on
+screen. That is the trade this one constant represents, if it ever bites.
 
 ## Keeping it replaceable
 

--- a/docs/rendering.md
+++ b/docs/rendering.md
@@ -1,0 +1,254 @@
+# How scores are rendered
+
+Fermata renders interactive notation and tablature with
+[alphaTab](https://alphatab.net) 1.8. Everything the renderer is told lives in
+one module, [`web/src/lib/score-render.js`](../web/src/lib/score-render.js).
+No component imports the renderer or names one of its types.
+
+This document is for the contributor who looks at that dependency and asks why
+it is not VexFlow.
+
+## What was compared
+
+Three candidates were built side by side, all rendering the same file — a
+four-bar polyphonic guitar study emitted by Fermata's own MusicXML writer, with
+two voices in every bar, a chord, dotted values, a rest and an accidental — and
+each given a working "select a note and change its fret" control. The point was
+not engraving quality, which all three have. It was **how much of an editor
+each one already is**, because score editing is on the roadmap and the browser
+library is the part that would have to support it.
+
+| | alphaTab | OpenSheetMusicDisplay | VexFlow |
+| --- | --- | --- | --- |
+| Reads MusicXML | native | native | none — a reader had to be written |
+| Tab staff | native | native | from primitives |
+| Notation staff from a TAB-only file | native, one flag | not possible — the file had to be rewritten into two staves | by hand |
+| Note under the cursor | native event | hand-built | hand-built |
+| Editable model | native and writable | none — read-only getters | ours by construction |
+| Incremental re-render | native | none — full reparse and redraw | per measure, if you build it |
+| Playback | native synthesiser and soundfont | none | none |
+| Writes MusicXML back | no | no | no |
+| Lines of integration code | **159** | 374 | 312 |
+
+Measured re-render, Chrome at 1500×1000, medians of five, three independent
+runs: alphaTab 2.0–2.5 ms incremental, OSMD 10.0–11.4 ms (its only edit path is
+a full reparse), VexFlow 1.9–2.1 ms per measure and 6.2–7.3 ms whole-score.
+First render: alphaTab 157–188 ms, OSMD 20–40 ms, VexFlow 25–32 ms. alphaTab's
+first render is paying for a font and a soundfont, once.
+
+One finding decided more than the table did. OSMD's tab notes never enter the
+DOM, so a glyph-to-note mapping has to be reconstructed by hand from layout
+geometry. That mapping agreed with the source on 29 of 29 notes before any
+edit — and on roughly 7 of 19 after a single duration change, because the bar
+no longer added up, OSMD regrouped its voice entries, and every ordinal after
+the edit slid. Nothing threw and nothing warned; the next click would select
+the wrong note. That is the characteristic failure of a hand-built bridge
+between a drawn glyph and a source note, and it is not a gap that more code
+closes.
+
+## Why alphaTab
+
+It is the only one of the three that is an editor substrate rather than a
+viewer: the only one with a writable model, the only one with a documented
+incremental re-render, the only one that hands over the note under the cursor,
+and the only one that makes a sound. An edit is `note.fret = 4`.
+
+VexFlow stayed credible throughout and remains the realistic alternative. It is
+MIT, its model would be entirely ours, and it needed no transform of our
+single-TAB-staff MusicXML. What it asks for is the rest of an engraving
+application: system and page breaking, responsive measure widths, ties and slurs
+across barlines, repeats, multi-voice rest placement, a real MusicXML reader,
+and an entire audio stack. Choosing VexFlow is choosing to own the editor's
+model and layout — which is defensible precisely because Fermata's model is
+already on the server as MusicXML, and it is the reason the rendering layer is
+built as a seam rather than spread through the components.
+
+OSMD is the weakest fit here, and not for engraving reasons. It is
+architecturally a viewer: read-only notes, no incremental render, no note
+events, no audio, and the mapping problem above.
+
+## Licence
+
+alphaTab is **MPL-2.0** — file-level copyleft. Linking it from an MIT project is
+fine; only modifications to alphaTab's own files would have to be published
+under MPL-2.0. It bundles third-party code under MIT and BSD-3-Clause
+(TinySoundFont, SFZero, the Haxe standard library, SharpZipLib, NVorbis, and
+libvorbis-derived code), listed in the package's own `LICENSE.header`.
+
+This is why the branding override below is a runtime patch from our own code
+rather than a vendored copy of the library with one method edited out: a
+modified copy would put us under the obligation to publish it.
+
+## What the renderer does natively
+
+MusicXML and Guitar Pro import, notation and tablature staves, page and
+horizontal layout, system breaking, a synthesiser with a bundled soundfont, a
+following playback cursor, drag-to-select a bar range, looping, a metronome and
+a count-in, and an incremental re-render.
+
+## What this layer adds
+
+`score-render.js` exports `createScoreView(host, options)` plus the constants
+and pure functions behind it. Its vocabulary is Fermata's — profiles, widths,
+presets, themes — not the renderer's.
+
+### One place that configures the renderer
+
+`createScoreView` is the only call site that constructs a renderer. Profiles
+(`"score"`, `"tab"`, `"scoretab"`), sources (`{kind:"alphatex"}`,
+`{kind:"musicxml"}`, `{kind:"file", url}`), transport state, fonts, colours and
+layout all flow through it. The view it returns exposes `setProfile`,
+`setPreset`, `setTheme`, `setSpeed`, `setLooping`, `setMetronome`, `setCountIn`,
+`playPause`, `stop` and `destroy`, and reports `layout`, `theme`, `profile`,
+`preset` and `lastRenderMs`.
+
+### Responsive layout
+
+The layer picks `layoutMode`, `barsPerRow` and `scale` from the width of the
+**score container** — not the window, because a side-by-side PDF comparison
+hands the staff half a desktop and half a desktop should lay out like the tablet
+it is that wide. Breakpoints are `PHONE_MAX_WIDTH` (620) and `TABLET_MAX_WIDTH`
+(1100), and the choice is re-applied from the renderer's own `resize` event, in
+the handler, so a viewport change costs one render rather than two.
+
+There are two presets, because the same width wants different answers depending
+on where the screen is:
+
+| | phone (≤620) | tablet (≤1100) | desktop |
+| --- | --- | --- | --- |
+| `desk` | page, 1 bar/row, scale 1.15 | page, 2 bars/row, scale 1.05 | page, auto bars/row, scale 1.00 |
+| `stand` | horizontal, scale 1.30 | horizontal, scale 1.20 | page, 2 bars/row, scale 1.15 |
+
+`desk` is a pointer and a whole window: more bars on screen at once is worth
+more than size. `stand` is gig mode — a tablet propped on a music stand, read
+from a metre away with both hands busy — so glyphs get bigger and the layout
+becomes one endless system scrolled sideways, which is what horizontal layout
+exists for: no page breaks to lose your place at, and a single scroll axis a
+thumb or a pedal can drive.
+
+The layer's decisions are reflected onto the host element as `data-score-*`
+attributes, so what it chose is readable in devtools and assertable in a test
+rather than only visible in a screenshot.
+
+### Theming
+
+The staff is drawn from Fermata's own palette. The tokens live in
+`web/src/app.css` and the layer reads them from the live stylesheet, so the
+palette has one home:
+
+```
+--score-surface  --score-ink  --score-ink-soft  --score-line  --score-accent
+--score-dark-surface  --score-dark-ink  --score-dark-ink-soft  ...
+```
+
+Two themes: `parchment` (warm paper, dark ink) and `slate` (a dark staff for
+practising in the dark). The PDF reader has to invert a fixed page; a rendered
+staff can simply be drawn dark, which is what `slate` does.
+
+Values must stay in a form the renderer's colour parser accepts — hex, `rgb()`
+or `rgba()`. It answers `null` for anything else rather than raising, and a null
+colour draws as nothing at all, so the layer validates each token and falls back
+to a built-in default.
+
+**Exactly what the renderer exposes** — this is the whole surface:
+
+| Resource | What it colours |
+| --- | --- |
+| `mainGlyphColor` | every glyph of voice 1: note heads, stems, beams, rests, clefs, fret numbers |
+| `secondaryGlyphColor` | the same for voice 2 and up |
+| `staffLineColor` | staff and tab lines |
+| `barSeparatorColor` | barlines, braces and brackets |
+| `barNumberColor` | bar numbers |
+| `scoreInfoColor` | title, subtitle, words |
+| `tablatureFont`, `graceFont`, `numberedNotationFont`, `numberedNotationGraceFont` | the four font resources settable through settings |
+| `elementFonts` | per-element fonts (title, subtitle, words, bar numbers, markers, …), reachable only through the resource object, not through settings |
+| `engravingSettings` | SMuFL metrics — stem thickness, staff line thickness, beam spacing, and ~80 more |
+
+**What is therefore out of reach of configuration:**
+
+- **There is no separate note-head, stem or beam colour.** Every one of them
+  follows `mainGlyphColor` or `secondaryGlyphColor` according to which voice the
+  note belongs to. Anything finer means writing colours into the score model
+  (`note.style.colors` and friends) after every load — per-document overrides,
+  not configuration.
+- **There is no background colour, and no background at all.** The surface the
+  renderer draws on is transparent and it emits no background rectangle. The
+  paper behind the staff is ours, in CSS.
+- **Cursors and the range selection ship with no colour.** The renderer creates
+  `.at-cursor-bar`, `.at-cursor-beat` and the selection divs with position only,
+  which means they are invisible until styled. They are styled in
+  `TabViewer.svelte` from the same tokens — before this layer they were not
+  styled at all.
+- One hardcoded exception found in the source: a tab bend spanning more than one
+  note is forced to the secondary colour regardless of voice.
+
+### The branding override
+
+The renderer draws **"rendered by alphaTab"** onto every score. It comes from
+`_layoutAndRenderAnnotation`, a private method on its layout base class, called
+unconditionally from four render paths. There is no setting to disable it, and
+the MPL-2.0 licence asks for no attribution in rendered output.
+
+`score-render.js` neutralises it at runtime:
+
+- It walks up the prototype chain from the live layout object to whichever
+  prototype **owns** the method, and replaces it there. In 1.8.4 the concrete
+  layouts are `PageViewLayout` and `ParchmentLayout` (via `VerticalLayoutBase`)
+  and `HorizontalScreenLayout` (directly), and the owner is `ScoreLayout` in
+  every case — so patching the owner covers all layout modes rather than only
+  whichever one happens to be active. None of those classes is exported, so a
+  live instance is the only route to them.
+- It is applied once, to the prototype, not per view.
+- If the method cannot be found it **warns to the console and carries on**. The
+  only consequence of the patch missing is that the annotation comes back, so
+  failing loudly would be worse than a warning — but failing silently would mean
+  noticing in a screenshot months later.
+
+Two things about this are worth knowing before an upgrade.
+
+**It reaches past the public API.** `_layoutAndRenderAnnotation` is not declared
+in the type definitions and its owner is not exported. It is present verbatim in
+the bundle the app imports (`dist/alphaTab.core.mjs`, which is not minified), and
+a stock Vite production build does not mangle property names — verified against
+the built output, where the annotation is still absent. A future version that
+renames or moves the method will trip the warning.
+
+**It requires the renderer on the main thread.** By default alphaTab runs layout
+and drawing in a Web Worker, and then the layout object does not exist in our
+realm at all — there is no prototype to patch. So the layer sets
+`core.useWorkers: false` (the `RENDER_IN_WORKER` constant). Measured cost, same
+scores, same machine:
+
+| | main thread | in a worker |
+| --- | --- | --- |
+| First paint, navigation to first staff on screen | 267–403 ms | 504–621 ms |
+| First render, as the library reports it | 6.9–16 ms | 7.9–13.5 ms |
+| Re-render, library work | 0.3–1.6 ms | 0.2–0.6 ms |
+| Re-render, to pixels | 16–35 ms | 17–36 ms |
+
+The worker costs 130–260 ms of startup and buys nothing measurable back: layout
+of a 27 KB transcription is 12 ms, so it never gets close to a frame budget. On
+a much longer score main-thread layout would block briefly on load, and that is
+the trade this constant represents — one line to change if it ever bites.
+
+## Keeping it replaceable
+
+The reason this is a seam and not a scattering of settings is that VexFlow
+remains a credible alternative, and it stays credible because the authoritative
+model lives on the server as MusicXML — the browser library is a view, not the
+source of truth. So:
+
+- Components pass and read Fermata's vocabulary. `layout.mode` is `"page"` or
+  `"horizontal"`, not an enum from the library. `profile` is `"scoretab"`, not a
+  stave-profile constant. Themes are token names.
+- Loading is expressed as a source shape (`alphatex`, `musicxml`, `file`), not as
+  the byte-loader call the library happens to want.
+- The transport is `setSpeed` / `setLooping` / `setMetronome` / `setCountIn` /
+  `playPause` / `stop`, not volume fields and boolean properties on a live api
+  object.
+- The renderer's event names, enums, settings tree, colour objects, font objects
+  and prototype quirks all stop at this file.
+
+If replacing the renderer would mean touching anything other than
+`score-render.js` and the `--score-*` tokens, the boundary has drifted and
+should be pulled back.

--- a/web/src/app.css
+++ b/web/src/app.css
@@ -12,6 +12,25 @@
   --radius: 10px;
   --font-display: "Fraunces Variable", Georgia, serif;
   --font-ui: "Figtree Variable", "Segoe UI", sans-serif;
+
+  /* Staff palette. These are not only CSS: lib/score-render.js reads them and
+     hands them to the notation renderer as its own colour resources, so the
+     staff is themed here rather than left at the renderer's defaults. Values
+     must stay in a form the renderer's colour parser accepts - hex or
+     rgb()/rgba() - because anything else it silently ignores. */
+  --score-surface: #f7f2e6;
+  --score-ink: #241d0f;
+  --score-ink-soft: #6f6045;
+  --score-line: #b3a284;
+  --score-accent: #8a6a24;
+
+  /* The same staff for practising in the dark. Drawn dark rather than
+     inverted, which is what the PDF reader has to do with a fixed page. */
+  --score-dark-surface: #191510;
+  --score-dark-ink: #ece2cd;
+  --score-dark-ink-soft: #94866a;
+  --score-dark-line: #4d4331;
+  --score-dark-accent: #c9a45c;
 }
 
 * {

--- a/web/src/app.css
+++ b/web/src/app.css
@@ -16,8 +16,11 @@
   /* Staff palette. These are not only CSS: lib/score-render.js reads them and
      hands them to the notation renderer as its own colour resources, so the
      staff is themed here rather than left at the renderer's defaults. Values
-     must stay in a form the renderer's colour parser accepts - hex or
-     rgb()/rgba() - because anything else it silently ignores. */
+     must stay in a form the renderer's colour parser accepts: hex, or the
+     comma-separated rgb()/rgba() form. It splits on commas, so the modern
+     space-separated syntax - rgb(36 29 15) - is not one of them. A value it
+     cannot read falls back to a built-in default rather than drawing nothing;
+     score-render.js checks each one against the parser itself. */
   --score-surface: #f7f2e6;
   --score-ink: #241d0f;
   --score-ink-soft: #6f6045;

--- a/web/src/lib/ScoreCompare.svelte
+++ b/web/src/lib/ScoreCompare.svelte
@@ -354,7 +354,7 @@
     <!-- both panes always mount, one hidden with CSS rather than an {#if} -
          switching layout used to unmount+remount PdfViewer (re-fetching and
          re-rendering every page, losing scroll position) and tear down and
-         rebuild alphaTab (stopping playback) -->
+         rebuild the score renderer (stopping playback) -->
     {@render pdfPane(activeLayout === "staff")}
     {@render staffPane(activeLayout === "pdf")}
   </div>

--- a/web/src/lib/TabViewer.svelte
+++ b/web/src/lib/TabViewer.svelte
@@ -1,7 +1,7 @@
 <script>
   import { untrack } from "svelte";
-  import * as alphaTab from "@coderline/alphatab";
   import { api } from "./api.js";
+  import { createScoreView } from "./score-render.js";
 
   let {
     score = null,
@@ -19,7 +19,7 @@
 
   let host;
   let scroller;
-  let atApi = $state(null);
+  let view = $state(null);
   let profile = $state("scoretab");
   let playing = $state(false);
   let playerReady = $state(false);
@@ -32,20 +32,15 @@
   let ladderStart = $state(60);
   let ladderStep = $state(5);
   let ladderTarget = $state(100);
+  let darkStaff = $state(false);
 
-  const PROFILES = [
+  const PROFILE_LABELS = [
     ["score", "Notation"],
     ["tab", "Tab"],
     ["scoretab", "Both"],
   ];
 
   const SPEEDS = [0.5, 0.75, 1, 1.25];
-
-  const PROFILE_MAP = {
-    score: alphaTab.StaveProfile.Score,
-    tab: alphaTab.StaveProfile.Tab,
-    scoretab: alphaTab.StaveProfile.ScoreTab,
-  };
 
   const DEMO_TEX = `\\title "Fermata Demo"
 \\subtitle "Estudio in E minor"
@@ -57,114 +52,92 @@
 :8 0.1 0.2 1.3 0.1 0.2 1.3 0.1 0.2 |
 :2 (0.6 2.5 2.4 0.3 0.2 0.1) :2 (0.6 2.5 2.4 0.3 0.2 0.1)`;
 
+  function source() {
+    if (demo) return { kind: "alphatex", text: DEMO_TEX };
+    if (tex != null) return { kind: format === "musicxml" ? "musicxml" : "alphatex", text: tex };
+    if (score) return { kind: "file", url: api.fileUrl(score.id) };
+    return null;
+  }
+
+  function advanceLadder() {
+    if (!ladder) return;
+    const next = Math.round(speed * 100) + ladderStep;
+    if (next >= ladderTarget) {
+      speed = ladderTarget / 100;
+      ladder = false;
+    } else {
+      speed = next / 100;
+    }
+    view?.setSpeed(speed);
+  }
+
   $effect(() => {
+    // read tracked, outside the untrack below: a new tex/score/demo has to
+    // rebuild the renderer, which is what makes "Save & render" re-render
+    const src = source();
     // a stale error or transport state from a previous load (e.g. a bad
-    // edit) must not linger once a new tex/score/demo load starts - without
-    // this, "Save & render" leaves the old Pause/enabled buttons showing
-    // while the new player is still loading its soundfont
+    // edit) must not linger once a new load starts - without this, "Save &
+    // render" leaves the old Pause/enabled buttons showing while the new
+    // player is still loading its soundfont
     loadError = "";
     playerReady = false;
     playing = false;
-    const at = new alphaTab.AlphaTabApi(host, {
-      // worker/audio-worklet URLs are wired up by the @coderline/alphatab-vite
-      // plugin (vite.config.js); fontDirectory/soundFont still need to match
-      // where that plugin copies the assets (site root, see its README).
-      core: {
-        fontDirectory: "/font/",
-      },
-      player: {
-        enablePlayer: true,
-        soundFont: "/soundfont/sonivox.sf2",
-        scrollElement: scroller,
-      },
-      display: {
-        // untrack: profile changes are handled imperatively in setProfile;
-        // tracking it here would tear down and recreate the player.
-        staveProfile: PROFILE_MAP[untrack(() => profile)],
-        scale: 1,
-      },
-    });
+    // untrack: everything below is driven imperatively once the view exists;
+    // tracking it here would tear down and rebuild the renderer (and stop
+    // playback) on a profile switch or a toggle.
+    const v = untrack(() =>
+      createScoreView(host, {
+        scroller,
+        source: src,
+        profile,
+        preset: gigMode ? "stand" : "desk",
+        theme: darkStaff ? "slate" : "parchment",
+        transport: { speed, looping, metronome, countIn },
+        onReady: () => (playerReady = true),
+        onPlaying: (p) => (playing = p),
+        onError: (m) => (loadError = m),
+        onPassComplete: advanceLadder,
+      }),
+    );
+    view = v;
+    return () => v.destroy();
+  });
 
-    // A new player starts at its own defaults, so carry the practice settings
-    // over; switching scores reuses this component and would silently drop them.
-    // untrack keeps the toggles from tearing the player down when they change.
-    untrack(() => {
-      at.isLooping = looping;
-      at.playbackSpeed = speed;
-      at.metronomeVolume = metronome ? 1 : 0;
-      at.countInVolume = countIn ? 1 : 0;
-    });
+  // Gig mode is the same width read from further away, so it wants a
+  // different layout at that width rather than a different width.
+  $effect(() => {
+    view?.setPreset(gigMode ? "stand" : "desk");
+  });
 
-    at.playerReady.on(() => (playerReady = true));
-    at.playerStateChanged.on((e) => (playing = e.state === 1));
-    at.error.on((e) => {
-      loadError = e?.message ?? "failed to load score";
-    });
-    // playerFinished fires at the end of each loop pass (not just final stop),
-    // which is what makes it usable as the "one clean pass done" signal below.
-    at.playerFinished.on(() => {
-      if (!ladder) return;
-      const next = Math.round(speed * 100) + ladderStep;
-      if (next >= ladderTarget) {
-        speed = ladderTarget / 100;
-        ladder = false;
-      } else {
-        speed = next / 100;
-      }
-      at.playbackSpeed = speed;
-    });
-
-    if (demo) {
-      at.tex(DEMO_TEX);
-    } else if (tex != null && format === "musicxml") {
-      // MusicXML goes through the same byte loader a file from the library
-      // uses - alphaTab detects the format from the content, so there is no
-      // separate MusicXML entry point. Re-runs whenever tex changes, so
-      // saving or reverting an edit re-renders.
-      at.load(new TextEncoder().encode(tex));
-    } else if (tex != null) {
-      // caller supplies alphaTex directly - re-runs whenever tex changes, so
-      // saving/reverting an edit re-renders
-      at.tex(tex);
-    } else if (score) {
-      fetch(api.fileUrl(score.id))
-        .then((r) => r.arrayBuffer())
-        .then((buf) => at.load(new Uint8Array(buf)))
-        .catch((e) => (loadError = String(e)));
-    }
-
-    atApi = at;
-    return () => at.destroy();
+  $effect(() => {
+    view?.setTheme(darkStaff ? "slate" : "parchment");
   });
 
   function setProfile(p) {
     profile = p;
-    if (!atApi) return;
-    atApi.settings.display.staveProfile = PROFILE_MAP[p];
-    atApi.updateSettings();
-    atApi.render();
+    view?.setProfile(p);
   }
 
   function setSpeed(ev) {
     speed = Number(ev.target.value);
-    if (atApi) atApi.playbackSpeed = speed;
+    view?.setSpeed(speed);
   }
 
   function toggleLoop() {
     looping = !looping;
-    if (atApi) atApi.isLooping = looping;
+    view?.setLooping(looping);
     // the ladder advances on loop completions, so it cannot run unlooped
     if (!looping) ladder = false;
   }
 
   function toggleMetronome() {
     metronome = !metronome;
-    if (atApi) atApi.metronomeVolume = metronome ? 1 : 0;
+    view?.setMetronome(metronome);
   }
 
   function toggleCountIn() {
     countIn = !countIn;
-    if (atApi) atApi.countInVolume = countIn ? 1 : 0;
+    view?.setCountIn(countIn);
   }
 
   function clamp(n, lo, hi) {
@@ -179,10 +152,8 @@
     if (ladderTarget <= ladderStart) ladderTarget = Math.min(200, ladderStart + ladderStep);
     looping = true;
     speed = ladderStart / 100;
-    if (atApi) {
-      atApi.isLooping = true;
-      atApi.playbackSpeed = speed;
-    }
+    view?.setLooping(true);
+    view?.setSpeed(speed);
   }
 
   function setLadderStart(ev) {
@@ -205,10 +176,10 @@
     <!-- gig mode: hide the practice toolbar chrome, but playback and the way
     back out must stay reachable even with no keyboard (touch/tablet) -->
     <div class="gig-hud">
-      <button class="primary" disabled={!playerReady} onclick={() => atApi?.playPause()}>
+      <button class="primary" disabled={!playerReady} onclick={() => view?.playPause()}>
         {playing ? "❚❚ Pause" : "▶ Play"}
       </button>
-      <button disabled={!playerReady} onclick={() => atApi?.stop()}>■</button>
+      <button disabled={!playerReady} onclick={() => view?.stop()}>■</button>
       {#if practiceLabel}
         <button class="practice-indicator" onclick={onStopPractice} title="Stop practice timer">
           ● {practiceLabel}
@@ -219,15 +190,15 @@
   {:else}
     <div class="toolbar">
       <div class="seg">
-        {#each PROFILES as [value, label]}
+        {#each PROFILE_LABELS as [value, label]}
           <button class:on={profile === value} onclick={() => setProfile(value)}>{label}</button>
         {/each}
       </div>
       <div class="player">
-        <button class="primary" disabled={!playerReady} onclick={() => atApi?.playPause()}>
+        <button class="primary" disabled={!playerReady} onclick={() => view?.playPause()}>
           {playing ? "❚❚ Pause" : "▶ Play"}
         </button>
-        <button disabled={!playerReady} onclick={() => atApi?.stop()}>■</button>
+        <button disabled={!playerReady} onclick={() => view?.stop()}>■</button>
         <select value={speed} onchange={setSpeed} title="Playback speed">
           {#if !SPEEDS.includes(speed)}
             <!-- the ladder steps to speeds between the presets -->
@@ -258,6 +229,13 @@
           >
             Ladder
           </button>
+          <button
+            class:on={darkStaff}
+            onclick={() => (darkStaff = !darkStaff)}
+            title="Draw the staff dark for practising in the dark"
+          >
+            ◐
+          </button>
           {#if ladder}
             <div class="ladder-controls">
               <label>
@@ -285,7 +263,7 @@
   {/if}
 
   <div class="score-scroll" bind:this={scroller}>
-    <div class="at-host" bind:this={host}></div>
+    <div class="at-host" class:dark={darkStaff} bind:this={host}></div>
   </div>
 </div>
 
@@ -405,17 +383,50 @@
 
   .score-scroll {
     flex: 1;
-    overflow-y: auto;
+    /* horizontal layout is one endless system, so the stage has to scroll
+       sideways as well - page layout never overflows this way */
+    overflow: auto;
     padding: 20px;
   }
 
   .at-host {
-    background: var(--paper);
+    background: var(--score-surface);
     border-radius: 6px;
-    max-width: 1100px;
+    /* the staff's own width is what score-render.js picks a layout from, so
+       this cap is what decides where the desktop tier starts - keep it above
+       TABLET_MAX_WIDTH or that tier is unreachable */
+    max-width: 1400px;
     margin: 0 auto;
     padding: 24px;
     box-shadow: 0 4px 24px rgba(0, 0, 0, 0.55);
+  }
+
+  .at-host.dark {
+    background: var(--score-dark-surface);
+  }
+
+  /* The renderer creates its cursors and selection with position only and no
+     colour at all - they are invisible until styled here. */
+  .at-host :global(.at-cursor-bar) {
+    background: var(--score-accent);
+    opacity: 0.1;
+  }
+
+  .at-host :global(.at-cursor-beat) {
+    background: var(--score-accent);
+    width: 3px;
+    opacity: 0.85;
+  }
+
+  .at-host :global(.at-selection div) {
+    background: var(--score-accent);
+    opacity: 0.16;
+  }
+
+  .at-host.dark :global(.at-cursor-bar),
+  .at-host.dark :global(.at-cursor-beat),
+  .at-host.dark :global(.at-selection div) {
+    background: var(--score-dark-accent);
   }
 
   .error {

--- a/web/src/lib/TabViewer.svelte
+++ b/web/src/lib/TabViewer.svelte
@@ -392,9 +392,9 @@
   .at-host {
     background: var(--score-surface);
     border-radius: 6px;
-    /* the staff's own width is what score-render.js picks a layout from, so
-       this cap is what decides where the desktop tier starts - keep it above
-       TABLET_MAX_WIDTH or that tier is unreachable */
+    /* a reading measure for page layout. score-render.js overrides it for
+       horizontal layout, where the paper has to run the whole length of the
+       score rather than stop at a comfortable column width. */
     max-width: 1400px;
     margin: 0 auto;
     padding: 24px;
@@ -412,9 +412,11 @@
     opacity: 0.1;
   }
 
+  /* width is the renderer's: it writes an inline width with a matching scale
+     transform, and overriding one without the other would scale our value
+     down to nothing */
   .at-host :global(.at-cursor-beat) {
     background: var(--score-accent);
-    width: 3px;
     opacity: 0.85;
   }
 

--- a/web/src/lib/score-render.js
+++ b/web/src/lib/score-render.js
@@ -66,7 +66,7 @@ const LAYOUT_MODE = {
  */
 export function layoutForWidth(width, preset = "desk") {
   const rows = LAYOUT_TABLE[preset] ?? LAYOUT_TABLE.desk;
-  // width 0 happens once at construction, before the host is measured
+  // width 0 happens once at construction, before the stage is measured
   const w = Number.isFinite(width) && width > 0 ? width : TABLET_MAX_WIDTH;
   return rows.find((r) => w <= r.maxWidth) ?? rows[rows.length - 1];
 }
@@ -99,11 +99,6 @@ const THEME_TOKENS = {
   },
 };
 
-// The renderer's colour parser answers null for anything it does not
-// recognise - not an error - and a null colour draws as nothing at all. So a
-// token is only used if it is a form the parser accepts.
-const COLOR_RE = /^(#(?:[0-9a-f]{3,4}|[0-9a-f]{6}|[0-9a-f]{8})|rgba?\([^)]*\))$/i;
-
 function cssValue(root, token) {
   try {
     return getComputedStyle(root).getPropertyValue(token).trim();
@@ -112,13 +107,38 @@ function cssValue(root, token) {
   }
 }
 
-/** Resolve a theme's tokens against the live stylesheet. */
+/**
+ * Ask the renderer's own parser whether it can read this value, because
+ * guessing at the syntax it accepts gets it wrong: it splits an `rgb()` body on
+ * commas, so the modern space-separated form (`rgb(36 29 15)`) parses to null
+ * rather than raising, and a null colour draws as nothing at all. It also
+ * throws outright on some malformed input. Anything it will not take is a
+ * token we must not use.
+ */
+function parseColor(value) {
+  if (!value) return null;
+  try {
+    return alphaTab.model.Color.fromJson(value) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve a theme's tokens against the live stylesheet. Each token is kept only
+ * if the renderer can parse it; otherwise the built-in fallback is used, so a
+ * mistyped token degrades to a readable staff rather than an invisible one.
+ */
 export function readScoreTheme(name = SCORE_THEMES[0], root = document.documentElement) {
-  const tokens = THEME_TOKENS[name] ?? THEME_TOKENS[SCORE_THEMES[0]];
-  const theme = { name: THEME_TOKENS[name] ? name : SCORE_THEMES[0] };
-  for (const [key, [token, fallback]] of Object.entries(tokens)) {
+  // includes(), not a property lookup: "constructor" and "toString" are
+  // truthy on any object and would yield a theme with no colours in it.
+  const resolved = SCORE_THEMES.includes(name) ? name : SCORE_THEMES[0];
+  const theme = { name: resolved, colors: {} };
+  for (const [key, [token, fallback]] of Object.entries(THEME_TOKENS[resolved])) {
     const value = cssValue(root, token);
-    theme[key] = COLOR_RE.test(value) ? value : fallback;
+    const parsed = parseColor(value);
+    theme[key] = parsed ? value : fallback;
+    theme.colors[key] = parsed ?? parseColor(fallback);
   }
   return theme;
 }
@@ -155,20 +175,20 @@ function fontsFor(root) {
 // The renderer's colour resources have to hold its own Color objects. A hex
 // string is only accepted when the whole settings tree is handed over as JSON
 // at construction; assigning one onto a live resource leaves the renderer with
-// a string where it expects a colour, and it draws nothing. So colours are
-// converted once, here, and the same objects are used on every path.
+// a string where it expects a colour, and it draws nothing. readScoreTheme
+// parsed them once, so this only names them.
 function themeColors(theme) {
-  const { Color } = alphaTab.model;
+  const c = theme.colors;
   return {
-    mainGlyphColor: Color.fromJson(theme.ink),
-    // Voice 2 and up, and whatever else the renderer treats as secondary.
-    // Not a note-head or stem colour - there is no such resource; every glyph
+    mainGlyphColor: c.ink,
+    // Voice 2 and up, and whatever else the renderer treats as secondary. Not
+    // a note-head or stem colour - there is no such resource; every glyph
     // follows main or secondary according to the voice it belongs to.
-    secondaryGlyphColor: Color.fromJson(theme.inkSoft),
-    staffLineColor: Color.fromJson(theme.line),
-    barSeparatorColor: Color.fromJson(theme.inkSoft),
-    barNumberColor: Color.fromJson(theme.accent),
-    scoreInfoColor: Color.fromJson(theme.ink),
+    secondaryGlyphColor: c.inkSoft,
+    staffLineColor: c.line,
+    barSeparatorColor: c.inkSoft,
+    barNumberColor: c.accent,
+    scoreInfoColor: c.ink,
   };
 }
 
@@ -277,10 +297,26 @@ export function createScoreView(host, opts = {}) {
   let preset = LAYOUT_PRESETS.includes(initialPreset) ? initialPreset : "desk";
   let theme = readScoreTheme(initialTheme);
   const fonts = fontsFor(document.documentElement);
-  let layout = layoutForWidth(host?.clientWidth ?? 0, preset);
+
+  // The width to choose a layout from is the space the score has to fill - the
+  // scrolling stage - and never the host's own width. In horizontal layout the
+  // host grows to fit the score it is given, so measuring it would feed the
+  // layout's own output back into its input: a wide score would read as a wide
+  // screen, flip to the desktop tier, shrink, read as narrow, and oscillate.
+  function stageWidth() {
+    const el = scroller ?? host;
+    if (!el) return 0;
+    const style = getComputedStyle(el);
+    const padding = Number.parseFloat(style.paddingLeft) + Number.parseFloat(style.paddingRight);
+    return el.clientWidth - (Number.isFinite(padding) ? padding : 0);
+  }
+
+  let layout = layoutForWidth(stageWidth(), preset);
   let renderStartedAt = 0;
   let lastRenderMs = null;
   let renderCount = 0;
+  // a queued resize render must not touch a torn-down renderer
+  let destroyed = false;
 
   const api = new alphaTab.AlphaTabApi(host, {
     // worker/audio-worklet URLs are wired up by the @coderline/alphatab-vite
@@ -326,6 +362,57 @@ export function createScoreView(host, opts = {}) {
       host.dataset.scoreRenders = String(renderCount);
     }
   }
+  // Horizontal layout sizes its drawing surface from the total width the
+  // renderer reports, but draws partials wider than that and clips the excess
+  // with overflow:hidden - on a real transcription that hid 53 of 316 glyphs,
+  // the last bar, with nothing able to scroll to them. So after a horizontal
+  // render the paper is grown to cover what was actually drawn.
+  //
+  // The host is also the renderer's own container, so it must be back to its
+  // natural width before any render or the renderer would measure the last
+  // score's width instead of the screen's. Hence two functions, and the reset
+  // runs first.
+  function resetSurfaceFit() {
+    if (!host) return;
+    const surface = host.querySelector(".at-surface");
+    if (surface) surface.style.overflow = "";
+    host.style.width = "";
+    host.style.maxWidth = "";
+  }
+
+  function growPaperToDrawing() {
+    if (!host || layout.mode !== "horizontal") return;
+    const drawn = [...host.querySelectorAll("svg")].reduce((w, s) => Math.max(w, s.getBoundingClientRect().width), 0);
+    if (!drawn) return;
+    const surface = host.querySelector(".at-surface");
+    if (surface) surface.style.overflow = "visible";
+    const style = getComputedStyle(host);
+    const padding = Number.parseFloat(style.paddingLeft) + Number.parseFloat(style.paddingRight);
+    // never narrower than the stage, or a short score would stop mid-screen
+    const width = `${Math.max(Math.ceil(drawn + (Number.isFinite(padding) ? padding : 0)), stageWidth())}px`;
+    if (host.style.width === width) return;
+    // an explicit width, not max-content: the surface clips its own overflow,
+    // so content-based sizing would measure the same short width that hid the
+    // last bar. The stylesheet's reading-measure cap has to give way here.
+    host.style.maxWidth = "none";
+    host.style.width = width;
+  }
+
+  // Partials reach the DOM after the render reports itself finished, and in
+  // horizontal layout more of them arrive as the score is scrolled, so the
+  // measurement above has to follow the partials rather than the render.
+  // childList only: our own style writes must not retrigger it.
+  let fitQueued = false;
+  const partialWatcher = new MutationObserver(() => {
+    if (fitQueued || layout.mode !== "horizontal") return;
+    fitQueued = true;
+    requestAnimationFrame(() => {
+      fitQueued = false;
+      if (!destroyed) growPaperToDrawing();
+    });
+  });
+  if (host) partialWatcher.observe(host, { childList: true, subtree: true });
+
   publish();
   onLayout(layout);
 
@@ -341,6 +428,7 @@ export function createScoreView(host, opts = {}) {
     lastRenderMs = performance.now() - renderStartedAt;
     renderCount += 1;
     publish();
+    growPaperToDrawing();
   });
 
   api.playerReady.on(() => onReady());
@@ -357,24 +445,46 @@ export function createScoreView(host, opts = {}) {
   if (transport.metronome != null) api.metronomeVolume = transport.metronome ? 1 : 0;
   if (transport.countIn != null) api.countInVolume = transport.countIn ? 1 : 0;
 
-  // The renderer raises this before it re-renders, and settings changed in
-  // the handler are the ones it uses - so this is where a viewport change
-  // becomes a layout change, with no extra render of our own.
-  api.resize.on((e) => {
-    const next = layoutForWidth(e.newWidth, preset);
+  // A tier change is applied as a full render of our own, because the
+  // renderer's own answer to a width change is resize-*optimised* rather than
+  // a re-layout:
+  //
+  //  - it only rebuilds the layout when layoutMode itself changed;
+  //  - otherwise it asks the layout to resize, and horizontal layout declines
+  //    (supportsResize is false, doResize is empty) so nothing is drawn at all;
+  //  - and the vertical layouts only regroup systems when barsPerRow is auto.
+  //    With an explicit barsPerRow they keep the grouping they already have and
+  //    merely refit widths, so phone (1 bar) -> tablet (2 bars) would stay one
+  //    stretched bar per row.
+  //
+  // Watching the stage rather than listening for the renderer's own resize
+  // event, because the event reports the host's width - which in horizontal
+  // layout is the score's width, not the screen's.
+  let resizePending = false;
+  const observer = new ResizeObserver(() => {
+    const next = layoutForWidth(stageWidth(), preset);
     if (next === layout) return;
     layout = next;
-    const display = e.settings?.display;
-    if (display) {
-      display.layoutMode = LAYOUT_MODE[layout.mode];
-      display.barsPerRow = layout.barsPerRow;
-      display.scale = layout.scale;
-    }
-    publish();
-    onLayout(layout);
+    if (resizePending) return;
+    resizePending = true;
+    // out of the observer callback: rendering inside it would measure and
+    // mutate layout in the same frame the browser is still resolving
+    queueMicrotask(() => {
+      resizePending = false;
+      if (destroyed) return;
+      reapply();
+      onLayout(layout);
+    });
   });
+  if (scroller ?? host) observer.observe(scroller ?? host);
 
   function reapply() {
+    // before anything measures it: the host carries the previous layout's
+    // width when that layout was horizontal
+    resetSurfaceFit();
+    // and tell the renderer that width directly rather than waiting for it to
+    // notice, so the render below cannot use the stale one
+    api.renderer.width = host?.clientWidth ?? 0;
     const display = api.settings.display;
     display.staveProfile = STAVE_PROFILE[profile];
     display.layoutMode = LAYOUT_MODE[layout.mode];
@@ -431,7 +541,7 @@ export function createScoreView(host, opts = {}) {
     setPreset(next) {
       if (!LAYOUT_PRESETS.includes(next) || next === preset) return;
       preset = next;
-      layout = layoutForWidth(host?.clientWidth ?? 0, preset);
+      layout = layoutForWidth(stageWidth(), preset);
       reapply();
       onLayout(layout);
     },
@@ -462,6 +572,9 @@ export function createScoreView(host, opts = {}) {
     },
 
     destroy() {
+      destroyed = true;
+      observer.disconnect();
+      partialWatcher.disconnect();
       api.destroy();
     },
   };

--- a/web/src/lib/score-render.js
+++ b/web/src/lib/score-render.js
@@ -1,0 +1,468 @@
+// The seam between Fermata and its notation renderer. Every setting the
+// renderer is given, the theme it draws in, the layout it picks for a width,
+// and the one behaviour it offers no setting for, are all decided here.
+// Components deal in scores, profiles, widths and themes; nothing outside this
+// file imports the renderer or names one of its types. Swapping the renderer
+// (VexFlow was the runner-up, and our model lives on the server as MusicXML)
+// should mean rewriting this file and nothing else - see docs/rendering.md.
+import * as alphaTab from "@coderline/alphatab";
+
+// ---------------------------------------------------------------- profiles
+
+/** Which staves a score is drawn with. */
+export const SCORE_PROFILES = ["score", "tab", "scoretab"];
+
+const STAVE_PROFILE = {
+  score: alphaTab.StaveProfile.Score,
+  tab: alphaTab.StaveProfile.Tab,
+  scoretab: alphaTab.StaveProfile.ScoreTab,
+};
+
+// ---------------------------------------------------------------- layout
+
+// Widths are of the score container, not the window: a side-by-side PDF
+// comparison hands the staff half a desktop, and half a desktop should lay
+// out like the tablet it is that wide.
+export const PHONE_MAX_WIDTH = 620;
+export const TABLET_MAX_WIDTH = 1100;
+
+/**
+ * "desk" is a pointer and a whole window, where more bars on screen at once is
+ * worth more than size. "stand" is a tablet propped on a music stand, read
+ * from a metre away with both hands busy - big glyphs, and scrolling in one
+ * direction only. The same width wants different answers in each, so the
+ * preset is the caller's to choose rather than a function of the width.
+ */
+export const LAYOUT_PRESETS = ["desk", "stand"];
+
+// The renderer's own "fit as many as will fit" value.
+const AUTO_BARS_PER_ROW = -1;
+
+const LAYOUT_TABLE = {
+  desk: [
+    { maxWidth: PHONE_MAX_WIDTH, mode: "page", barsPerRow: 1, scale: 1.15 },
+    { maxWidth: TABLET_MAX_WIDTH, mode: "page", barsPerRow: 2, scale: 1.05 },
+    { maxWidth: Infinity, mode: "page", barsPerRow: AUTO_BARS_PER_ROW, scale: 1 },
+  ],
+  stand: [
+    // One endless system scrolled sideways is what horizontal layout is for,
+    // and it is the layout a stand wants: no page breaks to lose your place
+    // at, and a single scroll axis a thumb or a pedal can drive.
+    { maxWidth: PHONE_MAX_WIDTH, mode: "horizontal", barsPerRow: AUTO_BARS_PER_ROW, scale: 1.3 },
+    { maxWidth: TABLET_MAX_WIDTH, mode: "horizontal", barsPerRow: AUTO_BARS_PER_ROW, scale: 1.2 },
+    { maxWidth: Infinity, mode: "page", barsPerRow: 2, scale: 1.15 },
+  ],
+};
+
+const LAYOUT_MODE = {
+  page: alphaTab.LayoutMode.Page,
+  horizontal: alphaTab.LayoutMode.Horizontal,
+};
+
+/**
+ * The layout this width and preset should be drawn with. `mode` is ours
+ * ("page" / "horizontal"), not the renderer's enum, so callers can read and
+ * assert on it without importing anything.
+ */
+export function layoutForWidth(width, preset = "desk") {
+  const rows = LAYOUT_TABLE[preset] ?? LAYOUT_TABLE.desk;
+  // width 0 happens once at construction, before the host is measured
+  const w = Number.isFinite(width) && width > 0 ? width : TABLET_MAX_WIDTH;
+  return rows.find((r) => w <= r.maxWidth) ?? rows[rows.length - 1];
+}
+
+// ---------------------------------------------------------------- theme
+
+/**
+ * The renderer exposes six colours and no background at all - the surface it
+ * draws on is transparent - so a theme is five tokens: one for the paper the
+ * application paints behind the staff, and four the renderer itself uses.
+ * Values come from web/src/app.css so the palette has one home; the fallbacks
+ * here only matter if a token is missing or unparseable.
+ */
+export const SCORE_THEMES = ["parchment", "slate"];
+
+const THEME_TOKENS = {
+  parchment: {
+    surface: ["--score-surface", "#f7f2e6"],
+    ink: ["--score-ink", "#241d0f"],
+    inkSoft: ["--score-ink-soft", "#6f6045"],
+    line: ["--score-line", "#b3a284"],
+    accent: ["--score-accent", "#8a6a24"],
+  },
+  slate: {
+    surface: ["--score-dark-surface", "#191510"],
+    ink: ["--score-dark-ink", "#ece2cd"],
+    inkSoft: ["--score-dark-ink-soft", "#94866a"],
+    line: ["--score-dark-line", "#4d4331"],
+    accent: ["--score-dark-accent", "#c9a45c"],
+  },
+};
+
+// The renderer's colour parser answers null for anything it does not
+// recognise - not an error - and a null colour draws as nothing at all. So a
+// token is only used if it is a form the parser accepts.
+const COLOR_RE = /^(#(?:[0-9a-f]{3,4}|[0-9a-f]{6}|[0-9a-f]{8})|rgba?\([^)]*\))$/i;
+
+function cssValue(root, token) {
+  try {
+    return getComputedStyle(root).getPropertyValue(token).trim();
+  } catch {
+    return "";
+  }
+}
+
+/** Resolve a theme's tokens against the live stylesheet. */
+export function readScoreTheme(name = SCORE_THEMES[0], root = document.documentElement) {
+  const tokens = THEME_TOKENS[name] ?? THEME_TOKENS[SCORE_THEMES[0]];
+  const theme = { name: THEME_TOKENS[name] ? name : SCORE_THEMES[0] };
+  for (const [key, [token, fallback]] of Object.entries(tokens)) {
+    const value = cssValue(root, token);
+    theme[key] = COLOR_RE.test(value) ? value : fallback;
+  }
+  return theme;
+}
+
+// A CSS font-family list ("\"Figtree Variable\", Segoe UI, sans-serif") as the
+// renderer wants it: a plain array of family names.
+function familyList(root, token, fallback) {
+  const raw = cssValue(root, token) || fallback;
+  return raw
+    .split(",")
+    .map((f) => f.trim().replace(/^['"]|['"]$/g, ""))
+    .filter(Boolean);
+}
+
+function fontsFor(root) {
+  const { Font, FontStyle, FontWeight } = alphaTab.model;
+  const display = familyList(root, "--font-display", "Georgia, serif");
+  const ui = familyList(root, "--font-ui", "Segoe UI, sans-serif");
+  return {
+    // Fret numbers and their grace-size cousin. These are the two font
+    // resources the renderer will accept through settings.
+    tablature: Font.withFamilyList(ui, 13, FontStyle.Plain, FontWeight.Bold),
+    grace: Font.withFamilyList(ui, 11, FontStyle.Plain, FontWeight.Regular),
+    // Title block. These live behind deprecated accessors that write into the
+    // renderer's per-element font map, and are ignored if passed as settings,
+    // so they are assigned after construction instead.
+    title: Font.withFamilyList(display, 32, FontStyle.Plain, FontWeight.Bold),
+    subTitle: Font.withFamilyList(display, 19, FontStyle.Plain, FontWeight.Regular),
+    words: Font.withFamilyList(ui, 14, FontStyle.Plain, FontWeight.Regular),
+    barNumber: Font.withFamilyList(ui, 10, FontStyle.Plain, FontWeight.Regular),
+  };
+}
+
+// The renderer's colour resources have to hold its own Color objects. A hex
+// string is only accepted when the whole settings tree is handed over as JSON
+// at construction; assigning one onto a live resource leaves the renderer with
+// a string where it expects a colour, and it draws nothing. So colours are
+// converted once, here, and the same objects are used on every path.
+function themeColors(theme) {
+  const { Color } = alphaTab.model;
+  return {
+    mainGlyphColor: Color.fromJson(theme.ink),
+    // Voice 2 and up, and whatever else the renderer treats as secondary.
+    // Not a note-head or stem colour - there is no such resource; every glyph
+    // follows main or secondary according to the voice it belongs to.
+    secondaryGlyphColor: Color.fromJson(theme.inkSoft),
+    staffLineColor: Color.fromJson(theme.line),
+    barSeparatorColor: Color.fromJson(theme.inkSoft),
+    barNumberColor: Color.fromJson(theme.accent),
+    scoreInfoColor: Color.fromJson(theme.ink),
+  };
+}
+
+function displaySettings(theme, fonts, layout, profile) {
+  return {
+    staveProfile: STAVE_PROFILE[profile] ?? STAVE_PROFILE.scoretab,
+    layoutMode: LAYOUT_MODE[layout.mode],
+    barsPerRow: layout.barsPerRow,
+    scale: layout.scale,
+    resources: {
+      ...themeColors(theme),
+      tablatureFont: fonts.tablature,
+      graceFont: fonts.grace,
+    },
+  };
+}
+
+// ------------------------------------------------- the branding override
+
+// The renderer draws "rendered by alphaTab" onto every score, from a private
+// method on its layout base class, called unconditionally from four render
+// paths. There is no setting to turn it off, and its licence (MPL-2.0) asks
+// for no attribution in the output - so this reaches past the public API to
+// neutralise it rather than vendoring a patched copy of the library, which
+// would put us under MPL-2.0's obligation to publish the modified file.
+//
+// The method is defined on a base class two or three levels above whichever
+// layout is active, and is not exported, so the only way to it is up the
+// prototype chain from a live layout object. Patching what we find there
+// covers every layout mode rather than only the one that happens to be in
+// use. If a future version renames or moves it the patch simply misses, the
+// annotation comes back, and the warning below is the only thing that will
+// tell us - so it warns rather than failing quietly.
+const BRAND_METHOD = "_layoutAndRenderAnnotation";
+
+let brandingState = "pending";
+
+function applyBrandingOverride(api) {
+  if (brandingState === "applied") return;
+  // The layout object is created by the renderer, not the api, and only exists
+  // on this thread at all because RENDER_IN_WORKER is off.
+  const layout = api?.renderer?.instance?.layout;
+  let proto = layout ? Object.getPrototypeOf(layout) : null;
+  while (proto && !Object.prototype.hasOwnProperty.call(proto, BRAND_METHOD)) {
+    proto = Object.getPrototypeOf(proto);
+  }
+  if (!proto) {
+    if (brandingState !== "missing") {
+      brandingState = "missing";
+      console.warn(
+        `score-render: could not find ${BRAND_METHOD} on the layout's prototype chain. ` +
+          "The renderer's own annotation will be drawn on every score until this is updated.",
+      );
+    }
+    return;
+  }
+  // The original returns the y it was given plus the height it consumed;
+  // consuming nothing is exactly what "do not draw it" means.
+  proto[BRAND_METHOD] = function neutralised(y) {
+    return y;
+  };
+  brandingState = "applied";
+}
+
+// Put the renderer in a worker and its layout object does not exist in our
+// realm, so there is no prototype to reach - which is the only reason this is
+// off. It measured faster either way: the worker costs 130-260 ms of startup
+// and re-renders identically. docs/rendering.md has the numbers.
+const RENDER_IN_WORKER = false;
+
+// ---------------------------------------------------------------- the view
+
+/**
+ * Create a score view on `host`. Returns a handle whose vocabulary is
+ * Fermata's, not the renderer's.
+ *
+ * @param host      element the score is drawn into
+ * @param opts.scroller     scrolling ancestor the playback cursor follows
+ * @param opts.source       {kind:"alphatex",text} | {kind:"musicxml",text} | {kind:"file",url}
+ * @param opts.profile      one of SCORE_PROFILES
+ * @param opts.preset       one of LAYOUT_PRESETS
+ * @param opts.theme        one of SCORE_THEMES
+ * @param opts.transport    {speed, looping, metronome, countIn} to start at
+ * @param opts.onReady      playback became available
+ * @param opts.onPlaying    (boolean) transport state changed
+ * @param opts.onError      (message) load or render failed
+ * @param opts.onPassComplete  one pass finished (drives the tempo ladder)
+ * @param opts.onLayout     (layout) the chosen layout changed
+ */
+export function createScoreView(host, opts = {}) {
+  const {
+    scroller = null,
+    source = null,
+    profile: initialProfile = "scoretab",
+    preset: initialPreset = "desk",
+    theme: initialTheme = SCORE_THEMES[0],
+    transport = {},
+    onReady = () => {},
+    onPlaying = () => {},
+    onError = () => {},
+    onPassComplete = () => {},
+    onLayout = () => {},
+  } = opts;
+
+  let profile = SCORE_PROFILES.includes(initialProfile) ? initialProfile : "scoretab";
+  let preset = LAYOUT_PRESETS.includes(initialPreset) ? initialPreset : "desk";
+  let theme = readScoreTheme(initialTheme);
+  const fonts = fontsFor(document.documentElement);
+  let layout = layoutForWidth(host?.clientWidth ?? 0, preset);
+  let renderStartedAt = 0;
+  let lastRenderMs = null;
+  let renderCount = 0;
+
+  const api = new alphaTab.AlphaTabApi(host, {
+    // worker/audio-worklet URLs are wired up by the @coderline/alphatab-vite
+    // plugin (vite.config.js); fontDirectory/soundFont still need to match
+    // where that plugin copies the assets (site root, see its README).
+    core: {
+      fontDirectory: "/font/",
+      useWorkers: RENDER_IN_WORKER,
+    },
+    player: {
+      enablePlayer: true,
+      soundFont: "/soundfont/sonivox.sf2",
+      scrollElement: scroller ?? undefined,
+    },
+    display: displaySettings(theme, fonts, layout, profile),
+  });
+
+  applyBrandingOverride(api);
+
+  // Fonts for the title block are not readable through settings; they are
+  // assigned onto the live resource object, which is why this happens after
+  // construction and before the first score is loaded.
+  const resources = api.settings.display.resources;
+  resources.titleFont = fonts.title;
+  resources.subTitleFont = fonts.subTitle;
+  resources.wordsFont = fonts.words;
+  resources.barNumberFont = fonts.barNumber;
+  api.updateSettings();
+
+  // Reflect the layer's decisions onto the host: readable in devtools, and
+  // the only thing a test needs in order to assert that a width produced a
+  // different layout rather than merely a different screenshot.
+  function publish() {
+    if (!host) return;
+    host.dataset.scoreLayout = layout.mode;
+    host.dataset.scoreBarsPerRow = String(layout.barsPerRow);
+    host.dataset.scoreScale = String(layout.scale);
+    host.dataset.scorePreset = preset;
+    host.dataset.scoreTheme = theme.name;
+    host.dataset.scoreProfile = profile;
+    if (lastRenderMs != null) {
+      host.dataset.scoreRenderMs = lastRenderMs.toFixed(1);
+      host.dataset.scoreRenders = String(renderCount);
+    }
+  }
+  publish();
+  onLayout(layout);
+
+  // Second chance for the override: the layout object exists by the time the
+  // view is built today, but it is created by the renderer rather than the
+  // api, so a version that creates it later would still be covered here -
+  // before the first layout pass, which is when the annotation is drawn.
+  api.renderStarted.on(() => {
+    renderStartedAt = performance.now();
+    applyBrandingOverride(api);
+  });
+  api.postRenderFinished.on(() => {
+    lastRenderMs = performance.now() - renderStartedAt;
+    renderCount += 1;
+    publish();
+  });
+
+  api.playerReady.on(() => onReady());
+  api.playerStateChanged.on((e) => onPlaying(e.state === 1));
+  api.error.on((e) => onError(e?.message ?? "failed to load score"));
+  // Fires at the end of each loop pass, not only the final stop, which is
+  // what makes it usable as "one clean pass done".
+  api.playerFinished.on(() => onPassComplete());
+
+  // A fresh renderer starts at its own transport defaults, so carry over
+  // whatever the caller was already using.
+  if (transport.speed != null) api.playbackSpeed = transport.speed;
+  if (transport.looping != null) api.isLooping = transport.looping;
+  if (transport.metronome != null) api.metronomeVolume = transport.metronome ? 1 : 0;
+  if (transport.countIn != null) api.countInVolume = transport.countIn ? 1 : 0;
+
+  // The renderer raises this before it re-renders, and settings changed in
+  // the handler are the ones it uses - so this is where a viewport change
+  // becomes a layout change, with no extra render of our own.
+  api.resize.on((e) => {
+    const next = layoutForWidth(e.newWidth, preset);
+    if (next === layout) return;
+    layout = next;
+    const display = e.settings?.display;
+    if (display) {
+      display.layoutMode = LAYOUT_MODE[layout.mode];
+      display.barsPerRow = layout.barsPerRow;
+      display.scale = layout.scale;
+    }
+    publish();
+    onLayout(layout);
+  });
+
+  function reapply() {
+    const display = api.settings.display;
+    display.staveProfile = STAVE_PROFILE[profile];
+    display.layoutMode = LAYOUT_MODE[layout.mode];
+    display.barsPerRow = layout.barsPerRow;
+    display.scale = layout.scale;
+    Object.assign(display.resources, themeColors(theme));
+    api.updateSettings();
+    api.render();
+    publish();
+  }
+
+  function load(next) {
+    if (!next) return;
+    if (next.kind === "alphatex") {
+      api.tex(next.text);
+    } else if (next.kind === "musicxml") {
+      // Goes through the same byte loader a library file uses: the format is
+      // detected from the content, so there is no separate entry point.
+      api.load(new TextEncoder().encode(next.text));
+    } else if (next.kind === "file") {
+      fetch(next.url)
+        .then((r) => r.arrayBuffer())
+        .then((buf) => api.load(new Uint8Array(buf)))
+        .catch((e) => onError(String(e)));
+    }
+  }
+
+  load(source);
+
+  return {
+    get layout() {
+      return layout;
+    },
+    get theme() {
+      return theme;
+    },
+    get profile() {
+      return profile;
+    },
+    get preset() {
+      return preset;
+    },
+    /** Milliseconds of renderer work in the last render, not time to pixels. */
+    get lastRenderMs() {
+      return lastRenderMs;
+    },
+
+    setProfile(next) {
+      if (!SCORE_PROFILES.includes(next) || next === profile) return;
+      profile = next;
+      reapply();
+    },
+    /** Gig mode wants "stand" at the same width a desk session wants "desk". */
+    setPreset(next) {
+      if (!LAYOUT_PRESETS.includes(next) || next === preset) return;
+      preset = next;
+      layout = layoutForWidth(host?.clientWidth ?? 0, preset);
+      reapply();
+      onLayout(layout);
+    },
+    setTheme(next) {
+      const resolved = readScoreTheme(next);
+      if (resolved.name === theme.name) return;
+      theme = resolved;
+      reapply();
+    },
+
+    setSpeed(v) {
+      api.playbackSpeed = v;
+    },
+    setLooping(v) {
+      api.isLooping = v;
+    },
+    setMetronome(v) {
+      api.metronomeVolume = v ? 1 : 0;
+    },
+    setCountIn(v) {
+      api.countInVolume = v ? 1 : 0;
+    },
+    playPause() {
+      api.playPause();
+    },
+    stop() {
+      api.stop();
+    },
+
+    destroy() {
+      api.destroy();
+    },
+  };
+}

--- a/web/vite.config.js
+++ b/web/vite.config.js
@@ -4,7 +4,7 @@ import { defineConfig } from "vite";
 
 export default defineConfig({
   // alphaTab() wires up the worker/audio-worklet bundling and copies its
-  // font + soundfont assets into public/ — see TabViewer.svelte for the
+  // font + soundfont assets into public/ — see src/lib/score-render.js for the
   // matching core.fontDirectory / player.soundFont paths.
   plugins: [svelte(), alphaTab()],
   server: {


### PR DESCRIPTION
`TabViewer.svelte` configured the notation renderer inline, so appearance,
responsive layout and the renderer's quirks were spread through a component
that is mostly a toolbar. This puts all of it behind one module.

## The seam

`web/src/lib/score-render.js` (468 lines) owns every interaction with the
renderer. Nothing else in `web/src` imports it or names one of its types — the
only remaining mention outside that file is a comment in `vite.config.js` about
where the plugin copies fonts.

```js
createScoreView(host, {
  scroller, source, profile, preset, theme, transport,
  onReady, onPlaying, onError, onPassComplete, onLayout,
})
// -> { layout, theme, profile, preset, lastRenderMs,
//      setProfile, setPreset, setTheme,
//      setSpeed, setLooping, setMetronome, setCountIn,
//      playPause, stop, destroy }
```

Plus `SCORE_PROFILES`, `LAYOUT_PRESETS`, `SCORE_THEMES`, `PHONE_MAX_WIDTH`,
`TABLET_MAX_WIDTH`, `layoutForWidth(width, preset)` and
`readScoreTheme(name, root)`.

The vocabulary is deliberately Fermata's rather than the library's, because
VexFlow was the credible runner-up and stays credible while the authoritative
model is MusicXML on the server. `layout.mode` is `"page"` or `"horizontal"`,
not an enum. A source is `{kind: "alphatex" | "musicxml" | "file"}`, not the
byte-loader call the library happens to want. The transport is `setLooping` and
`setMetronome`, not volume fields on a live api object. Event names, settings
trees, colour objects, font objects and prototype quirks all stop at the file.

## Responsive layout

Layout is chosen from the width of the **score container**, not the window: a
side-by-side PDF comparison hands the staff half a desktop, and half a desktop
should lay out like the tablet it is that wide. Breakpoints are named constants
(`PHONE_MAX_WIDTH` 620, `TABLET_MAX_WIDTH` 1100) and re-applied inside the
renderer's own `resize` event, so a viewport change costs one render, not two.

There are two presets, because the same width wants different answers depending
on where the screen is:

| | phone (≤620) | tablet (≤1100) | desktop |
| --- | --- | --- | --- |
| `desk` | page, 1 bar/row, scale 1.15 | page, 2 bars/row, scale 1.05 | page, auto, scale 1.00 |
| `stand` | horizontal, scale 1.30 | horizontal, scale 1.20 | page, 2 bars/row, scale 1.15 |

`desk` is a pointer and a whole window, where more bars on screen beats size.
`stand` — what gig mode asks for — is a tablet on a music stand read from a
metre away with both hands busy, so glyphs grow and the score becomes one
endless system scrolled sideways: no page breaks to lose your place at, and a
single scroll axis a thumb or a pedal can drive.

The layer reflects its choices onto the host as `data-score-*` attributes, so
what it decided is readable in devtools and assertable in a test rather than
only visible in a screenshot.

## Theming

The staff is drawn from Fermata's palette. Tokens live in `web/src/app.css`
(`--score-ink`, `--score-line`, `--score-accent`, …) and the layer reads them
from the live stylesheet, so the palette keeps one home. Two themes: `parchment`
and `slate`, a dark staff for practising in the dark — drawn dark rather than
inverted, which is what the PDF reader has to do with a fixed page.

The renderer's playback cursor and range selection ship with **no colour at
all** — it creates their elements with position only, so they were invisible
before this. They are styled from the same tokens now.

`docs/rendering.md` lists exactly which resources the renderer exposes and,
more usefully, what is out of configuration's reach: there is no separate
note-head, stem or beam colour (every glyph follows main or secondary by which
voice it belongs to), there is no background colour and no background at all
(the surface is transparent), and the deprecated per-element font accessors are
silently ignored when passed as settings.

## The branding override

The renderer draws "rendered by alphaTab" onto every score from a private
method on its layout base class, called unconditionally from four render paths,
with no setting to disable it. The layer walks up the prototype chain from the
live layout object to the prototype that **defines** the method and replaces it
there, once. In 1.8.4 that owner is `ScoreLayout` for all three concrete
layouts — `PageViewLayout` and `ParchmentLayout` through `VerticalLayoutBase`,
`HorizontalScreenLayout` directly — so patching the owner covers every layout
mode rather than only the active subclass. None of those classes is exported, so
a live instance is the only route to them.

If the method cannot be found it warns to the console and carries on. Verified
by pointing the constant at a name that does not exist: one warning, no
exception, the score still rendered, and the only consequence was the
annotation reappearing.

Two honest costs, both in the doc:

- **It reaches past the public API.** The method is undeclared in the type
  definitions and its owner is unexported. It survives a stock Vite production
  build (property names are not mangled) — checked against the built output, not
  assumed. A version that renames it will trip the warning.
- **It needs the renderer on the main thread.** With the render worker on, the
  layout object does not exist in our realm and there is nothing to patch. So
  `core.useWorkers` is off, behind a `RENDER_IN_WORKER` constant. Measured, it
  is the faster choice anyway: the worker cost 130–260 ms of startup and
  re-rendered identically.

This is a runtime patch rather than a vendored copy with one method removed
because alphaTab is MPL-2.0 — modifying its files would oblige us to publish
the modified file.

## Verification

Driven in real Chrome, not inferred from a passing build.

- Demo route and a real transcription (a 27 KB MusicXML transcription of an
  engraved PDF, in the side-by-side comparison view) both render.
- Playback plays and pauses, the cursor advances and is visible; loop,
  metronome and count-in toggle; the speed select applies; the tempo ladder
  opens its controls, forces loop on and starts at its configured percentage.
- All three profiles render and change staff height (notation 230 px, tab
  213 px, both 321 px on the same score).
- **The annotation is absent from the rendered output** — asserted on the SVG
  text, not on the patch having run — at all three widths, in page and
  horizontal layout, in gig mode, and in the minified production build.
- Three widths produce three layouts (1 / 2 / auto bars per row at scale
  1.15 / 1.05 / 1.00; 6 / 5 / 3 partials; 943 / 708 / 321 px tall). Resizing
  back and forth through all three, twice, threw nothing and lost nothing.
- Themed colours reach the staff: `#241D0F`, `#B3A284`, `#6F6045`, `#8A6A24`
  in parchment and `#ECE2CD`, `#4D4331`, `#94866A`, `#C9A45C` in slate are the
  only fills in the output, and the title renders in Fraunces, fret numbers in
  Figtree.
- Gig mode still works: HUD appears, toolbar and header hide, preset flips to
  `stand`, and at tablet width the score becomes one 2246 px-wide system in an
  860 px viewport that scrolls sideways without losing partials. Escape
  restores `desk`.
- No console errors and no page errors in any run.

Timings after the change, medians on a real score:

| | |
| --- | --- |
| First render, renderer work | 6.9–16 ms |
| First paint, navigation to staff on screen | 267–403 ms |
| Re-render, renderer work | 0.5–1.0 ms |
| Re-render, to pixels | 16–35 ms |
| Resize-driven re-render, renderer work | 0.1–0.3 ms |

## Not changed

The demo route has never passed `gigMode` down to the viewer, so pressing F
there hides the header without showing the HUD. That predates this branch and
is left alone rather than folded into a refactor.
