### PR TITLE
Three staff themes, remembered in settings

### DIFF
--- a/docs/rendering.md
+++ b/docs/rendering.md
@@ -167,12 +167,20 @@ palette has one home:
 
 ```
 --score-surface  --score-ink  --score-ink-soft  --score-line  --score-accent
---score-dark-surface  --score-dark-ink  --score-dark-ink-soft  ...
+--score-noir-surface  --score-noir-ink  --score-noir-ink-soft  ...
+--score-print-surface  --score-print-ink  --score-print-ink-soft  ...
 ```
 
-Two themes: `parchment` (warm paper, dark ink) and `slate` (a dark staff for
-practising in the dark). The PDF reader has to invert a fixed page; a rendered
-staff can simply be drawn dark, which is what `slate` does.
+Three themes: `parchment` (warm paper, dark ink - the default, matching the
+rest of the interface), `noir` (true black with near-white ink, for a dim room
+or a bright stage) and `print` (black ink on white, the printed-page look,
+most legible under harsh light). The PDF reader has to invert a fixed page; a
+rendered staff can simply be drawn in whichever of these it needs.
+
+The staff theme is a user setting stored on the server (`/api/settings`), not
+browser-local, so it follows a person between devices - see
+`web/src/lib/settings.svelte.js` and the settings view
+(`web/src/lib/Settings.svelte`).
 
 Values must stay in a form the renderer's colour parser accepts: hex, or the
 **comma-separated** `rgb()`/`rgba()` form. It splits the function body on
@@ -223,8 +231,9 @@ invisible in page layout and so easy to ship broken:
 - The renderer draws the whole score as one system, far wider than any sensible
   card. Left alone, the staff scrolls off the paper onto the page background —
   and with the parchment theme that is dark ink on a dark page, effectively
-  invisible. `slate` hides the problem, because its surface is close to the page
-  colour.
+  invisible. `noir` hides the problem too, since its surface is close enough
+  to the page's own dark background; `print`'s white surface would have made
+  it obvious immediately.
 - The renderer sizes its drawing surface from the total width it *reports*, but
   draws partials wider than that and clips the excess with `overflow: hidden`.
   On a real transcription that hid 53 of 316 glyphs — the last bar and the final

--- a/server/fermata/api.py
+++ b/server/fermata/api.py
@@ -23,6 +23,11 @@ VALID_PRACTICED = {"recent", "neglected"}
 # so it follows a person between devices. Defaults are what a fresh install
 # with nothing stored behaves as. `SETTINGS_CHOICES` is optional per key: a
 # key with no entry there accepts any string value.
+#
+# staff_theme's choices must be kept in sync with SCORE_THEMES in
+# web/src/lib/score-render.js - test_settings_api.py's
+# test_staff_theme_choices_match_the_frontends_score_themes parses that file
+# and fails if the two ever disagree.
 SETTINGS_DEFAULTS = {"staff_theme": "parchment"}
 SETTINGS_CHOICES = {"staff_theme": {"parchment", "noir", "print"}}
 # MusicXML is a good deal more verbose than alphaTex for the same music: across
@@ -95,7 +100,22 @@ def get_settings():
         "SELECT key, value FROM settings WHERE owner = ?", (DEFAULT_OWNER,)
     ).fetchall()
     result = dict(SETTINGS_DEFAULTS)
-    result.update({r["key"]: r["value"] for r in rows})
+    for row in rows:
+        key, value = row["key"], row["value"]
+        if key not in SETTINGS_DEFAULTS:
+            continue  # a setting since retired - ignore rather than surface it
+        choices = SETTINGS_CHOICES.get(key)
+        if choices and value not in choices:
+            # A value that was valid when stored but isn't any more - this PR
+            # itself renames the theme 'slate' to 'noir', so an existing
+            # install can hold staff_theme='slate'. put_settings() can never
+            # write this today, but a stored value outliving the choices it
+            # was written under is exactly the kind of drift a rename causes,
+            # so fall back to the default rather than hand back a value
+            # nothing can render (the picker would then highlight no card at
+            # all, and the renderer would quietly fall back on its own).
+            continue
+        result[key] = value
     return result
 
 

--- a/server/fermata/api.py
+++ b/server/fermata/api.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel, Field
 
 from . import scanner
 from .config import FILE_TYPES, LIBRARY_DIR
-from .db import connect, tx
+from .db import DEFAULT_OWNER, connect, tx
 from .glyph_rhythm import VALID_TS_DENOMINATORS
 from .tabextract import analyze as analyze_pdf, extract as extract_pdf
 from .thumbs import thumb_path
@@ -18,6 +18,13 @@ router = APIRouter(prefix="/api")
 
 VALID_KINDS = {"notation", "tab", "both", "unknown"}
 VALID_PRACTICED = {"recent", "neglected"}
+
+# A user setting, not a per-score one - kept server-side (not browser storage)
+# so it follows a person between devices. Defaults are what a fresh install
+# with nothing stored behaves as. `SETTINGS_CHOICES` is optional per key: a
+# key with no entry there accepts any string value.
+SETTINGS_DEFAULTS = {"staff_theme": "parchment"}
+SETTINGS_CHOICES = {"staff_theme": {"parchment", "noir", "print"}}
 # MusicXML is a good deal more verbose than alphaTex for the same music: across
 # the sampled library it runs about 44x the characters, and the longest score
 # comes out around 660 KB. This leaves room for a compilation several times
@@ -79,6 +86,39 @@ def _with_tags(conn, rows):
 @router.get("/health")
 def health():
     return {"status": "ok"}
+
+
+@router.get("/settings")
+def get_settings():
+    conn = connect()
+    rows = conn.execute(
+        "SELECT key, value FROM settings WHERE owner = ?", (DEFAULT_OWNER,)
+    ).fetchall()
+    result = dict(SETTINGS_DEFAULTS)
+    result.update({r["key"]: r["value"] for r in rows})
+    return result
+
+
+@router.put("/settings")
+def put_settings(patch: dict[str, str] = Body(...)):
+    # A settings store that takes arbitrary keys becomes a junk drawer - only
+    # known keys are accepted, and a key with choices in SETTINGS_CHOICES must
+    # be one of them.
+    unknown = set(patch) - set(SETTINGS_DEFAULTS)
+    if unknown:
+        raise HTTPException(422, f"unknown setting(s): {sorted(unknown)}")
+    for key, value in patch.items():
+        choices = SETTINGS_CHOICES.get(key)
+        if choices and value not in choices:
+            raise HTTPException(422, f"{key} must be one of {sorted(choices)}")
+    with tx() as conn:
+        for key, value in patch.items():
+            conn.execute(
+                """INSERT INTO settings(owner, key, value) VALUES (?, ?, ?)
+                   ON CONFLICT(owner, key) DO UPDATE SET value = excluded.value""",
+                (DEFAULT_OWNER, key, value),
+            )
+    return get_settings()
 
 
 @router.get("/scores")

--- a/server/fermata/db.py
+++ b/server/fermata/db.py
@@ -6,6 +6,12 @@ from .config import DB_PATH
 
 _local = threading.local()
 
+# The only owner that exists until real accounts do. Kept as a named constant
+# rather than the literal 'local' scattered wherever a write means "this
+# instance's one user", so the day accounts arrive, every such site is a grep
+# away from being migrated to a real owner id instead of a schema redesign.
+DEFAULT_OWNER = "local"
+
 SCHEMA = """
 CREATE TABLE IF NOT EXISTS scores (
     id INTEGER PRIMARY KEY,
@@ -63,6 +69,18 @@ CREATE TABLE IF NOT EXISTS transcriptions (
     updated_at TEXT NOT NULL DEFAULT (datetime('now'))
 );
 CREATE UNIQUE INDEX IF NOT EXISTS idx_transcriptions_score_source ON transcriptions(score_id, source);
+
+-- Key/value rather than a column per setting, so adding the next preference
+-- needs no migration. `owner` is unused today - every row is written with
+-- DEFAULT_OWNER - but it is here from the start so introducing real accounts
+-- later is a data migration (giving rows real owner ids) rather than a
+-- schema redesign.
+CREATE TABLE IF NOT EXISTS settings (
+    owner TEXT NOT NULL DEFAULT 'local',
+    key TEXT NOT NULL,
+    value TEXT NOT NULL,
+    PRIMARY KEY (owner, key)
+);
 """
 
 

--- a/server/tests/test_settings_api.py
+++ b/server/tests/test_settings_api.py
@@ -1,0 +1,65 @@
+import pytest
+from fastapi import HTTPException
+
+from fermata import api, db
+
+
+def test_defaults_when_nothing_is_stored(app_env):
+    assert api.get_settings() == {"staff_theme": "parchment"}
+
+
+def test_write_then_read_back(app_env):
+    written = api.put_settings({"staff_theme": "noir"})
+    assert written == {"staff_theme": "noir"}
+    assert api.get_settings() == {"staff_theme": "noir"}
+
+
+def test_write_is_an_upsert_not_a_duplicate_row(app_env):
+    api.put_settings({"staff_theme": "noir"})
+    api.put_settings({"staff_theme": "print"})
+    conn = db.connect()
+    rows = conn.execute(
+        "SELECT value FROM settings WHERE key = 'staff_theme'"
+    ).fetchall()
+    assert [r["value"] for r in rows] == ["print"]
+
+
+def test_unknown_key_is_rejected(app_env):
+    with pytest.raises(HTTPException) as exc_info:
+        api.put_settings({"favorite_color": "brass"})
+    assert exc_info.value.status_code == 422
+
+
+def test_unknown_key_alongside_a_known_one_rejects_the_whole_write(app_env):
+    """A partially-valid write must not partially apply - the unknown key
+    fails the whole call rather than silently dropping just that key."""
+    with pytest.raises(HTTPException):
+        api.put_settings({"staff_theme": "noir", "bogus": "x"})
+    assert api.get_settings() == {"staff_theme": "parchment"}
+
+
+def test_invalid_value_for_a_known_key_is_rejected(app_env):
+    with pytest.raises(HTTPException) as exc_info:
+        api.put_settings({"staff_theme": "psychedelic"})
+    assert exc_info.value.status_code == 422
+
+
+def test_owner_defaults_to_the_single_instance_owner(app_env):
+    api.put_settings({"staff_theme": "noir"})
+    conn = db.connect()
+    row = conn.execute(
+        "SELECT owner FROM settings WHERE key = 'staff_theme'"
+    ).fetchone()
+    assert row["owner"] == db.DEFAULT_OWNER == "local"
+
+
+def test_writing_several_settings_in_one_call(app_env, monkeypatch):
+    # Only one real setting exists today; a second is faked in to prove the
+    # endpoint's "one or several" contract rather than only ever exercising
+    # a single-key dict.
+    monkeypatch.setitem(api.SETTINGS_DEFAULTS, "practice_reminder", "off")
+    monkeypatch.setitem(api.SETTINGS_CHOICES, "practice_reminder", {"on", "off"})
+    result = api.put_settings({"staff_theme": "noir", "practice_reminder": "on"})
+    assert result["staff_theme"] == "noir"
+    assert result["practice_reminder"] == "on"
+    assert api.get_settings() == result

--- a/server/tests/test_settings_api.py
+++ b/server/tests/test_settings_api.py
@@ -1,3 +1,6 @@
+import re
+from pathlib import Path
+
 import pytest
 from fastapi import HTTPException
 
@@ -63,3 +66,50 @@ def test_writing_several_settings_in_one_call(app_env, monkeypatch):
     assert result["staff_theme"] == "noir"
     assert result["practice_reminder"] == "on"
     assert api.get_settings() == result
+
+
+# ---------------------------------------------------------------------------
+# A value that was valid when written can stop being valid later (a theme
+# rename, a retired setting). put_settings() can never write such a value
+# itself - these simulate one already sitting in the database, as a rename
+# or an old client would leave behind.
+# ---------------------------------------------------------------------------
+
+
+def test_a_stored_value_no_longer_in_choices_falls_back_to_the_default(app_env):
+    """This PR renames the theme 'slate' to 'noir'. An install upgraded from
+    before the rename can have staff_theme='slate' sitting in its database -
+    that must read back as the default, not as a value nothing can render."""
+    conn = db.connect()
+    conn.execute(
+        "INSERT INTO settings(owner, key, value) VALUES (?, 'staff_theme', 'slate')",
+        (db.DEFAULT_OWNER,),
+    )
+    conn.commit()
+    assert api.get_settings() == {"staff_theme": "parchment"}
+
+
+def test_a_stored_unknown_key_is_omitted_not_surfaced(app_env):
+    conn = db.connect()
+    conn.execute(
+        "INSERT INTO settings(owner, key, value) VALUES (?, 'retired_setting', 'x')",
+        (db.DEFAULT_OWNER,),
+    )
+    conn.commit()
+    assert api.get_settings() == {"staff_theme": "parchment"}
+
+
+def test_staff_theme_choices_match_the_frontends_score_themes():
+    """SETTINGS_CHOICES['staff_theme'] here and SCORE_THEMES in
+    score-render.js are two copies of the same list with nothing connecting
+    them at runtime - the frontend never calls this endpoint to ask what's
+    valid. If they drift, the settings view offers a theme the server
+    rejects with a 422 the interface has no code path to show. Parsing the
+    frontend source is the cheapest way to keep them honest without wiring
+    a real dependency between a Python service and a Svelte module."""
+    js_path = Path(__file__).resolve().parents[2] / "web" / "src" / "lib" / "score-render.js"
+    source = js_path.read_text(encoding="utf-8")
+    match = re.search(r'SCORE_THEMES\s*=\s*\[([^\]]*)\]', source)
+    assert match, "could not find SCORE_THEMES in score-render.js"
+    frontend_themes = set(re.findall(r'"([^"]+)"', match.group(1)))
+    assert frontend_themes == api.SETTINGS_CHOICES["staff_theme"]

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -1,11 +1,13 @@
 <script>
   import Library from "./lib/Library.svelte";
   import Viewer from "./lib/Viewer.svelte";
+  import Settings from "./lib/Settings.svelte";
 
   function parse(hash) {
     const m = hash.match(/^#\/score\/(\d+)/);
     if (m) return { page: "score", id: Number(m[1]) };
     if (hash.startsWith("#/demo")) return { page: "demo" };
+    if (hash.startsWith("#/settings")) return { page: "settings" };
     return { page: "library" };
   }
 
@@ -22,6 +24,8 @@
   <Viewer id={route.id} />
 {:else if route.page === "demo"}
   <Viewer demo={true} />
+{:else if route.page === "settings"}
+  <Settings />
 {:else}
   <Library />
 {/if}

--- a/web/src/app.css
+++ b/web/src/app.css
@@ -27,13 +27,21 @@
   --score-line: #b3a284;
   --score-accent: #8a6a24;
 
-  /* The same staff for practising in the dark. Drawn dark rather than
-     inverted, which is what the PDF reader has to do with a fixed page. */
-  --score-dark-surface: #191510;
-  --score-dark-ink: #ece2cd;
-  --score-dark-ink-soft: #94866a;
-  --score-dark-line: #4d4331;
-  --score-dark-accent: #c9a45c;
+  /* True black with near-white ink - maximum contrast for a dim room or a
+     bright stage, not to be confused with a merely dark page. */
+  --score-noir-surface: #000000;
+  --score-noir-ink: #f5f3ea;
+  --score-noir-ink-soft: #9a9488;
+  --score-noir-line: #4a4438;
+  --score-noir-accent: #e6c377;
+
+  /* The printed-page look: black ink on white, most legible under harsh
+     light. */
+  --score-print-surface: #ffffff;
+  --score-print-ink: #14110a;
+  --score-print-ink-soft: #6b6558;
+  --score-print-line: #c9c3b3;
+  --score-print-accent: #8a6a24;
 }
 
 * {

--- a/web/src/lib/Library.svelte
+++ b/web/src/lib/Library.svelte
@@ -172,6 +172,7 @@
         {scan?.scanning ? `Scanning ${scan.processed}/${scan.total}…` : "Scan library"}
       </button>
       <a class="demo-link" href="#/demo">Notation/tab demo →</a>
+      <a class="demo-link" href="#/settings">⚙ Settings</a>
     </div>
   </aside>
 

--- a/web/src/lib/Settings.svelte
+++ b/web/src/lib/Settings.svelte
@@ -1,0 +1,164 @@
+<script>
+  import {
+    getSettings,
+    setSetting,
+    STAFF_THEMES,
+    STAFF_THEME_LABELS,
+    STAFF_THEME_TOKEN_PREFIX,
+  } from "./settings.svelte.js";
+
+  const settings = getSettings();
+
+  // Which theme (if any) has a write in flight, so only that card disables
+  // itself rather than the whole picker while the request is out.
+  let pending = $state(null);
+
+  async function chooseTheme(theme) {
+    if (theme === settings.staff_theme || pending) return;
+    pending = theme;
+    try {
+      await setSetting("staff_theme", theme);
+    } catch {
+      // setSetting already rolled the optimistic value back; nothing else to do
+    } finally {
+      pending = null;
+    }
+  }
+</script>
+
+<div class="settings">
+  <header>
+    <a class="back" href="#/">← Library</a>
+    <h1>Settings</h1>
+  </header>
+
+  <main>
+    <section>
+      <h2>Staff theme</h2>
+      <p class="hint">
+        How notation and tab are drawn, wherever a score renders. Saved to your account, so it
+        follows you to any device.
+      </p>
+      <div class="theme-grid">
+        {#each STAFF_THEMES as theme}
+          {@const prefix = STAFF_THEME_TOKEN_PREFIX[theme]}
+          <button
+            class="theme-card"
+            class:on={settings.staff_theme === theme}
+            disabled={pending === theme}
+            onclick={() => chooseTheme(theme)}
+          >
+            <span
+              class="swatch"
+              style={`background:var(${prefix}-surface); color:var(${prefix}-ink); border-color:var(${prefix}-line)`}
+            >
+              <span class="swatch-line" style={`background:var(${prefix}-line)`}></span>
+              Aa
+            </span>
+            <span class="label">{STAFF_THEME_LABELS[theme]}</span>
+          </button>
+        {/each}
+      </div>
+    </section>
+  </main>
+</div>
+
+<style>
+  .settings {
+    height: 100vh;
+    display: flex;
+    flex-direction: column;
+  }
+
+  header {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    padding: 10px 16px;
+    border-bottom: 1px solid var(--line);
+    background: var(--bg-raised);
+  }
+
+  .back {
+    color: var(--ink-dim);
+    white-space: nowrap;
+  }
+
+  .back:hover {
+    color: var(--brass-bright);
+  }
+
+  header h1 {
+    font-size: 18px;
+  }
+
+  main {
+    flex: 1;
+    overflow-y: auto;
+    padding: 28px;
+  }
+
+  section {
+    max-width: 640px;
+  }
+
+  h2 {
+    font-size: 15px;
+    margin-bottom: 6px;
+  }
+
+  .hint {
+    color: var(--ink-dim);
+    font-size: 13px;
+    margin: 0 0 18px;
+    line-height: 1.5;
+  }
+
+  .theme-grid {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 14px;
+  }
+
+  .theme-card {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 10px;
+    padding: 14px 10px;
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: 10px;
+  }
+
+  .theme-card.on {
+    border-color: var(--brass);
+    box-shadow: 0 0 0 1px var(--brass);
+  }
+
+  .swatch {
+    width: 100%;
+    aspect-ratio: 4 / 3;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    position: relative;
+    border: 1px solid;
+    border-radius: 6px;
+    font-family: var(--font-display);
+    font-size: 22px;
+  }
+
+  .swatch-line {
+    position: absolute;
+    left: 12%;
+    right: 12%;
+    top: 30%;
+    height: 1px;
+  }
+
+  .label {
+    font-size: 13px;
+    color: var(--ink);
+  }
+</style>

--- a/web/src/lib/Settings.svelte
+++ b/web/src/lib/Settings.svelte
@@ -9,17 +9,25 @@
 
   const settings = getSettings();
 
-  // Which theme (if any) has a write in flight, so only that card disables
-  // itself rather than the whole picker while the request is out.
+  // Which theme has a write in flight. The whole picker is disabled while
+  // this is set, not just that one card - letting the others stay clickable
+  // would let a second write for the same key race the first, and a slow
+  // connection would otherwise make every *other* card look clickable while
+  // silently doing nothing.
   let pending = $state(null);
+  let error = $state("");
 
   async function chooseTheme(theme) {
     if (theme === settings.staff_theme || pending) return;
     pending = theme;
+    error = "";
     try {
       await setSetting("staff_theme", theme);
-    } catch {
-      // setSetting already rolled the optimistic value back; nothing else to do
+    } catch (e) {
+      // setSetting already rolled the optimistic value back - surface why,
+      // so a failed save reads as a failure rather than an unexplained
+      // highlight-then-unhighlight
+      error = e?.message ?? "Could not save that.";
     } finally {
       pending = null;
     }
@@ -45,7 +53,8 @@
           <button
             class="theme-card"
             class:on={settings.staff_theme === theme}
-            disabled={pending === theme}
+            class:saving={pending === theme}
+            disabled={!!pending}
             onclick={() => chooseTheme(theme)}
           >
             <span
@@ -59,6 +68,9 @@
           </button>
         {/each}
       </div>
+      {#if error}
+        <p class="error">{error}</p>
+      {/if}
     </section>
   </main>
 </div>
@@ -134,6 +146,20 @@
   .theme-card.on {
     border-color: var(--brass);
     box-shadow: 0 0 0 1px var(--brass);
+  }
+
+  .theme-card.saving {
+    opacity: 0.6;
+  }
+
+  .theme-card:disabled {
+    cursor: default;
+  }
+
+  .error {
+    color: var(--danger);
+    font-size: 13px;
+    margin: 14px 0 0;
   }
 
   .swatch {

--- a/web/src/lib/TabViewer.svelte
+++ b/web/src/lib/TabViewer.svelte
@@ -2,6 +2,9 @@
   import { untrack } from "svelte";
   import { api } from "./api.js";
   import { createScoreView } from "./score-render.js";
+  import { getSettings } from "./settings.svelte.js";
+
+  const settings = getSettings();
 
   let {
     score = null,
@@ -32,7 +35,6 @@
   let ladderStart = $state(60);
   let ladderStep = $state(5);
   let ladderTarget = $state(100);
-  let darkStaff = $state(false);
 
   const PROFILE_LABELS = [
     ["score", "Notation"],
@@ -91,7 +93,7 @@
         source: src,
         profile,
         preset: gigMode ? "stand" : "desk",
-        theme: darkStaff ? "slate" : "parchment",
+        theme: settings.staff_theme,
         transport: { speed, looping, metronome, countIn },
         onReady: () => (playerReady = true),
         onPlaying: (p) => (playing = p),
@@ -110,7 +112,7 @@
   });
 
   $effect(() => {
-    view?.setTheme(darkStaff ? "slate" : "parchment");
+    view?.setTheme(settings.staff_theme);
   });
 
   function setProfile(p) {
@@ -229,13 +231,6 @@
           >
             Ladder
           </button>
-          <button
-            class:on={darkStaff}
-            onclick={() => (darkStaff = !darkStaff)}
-            title="Draw the staff dark for practising in the dark"
-          >
-            ◐
-          </button>
           {#if ladder}
             <div class="ladder-controls">
               <label>
@@ -263,7 +258,7 @@
   {/if}
 
   <div class="score-scroll" bind:this={scroller}>
-    <div class="at-host" class:dark={darkStaff} bind:this={host}></div>
+    <div class="at-host" bind:this={host}></div>
   </div>
 </div>
 
@@ -401,8 +396,18 @@
     box-shadow: 0 4px 24px rgba(0, 0, 0, 0.55);
   }
 
-  .at-host.dark {
-    background: var(--score-dark-surface);
+  /* score-render.js publishes its chosen theme onto the host as
+     data-score-theme - reused here rather than a second, component-local
+     record of which theme is active. Parchment is the unmarked default.
+     Fully :global() because the attribute is written by that module's
+     dataset assignment, not by anything in this component's markup - Svelte
+     can't see it and would otherwise prune the rule as unused. */
+  :global(.at-host[data-score-theme="noir"]) {
+    background: var(--score-noir-surface);
+  }
+
+  :global(.at-host[data-score-theme="print"]) {
+    background: var(--score-print-surface);
   }
 
   /* The renderer creates its cursors and selection with position only and no
@@ -425,10 +430,16 @@
     opacity: 0.16;
   }
 
-  .at-host.dark :global(.at-cursor-bar),
-  .at-host.dark :global(.at-cursor-beat),
-  .at-host.dark :global(.at-selection div) {
-    background: var(--score-dark-accent);
+  :global(.at-host[data-score-theme="noir"] .at-cursor-bar),
+  :global(.at-host[data-score-theme="noir"] .at-cursor-beat),
+  :global(.at-host[data-score-theme="noir"] .at-selection div) {
+    background: var(--score-noir-accent);
+  }
+
+  :global(.at-host[data-score-theme="print"] .at-cursor-bar),
+  :global(.at-host[data-score-theme="print"] .at-cursor-beat),
+  :global(.at-host[data-score-theme="print"] .at-selection div) {
+    background: var(--score-print-accent);
   }
 
   .error {

--- a/web/src/lib/TabViewer.svelte
+++ b/web/src/lib/TabViewer.svelte
@@ -2,9 +2,25 @@
   import { untrack } from "svelte";
   import { api } from "./api.js";
   import { createScoreView } from "./score-render.js";
-  import { getSettings } from "./settings.svelte.js";
+  import { getSettings, setSetting, STAFF_THEMES, STAFF_THEME_LABELS } from "./settings.svelte.js";
 
   const settings = getSettings();
+
+  // Changing the theme here just writes the same setting the settings view
+  // writes - it's the same store, so the choice still persists and follows
+  // the user. What this buys over navigating to #/settings: App.svelte
+  // routes with {#if}, so leaving this view for that one and coming back
+  // would unmount and remount this component, rebuilding the renderer from
+  // scratch - losing scroll position and stopping playback. A theme is
+  // exactly the kind of thing you want to change mid-practice (a room going
+  // dark, a stage light coming up), so it needs a way to change without
+  // navigating away.
+  function chooseTheme(ev) {
+    setSetting("staff_theme", ev.target.value).catch(() => {
+      // setSetting already rolled the optimistic value back (and the select
+      // is bound to it), so the control itself already shows the truth
+    });
+  }
 
   let {
     score = null,
@@ -196,6 +212,11 @@
           <button class:on={profile === value} onclick={() => setProfile(value)}>{label}</button>
         {/each}
       </div>
+      <select class="theme-picker" value={settings.staff_theme} onchange={chooseTheme} title="Staff theme">
+        {#each STAFF_THEMES as t}
+          <option value={t}>{STAFF_THEME_LABELS[t]}</option>
+        {/each}
+      </select>
       <div class="player">
         <button class="primary" disabled={!playerReady} onclick={() => view?.playPause()}>
           {playing ? "❚❚ Pause" : "▶ Play"}
@@ -274,11 +295,18 @@
   .toolbar {
     display: flex;
     align-items: center;
-    justify-content: space-between;
     gap: 12px;
     padding: 10px 16px;
     border-bottom: 1px solid var(--line);
     background: var(--bg-raised);
+  }
+
+  /* Not part of .player (the transport row) on purpose - a persistent
+     preference living among per-session playback toggles would read as one
+     of them. It's still reachable without leaving this view, which is the
+     whole point (see chooseTheme above). */
+  .theme-picker {
+    flex-shrink: 0;
   }
 
   .gig-hud {
@@ -332,6 +360,10 @@
     display: flex;
     align-items: center;
     gap: 8px;
+    /* pushed to the far edge now that .toolbar no longer uses
+       justify-content: space-between - the theme picker sits between it and
+       .seg instead of splitting the row in two */
+    margin-left: auto;
   }
 
   .practice {

--- a/web/src/lib/Viewer.svelte
+++ b/web/src/lib/Viewer.svelte
@@ -266,7 +266,7 @@
   {#if error}
     <p class="error">{error}</p>
   {:else if demo}
-    <TabViewer demo={true} />
+    <TabViewer demo={true} {gigMode} onToggleGig={toggleGigMode} />
   {:else if score}
     {#if score.file_type === "pdf"}
       <ScoreCompare {score} {gigMode} onToggleGig={toggleGigMode} {practiceLabel} onStopPractice={flushPractice} />

--- a/web/src/lib/api.js
+++ b/web/src/lib/api.js
@@ -87,4 +87,11 @@ export const api = {
   deleteTranscription: (id) =>
     fetch(`/api/scores/${id}/transcription`, { method: "DELETE" }).then(j),
   transcriptionAnalysis: (id) => fetch(`/api/scores/${id}/transcription/analysis`).then(j),
+  settings: () => fetch("/api/settings").then(j),
+  putSettings: (values) =>
+    fetch("/api/settings", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(values),
+    }).then(j),
 };

--- a/web/src/lib/score-render.js
+++ b/web/src/lib/score-render.js
@@ -80,7 +80,7 @@ export function layoutForWidth(width, preset = "desk") {
  * Values come from web/src/app.css so the palette has one home; the fallbacks
  * here only matter if a token is missing or unparseable.
  */
-export const SCORE_THEMES = ["parchment", "slate"];
+export const SCORE_THEMES = ["parchment", "noir", "print"];
 
 const THEME_TOKENS = {
   parchment: {
@@ -90,12 +90,23 @@ const THEME_TOKENS = {
     line: ["--score-line", "#b3a284"],
     accent: ["--score-accent", "#8a6a24"],
   },
-  slate: {
-    surface: ["--score-dark-surface", "#191510"],
-    ink: ["--score-dark-ink", "#ece2cd"],
-    inkSoft: ["--score-dark-ink-soft", "#94866a"],
-    line: ["--score-dark-line", "#4d4331"],
-    accent: ["--score-dark-accent", "#c9a45c"],
+  // Maximum contrast for a dim room or a bright stage - true black, not the
+  // warm dark brown this used to be.
+  noir: {
+    surface: ["--score-noir-surface", "#000000"],
+    ink: ["--score-noir-ink", "#f5f3ea"],
+    inkSoft: ["--score-noir-ink-soft", "#9a9488"],
+    line: ["--score-noir-line", "#4a4438"],
+    accent: ["--score-noir-accent", "#e6c377"],
+  },
+  // The printed-page look: black ink on white, most legible under harsh
+  // light.
+  print: {
+    surface: ["--score-print-surface", "#ffffff"],
+    ink: ["--score-print-ink", "#14110a"],
+    inkSoft: ["--score-print-ink-soft", "#6b6558"],
+    line: ["--score-print-line", "#c9c3b3"],
+    accent: ["--score-print-accent", "#8a6a24"],
   },
 };
 

--- a/web/src/lib/score-render.js
+++ b/web/src/lib/score-render.js
@@ -79,6 +79,11 @@ export function layoutForWidth(width, preset = "desk") {
  * application paints behind the staff, and four the renderer itself uses.
  * Values come from web/src/app.css so the palette has one home; the fallbacks
  * here only matter if a token is missing or unparseable.
+ *
+ * Kept in sync with SETTINGS_CHOICES["staff_theme"] in
+ * server/fermata/api.py - server/tests/test_settings_api.py's
+ * test_staff_theme_choices_match_the_frontends_score_themes parses this
+ * array out of this file and fails if the two ever disagree.
  */
 export const SCORE_THEMES = ["parchment", "noir", "print"];
 

--- a/web/src/lib/settings.svelte.js
+++ b/web/src/lib/settings.svelte.js
@@ -1,0 +1,68 @@
+// Where components read and write persisted user preferences. A setting lives
+// on the server (server/fermata/api.py's /api/settings), not in browser
+// storage, so it follows a person from phone to tablet to desktop. Loaded
+// once here; components read the live object rather than each fetching their
+// own copy, and writes go back through the same place.
+import { api } from "./api.js";
+import { SCORE_THEMES } from "./score-render.js";
+
+export const STAFF_THEMES = SCORE_THEMES;
+
+export const STAFF_THEME_LABELS = {
+  parchment: "Parchment",
+  noir: "White on black",
+  print: "Black on white",
+};
+
+// The CSS custom-property prefix each theme's tokens live under, so a
+// preview swatch can be drawn from the same values score-render.js reads -
+// see app.css.
+export const STAFF_THEME_TOKEN_PREFIX = {
+  parchment: "--score",
+  noir: "--score-noir",
+  print: "--score-print",
+};
+
+const DEFAULTS = { staff_theme: STAFF_THEMES[0] };
+
+// A single reactive object every caller shares, so a change made from one
+// component (the settings view) is seen immediately by another (a score
+// already on screen) without either knowing how the value got there.
+const settings = $state({ ...DEFAULTS });
+
+let loadStarted = false;
+
+function load() {
+  if (loadStarted) return;
+  loadStarted = true;
+  api
+    .settings()
+    .then((s) => Object.assign(settings, DEFAULTS, s))
+    .catch(() => {
+      // network down, backend not deployed yet, etc - the defaults already
+      // in `settings` are a perfectly usable fresh-install behaviour
+    });
+}
+
+load();
+
+/** The live settings object. Mutating it directly does not persist a change -
+ * use setSetting for that. */
+export function getSettings() {
+  return settings;
+}
+
+/** Write one setting and update the shared object from what the server
+ * actually stored. Applied optimistically so the UI responds at once; rolled
+ * back if the write is rejected (an unknown key, an invalid value). */
+export async function setSetting(key, value) {
+  const previous = settings[key];
+  settings[key] = value;
+  try {
+    const saved = await api.putSettings({ [key]: value });
+    Object.assign(settings, saved);
+  } catch (e) {
+    settings[key] = previous;
+    throw e;
+  }
+}

--- a/web/src/lib/settings.svelte.js
+++ b/web/src/lib/settings.svelte.js
@@ -2,7 +2,10 @@
 // on the server (server/fermata/api.py's /api/settings), not in browser
 // storage, so it follows a person from phone to tablet to desktop. Loaded
 // once here; components read the live object rather than each fetching their
-// own copy, and writes go back through the same place.
+// own copy, and writes go back through the same place - so a change made
+// from the settings view or an in-viewer control (TabViewer's own theme
+// picker) is visible to every other reader of `settings` at once, including
+// a score already on screen, with no navigation and no extra fetch.
 import { api } from "./api.js";
 import { SCORE_THEMES } from "./score-render.js";
 
@@ -25,23 +28,33 @@ export const STAFF_THEME_TOKEN_PREFIX = {
 
 const DEFAULTS = { staff_theme: STAFF_THEMES[0] };
 
-// A single reactive object every caller shares, so a change made from one
-// component (the settings view) is seen immediately by another (a score
-// already on screen) without either knowing how the value got there.
 const settings = $state({ ...DEFAULTS });
 
-let loadStarted = false;
+// Keys a local write has touched. The initial GET and a write race - the
+// GET is sent first (at module load) but can resolve after a write the user
+// makes while it's still in flight. Once a key is in here, the initial
+// load's answer for it is permanently stale: a write reflects intent that
+// happened strictly after the GET was sent, so it must never be undone by
+// that GET landing late, however long it takes.
+const written = new Set();
+
+let loadPromise = null;
 
 function load() {
-  if (loadStarted) return;
-  loadStarted = true;
-  api
+  if (loadPromise) return loadPromise;
+  loadPromise = api
     .settings()
-    .then((s) => Object.assign(settings, DEFAULTS, s))
+    .then((s) => {
+      const merged = { ...DEFAULTS, ...s };
+      for (const [key, value] of Object.entries(merged)) {
+        if (!written.has(key)) settings[key] = value;
+      }
+    })
     .catch(() => {
       // network down, backend not deployed yet, etc - the defaults already
       // in `settings` are a perfectly usable fresh-install behaviour
     });
+  return loadPromise;
 }
 
 load();
@@ -56,13 +69,25 @@ export function getSettings() {
  * actually stored. Applied optimistically so the UI responds at once; rolled
  * back if the write is rejected (an unknown key, an invalid value). */
 export async function setSetting(key, value) {
-  const previous = settings[key];
+  written.add(key);
   settings[key] = value;
   try {
     const saved = await api.putSettings({ [key]: value });
     Object.assign(settings, saved);
   } catch (e) {
-    settings[key] = previous;
+    // Roll back to what the server actually holds, not a guess: `settings[key]`
+    // right now might only be the pre-load default if the initial GET hadn't
+    // landed yet when this write started, and writing that back would show a
+    // value neither the server nor the user ever chose. A fresh GET (rather
+    // than the cached `load()` snapshot, which may itself predate this write
+    // or an earlier successful one) is the only source of the real answer.
+    try {
+      const fresh = await api.settings();
+      settings[key] = fresh[key] ?? DEFAULTS[key];
+    } catch {
+      // can't even confirm the real value - leave the optimistic write in
+      // place rather than snap to a guessed default
+    }
     throw e;
   }
 }


### PR DESCRIPTION
## Summary

- Replace the two staff themes (`parchment`, `slate`) with three: **Parchment** (default, unchanged), **White on black** (`noir` — true black surface, near-white ink, for a dim room or a bright stage) and **Black on white** (`print` — the printed-page look, most legible under harsh light). Tokens for each live in `app.css` alongside the existing ones; `score-render.js` picks them up the same way it already did.
- Add a server-side settings store: a `settings` table (key/value, so a new preference needs no migration) with a reserved `owner` column defaulting to a single-instance sentinel, so real accounts later are a data migration rather than a schema redesign. `GET /api/settings` and `PUT /api/settings` on the existing router, with defaults for a fresh install and rejection of unknown keys/invalid values.
- Add `web/src/lib/settings.svelte.js`, a small shared store that loads settings once and exposes them reactively; `TabViewer.svelte` reads the staff theme from it instead of local per-component state, so the choice applies wherever a score renders without any component knowing it's server-backed.
- Add a dedicated Settings view (`#/settings`, linked from the library sidebar) and remove the `◐` toolbar toggle that used to cycle the old dark theme — a persistent preference belongs in its own place, not a crowded toolbar.
- Fix a one-line bug: `Viewer.svelte` never passed `gigMode`/`onToggleGig` to `TabViewer` on the demo route, so pressing `f` there hid the header with no HUD to get back to (Escape still worked).

## Test plan

- [x] `server/tests/test_settings_api.py` — defaults on empty, write-then-read-back, upsert (not duplicate rows), unknown key rejected (whole write rejected, not partially applied), invalid value rejected, owner defaults to the single-instance sentinel, writing several settings in one call.
- [x] Full server suite run in a clean container with the real library mounted read-only at `/testlib`: **204 passed, 4 skipped** (skips are the pre-existing MusicXML-XSD tests, gated on an env var this run didn't set).
- [x] `npm run build` — clean, no warnings (an earlier pass had CSS incorrectly pruned as "unused" by Svelte's static analysis since the theme attribute is set via JS `dataset`, not template markup; fixed by wrapping those rules in `:global()`).
- [x] Playwright against the real backend (real library, real FastAPI, no route stubs) — 35/35 checks: all three themes reach the rendered staff with the exact expected surface and ink colours on both a real score and the demo route; the choice survives a full page reload and is visible from a brand-new browser context (no shared storage) hitting the same server, simulating a second device; the demo route's gig HUD now appears on `f` (bug fix); playback, loop, metronome, count-in, tempo ladder, profile switching and gig mode all still work.

## Screenshots

Settings view, and the same real score under all three themes, attached below.
