### PR TITLE
Summarise the transcription warnings

### DIFF
--- a/web/e2e/fixtures/transcription-warnings.js
+++ b/web/e2e/fixtures/transcription-warnings.js
@@ -150,12 +150,47 @@ export function transcriptionResponse({ warnings, confidence, bars, nestWarnings
 }
 
 /**
+ * A saved hand edit's response shape, mirroring server/fermata/api.py's
+ * _transcription_dict exactly for a row whose `confidence` column is NULL
+ * (every edited row): `warnings` is stated as `[]` and all four bar keys as
+ * `null` - NEVER omitted - specifically because an earlier version of the
+ * backend omitted them, and a client that spread such a response over the
+ * transcription it already held kept the PRE-EDIT figures. A user opened a
+ * score reading "4 of 50 bars don't add up", fixed exactly those bars,
+ * saved, and the panel still said "4 of 50 bars don't add up" and still
+ * listed warnings about notes that no longer existed - the confidently
+ * wrong state this whole feature exists to prevent. `null` (not `0`) is the
+ * deliberate way of saying "nothing has measured this content"; `0` would
+ * claim every bar was measured and every one of them added up.
+ */
+export function editedTranscriptionResponse() {
+  return {
+    id: 1,
+    score_id: 1,
+    format: "musicxml",
+    content: "<score-partwise><!-- hand-edited --></score-partwise>",
+    source: "edited",
+    confidence: null,
+    warnings: [],
+    bars_overfull: null,
+    bars_short: null,
+    bars_defective: null,
+    bars_measured: null,
+  };
+}
+
+/**
  * Stubs every /api route ScoreCompare.svelte/PdfViewer/TabViewer touch for
  * score id 1. `transcription` is either a transcriptionResponse() object, or
  * `null` for "no transcription yet" (GET returns 404, matching a fresh
  * score).
+ *
+ * `editRevert`, if given, wires PUT (save) to always answer with
+ * `editedTranscriptionResponse()` and DELETE (revert) to always answer with
+ * `transcription` again - modeling "hand-edit this extracted row, then
+ * revert" regardless of what the test actually types into the editor.
  */
-export async function stubScoreApi(page, transcription) {
+export async function stubScoreApi(page, transcription, { editRevert = false } = {}) {
   await page.route("**/api/scores/1", (route) => route.fulfill({ json: SCORE }));
   await page.route("**/api/scores/1/file", (route) =>
     route.fulfill({ body: MIN_PDF, contentType: "application/pdf" }),
@@ -166,6 +201,15 @@ export async function stubScoreApi(page, transcription) {
   await page.route("**/api/scores/1/transcription/analysis", (route) =>
     route.fulfill({ json: { extractable: true } }),
   );
+  if (editRevert) {
+    await page.route("**/api/scores/1/transcription", (route) => {
+      const method = route.request().method();
+      if (method === "PUT") return route.fulfill({ json: editedTranscriptionResponse() });
+      if (method === "DELETE") return route.fulfill({ json: transcription });
+      return route.fulfill({ json: transcription });
+    });
+    return;
+  }
   await page.route("**/api/scores/1/transcription", (route) => {
     if (route.request().method() !== "GET") return route.continue();
     if (!transcription) return route.fulfill({ status: 404, json: { detail: "not found" } });

--- a/web/e2e/fixtures/transcription-warnings.js
+++ b/web/e2e/fixtures/transcription-warnings.js
@@ -1,0 +1,174 @@
+// Fixture data + route stubs for the transcription-warnings behavior in
+// ScoreCompare.svelte (see ../score-compare-warnings.spec.js). Kept separate
+// from the spec so the shapes below can be reused across scenarios and
+// stay obviously in sync with the real backend contract they model.
+//
+// The transcription-object shape mirrors server/fermata/api.py's
+// _transcription_dict / _BLOB_TOP_LEVEL exactly: `warnings`, `bars_overfull`,
+// `bars_short`, `bars_defective`, and `bars_measured` are lifted to the TOP
+// LEVEL of the transcription object on both GET /transcription and POST
+// /transcribe - they are siblings of `confidence`, not nested inside it.
+// `confidence` itself stays a pure aspect->sentence mapping
+// (frets/rhythm/time_signature); dropping numbers into it would make
+// anything that renders it as prose print "40" as a confidence statement.
+// Getting this backwards was a real integration bug (frontend read the bar
+// counts nested inside confidence.confidence; the server never put them
+// there) that neither side's own tests caught, because each was written
+// against its own idea of the shape. These fixtures exist so that mistake
+// can't quietly happen again on either side of this file.
+
+export const MIN_PDF = Buffer.from(
+  "%PDF-1.4\n1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj\n" +
+    "2 0 obj<</Type/Pages/Kids[3 0 R]/Count 1>>endobj\n" +
+    "3 0 obj<</Type/Page/Parent 2 0 R/MediaBox[0 0 200 200]>>endobj\n" +
+    "xref\n0 4\n0000000000 65535 f \n0000000009 00000 n \n0000000052 00000 n \n0000000101 00000 n \n" +
+    "trailer<</Size 4/Root 1 0 R>>\nstartxref\n164\n%%EOF",
+  "utf-8",
+);
+
+export const SCORE = {
+  id: 1,
+  title: "Test Score",
+  file_type: "pdf",
+  has_transcription: true,
+  favorite: false,
+  content_kind: "tab",
+  tags: [],
+};
+
+// Renders a real staff/tab via the real alphaTab importer - not a stub - so
+// a test that checks the staff pane's bounding box is measuring something
+// that actually painted, the way "a viewer that built cleanly and rendered
+// nothing" would not.
+export const SAMPLE_TEX = `\\title "Test Score"
+\\tempo 90
+.
+:8 0.1 3.2 2.3 0.1 3.2 2.3 0.1 3.2 |
+:8 0.2 2.3 2.4 0.2 2.3 2.4 0.2 2.3 |
+:2 (0.6 2.5 2.4 0.3 0.2 0.1) :2 (0.6 2.5 2.4 0.3 0.2 0.1)`;
+
+// A realistic nine-item warning list: one bar-conformance sentence plus the
+// two standing-limitation sentences (tuplets/ties - see warning-patterns.js)
+// plus six other per-score items, matching the shape (if not the literal
+// wording) of a real transcribe() response - see the "9 of 50" numbers.
+export const NINE_WARNINGS = [
+  "3 of 50 bar(s) hold more than their time signature allows. Music written in two voices (a melody over a separate bass line) is separated into concurrent voices where the stems say so, but a bar whose voices the stems do not separate is still flattened into one, and an undetected tuplet or a missed flag lands here too - the notes and their individual durations can still be right while the bar as a whole is not, so playback timing will drift in those bars",
+  "tuplets (triplets and similar) are not detected - a note written inside a tuplet will show its plain written duration rather than the shortened tuplet duration",
+  "tie detection is low confidence - some tied notes may show up as separately re-struck notes instead of one held note",
+  "time signature not detected - glyphs live in a subsetted music font at remapped codepoints; assumed 4/4 for bar/beat grouping, pass time_signature to override",
+  "key signature: could not be read - notes are spelled as if there were none",
+  "2 fret number(s) could not be matched to a note in the engraved notation and got an estimated duration instead - treat those specific notes as low confidence",
+  "5 digit token(s) near a tab staff could not be assigned to a string",
+  "music font: unrecognised glyph set 'CustomTabFont-Subset' - some symbols may not decode",
+  "1 fret number(s) above 24 were read directly from the PDF's own text (not from a merge) - likely two adjacent notes rendered as one text span in the source - treat those frets as low confidence",
+];
+// scopedWarnings = NINE_WARNINGS minus the 2 standing-limitation lines = 7.
+// One of those 7 is the bar-conformance sentence above; with the structured
+// bars_defective/bars_measured fields present (see REALISTIC_TRANSCRIPTION)
+// that line is folded into the headline, leaving 6 "more".
+export const NINE_WARNINGS_EXPECTED_SUMMARY =
+  "3 of 50 bars don't add up · rhythm confidence medium · 6 more";
+
+export const CAPPED_CONFIDENCE = {
+  frets: "high - read directly from vector text spans positioned against detected tab staff lines",
+  rhythm:
+    "medium - decoded from the score's engraving, but some music-font glyphs used by this score are outside the decoder's calibrated vocabulary",
+  time_signature: "low - not detected, assumed 4/4",
+};
+
+export const CLEAN_CONFIDENCE = {
+  frets: "high - read directly from vector text spans positioned against detected tab staff lines",
+  rhythm:
+    "high - decoded directly from the notehead/stem/flag/beam/dot glyphs in the score's own engraving",
+  time_signature: "high - read directly from the time-signature digit glyphs printed on the score",
+};
+
+// The regression fixture for finding 1: a bar wrong in BOTH directions at
+// once (typical of two-voice writing, one voice over its meter and the
+// other under) is counted into BOTH tabextract._bar_conformance's overfull
+// and short - so summing the two warning sentences' counts (7 + 6 = 13)
+// would claim more defective bars than exist (12 measured). Across the full
+// production library (144 extractable scores) not one score is wrong in
+// both directions at once - this does not reproduce on any real score, only
+// on constructed two-voice material - so this fixture is the only place
+// this case is exercised at all. If it is lost, the bug it encodes will not
+// be rediscovered by testing against real scores.
+export const TWO_VOICE_WARNINGS = [
+  "7 of 12 bar(s) hold more than their time signature allows. Music written in two voices (a melody over a separate bass line) is separated into concurrent voices where the stems say so, but a bar whose voices the stems do not separate is still flattened into one, and an undetected tuplet or a missed flag lands here too - the notes and their individual durations can still be right while the bar as a whole is not, so playback timing will drift in those bars",
+  "6 of 12 bar(s) hold less than their time signature allows - a note whose duration was read short, or one dropped for want of a fret number, leaves the bar with a gap at the end. The emitted score says so rather than padding it out, so any MusicXML tool will report those bars too",
+];
+export const TWO_VOICE_CONFIDENCE = {
+  frets: "high - read directly from vector text spans positioned against detected tab staff lines",
+  rhythm:
+    "low overall - individual durations were read from the score's own engraving, but 9 of 12 bar(s) do not add up to their time signature",
+  time_signature: "high - read directly from the time-signature digit glyphs printed on the score",
+};
+
+export const STANDING_LIMITS_ONLY_WARNINGS = [
+  "tuplets (triplets and similar) are not detected - a note written inside a tuplet will show its plain written duration rather than the shortened tuplet duration",
+  "tie detection is low confidence - some tied notes may show up as separately re-struck notes instead of one held note",
+];
+
+/**
+ * Builds a GET /transcription (or POST /transcribe) response body.
+ *
+ * `bars` is `{ defective, measured, overfull, short }` or omitted entirely -
+ * mirrors _transcription_dict lifting bars_* out of the stored blob onto the
+ * top level ONLY when they were present in it (an edited row, or a row
+ * written before this field existed, legitimately has none - absent, not
+ * zero, is what that means; see _BLOB_TOP_LEVEL in api.py).
+ *
+ * `nestWarningsOnly` models the GET-shape inconsistency that motivated
+ * ScoreCompare.svelte's own defensive read: when true, `warnings` is
+ * IsUnusual and only present nested inside the `confidence` JSON string,
+ * not at the top level, and the frontend must still find it.
+ */
+export function transcriptionResponse({ warnings, confidence, bars, nestWarningsOnly = false }) {
+  const blob = { warnings, confidence };
+  if (bars) {
+    blob.bars_overfull = bars.overfull ?? 0;
+    blob.bars_short = bars.short ?? 0;
+    blob.bars_defective = bars.defective;
+    blob.bars_measured = bars.measured;
+  }
+  const body = {
+    id: 1,
+    score_id: 1,
+    format: "alphatex",
+    content: SAMPLE_TEX,
+    source: "extracted",
+    confidence: JSON.stringify(blob),
+  };
+  if (!nestWarningsOnly) body.warnings = warnings;
+  if (bars) {
+    body.bars_overfull = blob.bars_overfull;
+    body.bars_short = blob.bars_short;
+    body.bars_defective = blob.bars_defective;
+    body.bars_measured = blob.bars_measured;
+  }
+  return body;
+}
+
+/**
+ * Stubs every /api route ScoreCompare.svelte/PdfViewer/TabViewer touch for
+ * score id 1. `transcription` is either a transcriptionResponse() object, or
+ * `null` for "no transcription yet" (GET returns 404, matching a fresh
+ * score).
+ */
+export async function stubScoreApi(page, transcription) {
+  await page.route("**/api/scores/1", (route) => route.fulfill({ json: SCORE }));
+  await page.route("**/api/scores/1/file", (route) =>
+    route.fulfill({ body: MIN_PDF, contentType: "application/pdf" }),
+  );
+  await page.route("**/api/scores/1/practice", (route) =>
+    route.fulfill({ json: { total_seconds: 0, sessions: [] } }),
+  );
+  await page.route("**/api/scores/1/transcription/analysis", (route) =>
+    route.fulfill({ json: { extractable: true } }),
+  );
+  await page.route("**/api/scores/1/transcription", (route) => {
+    if (route.request().method() !== "GET") return route.continue();
+    if (!transcription) return route.fulfill({ status: 404, json: { detail: "not found" } });
+    return route.fulfill({ json: transcription });
+  });
+}

--- a/web/e2e/score-compare-warnings.spec.js
+++ b/web/e2e/score-compare-warnings.spec.js
@@ -1,0 +1,281 @@
+// Preserved Playwright coverage for the transcription-warnings summary in
+// ScoreCompare.svelte (issue #45 / PR #67, and the shape fix that followed
+// once server/fermata/api.py started lifting bars_defective/bars_measured
+// to the top level of the transcription object - PR #70).
+//
+// NOT WIRED TO A RUNNER YET. This repo has no frontend test harness as of
+// this writing - no @playwright/test dependency, no config, no CI job. A
+// separate branch is bringing one in (a "Browser tests" CI job). Adding a
+// second, competing harness here would be worse than adding none, so this
+// file is deliberately inert: it imports "@playwright/test", which will not
+// resolve until that dependency exists. What's preserved is the exact
+// scenarios and assertions this component was verified against by hand
+// (chromium.launch() + manual route stubs, run from a scratchpad, results
+// checked against real screenshots) - written in real spec form so wiring
+// it up later is "move this file and run it", not "remember what to test".
+//
+// Every scenario here was actually exercised against a running instance
+// before being written down: the mocked ones via `page.route`, and the
+// "structured field" shape specifically against a real server built from
+// fix/persist-bar-conformance (PR #70) transcribing the real "To Zanarkand"
+// PDF from the library, reloading, and confirming the same N/M survived -
+// see the PR discussion for that run's output. The two-voice fixture below
+// does not reproduce on any of the 144 extractable scores in the real
+// library; it exists because a fixture is the only way to exercise it.
+import { test, expect } from "@playwright/test";
+import {
+  SCORE,
+  NINE_WARNINGS,
+  NINE_WARNINGS_EXPECTED_SUMMARY,
+  CAPPED_CONFIDENCE,
+  CLEAN_CONFIDENCE,
+  TWO_VOICE_WARNINGS,
+  TWO_VOICE_CONFIDENCE,
+  STANDING_LIMITS_ONLY_WARNINGS,
+  transcriptionResponse,
+  stubScoreApi,
+} from "./fixtures/transcription-warnings.js";
+
+test.describe("ScoreCompare warnings summary", () => {
+  test("states the bar count and capped confidence without interaction, keeps the staff in view, and its detail toggles", async ({
+    page,
+  }) => {
+    const consoleErrors = [];
+    page.on("console", (msg) => {
+      if (msg.type() === "error") consoleErrors.push(msg.text());
+    });
+
+    await stubScoreApi(
+      page,
+      transcriptionResponse({
+        warnings: NINE_WARNINGS,
+        confidence: CAPPED_CONFIDENCE,
+        bars: { defective: 3, measured: 50, overfull: 3, short: 0 },
+      }),
+    );
+    await page.goto("/#/score/1");
+    await page.waitForSelector(".warnings-summary");
+
+    // the one-line summary is the thing that must be true without clicking
+    // anything - both the bar count and the capped confidence live here
+    await expect(page.locator(".warn-text")).toHaveText(NINE_WARNINGS_EXPECTED_SUMMARY);
+
+    // expanded the first time this score's warnings are seen this session
+    await expect(page.locator(".warnings-detail")).toBeVisible();
+
+    // the justification for each item is readable without hovering - not
+    // parked behind a title-only tooltip, unreachable on a touch device
+    await expect(page.locator(".warnings-detail")).toContainText(
+      "treat those specific notes as low confidence",
+    );
+
+    // the staff must render within the viewport rather than below the fold -
+    // the entire point of summarising instead of listing prose
+    const staffBox = await page.locator(".staff-render").boundingBox();
+    expect(staffBox.y).toBeLessThan(page.viewportSize().height);
+
+    // toggles closed and back open
+    await page.locator(".warnings-summary").click();
+    await expect(page.locator(".warnings-detail")).toBeHidden();
+    await page.locator(".warnings-summary").click();
+    await expect(page.locator(".warnings-detail")).toBeVisible();
+
+    expect(consoleErrors).toEqual([]);
+  });
+
+  test("says nothing about bars when bars_defective/bars_measured are absent, even though the warning prose describes a bar wrong in both directions", async ({
+    page,
+  }) => {
+    // No `bars` passed - models an edited row (no confidence at all is
+    // normal) or a transcription stored before this field existed. Summing
+    // the two sentences' counts (7 + 6) would claim 13 of 12 bars are
+    // defective, which is impossible - the headline must say nothing about
+    // bars rather than something confidently wrong.
+    await stubScoreApi(
+      page,
+      transcriptionResponse({ warnings: TWO_VOICE_WARNINGS, confidence: TWO_VOICE_CONFIDENCE }),
+    );
+    await page.goto("/#/score/1");
+    await page.waitForSelector(".warnings-summary");
+
+    const summary = await page.locator(".warn-text").innerText();
+    expect(summary).not.toMatch(/\d+ of \d+ bars? don't add up/);
+    expect(summary).toBe("rhythm confidence low overall · 2 more");
+
+    // nothing is lost - both full sentences are still in the detail list
+    await page.locator(".warnings-summary").click();
+    const detail = await page.locator(".warnings-detail").innerText();
+    expect(detail).toContain("7 of 12");
+    expect(detail).toContain("6 of 12");
+  });
+
+  test("prefers the structured bars_defective/bars_measured over the warning prose when both are present", async ({
+    page,
+  }) => {
+    // Deliberately mismatched prose ("2 of 999") - a pass here can only mean
+    // the structured top-level fields were read, not the regex fallback.
+    await stubScoreApi(
+      page,
+      transcriptionResponse({
+        warnings: ["2 of 999 bar(s) hold more than their time signature allows."],
+        confidence: CAPPED_CONFIDENCE,
+        bars: { defective: 7, measured: 40 },
+      }),
+    );
+    await page.goto("/#/score/1");
+    await page.waitForSelector(".warnings-summary");
+    await expect(page.locator(".warn-text")).toContainText("7 of 40 bars don't add up");
+  });
+
+  test("still surfaces warnings nested under confidence.warnings, the shape GET /transcription can return", async ({
+    page,
+  }) => {
+    await stubScoreApi(
+      page,
+      transcriptionResponse({
+        warnings: NINE_WARNINGS,
+        confidence: CAPPED_CONFIDENCE,
+        bars: { defective: 3, measured: 50, overfull: 3, short: 0 },
+        nestWarningsOnly: true, // no top-level `warnings` key
+      }),
+    );
+    await page.goto("/#/score/1");
+    await page.waitForSelector(".warnings-summary");
+    await expect(page.locator(".warnings")).toBeVisible();
+    await expect(page.locator(".warn-text")).toHaveText(NINE_WARNINGS_EXPECTED_SUMMARY);
+  });
+
+  test("renders nothing intrusive when there are no warnings", async ({ page }) => {
+    await stubScoreApi(
+      page,
+      transcriptionResponse({ warnings: [], confidence: CLEAN_CONFIDENCE }),
+    );
+    await page.goto("/#/score/1");
+    await page.waitForSelector(".staff-render");
+    await expect(page.locator(".warnings")).toHaveCount(0);
+    await expect(page.locator(".standing-footnote")).toHaveCount(0);
+  });
+
+  test("shows a quiet footnote, not the warnings box, when only standing limitations apply", async ({
+    page,
+  }) => {
+    await stubScoreApi(
+      page,
+      transcriptionResponse({ warnings: STANDING_LIMITS_ONLY_WARNINGS, confidence: CLEAN_CONFIDENCE }),
+    );
+    await page.goto("/#/score/1");
+    await page.waitForSelector(".staff-render");
+    await expect(page.locator(".warnings")).toHaveCount(0);
+    await expect(page.locator(".standing-footnote")).toHaveText(
+      "Standing limits: tuplets aren't detected; tie detection is approximate.",
+    );
+  });
+
+  test("expands on a score's first view this session and collapses on a later visit", async ({
+    page,
+  }) => {
+    await stubScoreApi(
+      page,
+      transcriptionResponse({
+        warnings: NINE_WARNINGS,
+        confidence: CAPPED_CONFIDENCE,
+        bars: { defective: 3, measured: 50, overfull: 3, short: 0 },
+      }),
+    );
+    await page.goto("/#/score/1");
+    await page.waitForSelector(".warnings-summary");
+    await expect(page.locator(".warnings-detail")).toBeVisible();
+
+    // navigate away and back within the same session (sessionStorage persists)
+    await page.goto("/#/");
+    await page.goto("/#/score/1");
+    await page.waitForSelector(".warnings-summary");
+    await expect(page.locator(".warnings-detail")).toBeHidden();
+  });
+
+  test("gig mode drops the warnings block entirely and the score fills the view", async ({
+    page,
+  }) => {
+    await stubScoreApi(
+      page,
+      transcriptionResponse({
+        warnings: NINE_WARNINGS,
+        confidence: CAPPED_CONFIDENCE,
+        bars: { defective: 3, measured: 50, overfull: 3, short: 0 },
+      }),
+    );
+    await page.goto("/#/score/1");
+    await page.waitForSelector(".staff-render");
+    // side-by-side is the default layout once a transcription exists, and
+    // gig mode falls back from "side" to the PDF pane alone (a single HUD) -
+    // switch to Staff first so gig mode is actually showing the tab.
+    await page.locator('.seg button:has-text("Staff")').click();
+    await page.locator('button:has-text("Gig mode")').click();
+
+    await expect(page.locator(".warnings")).toHaveCount(0);
+    await expect(page.locator(".standing-footnote")).toHaveCount(0);
+
+    const viewport = page.viewportSize();
+    const scoreBox = await page.locator(".staff-render").boundingBox();
+    expect(scoreBox.height / viewport.height).toBeGreaterThan(0.95);
+  });
+
+  test("gig mode shows a small mark, with the specific fact in its title, only when something is actually unverified", async ({
+    page,
+  }) => {
+    await stubScoreApi(
+      page,
+      transcriptionResponse({
+        warnings: NINE_WARNINGS,
+        confidence: CAPPED_CONFIDENCE,
+        bars: { defective: 3, measured: 50, overfull: 3, short: 0 },
+      }),
+    );
+    await page.goto("/#/score/1");
+    await page.waitForSelector(".staff-render");
+    await page.locator('.seg button:has-text("Staff")').click();
+    await page.locator('button:has-text("Gig mode")').click();
+
+    const mark = page.locator(".gig-mark");
+    await expect(mark).toHaveCount(1);
+    await expect(mark).toHaveAttribute(
+      "title",
+      "3 of 50 bars don't add up · rhythm confidence: medium",
+    );
+  });
+
+  test("gig mode shows no mark on a clean score", async ({ page }) => {
+    await stubScoreApi(
+      page,
+      transcriptionResponse({ warnings: [], confidence: CLEAN_CONFIDENCE }),
+    );
+    await page.goto("/#/score/1");
+    await page.waitForSelector(".staff-render");
+    await page.locator('.seg button:has-text("Staff")').click();
+    await page.locator('button:has-text("Gig mode")').click();
+    await expect(page.locator(".gig-mark")).toHaveCount(0);
+  });
+
+  test("gig mode shows no mark when only standing limitations apply", async ({ page }) => {
+    await stubScoreApi(
+      page,
+      transcriptionResponse({ warnings: STANDING_LIMITS_ONLY_WARNINGS, confidence: CLEAN_CONFIDENCE }),
+    );
+    await page.goto("/#/score/1");
+    await page.waitForSelector(".staff-render");
+    await page.locator('.seg button:has-text("Staff")').click();
+    await page.locator('button:has-text("Gig mode")').click();
+    await expect(page.locator(".gig-mark")).toHaveCount(0);
+  });
+
+  test("the #/demo route still renders with no console errors", async ({ page }) => {
+    const consoleErrors = [];
+    page.on("console", (msg) => {
+      if (msg.type() === "error") consoleErrors.push(msg.text());
+    });
+    page.on("pageerror", (err) => consoleErrors.push(String(err)));
+    await page.goto("/#/demo");
+    await page.waitForTimeout(2000);
+    expect(consoleErrors).toEqual([]);
+  });
+});

--- a/web/e2e/score-compare-warnings.spec.js
+++ b/web/e2e/score-compare-warnings.spec.js
@@ -34,7 +34,15 @@ import {
   STANDING_LIMITS_ONLY_WARNINGS,
   transcriptionResponse,
   stubScoreApi,
+  editedTranscriptionResponse,
 } from "./fixtures/transcription-warnings.js";
+
+// This bug and its fix were verified for real against fix/persist-bar-
+// conformance (commit 81532ec) and the real "To Zanarkand" PDF: transcribe
+// (headline shows real figures) -> hand-edit and save through the UI
+// (panel goes to nothing, not the pre-edit figures) -> revert to extracted
+// (real figures return, identical to the first transcribe). The scenario
+// below is the mocked version of that same three-state check.
 
 test.describe("ScoreCompare warnings summary", () => {
   test("states the bar count and capped confidence without interaction, keeps the staff in view, and its detail toggles", async ({
@@ -125,6 +133,36 @@ test.describe("ScoreCompare warnings summary", () => {
     await page.goto("/#/score/1");
     await page.waitForSelector(".warnings-summary");
     await expect(page.locator(".warn-text")).toContainText("7 of 40 bars don't add up");
+  });
+
+  test("saving a hand edit clears the stale bar figures and warnings instead of preserving them, and reverting restores the real ones", async ({
+    page,
+  }) => {
+    const extracted = transcriptionResponse({
+      warnings: NINE_WARNINGS,
+      confidence: CAPPED_CONFIDENCE,
+      bars: { defective: 3, measured: 50, overfull: 3, short: 0 },
+    });
+    await stubScoreApi(page, extracted, { editRevert: true });
+    await page.goto("/#/score/1");
+    await page.waitForSelector(".warnings-summary");
+    await expect(page.locator(".warn-text")).toHaveText(NINE_WARNINGS_EXPECTED_SUMMARY);
+
+    await page.locator('button:has-text("Edit source")').click();
+    await page.locator(".editor-input").fill("<score-partwise><!-- fixed the bars --></score-partwise>");
+    await page.locator('button:has-text("Save & render")').click();
+    await expect(page.locator(".editor-input")).toHaveCount(0);
+
+    // the panel must go to NOTHING - not the pre-edit "3 of 50", which an
+    // endpoint that omits rather than states its empty keys would silently
+    // preserve through the { ...transcription, ...res } merge in saveEdit()
+    await expect(page.locator(".warnings")).toHaveCount(0);
+    await expect(page.locator(".standing-footnote")).toHaveCount(0);
+    await expect(page.locator(".source-badge.edited")).toBeVisible();
+
+    await page.locator('button:has-text("Revert to extracted")').click();
+    await page.waitForSelector(".warnings-summary");
+    await expect(page.locator(".warn-text")).toHaveText(NINE_WARNINGS_EXPECTED_SUMMARY);
   });
 
   test("still surfaces warnings nested under confidence.warnings, the shape GET /transcription can return", async ({

--- a/web/package.json
+++ b/web/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build && node scripts/check-assets.mjs",
+    "build": "vite build && node scripts/check-assets.mjs && node scripts/check-warning-patterns.mjs",
     "preview": "vite preview"
   },
   "devDependencies": {

--- a/web/scripts/check-warning-patterns.mjs
+++ b/web/scripts/check-warning-patterns.mjs
@@ -1,0 +1,54 @@
+// ScoreCompare.svelte classifies backend transcription warnings by matching
+// known wording (see src/lib/warning-patterns.js) rather than by any
+// structured tag from the server. A plain build can't catch a rewording in
+// server/fermata/tabextract.py silently degrading that classification - the
+// per-score list would just start missing lines, or the headline bar count
+// would quietly stop appearing, with nothing failing anywhere. Assert the
+// patterns still match strings taken from the current backend wording, so a
+// mismatch fails loudly here instead of only showing up as a worse summary.
+import { STANDING_LIMITS, BAR_RE } from "../src/lib/warning-patterns.js";
+
+// Copied verbatim from server/fermata/tabextract.py at the time this check
+// was written (_TUPLET_WARNING, _TIE_WARNING, and _rhythm_report's
+// bar-conformance sentences). Update these fixtures - and check the
+// patterns above still make sense - whenever that wording changes on
+// purpose; that's exactly the case this check exists to catch otherwise.
+const TUPLET_WARNING =
+  "tuplets (triplets and similar) are not detected - a note written inside a tuplet " +
+  "will show its plain written duration rather than the shortened tuplet duration";
+const TIE_WARNING =
+  "tie detection is low confidence - some tied notes may show up as separately " +
+  "re-struck notes instead of one held note";
+const OVERFULL_BARS_SENTENCE =
+  "3 of 50 bar(s) hold more than their time signature allows. Music written in two " +
+  "voices (a melody over a separate bass line) is separated into concurrent voices " +
+  "where the stems say so, but a bar whose voices the stems do not separate is still " +
+  "flattened into one, and an undetected tuplet or a missed flag lands here too - the " +
+  "notes and their individual durations can still be right while the bar as a whole is " +
+  "not, so playback timing will drift in those bars";
+const SHORT_BARS_SENTENCE =
+  "1 of 50 bar(s) hold less than their time signature allows - a note whose duration " +
+  "was read short, or one dropped for want of a fret number, leaves the bar with a gap " +
+  "at the end. The emitted score says so rather than padding it out, so any MusicXML " +
+  "tool will report those bars too";
+
+const problems = [];
+
+if (!STANDING_LIMITS.some((lim) => lim.test.test(TUPLET_WARNING))) {
+  problems.push("STANDING_LIMITS no longer matches tabextract.py's _TUPLET_WARNING wording");
+}
+if (!STANDING_LIMITS.some((lim) => lim.test.test(TIE_WARNING))) {
+  problems.push("STANDING_LIMITS no longer matches tabextract.py's _TIE_WARNING wording");
+}
+if (!BAR_RE.test(OVERFULL_BARS_SENTENCE)) {
+  problems.push("BAR_RE no longer matches _rhythm_report's overfull-bars sentence");
+}
+if (!BAR_RE.test(SHORT_BARS_SENTENCE)) {
+  problems.push("BAR_RE no longer matches _rhythm_report's short-bars sentence");
+}
+
+if (problems.length) {
+  console.error("warning pattern check failed:\n  " + problems.join("\n  "));
+  process.exit(1);
+}
+console.log("warning pattern check passed");

--- a/web/src/lib/ScoreCompare.svelte
+++ b/web/src/lib/ScoreCompare.svelte
@@ -3,6 +3,7 @@
   import { api } from "./api.js";
   import PdfViewer from "./PdfViewer.svelte";
   import TabViewer from "./TabViewer.svelte";
+  import { STANDING_LIMITS, BAR_RE } from "./warning-patterns.js";
 
   let {
     score,
@@ -110,14 +111,6 @@
   let rhythmCapped = $derived(!!rhythmConfidence && !/^high\b/i.test(rhythmConfidence));
   let rhythmLabel = $derived(rhythmConfidence ? rhythmConfidence.split(" - ")[0].trim() : "");
 
-  // Two caveats that read identically on every transcribed score
-  // (tabextract._TUPLET_WARNING / _TIE_WARNING) - a standing limit of the
-  // feature, not a fact about this score, so they're kept out of the
-  // per-score list and its count.
-  const STANDING_LIMITS = [
-    { test: /tuplets? \(triplets and similar\) are not detected/i, label: "tuplets aren't detected" },
-    { test: /tie detection is low confidence/i, label: "tie detection is approximate" },
-  ];
   let standingNotes = $derived.by(() => {
     const found = [];
     for (const w of warningsList) {
@@ -131,13 +124,19 @@
     warningsList.filter((w) => !STANDING_LIMITS.some((lim) => lim.test.test(w))),
   );
 
-  const BAR_RE = /^(\d+) of (\d+) bar\(s\) hold (?:more|less) than (?:its|their) time signature allows/i;
-  // Preferred source: confidence.confidence.bars_defective / bars_measured,
-  // the same counts ExtractionResult already carries as data (see
-  // tabextract.py) - read directly rather than reconstructed, once the
-  // backend persists them there. Only trusted when bars_measured is present
-  // as a number at all (including 0, meaning "no bars measured" - a real
-  // answer, not a missing one).
+  // The bar-defect count comes ONLY from confidence.confidence.bars_defective
+  // / bars_measured, the same counts ExtractionResult already carries as
+  // data (see tabextract.py). There is no honest fallback: the backend
+  // emits the overfull and short counts as two separate sentences, and a bar
+  // wrong in both directions at once (two-voice writing where one voice is
+  // over its meter and the other under) is counted into BOTH - per
+  // docs/musicxml-tab-profile.md, overfull + short double-counts such a bar
+  // and can exceed bars_measured, while bars_defective is the one figure
+  // that counts it once. That total isn't recoverable from the two
+  // sentences by any arithmetic - summing guesses high, and "take the
+  // larger one" is still a guess - so when the structured field isn't
+  // there, this says nothing about bars rather than something confidently
+  // wrong. The individual sentences are still in the detail list either way.
   let barSummary = $derived.by(() => {
     const structured = confidenceBlob?.confidence;
     if (structured && typeof structured.bars_measured === "number") {
@@ -145,29 +144,13 @@
         ? { defective: structured.bars_defective ?? 0, total: structured.bars_measured }
         : null;
     }
-    // Fallback for a backend that hasn't started persisting bars_defective /
-    // bars_measured yet: parse the same counts out of the warning prose
-    // instead. This is inherently fragile - it breaks silently (the headline
-    // count just disappears) the moment that wording changes, which it has
-    // already done twice in this project - so drop this branch once the
-    // structured field above is always present.
-    //
-    // Bars holding too much and bars holding too little both count as
-    // "don't add up" for the headline; a bar wrong in both directions at
-    // once would be counted twice here (the backend's own comments flag
-    // this as the rare edge case) - the exact per-direction figures are
-    // still in the detail list below.
-    let defective = 0;
-    let total = 0;
-    for (const w of scopedWarnings) {
-      const m = BAR_RE.exec(w);
-      if (m) {
-        defective += Number(m[1]);
-        total = Math.max(total, Number(m[2]));
-      }
-    }
-    return total ? { defective, total } : null;
+    return null;
   });
+
+  // Bar-conformance lines are folded into the headline via barSummary above
+  // (only once a real total exists) - don't also count them a second time
+  // under "N more", or the toggle would promise more bullets than it opens.
+  let barLineCount = $derived(scopedWarnings.filter((w) => BAR_RE.test(w)).length);
 
   let warningsSummary = $derived.by(() => {
     const parts = [];
@@ -177,8 +160,7 @@
       );
     }
     if (rhythmCapped) parts.push(`rhythm confidence ${rhythmLabel}`);
-    const barLines = scopedWarnings.filter((w) => BAR_RE.test(w)).length;
-    const remaining = scopedWarnings.length - barLines;
+    const remaining = scopedWarnings.length - (barSummary ? barLineCount : 0);
     if (!parts.length) {
       const n = remaining || standingNotes.length;
       parts.push(n === 1 ? "1 caveat" : `${n} caveats`);
@@ -206,15 +188,18 @@
   });
 
   // A warning's full sentence justifies itself after " - " or a full stop;
-  // the lead clause alone already carries the count and the cause, so
-  // that's what's shown - the rest is a hover away rather than repeated in
-  // full above every score.
-  function terseText(w) {
+  // the lead clause alone already carries the count and the cause. The
+  // justification is still shown, just dimmer - a `title` tooltip alone
+  // would put it a hover away, unreachable on the tablet-on-a-music-stand
+  // this app is mostly used on, so nothing here depends on hover to be read.
+  function splitWarning(w) {
     const dot = w.indexOf(". ");
     const dash = w.indexOf(" - ");
-    if (dot === -1 && dash === -1) return w;
-    if (dot !== -1 && (dash === -1 || dot < dash)) return w.slice(0, dot + 1);
-    return w.slice(0, dash);
+    let cut = -1;
+    if (dot !== -1 && (dash === -1 || dot < dash)) cut = dot + 1;
+    else if (dash !== -1) cut = dash;
+    if (cut === -1) return [w, ""];
+    return [w.slice(0, cut), w.slice(cut).replace(/^\s*-\s*/, " — ")];
   }
 
   // Expanded the first time a score's warnings are seen this session,
@@ -243,6 +228,30 @@
   }
 
   let detailOpen = $state(false);
+
+  // The one place that recomputes detailOpen, called after every state
+  // change that can make `transcription` (and so warningsList) point at a
+  // different row - a fresh load, a transcribe, a saved edit (which drops
+  // warnings), or a revert (which can bring them back). Reads warningsList
+  // fresh rather than taking it as an argument, so it only has to be called
+  // after `transcription` is already reassigned.
+  //
+  // Guarded on warningsList.length: an edited row carries no confidence, so
+  // marking a score "seen" while its list is empty would make a REAL
+  // warning list (from a later revert, or reloading in a session that
+  // hadn't shown one yet) default to collapsed on its first-ever showing -
+  // the opposite of the intent. Also guarded on !gigMode: gig mode
+  // suppresses the whole block, so a score only ever viewed in gig mode
+  // must not be marked seen either, or its warnings arrive pre-collapsed
+  // the first time someone opens it in the toolbar view.
+  function refreshWarningsDisplay(id) {
+    if (warningsList.length && !gigMode) {
+      detailOpen = !warningsSeen(id);
+      markWarningsSeen(id);
+    } else {
+      detailOpen = false;
+    }
+  }
 
   // guards against a slower response for a previously-viewed score landing
   // after a newer navigation and overwriting what's on screen
@@ -274,8 +283,7 @@
       transcription = t;
       draft = t.content;
       transcriptionState = "ready";
-      detailOpen = warningsList.length ? !warningsSeen(id) : false;
-      markWarningsSeen(id);
+      refreshWarningsDisplay(id);
       maybeDefaultToSide();
     } catch (e) {
       if (gen !== loadGen) return;
@@ -315,8 +323,7 @@
       transcription = t;
       draft = t.content;
       transcriptionState = "ready";
-      detailOpen = warningsList.length ? !warningsSeen(score.id) : false;
-      markWarningsSeen(score.id);
+      refreshWarningsDisplay(score.id);
       maybeDefaultToSide();
     } catch (e) {
       if (gen !== loadGen) return;
@@ -347,6 +354,10 @@
       // `res` carries the format the server read off the content, which is
       // what the viewer dispatches on - so let it win over the loaded row's.
       transcription = { ...transcription, ...res, content: draft, source: "edited" };
+      // an edit is stored with no `confidence` row, so this is expected to
+      // land on "nothing to show" - going through the shared helper rather
+      // than assuming that keeps it correct if that ever stops being true
+      refreshWarningsDisplay(score.id);
       editorOpen = false;
     } catch (e) {
       saveError = String(e?.message ?? e);
@@ -365,6 +376,10 @@
       const t = await api.deleteTranscription(score.id);
       transcription = t;
       draft = t.content;
+      // reverting can bring warnings BACK (the extracted row can carry them
+      // even though the edited row just removed never had any) - recompute
+      // rather than leave detailOpen at whatever the edited row last set
+      refreshWarningsDisplay(score.id);
       editorOpen = false;
     } catch (e) {
       if (e.status === 404) {
@@ -372,6 +387,7 @@
         // failure, but don't pretend the old edit is still showing either
         transcription = null;
         transcriptionState = "none";
+        detailOpen = false;
         fetchError = "Reverted — no extracted transcription was left to fall back to.";
         loadAnalysis();
       } else if (e.status === 405) {
@@ -448,18 +464,21 @@
               <span class="warn-text">{warningsSummary}</span>
               <span class="chev">{detailOpen ? "▲" : "▼"}</span>
             </button>
-            {#if detailOpen}
-              <div class="warnings-detail" id="warnings-detail">
-                <ul>
-                  {#each scopedWarnings as w}
-                    <li title={w}>{terseText(w)}</li>
-                  {/each}
-                </ul>
-                {#if standingNotes.length}
-                  <p class="standing-note">Also: {standingNotes.join("; ")}.</p>
-                {/if}
-              </div>
-            {/if}
+            <!-- rendered unconditionally (hidden via the `hidden` attribute,
+                 not an {#if}) so aria-controls has something to point at
+                 even while collapsed - the one state where that reference
+                 actually gets used by anything reading it -->
+            <div class="warnings-detail" id="warnings-detail" hidden={!detailOpen}>
+              <ul>
+                {#each scopedWarnings as w}
+                  {@const [lead, tail] = splitWarning(w)}
+                  <li>{lead}{#if tail}<span class="detail-tail">{tail}</span>{/if}</li>
+                {/each}
+              </ul>
+              {#if standingNotes.length}
+                <p class="standing-note">Also: {standingNotes.join("; ")}.</p>
+              {/if}
+            </div>
           </div>
         {:else if standingNotes.length}
           <p class="standing-footnote">Standing limits: {standingNotes.join("; ")}.</p>
@@ -800,6 +819,12 @@
 
   .warnings-detail li {
     margin: 3px 0;
+  }
+
+  /* the justification clause, dimmer but always shown - never only in a
+     hover-only title, unreachable on a touch device */
+  .detail-tail {
+    color: var(--ink-dim);
   }
 
   .standing-note {

--- a/web/src/lib/ScoreCompare.svelte
+++ b/web/src/lib/ScoreCompare.svelte
@@ -132,12 +132,31 @@
   );
 
   const BAR_RE = /^(\d+) of (\d+) bar\(s\) hold (?:more|less) than (?:its|their) time signature allows/i;
-  // Bars holding too much and bars holding too little both count as "don't
-  // add up" for the headline; a bar wrong in both directions at once would
-  // be counted twice here (the backend's own comments flag this as the rare
-  // edge case) - the exact per-direction figures are still in the detail
-  // list below.
+  // Preferred source: confidence.confidence.bars_defective / bars_measured,
+  // the same counts ExtractionResult already carries as data (see
+  // tabextract.py) - read directly rather than reconstructed, once the
+  // backend persists them there. Only trusted when bars_measured is present
+  // as a number at all (including 0, meaning "no bars measured" - a real
+  // answer, not a missing one).
   let barSummary = $derived.by(() => {
+    const structured = confidenceBlob?.confidence;
+    if (structured && typeof structured.bars_measured === "number") {
+      return structured.bars_measured
+        ? { defective: structured.bars_defective ?? 0, total: structured.bars_measured }
+        : null;
+    }
+    // Fallback for a backend that hasn't started persisting bars_defective /
+    // bars_measured yet: parse the same counts out of the warning prose
+    // instead. This is inherently fragile - it breaks silently (the headline
+    // count just disappears) the moment that wording changes, which it has
+    // already done twice in this project - so drop this branch once the
+    // structured field above is always present.
+    //
+    // Bars holding too much and bars holding too little both count as
+    // "don't add up" for the headline; a bar wrong in both directions at
+    // once would be counted twice here (the backend's own comments flag
+    // this as the rare edge case) - the exact per-direction figures are
+    // still in the detail list below.
     let defective = 0;
     let total = 0;
     for (const w of scopedWarnings) {

--- a/web/src/lib/ScoreCompare.svelte
+++ b/web/src/lib/ScoreCompare.svelte
@@ -124,9 +124,18 @@
     warningsList.filter((w) => !STANDING_LIMITS.some((lim) => lim.test.test(w))),
   );
 
-  // The bar-defect count comes ONLY from confidence.confidence.bars_defective
-  // / bars_measured, the same counts ExtractionResult already carries as
-  // data (see tabextract.py). There is no honest fallback: the backend
+  // The bar-defect count comes ONLY from transcription.bars_defective /
+  // bars_measured - siblings of `confidence` at the TOP LEVEL of the
+  // transcription object (not nested inside it), the same counts
+  // ExtractionResult already carries as data (see tabextract.py).
+  // `confidence` itself is a mapping of aspect to human-readable sentence
+  // (frets/rhythm/time_signature) and deliberately stays that way, so these
+  // two numbers are lifted out to keep it uniform; _transcription_dict lifts
+  // them on both GET and POST, so this is one lookup, not a two-shape
+  // fallback like rhythmConfidence above.
+  //
+  // There is no honest fallback when they're absent (an edited row has no
+  // confidence at all, which is a normal case, not an error): the backend
   // emits the overfull and short counts as two separate sentences, and a bar
   // wrong in both directions at once (two-voice writing where one voice is
   // over its meter and the other under) is counted into BOTH - per
@@ -134,14 +143,13 @@
   // and can exceed bars_measured, while bars_defective is the one figure
   // that counts it once. That total isn't recoverable from the two
   // sentences by any arithmetic - summing guesses high, and "take the
-  // larger one" is still a guess - so when the structured field isn't
-  // there, this says nothing about bars rather than something confidently
-  // wrong. The individual sentences are still in the detail list either way.
+  // larger one" is still a guess - so this says nothing about bars rather
+  // than something confidently wrong. The individual sentences are still in
+  // the detail list either way.
   let barSummary = $derived.by(() => {
-    const structured = confidenceBlob?.confidence;
-    if (structured && typeof structured.bars_measured === "number") {
-      return structured.bars_measured
-        ? { defective: structured.bars_defective ?? 0, total: structured.bars_measured }
+    if (transcription && typeof transcription.bars_measured === "number") {
+      return transcription.bars_measured
+        ? { defective: transcription.bars_defective ?? 0, total: transcription.bars_measured }
         : null;
     }
     return null;

--- a/web/src/lib/ScoreCompare.svelte
+++ b/web/src/lib/ScoreCompare.svelte
@@ -188,6 +188,23 @@
     return parts.join(" · ");
   });
 
+  // Gig mode drops the warnings block entirely (see the !gigMode guard
+  // below) - performance isn't when anyone corrects a transcription. But an
+  // unverified rhythm silently drilled at tempo is the exact mistake the
+  // rest of this file exists to prevent, so the two facts that must never
+  // go missing keep a single unobtrusive mark: no text, no layout cost,
+  // nothing at all when the score is clean.
+  let gigMarkTitle = $derived.by(() => {
+    const parts = [];
+    if (barSummary?.defective) {
+      parts.push(
+        `${barSummary.defective} of ${barSummary.total} bar${barSummary.total === 1 ? "" : "s"} don't add up`,
+      );
+    }
+    if (rhythmCapped) parts.push(`rhythm confidence: ${rhythmLabel}`);
+    return parts.join(" · ");
+  });
+
   // A warning's full sentence justifies itself after " - " or a full stop;
   // the lead clause alone already carries the count and the cause, so
   // that's what's shown - the rest is a hover away rather than repeated in
@@ -461,6 +478,9 @@
         </div>
       {/if}
       <div class="staff-render">
+        {#if gigMode && gigMarkTitle}
+          <span class="gig-mark" title={gigMarkTitle} aria-label={`Unverified: ${gigMarkTitle}`}>●</span>
+        {/if}
         <TabViewer
           tex={transcription.content}
           format={transcription.format}
@@ -638,10 +658,26 @@
   }
 
   .staff-render {
+    position: relative;
     flex: 1;
     min-height: 0;
     display: flex;
     flex-direction: column;
+  }
+
+  /* The one thing that survives into gig mode: a dot, not a banner, sitting
+     clear of TabViewer's own bottom-center gig HUD - present only when
+     there's something unverified to flag (see gigMarkTitle), so it never
+     becomes decoration that stops meaning anything. */
+  .gig-mark {
+    position: absolute;
+    top: 10px;
+    right: 14px;
+    z-index: 3;
+    font-size: 10px;
+    line-height: 1;
+    color: var(--danger);
+    cursor: default;
   }
 
   .hint {

--- a/web/src/lib/ScoreCompare.svelte
+++ b/web/src/lib/ScoreCompare.svelte
@@ -361,10 +361,16 @@
       // edit itself is the source of truth for content/source either way
       // `res` carries the format the server read off the content, which is
       // what the viewer dispatches on - so let it win over the loaded row's.
+      // `res` STATES warnings ([]) and the four bars_* figures (null) on
+      // every response rather than omitting them for an edit, which has no
+      // confidence to report - an absent key would be silently kept by this
+      // spread, which is exactly how a saved edit once went on reporting the
+      // bar counts and warnings from the content it had just replaced. An
+      // explicit "not recorded" overwrites those stale values instead.
       transcription = { ...transcription, ...res, content: draft, source: "edited" };
-      // an edit is stored with no `confidence` row, so this is expected to
-      // land on "nothing to show" - going through the shared helper rather
-      // than assuming that keeps it correct if that ever stops being true
+      // expected to land on "nothing to show" now that `res` cleared the
+      // stale figures above - going through the shared helper rather than
+      // assuming that keeps it correct if this ever changes again
       refreshWarningsDisplay(score.id);
       editorOpen = false;
     } catch (e) {

--- a/web/src/lib/ScoreCompare.svelte
+++ b/web/src/lib/ScoreCompare.svelte
@@ -81,19 +81,132 @@
   // nests them under confidence.warnings (and confidence may still be the
   // raw JSON string if the backend's own parse of it ever failed) - read
   // whichever shape actually showed up rather than assuming one
+  let confidenceBlob = $derived.by(() => {
+    if (!transcription) return null;
+    let c = transcription.confidence;
+    if (typeof c === "string") {
+      try {
+        c = JSON.parse(c);
+      } catch {
+        c = null;
+      }
+    }
+    return c && typeof c === "object" ? c : null;
+  });
+
   let warningsList = $derived.by(() => {
     if (!transcription) return [];
     if (Array.isArray(transcription.warnings)) return transcription.warnings;
-    let confidence = transcription.confidence;
-    if (typeof confidence === "string") {
-      try {
-        confidence = JSON.parse(confidence);
-      } catch {
-        confidence = null;
+    return Array.isArray(confidenceBlob?.warnings) ? confidenceBlob.warnings : [];
+  });
+
+  // The one number the whole warning list exists to protect: an inferred
+  // rhythm mistaken for a verified one. /transcribe writes it nested as
+  // confidence.confidence.rhythm; read the flat shape too in case that ever
+  // changes.
+  let rhythmConfidence = $derived(
+    confidenceBlob?.confidence?.rhythm ?? confidenceBlob?.rhythm ?? null,
+  );
+  let rhythmCapped = $derived(!!rhythmConfidence && !/^high\b/i.test(rhythmConfidence));
+  let rhythmLabel = $derived(rhythmConfidence ? rhythmConfidence.split(" - ")[0].trim() : "");
+
+  // Two caveats that read identically on every transcribed score
+  // (tabextract._TUPLET_WARNING / _TIE_WARNING) - a standing limit of the
+  // feature, not a fact about this score, so they're kept out of the
+  // per-score list and its count.
+  const STANDING_LIMITS = [
+    { test: /tuplets? \(triplets and similar\) are not detected/i, label: "tuplets aren't detected" },
+    { test: /tie detection is low confidence/i, label: "tie detection is approximate" },
+  ];
+  let standingNotes = $derived.by(() => {
+    const found = [];
+    for (const w of warningsList) {
+      for (const lim of STANDING_LIMITS) {
+        if (lim.test.test(w) && !found.includes(lim.label)) found.push(lim.label);
       }
     }
-    return Array.isArray(confidence?.warnings) ? confidence.warnings : [];
+    return found;
   });
+  let scopedWarnings = $derived(
+    warningsList.filter((w) => !STANDING_LIMITS.some((lim) => lim.test.test(w))),
+  );
+
+  const BAR_RE = /^(\d+) of (\d+) bar\(s\) hold (?:more|less) than (?:its|their) time signature allows/i;
+  // Bars holding too much and bars holding too little both count as "don't
+  // add up" for the headline; a bar wrong in both directions at once would
+  // be counted twice here (the backend's own comments flag this as the rare
+  // edge case) - the exact per-direction figures are still in the detail
+  // list below.
+  let barSummary = $derived.by(() => {
+    let defective = 0;
+    let total = 0;
+    for (const w of scopedWarnings) {
+      const m = BAR_RE.exec(w);
+      if (m) {
+        defective += Number(m[1]);
+        total = Math.max(total, Number(m[2]));
+      }
+    }
+    return total ? { defective, total } : null;
+  });
+
+  let warningsSummary = $derived.by(() => {
+    const parts = [];
+    if (barSummary?.defective) {
+      parts.push(
+        `${barSummary.defective} of ${barSummary.total} bar${barSummary.total === 1 ? "" : "s"} don't add up`,
+      );
+    }
+    if (rhythmCapped) parts.push(`rhythm confidence ${rhythmLabel}`);
+    const barLines = scopedWarnings.filter((w) => BAR_RE.test(w)).length;
+    const remaining = scopedWarnings.length - barLines;
+    if (!parts.length) {
+      const n = remaining || standingNotes.length;
+      parts.push(n === 1 ? "1 caveat" : `${n} caveats`);
+    } else if (remaining) {
+      parts.push(`${remaining} more`);
+    }
+    return parts.join(" · ");
+  });
+
+  // A warning's full sentence justifies itself after " - " or a full stop;
+  // the lead clause alone already carries the count and the cause, so
+  // that's what's shown - the rest is a hover away rather than repeated in
+  // full above every score.
+  function terseText(w) {
+    const dot = w.indexOf(". ");
+    const dash = w.indexOf(" - ");
+    if (dot === -1 && dash === -1) return w;
+    if (dot !== -1 && (dash === -1 || dot < dash)) return w.slice(0, dot + 1);
+    return w.slice(0, dash);
+  }
+
+  // Expanded the first time a score's warnings are seen this session,
+  // collapsed on every later visit - the caveats don't change between
+  // visits, so re-reading them by default is friction, not safety.
+  const WARNINGS_SEEN_KEY = "fermata.warningsSeen";
+  function warningsSeen(id) {
+    try {
+      const raw = sessionStorage.getItem(WARNINGS_SEEN_KEY);
+      return raw ? JSON.parse(raw).includes(id) : false;
+    } catch {
+      return false;
+    }
+  }
+  function markWarningsSeen(id) {
+    try {
+      const raw = sessionStorage.getItem(WARNINGS_SEEN_KEY);
+      const seen = raw ? JSON.parse(raw) : [];
+      if (!seen.includes(id)) {
+        seen.push(id);
+        sessionStorage.setItem(WARNINGS_SEEN_KEY, JSON.stringify(seen));
+      }
+    } catch {
+      // storage unavailable - defaults to open every time, which is safe
+    }
+  }
+
+  let detailOpen = $state(false);
 
   // guards against a slower response for a previously-viewed score landing
   // after a newer navigation and overwriting what's on screen
@@ -125,6 +238,8 @@
       transcription = t;
       draft = t.content;
       transcriptionState = "ready";
+      detailOpen = warningsList.length ? !warningsSeen(id) : false;
+      markWarningsSeen(id);
       maybeDefaultToSide();
     } catch (e) {
       if (gen !== loadGen) return;
@@ -164,6 +279,8 @@
       transcription = t;
       draft = t.content;
       transcriptionState = "ready";
+      detailOpen = warningsList.length ? !warningsSeen(score.id) : false;
+      markWarningsSeen(score.id);
       maybeDefaultToSide();
     } catch (e) {
       if (gen !== loadGen) return;
@@ -282,15 +399,35 @@
         {/if}
       </div>
     {:else if transcriptionState === "ready"}
-      {#if warningsList.length}
-        <div class="warnings">
-          <div class="warnings-head">⚠ Unverified — check against the PDF</div>
-          <ul>
-            {#each warningsList as w}
-              <li>{w}</li>
-            {/each}
-          </ul>
-        </div>
+      {#if !gigMode && warningsList.length}
+        {#if scopedWarnings.length || rhythmCapped}
+          <div class="warnings">
+            <button
+              class="warnings-summary"
+              onclick={() => (detailOpen = !detailOpen)}
+              aria-expanded={detailOpen}
+              aria-controls="warnings-detail"
+            >
+              <span class="warn-icon">⚠</span>
+              <span class="warn-text">{warningsSummary}</span>
+              <span class="chev">{detailOpen ? "▲" : "▼"}</span>
+            </button>
+            {#if detailOpen}
+              <div class="warnings-detail" id="warnings-detail">
+                <ul>
+                  {#each scopedWarnings as w}
+                    <li title={w}>{terseText(w)}</li>
+                  {/each}
+                </ul>
+                {#if standingNotes.length}
+                  <p class="standing-note">Also: {standingNotes.join("; ")}.</p>
+                {/if}
+              </div>
+            {/if}
+          </div>
+        {:else if standingNotes.length}
+          <p class="standing-footnote">Standing limits: {standingNotes.join("; ")}.</p>
+        {/if}
       {/if}
       {#if editorOpen}
         <div class="editor">
@@ -560,27 +697,66 @@
 
   .warnings {
     margin: 12px 16px 0;
-    padding: 10px 14px;
     border: 1px solid var(--danger);
     border-radius: 8px;
     background: rgba(201, 106, 92, 0.12);
+    overflow: hidden;
   }
 
-  .warnings-head {
+  .warnings-summary {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    width: 100%;
+    background: none;
+    border: none;
+    border-radius: 0;
+    padding: 9px 14px;
     font-size: 13px;
-    font-weight: 600;
     color: var(--danger);
+    text-align: left;
   }
 
-  .warnings ul {
-    margin: 6px 0 0;
+  .warn-icon,
+  .chev {
+    flex: none;
+  }
+
+  .chev {
+    font-size: 10px;
+    opacity: 0.7;
+  }
+
+  .warn-text {
+    flex: 1;
+    font-weight: 600;
+  }
+
+  .warnings-detail {
+    padding: 0 14px 10px;
+  }
+
+  .warnings-detail ul {
+    margin: 0;
     padding-left: 20px;
     font-size: 12.5px;
     color: var(--ink);
   }
 
-  .warnings li {
-    margin: 2px 0;
+  .warnings-detail li {
+    margin: 3px 0;
+  }
+
+  .standing-note {
+    margin: 8px 0 0;
+    font-size: 11.5px;
+    color: var(--ink-dim);
+  }
+
+  .standing-footnote {
+    margin: 10px 16px 0;
+    font-size: 11.5px;
+    color: var(--ink-dim);
   }
 
   .editor {

--- a/web/src/lib/warning-patterns.js
+++ b/web/src/lib/warning-patterns.js
@@ -1,0 +1,29 @@
+// Patterns for classifying backend transcription warnings (see
+// server/fermata/tabextract.py: _rhythm_report, _bar_conformance) into
+// what's a fact about this score and what reads identically on every score.
+// Kept in their own module, apart from ScoreCompare.svelte's presentation
+// logic, so they can be checked directly against the backend's current
+// wording (see scripts/check-warning-patterns.mjs) instead of only ever
+// being exercised inside a component.
+
+// Two caveats that read identically on every transcribed score
+// (tabextract._TUPLET_WARNING / _TIE_WARNING) - a standing limit of the
+// feature, not a fact about this score, so they're kept out of the
+// per-score list and its count.
+export const STANDING_LIMITS = [
+  { test: /tuplets? \(triplets and similar\) are not detected/i, label: "tuplets aren't detected" },
+  { test: /tie detection is low confidence/i, label: "tie detection is approximate" },
+];
+
+// Identifies (but does not total) _rhythm_report's bar-conformance
+// sentences - "N of M bar(s) hold more/less than their time signature
+// allows...". Never sum the two matches' captured counts into a bar-defect
+// total: _bar_conformance counts a bar into BOTH overfull and short when one
+// voice is over its meter and another is under it (the two-voice case), so
+// overfull + short can double-count a bar and exceed bars_measured - see
+// docs/musicxml-tab-profile.md. bars_defective/bars_measured from the
+// backend's structured confidence field is the only correct source for that
+// total; this regex exists only to classify a warning line as "about bars"
+// (e.g. to avoid double-reporting it once the structured total already has).
+export const BAR_RE =
+  /^(\d+) of (\d+) bar\(s\) hold (?:more|less) than (?:its|their) time signature allows/i;


### PR DESCRIPTION
## Summary

Fixes #45. A transcribed score with nine warnings rendered them as full-sentence
prose above the staff, pushing the notation below the fold; gig mode showed the
same list on a music stand. The fix summarises instead of hiding:

- A one-line summary states the bar count and rhythm confidence when it's
  capped - both stay visible without expanding, since those are exactly the
  facts that would let someone mistake an inferred rhythm for a verified one.
- The rest (unmatched frets, time/key signature detection, font issues, etc.)
  collapses behind a toggle. Open the first time a score's warnings are seen
  in a session, collapsed on every later visit, tracked in `sessionStorage`.
- Two caveats that read identically on every score (tuplets not detected, tie
  detection is approximate) are pulled out of the per-score list into a quiet
  footnote, or - when there's nothing else to report - the only thing shown.
- Gig mode drops the block entirely; nobody corrects a transcription
  mid-performance.
- List items show their lead clause with the justification a hover away,
  rather than the full sentence, so the expanded panel stays short.

Warnings are read from whichever shape the endpoint returned (`transcription.warnings`
or the nested `confidence.warnings`), matching the existing fetch/transcribe
inconsistency this file already worked around.

## Test plan

Verified in a real browser (Playwright, `/api` stubbed via `page.route`), not
just a successful build:

- [x] Nine-warning payload with a capped `confidence.rhythm`: summary reads
      "4 of 50 bars don't add up · rhythm confidence medium · 5 more", visible
      without interaction; the staff renders within the viewport; detail
      toggles open/closed on click.
- [x] Warnings arriving only under `confidence.warnings` (the fetch-endpoint
      shape) still surface.
- [x] Zero warnings: nothing renders.
- [x] Only the two standing-limitation warnings present (a clean score):
      renders as a quiet footnote, not an alarming box.
- [x] Expanded on a score's first view in a session, collapsed on a later
      revisit in the same session.
- [x] Gig mode: warnings block doesn't render at all; the staff fills the view.
- [x] `#/demo` still renders with no console errors.
- [x] `npm run build` passes.
