### PR TITLE
Offer only the profiles a score can draw

### DIFF
--- a/docs/rendering.md
+++ b/docs/rendering.md
@@ -100,7 +100,17 @@ presets, themes — not the renderer's.
 layout all flow through it. The view it returns exposes `setProfile`,
 `setPreset`, `setTheme`, `setSpeed`, `setLooping`, `setMetronome`, `setCountIn`,
 `playPause`, `stop` and `destroy`, and reports `layout`, `theme`, `profile`,
-`preset` and `lastRenderMs`.
+`supportedProfiles`, `preset` and `lastRenderMs`.
+
+Which profiles a caller may ask for is score-dependent, not fixed: a score
+does not necessarily support all of `SCORE_PROFILES`, and `createScoreView`
+does not just trust whatever `profile` it was given. `onProfiles(profiles)`
+fires once the loaded score's own content has been inspected, with the
+subset it can actually be drawn under (possibly empty - see
+`supportedProfiles()`); `onProfileApplied(profile)` fires separately, once a
+render with that profile has actually finished, which is what a caller
+should wait for before treating a profile switch as visible on screen rather
+than merely requested.
 
 ### Responsive layout
 

--- a/web/src/lib/TabViewer.svelte
+++ b/web/src/lib/TabViewer.svelte
@@ -1,7 +1,7 @@
 <script>
   import { untrack } from "svelte";
   import { api } from "./api.js";
-  import { createScoreView, SCORE_PROFILES } from "./score-render.js";
+  import { createScoreView, UNRENDERABLE_MESSAGE } from "./score-render.js";
   import { getSettings, setSetting, STAFF_THEMES, STAFF_THEME_LABELS } from "./settings.svelte.js";
 
   const settings = getSettings();
@@ -40,11 +40,18 @@
   let scroller;
   let view = $state(null);
   let profile = $state("scoretab");
-  // Which profile buttons are worth showing at all - narrowed once the score
-  // has loaded and score-render.js has looked at what it actually contains.
-  // Starts permissive so nothing flashes and disappears while a score is
-  // still loading.
-  let profileOptions = $state(SCORE_PROFILES);
+  // Which profile buttons are worth showing at all - null while unknown (no
+  // score has finished loading yet), otherwise whatever score-render.js
+  // found this score can actually be drawn with - possibly empty. null is
+  // deliberately not "everything": a `score` prop loads over an async fetch,
+  // so there is a real window between mount and the load actually landing
+  // during which every button being live would let a click on "Tab" go
+  // through for a notation-only file before its content is even known - and
+  // then get silently walked back (the button vanishing out from under the
+  // pointer) the moment the fetch resolves and corrects it. Starting at null
+  // and rendering no buttons at all during that window is what avoids
+  // offering a choice this component cannot yet vouch for.
+  let profileOptions = $state(null);
   let playing = $state(false);
   let playerReady = $state(false);
   let speed = $state(1);
@@ -105,9 +112,9 @@
     loadError = "";
     playerReady = false;
     playing = false;
-    // a restriction the previous score earned (e.g. tab-only) must not keep
-    // hiding buttons for this one while it is still loading
-    profileOptions = SCORE_PROFILES;
+    // unknown again for this score, not "same as the last one" - see the
+    // comment on profileOptions's declaration
+    profileOptions = null;
     // untrack: everything below is driven imperatively once the view exists;
     // tracking it here would tear down and rebuild the renderer (and stop
     // playback) on a profile switch or a toggle.
@@ -123,13 +130,21 @@
         onPlaying: (p) => (playing = p),
         onError: (m) => (loadError = m),
         onPassComplete: advanceLadder,
-        // The renderer may have had to fall back off `profile` itself (e.g. a
-        // tab profile carried over to a score with no tablature) - `active`
-        // is what it actually ended up drawing with, so the toolbar's
-        // highlighted button has to follow it rather than the stale request.
-        onProfiles: (profiles, active) => {
+        // Only which buttons to offer, not which one is highlighted - see
+        // onProfileApplied for that. A score with nothing drawable reports an
+        // empty array here, not a fallback list; the empty-state notice in
+        // the markup below is what tells the profileOptions.length === 0
+        // case apart from "still loading" (profileOptions still null).
+        onProfiles: (profiles) => {
           profileOptions = profiles;
-          profile = active;
+        },
+        // The highlighted button has to follow what actually finished
+        // drawing, not what was most recently requested - setProfile() below
+        // deliberately does not set `profile` itself, because a requested
+        // profile that fails to render (or hasn't rendered yet) must not
+        // move the highlight onto a staff that isn't the one on screen.
+        onProfileApplied: (p) => {
+          profile = p;
         },
       }),
     );
@@ -149,11 +164,16 @@
 
   function setProfile(p) {
     // the buttons only ever offer a viable profile, but guard anyway rather
-    // than trust that: view.setProfile silently no-ops on one the score can't
-    // draw, and letting this flip the highlighted button without it would
-    // show a profile that was never actually rendered
-    if (!profileOptions.includes(p)) return;
-    profile = p;
+    // than trust that
+    if (!profileOptions?.includes(p)) return;
+    // `profile` (the highlighted button) is deliberately not set here. It is
+    // set from onProfileApplied, above, once a render with this profile has
+    // actually finished - setting it eagerly would move the highlight onto a
+    // staff that is not yet, or never, actually on screen: a render that
+    // fails for a reason other than an unsupported profile (still possible -
+    // see onError) would otherwise leave the highlight on a profile whose
+    // render just threw, with the previous, different render frozen
+    // underneath it. That mismatch was the original bug's second half.
     view?.setProfile(p);
   }
 
@@ -228,13 +248,15 @@
     </div>
   {:else}
     <div class="toolbar">
-      <div class="seg">
-        {#each PROFILE_LABELS as [value, label]}
-          {#if profileOptions.includes(value)}
-            <button class:on={profile === value} onclick={() => setProfile(value)}>{label}</button>
-          {/if}
-        {/each}
-      </div>
+      {#if profileOptions?.length}
+        <div class="seg">
+          {#each PROFILE_LABELS as [value, label]}
+            {#if profileOptions.includes(value)}
+              <button class:on={profile === value} onclick={() => setProfile(value)}>{label}</button>
+            {/if}
+          {/each}
+        </div>
+      {/if}
       <select class="theme-picker" value={settings.staff_theme} onchange={chooseTheme} title="Staff theme">
         {#each STAFF_THEMES as t}
           <option value={t}>{STAFF_THEME_LABELS[t]}</option>
@@ -301,7 +323,19 @@
     <p class="error">{loadError}</p>
   {/if}
 
-  <div class="score-scroll" bind:this={scroller}>
+  {#if profileOptions && profileOptions.length === 0}
+    <!-- Nothing about this score is drawable under any profile - see
+    score-render.js's supportedProfiles(). The renderer's own attempt to
+    render it anyway still runs (it cannot be cancelled from here) and still
+    throws internally, but that failure is caught and suppressed at the
+    source rather than shown, so this plain sentence - not a stack trace - is
+    the only thing a guitarist sees. The staff area below stays in the DOM
+    (score-render.js's `host` binding needs a stable element) but is hidden
+    rather than left showing whatever the failed render left behind. -->
+    <p class="notice">{UNRENDERABLE_MESSAGE}</p>
+  {/if}
+
+  <div class="score-scroll" class:hidden={profileOptions?.length === 0} bind:this={scroller}>
     <div class="at-host" bind:this={host}></div>
   </div>
 </div>
@@ -437,6 +471,19 @@
        sideways as well - page layout never overflows this way */
     overflow: auto;
     padding: 20px;
+  }
+
+  /* Stays in the DOM (score-render.js's `host` binding has to stay stable)
+     for a score with nothing drawable - just not shown, so whatever the
+     renderer's own suppressed failed render left behind is never visible. */
+  .score-scroll.hidden {
+    display: none;
+  }
+
+  .notice {
+    color: var(--ink-dim);
+    text-align: center;
+    margin: 32px 8px;
   }
 
   .at-host {

--- a/web/src/lib/TabViewer.svelte
+++ b/web/src/lib/TabViewer.svelte
@@ -1,7 +1,7 @@
 <script>
   import { untrack } from "svelte";
   import { api } from "./api.js";
-  import { createScoreView } from "./score-render.js";
+  import { createScoreView, SCORE_PROFILES } from "./score-render.js";
   import { getSettings, setSetting, STAFF_THEMES, STAFF_THEME_LABELS } from "./settings.svelte.js";
 
   const settings = getSettings();
@@ -40,6 +40,11 @@
   let scroller;
   let view = $state(null);
   let profile = $state("scoretab");
+  // Which profile buttons are worth showing at all - narrowed once the score
+  // has loaded and score-render.js has looked at what it actually contains.
+  // Starts permissive so nothing flashes and disappears while a score is
+  // still loading.
+  let profileOptions = $state(SCORE_PROFILES);
   let playing = $state(false);
   let playerReady = $state(false);
   let speed = $state(1);
@@ -100,6 +105,9 @@
     loadError = "";
     playerReady = false;
     playing = false;
+    // a restriction the previous score earned (e.g. tab-only) must not keep
+    // hiding buttons for this one while it is still loading
+    profileOptions = SCORE_PROFILES;
     // untrack: everything below is driven imperatively once the view exists;
     // tracking it here would tear down and rebuild the renderer (and stop
     // playback) on a profile switch or a toggle.
@@ -115,6 +123,14 @@
         onPlaying: (p) => (playing = p),
         onError: (m) => (loadError = m),
         onPassComplete: advanceLadder,
+        // The renderer may have had to fall back off `profile` itself (e.g. a
+        // tab profile carried over to a score with no tablature) - `active`
+        // is what it actually ended up drawing with, so the toolbar's
+        // highlighted button has to follow it rather than the stale request.
+        onProfiles: (profiles, active) => {
+          profileOptions = profiles;
+          profile = active;
+        },
       }),
     );
     view = v;
@@ -132,6 +148,11 @@
   });
 
   function setProfile(p) {
+    // the buttons only ever offer a viable profile, but guard anyway rather
+    // than trust that: view.setProfile silently no-ops on one the score can't
+    // draw, and letting this flip the highlighted button without it would
+    // show a profile that was never actually rendered
+    if (!profileOptions.includes(p)) return;
     profile = p;
     view?.setProfile(p);
   }
@@ -209,7 +230,9 @@
     <div class="toolbar">
       <div class="seg">
         {#each PROFILE_LABELS as [value, label]}
-          <button class:on={profile === value} onclick={() => setProfile(value)}>{label}</button>
+          {#if profileOptions.includes(value)}
+            <button class:on={profile === value} onclick={() => setProfile(value)}>{label}</button>
+          {/if}
         {/each}
       </div>
       <select class="theme-picker" value={settings.staff_theme} onchange={chooseTheme} title="Staff theme">

--- a/web/src/lib/TabViewer.svelte
+++ b/web/src/lib/TabViewer.svelte
@@ -143,8 +143,15 @@
         // deliberately does not set `profile` itself, because a requested
         // profile that fails to render (or hasn't rendered yet) must not
         // move the highlight onto a staff that isn't the one on screen.
+        // loadError is cleared here too: a render succeeding means whatever
+        // problem it described is resolved, and it must not keep showing
+        // (or keep the .error paragraph occupying space) once the view has
+        // recovered - score-render.js's own setProfile() guard would
+        // otherwise never get a chance to retry a *different* profile
+        // switch while a stale error from an earlier one sat on screen.
         onProfileApplied: (p) => {
           profile = p;
+          loadError = "";
         },
       }),
     );

--- a/web/src/lib/score-render.js
+++ b/web/src/lib/score-render.js
@@ -18,18 +18,33 @@ const STAVE_PROFILE = {
   scoretab: alphaTab.StaveProfile.ScoreTab,
 };
 
-// A profile only draws a staff if the renderer has some glyph type to draw it
-// with - standard notation for "score", a strung tuning for "tab", either (or
-// slash/numbered notation) for "scoretab". This mirrors the checks the
-// renderer's own bar-renderer factories make (ScoreBarRendererFactory,
-// TabBarRendererFactory, ...): when every staff of every rendered track fails
-// a profile's check, the renderer builds a staff system with no staves in it
-// at all, and StaffSystem.addBars crashes dereferencing the group that was
-// never created - that crash is what sends a MusicXML file with pitches but
-// no fret/string data into a broken view the moment "Tab" is chosen. Asking
-// first, here, is what lets a caller offer only profiles that will not do
-// that.
-function staffDrawableUnder(staff, profileKey) {
+// A profile only draws a (track, staff) pair if the renderer has a bar
+// renderer willing to take it - standard notation for "score", a strung
+// tuning for "tab", any glyph type at all for "scoretab". When every pair in
+// the rendered set fails a profile's check, the renderer builds a staff
+// system with no staves in it at all, and StaffSystem.addBars crashes
+// dereferencing the group that was never created - that crash is what sends
+// a MusicXML file with pitches but no fret/string data into a broken view the
+// moment "Tab" is chosen. Asking first, here, is what lets a caller offer
+// only profiles that will not do that.
+//
+// This mirrors PageViewLayout.createEmptyStaffSystem's own test -
+// `this.profile.has(factory.staffId) && factory.canCreate(track, staff)` -
+// against Environment.staveProfiles / Environment.defaultRenderers, the
+// renderer's own lookup and factory list. Both are plain public static class
+// fields (`/** @internal */` only in the source, which is why they are
+// missing from the shipped .d.ts and easy to miss), so calling the real
+// canCreate() is possible and is what canDrawStaff below does - a
+// reimplementation of the rules can only ever be *consistent with* the
+// library, never *be* it, and would silently answer wrong the day a rule
+// changes underneath it. It also picks up canCreate's other terms for free,
+// e.g. TabBarRendererFactory's hideOnPercussionTrack, without this file
+// having to know they exist.
+//
+// mirroredCanDraw is the fallback for when that internal shape moves or is
+// renamed - see environmentCanDraw below - kept as a hand-written second
+// opinion rather than deleted once the delegation was written.
+function mirroredCanDraw(_track, staff, profileKey) {
   const hasTab = staff.showTablature && staff.tuning.length > 0;
   switch (profileKey) {
     case "score":
@@ -44,19 +59,78 @@ function staffDrawableUnder(staff, profileKey) {
 }
 
 /**
+ * The real canDrawStaff(track, staff, profileKey), built from the renderer's
+ * own internals - or null if they are not shaped the way this expects, so the
+ * caller can fall back rather than trust a wrong answer. Checked once, at
+ * module load: Environment's static fields are initialised when the class is
+ * defined, which has already happened by the time this module's top-level
+ * code runs the import above.
+ */
+function environmentCanDraw() {
+  const env = alphaTab.Environment;
+  const staveProfiles = env?.staveProfiles;
+  const renderers = env?.defaultRenderers;
+  const expectedStaveProfiles = [STAVE_PROFILE.score, STAVE_PROFILE.tab, STAVE_PROFILE.scoretab];
+  if (
+    !(staveProfiles instanceof Map) ||
+    !expectedStaveProfiles.every((k) => staveProfiles.get(k) instanceof Set) ||
+    !Array.isArray(renderers) ||
+    renderers.length === 0 ||
+    !renderers.every((f) => typeof f?.staffId === "string" && typeof f?.canCreate === "function")
+  ) {
+    return null;
+  }
+  return (track, staff, profileKey) => {
+    // Map.get returns undefined for a key that was never registered - only
+    // reachable here if profileKey is not one of SCORE_PROFILES.
+    const staffIds = staveProfiles.get(STAVE_PROFILE[profileKey]);
+    if (!staffIds) return false;
+    return renderers.some((f) => staffIds.has(f.staffId) && f.canCreate(track, staff));
+  };
+}
+
+const canDrawStaff = environmentCanDraw();
+if (!canDrawStaff) {
+  console.warn(
+    "score-render: alphaTab's Environment.staveProfiles/defaultRenderers are not shaped as " +
+      "expected (an internal API this file depends on has likely moved or been renamed) - " +
+      "falling back to a hand-mirrored profile-support check, which can silently drift from " +
+      "the renderer's own rules after an upgrade. Update environmentCanDraw() in score-render.js.",
+  );
+}
+const canDraw = canDrawStaff ?? mirroredCanDraw;
+
+/**
  * Which of SCORE_PROFILES the given tracks can actually be drawn with, in
- * SCORE_PROFILES order. `tracks` is empty before anything has loaded, in
- * which case every profile is offered rather than none.
+ * SCORE_PROFILES order. Can legitimately be empty: a MusicXML part carrying a
+ * percussion clef together with `<staff-details><staff-tuning>` imports as
+ * showStandardNotation=false, showTablature=false (Staff.finish clears tuning
+ * and tablature for a percussion staff) and showSlash=showNumbered=false too
+ * - nothing this file, or the renderer, can draw that with. An earlier
+ * version of this function answered a wholly-unsupported score with "offer
+ * everything instead of nothing", which only moved this exact crash from a
+ * click to page load: the default profile would pass the (now permissive)
+ * support check, the renderer would still find zero drawable staves on its
+ * first render, and StaffSystem.addBars would still throw. There is no
+ * profile a caller can pick that fixes a score with nothing to draw - the
+ * caller has to be told that plainly instead (see UNRENDERABLE_MESSAGE and
+ * its use in createScoreView below), not handed a full-but-lying menu.
+ *
+ * The crash this exists to prevent only happens when *every* (track, staff)
+ * pair in the rendered set fails a profile's check - the renderer loops over
+ * all of them building one staff system - so a profile is supported the
+ * moment any single pair can draw it: this ORs canDraw across every pair, it
+ * does not decide from one staff. A two-track score where only the second
+ * track has tablature still has to offer "tab" - see multi-staff.musicxml in
+ * web/test-fixtures for a fixture that reaches this specifically.
  */
 export function supportedProfiles(tracks) {
-  const staves = (tracks ?? []).flatMap((t) => t.staves ?? []);
-  if (!staves.length) return SCORE_PROFILES;
-  const supported = SCORE_PROFILES.filter((p) => staves.some((s) => staffDrawableUnder(s, p)));
-  // Every profile failing would mean the renderer itself has nothing to draw
-  // this score with at all - not something restricting the choice can fix, so
-  // fall back to offering everything rather than leaving the switcher empty.
-  return supported.length ? supported : SCORE_PROFILES;
+  const pairs = (tracks ?? []).flatMap((t) => (t.staves ?? []).map((s) => [t, s]));
+  return SCORE_PROFILES.filter((p) => pairs.some(([t, s]) => canDraw(t, s, p)));
 }
+
+/** Shown in place of the staff view when supportedProfiles() comes back empty. */
+export const UNRENDERABLE_MESSAGE = "This score has no notation or tablature the staff view can draw.";
 
 // ---------------------------------------------------------------- layout
 
@@ -333,9 +407,16 @@ const RENDER_IN_WORKER = false;
  * @param opts.onError      (message) load or render failed
  * @param opts.onPassComplete  one pass finished (drives the tempo ladder)
  * @param opts.onLayout     (layout) the chosen layout changed
- * @param opts.onProfiles   (profiles, active) the profiles this score supports
- *                          changed - fires once a score has loaded, `active`
- *                          is the current profile after any fallback below
+ * @param opts.onProfiles   (profiles, unrenderable) the profiles this score
+ *                          supports changed - fires once a score has loaded.
+ *                          `profiles` can be empty; `unrenderable` is true in
+ *                          exactly that case, when nothing about this score
+ *                          can be drawn under any profile
+ * @param opts.onProfileApplied  (profile) a render has actually finished
+ *                          successfully with this profile showing - the
+ *                          signal a caller should wait for before treating a
+ *                          profile switch as having taken effect, rather than
+ *                          assuming success the moment it is requested
  */
 export function createScoreView(host, opts = {}) {
   const {
@@ -351,13 +432,26 @@ export function createScoreView(host, opts = {}) {
     onPassComplete = () => {},
     onLayout = () => {},
     onProfiles = () => {},
+    onProfileApplied = () => {},
   } = opts;
 
   let profile = SCORE_PROFILES.includes(initialProfile) ? initialProfile : "scoretab";
-  // Nothing has loaded yet, so nothing is ruled out - narrowed once
-  // scoreLoaded fires below, with SCORE_PROFILES itself as the safe fallback
-  // if a score turns out to support none of them (see supportedProfiles).
-  let scoreProfiles = SCORE_PROFILES;
+  // null until scoreLoaded fires below: nothing is known to be supported yet,
+  // which is not the same thing as everything being supported. A caller
+  // (TabViewer) reads null as "do not offer any profile button yet" rather
+  // than showing every button and having to walk one back once the real
+  // answer arrives - see the note on the "score" prop / async fetch path in
+  // web/test-fixtures/tab-profile-selection.md for the bug that came from
+  // treating "not yet known" as "everything works" here.
+  let scoreProfiles = null;
+  // Set once scoreLoaded finds a score with nothing to draw under any
+  // profile - see UNRENDERABLE_MESSAGE. The renderer's own automatic first
+  // render cannot be cancelled from this handler (AlphaTabApi calls it
+  // unconditionally right after scoreLoaded's listeners return), so it still
+  // runs and still throws inside addBars exactly as it always has - this
+  // flag is what lets the api.error handler below recognise that specific,
+  // predicted failure and swallow it instead of surfacing a TypeError.
+  let unrenderable = false;
   let preset = LAYOUT_PRESETS.includes(initialPreset) ? initialPreset : "desk";
   let theme = readScoreTheme(initialTheme);
   const fonts = fontsFor(document.documentElement);
@@ -379,6 +473,19 @@ export function createScoreView(host, opts = {}) {
   let renderStartedAt = 0;
   let lastRenderMs = null;
   let renderCount = 0;
+  // Set on renderStarted, cleared on postRenderFinished - a render that
+  // throws (see the error handler below) leaves this true, because
+  // ScoreRenderer.renderScore's try/catch means postRenderFinished never
+  // fires for a render that failed partway through. That makes this a
+  // complete failed-render detector: "a render started and none finished
+  // since" is exactly "the last render attempt failed", without needing to
+  // know why.
+  let renderInFlight = false;
+  // Whether the most recently *attempted* render actually finished. Kept
+  // distinct from renderCount/lastRenderMs, which only ever advance on
+  // success and would otherwise go stale and misleadingly report the
+  // previous successful render's numbers after a failed one.
+  let renderOk = true;
   // a queued resize render must not touch a torn-down renderer
   let destroyed = false;
 
@@ -421,7 +528,14 @@ export function createScoreView(host, opts = {}) {
     host.dataset.scorePreset = preset;
     host.dataset.scoreTheme = theme.name;
     host.dataset.scoreProfile = profile;
-    host.dataset.scoreProfiles = scoreProfiles.join(",");
+    // "" (not omitted) once scoreLoaded has run and found nothing to offer -
+    // distinct from the attribute being altogether absent, which means no
+    // score has loaded yet at all.
+    if (scoreProfiles != null) host.dataset.scoreProfiles = scoreProfiles.join(",");
+    // Read this before trusting scoreRenderMs/scoreRenders: those only ever
+    // advance on a successful render (see renderOk above), so after a failed
+    // one they still hold the previous successful render's numbers.
+    host.dataset.scoreRenderOk = String(renderOk);
     if (lastRenderMs != null) {
       host.dataset.scoreRenderMs = lastRenderMs.toFixed(1);
       host.dataset.scoreRenders = String(renderCount);
@@ -487,38 +601,68 @@ export function createScoreView(host, opts = {}) {
   // before the first layout pass, which is when the annotation is drawn.
   api.renderStarted.on(() => {
     renderStartedAt = performance.now();
+    renderInFlight = true;
     applyBrandingOverride(api);
   });
   api.postRenderFinished.on(() => {
+    renderInFlight = false;
+    renderOk = true;
     lastRenderMs = performance.now() - renderStartedAt;
     renderCount += 1;
     publish();
     growPaperToDrawing();
+    // The profile that just actually finished drawing - not the profile a
+    // caller most recently asked for, which may not be the same thing if a
+    // render is still in flight or the previous one failed. See onProfileApplied.
+    onProfileApplied(profile);
   });
 
   // A profile carried over from a previous score, or the "scoretab" default,
   // can be one this score has nothing to draw for a staff under - offering
   // "Tab" for a MusicXML file with pitches but no fret/string data is exactly
   // that, and the renderer's own answer to being asked for it anyway is to
-  // throw out of addBars (see staffDrawableUnder above) rather than draw an
-  // empty staff. Correcting the setting here, in the scoreLoaded handler,
-  // runs before the load's own first render: AlphaTabApi triggers scoreLoaded
+  // throw out of addBars (see canDraw above) rather than draw an empty
+  // staff. Correcting the setting here, in the scoreLoaded handler, runs
+  // before the load's own first render: AlphaTabApi triggers scoreLoaded
   // synchronously and only calls render() once every listener has returned,
   // so this is not a race against it.
   api.scoreLoaded.on((loadedScore) => {
     scoreProfiles = supportedProfiles(api.tracks?.length ? api.tracks : loadedScore.tracks);
-    if (!scoreProfiles.includes(profile)) {
+    unrenderable = scoreProfiles.length === 0;
+    if (!unrenderable && !scoreProfiles.includes(profile)) {
       profile = scoreProfiles[0];
       api.settings.display.staveProfile = STAVE_PROFILE[profile];
       api.updateSettings();
     }
     publish();
-    onProfiles(scoreProfiles, profile);
+    onProfiles(scoreProfiles, unrenderable);
   });
 
   api.playerReady.on(() => onReady());
   api.playerStateChanged.on((e) => onPlaying(e.state === 1));
-  api.error.on((e) => onError(e?.message ?? "failed to load score"));
+  api.error.on((e) => {
+    // renderStarted fired with no matching postRenderFinished since: this
+    // error came from the render throwing partway through, not from a load,
+    // soundfont, or MIDI failure - those never leave a render in flight.
+    const failedRender = renderInFlight;
+    if (failedRender) {
+      renderInFlight = false;
+      renderOk = false;
+      publish();
+    }
+    if (unrenderable && failedRender) {
+      // The exact, predicted failure UNRENDERABLE_MESSAGE exists for: every
+      // (track, staff) pair failed every profile's check, so this render was
+      // never going to succeed no matter which profile was set, and the
+      // caller has already been told so via onProfiles(profiles, true).
+      // Surfacing the renderer's own TypeError here on top of that would put
+      // a developer's stack trace in front of a guitarist for a condition
+      // that isn't actually broken - it's a score with nothing to stage.
+      console.debug("score-render: suppressed the predicted render failure for an unrenderable score.", e);
+      return;
+    }
+    onError(e?.message ?? "failed to load score");
+  });
   // Fires at the end of each loop pass, not only the final stop, which is
   // what makes it usable as "one clean pass done".
   api.playerFinished.on(() => onPassComplete());
@@ -545,6 +689,18 @@ export function createScoreView(host, opts = {}) {
   // Watching the stage rather than listening for the renderer's own resize
   // event, because the event reports the host's width - which in horizontal
   // layout is the score's width, not the screen's.
+  //
+  // The renderer registers its own ResizeObserver on the container, unasked
+  // and unconditionally, in the AlphaTabApi constructor - there is no setting
+  // to turn it off in 1.8.4, its unsubscribe closure is discarded, and the
+  // container class isn't exported, so this file cannot reach in and remove
+  // it. It is throttled at a hardcoded 10ms and its handler no-ops once
+  // `container.width === renderer.width`, which is what keeps the two
+  // observers from fighting each other once a render settles - reapply()
+  // below writes `api.renderer.width` before rendering specifically to reach
+  // that quiescent state. This is the fact whose absence caused the original
+  // resize oscillation bug here; if this observer's logic changes, re-check
+  // against the library's handler, not just against itself.
   let resizePending = false;
   const observer = new ResizeObserver(() => {
     const next = layoutForWidth(stageWidth(), preset);
@@ -564,6 +720,12 @@ export function createScoreView(host, opts = {}) {
   if (scroller ?? host) observer.observe(scroller ?? host);
 
   function reapply() {
+    // A resize, theme or preset change still fires while an unrenderable
+    // score is on screen, and unlike the load's own first render, this call
+    // is entirely ours to skip - re-attempting a render already known to
+    // find zero drawable staves would just repeat the same suppressed
+    // failure on every window resize for no benefit.
+    if (unrenderable) return;
     // before anything measures it: the host carries the previous layout's
     // width when that layout was horizontal
     resetSurfaceFit();
@@ -609,9 +771,14 @@ export function createScoreView(host, opts = {}) {
     get profile() {
       return profile;
     },
-    /** Which of SCORE_PROFILES the loaded score can actually be drawn with. */
+    /**
+     * Which of SCORE_PROFILES the loaded score can actually be drawn with -
+     * null before a score has loaded, possibly empty once one has (see
+     * supportedProfiles). A copy, not the live array, so a caller cannot
+     * accidentally mutate this instance's notion of what is supported.
+     */
     get supportedProfiles() {
-      return scoreProfiles;
+      return scoreProfiles ? [...scoreProfiles] : scoreProfiles;
     },
     get preset() {
       return preset;
@@ -622,7 +789,7 @@ export function createScoreView(host, opts = {}) {
     },
 
     setProfile(next) {
-      if (!scoreProfiles.includes(next) || next === profile) return;
+      if (!scoreProfiles?.includes(next) || next === profile) return;
       profile = next;
       reapply();
     },

--- a/web/src/lib/score-render.js
+++ b/web/src/lib/score-render.js
@@ -18,6 +18,46 @@ const STAVE_PROFILE = {
   scoretab: alphaTab.StaveProfile.ScoreTab,
 };
 
+// A profile only draws a staff if the renderer has some glyph type to draw it
+// with - standard notation for "score", a strung tuning for "tab", either (or
+// slash/numbered notation) for "scoretab". This mirrors the checks the
+// renderer's own bar-renderer factories make (ScoreBarRendererFactory,
+// TabBarRendererFactory, ...): when every staff of every rendered track fails
+// a profile's check, the renderer builds a staff system with no staves in it
+// at all, and StaffSystem.addBars crashes dereferencing the group that was
+// never created - that crash is what sends a MusicXML file with pitches but
+// no fret/string data into a broken view the moment "Tab" is chosen. Asking
+// first, here, is what lets a caller offer only profiles that will not do
+// that.
+function staffDrawableUnder(staff, profileKey) {
+  const hasTab = staff.showTablature && staff.tuning.length > 0;
+  switch (profileKey) {
+    case "score":
+      return staff.showStandardNotation;
+    case "tab":
+      return hasTab;
+    case "scoretab":
+      return staff.showStandardNotation || hasTab || staff.showSlash || staff.showNumbered;
+    default:
+      return false;
+  }
+}
+
+/**
+ * Which of SCORE_PROFILES the given tracks can actually be drawn with, in
+ * SCORE_PROFILES order. `tracks` is empty before anything has loaded, in
+ * which case every profile is offered rather than none.
+ */
+export function supportedProfiles(tracks) {
+  const staves = (tracks ?? []).flatMap((t) => t.staves ?? []);
+  if (!staves.length) return SCORE_PROFILES;
+  const supported = SCORE_PROFILES.filter((p) => staves.some((s) => staffDrawableUnder(s, p)));
+  // Every profile failing would mean the renderer itself has nothing to draw
+  // this score with at all - not something restricting the choice can fix, so
+  // fall back to offering everything rather than leaving the switcher empty.
+  return supported.length ? supported : SCORE_PROFILES;
+}
+
 // ---------------------------------------------------------------- layout
 
 // Widths are of the score container, not the window: a side-by-side PDF
@@ -293,6 +333,9 @@ const RENDER_IN_WORKER = false;
  * @param opts.onError      (message) load or render failed
  * @param opts.onPassComplete  one pass finished (drives the tempo ladder)
  * @param opts.onLayout     (layout) the chosen layout changed
+ * @param opts.onProfiles   (profiles, active) the profiles this score supports
+ *                          changed - fires once a score has loaded, `active`
+ *                          is the current profile after any fallback below
  */
 export function createScoreView(host, opts = {}) {
   const {
@@ -307,9 +350,14 @@ export function createScoreView(host, opts = {}) {
     onError = () => {},
     onPassComplete = () => {},
     onLayout = () => {},
+    onProfiles = () => {},
   } = opts;
 
   let profile = SCORE_PROFILES.includes(initialProfile) ? initialProfile : "scoretab";
+  // Nothing has loaded yet, so nothing is ruled out - narrowed once
+  // scoreLoaded fires below, with SCORE_PROFILES itself as the safe fallback
+  // if a score turns out to support none of them (see supportedProfiles).
+  let scoreProfiles = SCORE_PROFILES;
   let preset = LAYOUT_PRESETS.includes(initialPreset) ? initialPreset : "desk";
   let theme = readScoreTheme(initialTheme);
   const fonts = fontsFor(document.documentElement);
@@ -373,6 +421,7 @@ export function createScoreView(host, opts = {}) {
     host.dataset.scorePreset = preset;
     host.dataset.scoreTheme = theme.name;
     host.dataset.scoreProfile = profile;
+    host.dataset.scoreProfiles = scoreProfiles.join(",");
     if (lastRenderMs != null) {
       host.dataset.scoreRenderMs = lastRenderMs.toFixed(1);
       host.dataset.scoreRenders = String(renderCount);
@@ -445,6 +494,26 @@ export function createScoreView(host, opts = {}) {
     renderCount += 1;
     publish();
     growPaperToDrawing();
+  });
+
+  // A profile carried over from a previous score, or the "scoretab" default,
+  // can be one this score has nothing to draw for a staff under - offering
+  // "Tab" for a MusicXML file with pitches but no fret/string data is exactly
+  // that, and the renderer's own answer to being asked for it anyway is to
+  // throw out of addBars (see staffDrawableUnder above) rather than draw an
+  // empty staff. Correcting the setting here, in the scoreLoaded handler,
+  // runs before the load's own first render: AlphaTabApi triggers scoreLoaded
+  // synchronously and only calls render() once every listener has returned,
+  // so this is not a race against it.
+  api.scoreLoaded.on((loadedScore) => {
+    scoreProfiles = supportedProfiles(api.tracks?.length ? api.tracks : loadedScore.tracks);
+    if (!scoreProfiles.includes(profile)) {
+      profile = scoreProfiles[0];
+      api.settings.display.staveProfile = STAVE_PROFILE[profile];
+      api.updateSettings();
+    }
+    publish();
+    onProfiles(scoreProfiles, profile);
   });
 
   api.playerReady.on(() => onReady());
@@ -540,6 +609,10 @@ export function createScoreView(host, opts = {}) {
     get profile() {
       return profile;
     },
+    /** Which of SCORE_PROFILES the loaded score can actually be drawn with. */
+    get supportedProfiles() {
+      return scoreProfiles;
+    },
     get preset() {
       return preset;
     },
@@ -549,7 +622,7 @@ export function createScoreView(host, opts = {}) {
     },
 
     setProfile(next) {
-      if (!SCORE_PROFILES.includes(next) || next === profile) return;
+      if (!scoreProfiles.includes(next) || next === profile) return;
       profile = next;
       reapply();
     },

--- a/web/src/lib/score-render.js
+++ b/web/src/lib/score-render.js
@@ -34,7 +34,7 @@ const STAVE_PROFILE = {
 // renderer's own lookup and factory list. Both are plain public static class
 // fields (`/** @internal */` only in the source, which is why they are
 // missing from the shipped .d.ts and easy to miss), so calling the real
-// canCreate() is possible and is what canDrawStaff below does - a
+// canCreate() is possible and is what canDraw below does - a
 // reimplementation of the rules can only ever be *consistent with* the
 // library, never *be* it, and would silently answer wrong the day a rule
 // changes underneath it. It also picks up canCreate's other terms for free,
@@ -42,8 +42,9 @@ const STAVE_PROFILE = {
 // having to know they exist.
 //
 // mirroredCanDraw is the fallback for when that internal shape moves or is
-// renamed - see environmentCanDraw below - kept as a hand-written second
-// opinion rather than deleted once the delegation was written.
+// renamed, or when calling the real canCreate() throws despite looking
+// right - see environmentCanDraw and canDraw below - kept as a hand-written
+// second opinion rather than deleted once the delegation was written.
 function mirroredCanDraw(_track, staff, profileKey) {
   const hasTab = staff.showTablature && staff.tuning.length > 0;
   switch (profileKey) {
@@ -59,12 +60,12 @@ function mirroredCanDraw(_track, staff, profileKey) {
 }
 
 /**
- * The real canDrawStaff(track, staff, profileKey), built from the renderer's
- * own internals - or null if they are not shaped the way this expects, so the
- * caller can fall back rather than trust a wrong answer. Checked once, at
- * module load: Environment's static fields are initialised when the class is
- * defined, which has already happened by the time this module's top-level
- * code runs the import above.
+ * The delegate for canDraw(track, staff, profileKey), built from the
+ * renderer's own internals - or null if they are not shaped the way this
+ * expects, so the caller can fall back rather than trust a wrong answer.
+ * Checked once, at module load: Environment's static fields are initialised
+ * when the class is defined, which has already happened by the time this
+ * module's top-level code runs the import above.
  */
 function environmentCanDraw() {
   const env = alphaTab.Environment;
@@ -80,6 +81,20 @@ function environmentCanDraw() {
   ) {
     return null;
   }
+  // The checks above only validate the *containers* - that staveProfiles is a
+  // Map of Sets and every factory exposes a staffId string and a canCreate
+  // function - never that the two collections still refer to the same
+  // things. A future alphaTab release could rename every staffId (in both
+  // places, consistently with itself) and pass every check above while
+  // staveProfiles' sets and defaultRenderers' ids no longer overlap at all -
+  // every profile would then match zero factories, and supportedProfiles()
+  // would silently answer "nothing is drawable" for every score in the
+  // library, with no warning, which is the exact failure this guard exists
+  // to catch. Require the two to actually agree: the union of every stave
+  // profile's staff ids has to intersect the renderers' ids somewhere.
+  const renderersStaffIds = new Set(renderers.map((f) => f.staffId));
+  const allProfileStaffIds = new Set(expectedStaveProfiles.flatMap((k) => [...staveProfiles.get(k)]));
+  if (![...allProfileStaffIds].some((id) => renderersStaffIds.has(id))) return null;
   return (track, staff, profileKey) => {
     // Map.get returns undefined for a key that was never registered - only
     // reachable here if profileKey is not one of SCORE_PROFILES.
@@ -89,8 +104,8 @@ function environmentCanDraw() {
   };
 }
 
-const canDrawStaff = environmentCanDraw();
-if (!canDrawStaff) {
+const delegatedCanDraw = environmentCanDraw();
+if (!delegatedCanDraw) {
   console.warn(
     "score-render: alphaTab's Environment.staveProfiles/defaultRenderers are not shaped as " +
       "expected (an internal API this file depends on has likely moved or been renamed) - " +
@@ -98,7 +113,31 @@ if (!canDrawStaff) {
       "the renderer's own rules after an upgrade. Update environmentCanDraw() in score-render.js.",
   );
 }
-const canDraw = canDrawStaff ?? mirroredCanDraw;
+// The shape guard above only checks that canCreate *is* a function, never
+// that calling it is actually safe - a changed parameter list or return
+// contract would pass the guard and then throw the first time it is
+// actually called. That throw is caught here rather than left to escape:
+// once caught, this permanently downgrades to mirroredCanDraw for the rest
+// of the session (a structural incompatibility like a changed signature
+// will not un-happen on the next call) and warns exactly once, rather than
+// warning - or crashing whatever called it - every time.
+let canDrawBroken = false;
+function canDraw(track, staff, profileKey) {
+  if (delegatedCanDraw && !canDrawBroken) {
+    try {
+      return delegatedCanDraw(track, staff, profileKey);
+    } catch (e) {
+      canDrawBroken = true;
+      console.warn(
+        "score-render: alphaTab's canCreate() threw when called, despite passing the shape guard " +
+          "(likely a changed parameter list or return contract) - falling back to the hand-mirrored " +
+          "profile-support check for the rest of this session.",
+        e,
+      );
+    }
+  }
+  return mirroredCanDraw(track, staff, profileKey);
+}
 
 /**
  * Which of SCORE_PROFILES the given tracks can actually be drawn with, in
@@ -120,13 +159,45 @@ const canDraw = canDrawStaff ?? mirroredCanDraw;
  * pair in the rendered set fails a profile's check - the renderer loops over
  * all of them building one staff system - so a profile is supported the
  * moment any single pair can draw it: this ORs canDraw across every pair, it
- * does not decide from one staff. A two-track score where only the second
- * track has tablature still has to offer "tab" - see multi-staff.musicxml in
- * web/test-fixtures for a fixture that reaches this specifically.
+ * does not decide from one staff. A score with two staves in the one track
+ * that gets rendered - one notation-only, one tab-only - still has to offer
+ * both "score" and "tab", each justified by only one of the two staves; see
+ * multi-staff.musicxml in web/test-fixtures for a fixture built to reach
+ * exactly this (deliberately one track, not two - only the first track
+ * renders by default, so a second track would never be part of the pairs
+ * this function is given at all, and would not exercise the OR here).
  */
 export function supportedProfiles(tracks) {
-  const pairs = (tracks ?? []).flatMap((t) => (t.staves ?? []).map((s) => [t, s]));
-  return SCORE_PROFILES.filter((p) => pairs.some(([t, s]) => canDraw(t, s, p)));
+  // The whole body is inside the try, not just the canDraw loop: a malformed
+  // track (a `.staves` access that itself throws, say) has to degrade the
+  // same way a throwing canCreate() does, not escape past this function
+  // entirely just because it happened one line earlier.
+  try {
+    const pairs = (tracks ?? []).flatMap((t) => (t?.staves ?? []).map((s) => [t, s]));
+    return SCORE_PROFILES.filter((p) => pairs.some(([t, s]) => canDraw(t, s, p)));
+  } catch (e) {
+    // canDraw's own try/catch already turns a throwing canCreate() into a
+    // permanent, warned-once fallback (see above) - this is a second, outer
+    // net for anything else that could go wrong here. Without it, a throw
+    // escapes all the way out of the scoreLoaded handler below, skipping
+    // publish() and onProfiles() entirely: profileOptions would stay null
+    // forever, showing neither buttons nor the unrenderable notice, and the
+    // renderer's own attempt to draw with whatever profile it already had
+    // would still run and surface its raw error - silence that then breaks
+    // into the exact failure mode this file exists to prevent, rather than
+    // degrading to a checked answer.
+    console.warn("score-render: supportedProfiles() failed unexpectedly - falling back to the mirrored check.", e);
+    try {
+      const pairs = (tracks ?? []).flatMap((t) => (t?.staves ?? []).map((s) => [t, s]));
+      return SCORE_PROFILES.filter((p) => pairs.some(([t, s]) => mirroredCanDraw(t, s, p)));
+    } catch {
+      // Even re-reading `tracks` failed both times - there is nothing left
+      // to answer from. Offering nothing is the safe direction to fail in
+      // (see "A score that draws nothing" in the spec): the caller shows its
+      // plain notice rather than a menu this function cannot vouch for.
+      return [];
+    }
+  }
 }
 
 /** Shown in place of the staff view when supportedProfiles() comes back empty. */
@@ -436,21 +507,33 @@ export function createScoreView(host, opts = {}) {
   } = opts;
 
   let profile = SCORE_PROFILES.includes(initialProfile) ? initialProfile : "scoretab";
+  // The profile a caller has most recently asked for - not necessarily the
+  // one on screen; see appliedProfile below for that. Read by reapply() to
+  // configure the next render attempt.
+  //
   // null until scoreLoaded fires below: nothing is known to be supported yet,
   // which is not the same thing as everything being supported. A caller
   // (TabViewer) reads null as "do not offer any profile button yet" rather
   // than showing every button and having to walk one back once the real
-  // answer arrives - see the note on the "score" prop / async fetch path in
+  // answer arrives - see "Async load timing" in
   // web/test-fixtures/tab-profile-selection.md for the bug that came from
   // treating "not yet known" as "everything works" here.
   let scoreProfiles = null;
+  // The profile a render has actually finished with, successfully - distinct
+  // from `profile` above, which only records what was last requested. Used
+  // as setProfile()'s de-duplication key instead of `profile`: keying on the
+  // request would make a failed profile switch permanently unretriable, since
+  // asking for the same (already "current" by request, but never actually
+  // drawn) profile again would look like a no-op change and skip reapply()
+  // entirely. Also what onProfileApplied reports.
+  let appliedProfile = null;
   // Set once scoreLoaded finds a score with nothing to draw under any
   // profile - see UNRENDERABLE_MESSAGE. The renderer's own automatic first
   // render cannot be cancelled from this handler (AlphaTabApi calls it
   // unconditionally right after scoreLoaded's listeners return), so it still
-  // runs and still throws inside addBars exactly as it always has - this
-  // flag is what lets the api.error handler below recognise that specific,
-  // predicted failure and swallow it instead of surfacing a TypeError.
+  // runs and can still throw inside addBars exactly as it always has - see
+  // the api.error handler below for how that specific, predicted failure is
+  // told apart from an unrelated one.
   let unrenderable = false;
   let preset = LAYOUT_PRESETS.includes(initialPreset) ? initialPreset : "desk";
   let theme = readScoreTheme(initialTheme);
@@ -473,13 +556,23 @@ export function createScoreView(host, opts = {}) {
   let renderStartedAt = 0;
   let lastRenderMs = null;
   let renderCount = 0;
+  // A snapshot of `profile` taken when the render that is now finishing
+  // began, not whatever `profile` has since become - profile can only
+  // actually change between a render starting and finishing today because
+  // every render path here is synchronous, so reading the live variable at
+  // finish time happens to agree with this snapshot now, but only by
+  // accident of that timing. Taking the snapshot is one line and does not
+  // depend on it.
+  let renderingProfile = profile;
   // Set on renderStarted, cleared on postRenderFinished - a render that
   // throws (see the error handler below) leaves this true, because
   // ScoreRenderer.renderScore's try/catch means postRenderFinished never
   // fires for a render that failed partway through. That makes this a
   // complete failed-render detector: "a render started and none finished
   // since" is exactly "the last render attempt failed", without needing to
-  // know why.
+  // know why. Used only for data-score-render-ok below - not for deciding
+  // whether to suppress an error (see the api.error handler for why that
+  // has to be keyed on the error itself instead).
   let renderInFlight = false;
   // Whether the most recently *attempted* render actually finished. Kept
   // distinct from renderCount/lastRenderMs, which only ever advance on
@@ -530,8 +623,16 @@ export function createScoreView(host, opts = {}) {
     host.dataset.scoreProfile = profile;
     // "" (not omitted) once scoreLoaded has run and found nothing to offer -
     // distinct from the attribute being altogether absent, which means no
-    // score has loaded yet at all.
+    // score has loaded yet at all. Explicitly deleted rather than just left
+    // unset in the null case: `host` is the same DOM element across a score
+    // switch (TabViewer's markup does not recreate it, only this closure),
+    // so without the delete, publish()'s very first call for a *new* score -
+    // called below before anything is known - would leave the *previous*
+    // score's dataset.scoreProfiles sitting there through the whole loading
+    // window, silently breaking the "absent means nothing has loaded yet"
+    // contract this attribute is documented to have.
     if (scoreProfiles != null) host.dataset.scoreProfiles = scoreProfiles.join(",");
+    else delete host.dataset.scoreProfiles;
     // Read this before trusting scoreRenderMs/scoreRenders: those only ever
     // advance on a successful render (see renderOk above), so after a failed
     // one they still hold the previous successful render's numbers.
@@ -602,6 +703,7 @@ export function createScoreView(host, opts = {}) {
   api.renderStarted.on(() => {
     renderStartedAt = performance.now();
     renderInFlight = true;
+    renderingProfile = profile;
     applyBrandingOverride(api);
   });
   api.postRenderFinished.on(() => {
@@ -609,12 +711,13 @@ export function createScoreView(host, opts = {}) {
     renderOk = true;
     lastRenderMs = performance.now() - renderStartedAt;
     renderCount += 1;
+    appliedProfile = renderingProfile;
     publish();
     growPaperToDrawing();
-    // The profile that just actually finished drawing - not the profile a
-    // caller most recently asked for, which may not be the same thing if a
-    // render is still in flight or the previous one failed. See onProfileApplied.
-    onProfileApplied(profile);
+    // The profile that just actually finished drawing, snapshotted at the
+    // moment this render started rather than read live off `profile` here -
+    // see renderingProfile's declaration.
+    onProfileApplied(renderingProfile);
   });
 
   // A profile carried over from a previous score, or the "scoretab" default,
@@ -641,23 +744,37 @@ export function createScoreView(host, opts = {}) {
   api.playerReady.on(() => onReady());
   api.playerStateChanged.on((e) => onPlaying(e.state === 1));
   api.error.on((e) => {
-    // renderStarted fired with no matching postRenderFinished since: this
-    // error came from the render throwing partway through, not from a load,
-    // soundfont, or MIDI failure - those never leave a render in flight.
-    const failedRender = renderInFlight;
-    if (failedRender) {
+    if (renderInFlight) {
       renderInFlight = false;
       renderOk = false;
       publish();
     }
-    if (unrenderable && failedRender) {
-      // The exact, predicted failure UNRENDERABLE_MESSAGE exists for: every
-      // (track, staff) pair failed every profile's check, so this render was
-      // never going to succeed no matter which profile was set, and the
-      // caller has already been told so via onProfiles(profiles, true).
-      // Surfacing the renderer's own TypeError here on top of that would put
-      // a developer's stack trace in front of a guitarist for a condition
-      // that isn't actually broken - it's a score with nothing to stage.
+    // Keyed on the error itself - not on "a render happened to be in flight"
+    // - because a render being in flight is not specific enough. alphaTab
+    // registers its own resize handling unconditionally (see the
+    // ResizeObserver below) and, on an unrenderable score, that path can
+    // start and fail a render this file never sees start: unlike
+    // renderScore(), ScoreRenderer.resizeRender()'s full-rerender branch
+    // calls render() with no try/catch around it and never reaches api.error
+    // at all for its own failure, but it does leave renderInFlight set (this
+    // file's renderStarted listener still fires) with nothing to ever clear
+    // it. An earlier version keyed suppression on that flag alone, and it
+    // stayed armed across such an invisible failure until the *next*
+    // api.error of any kind - a soundfont load failure, unrelated to any of
+    // this - which then got silently swallowed too. Checking the error's own
+    // stack for the specific crash this suppression exists for means an
+    // unrelated error is never at risk, regardless of what left renderInFlight
+    // set.
+    const isPredictedEmptyStaffSystemCrash =
+      unrenderable && typeof e?.stack === "string" && e.stack.includes("StaffSystem") && e.stack.includes("addBars");
+    if (isPredictedEmptyStaffSystemCrash) {
+      // Every (track, staff) pair failed every profile's check (see
+      // supportedProfiles), so this render was never going to succeed no
+      // matter which profile was set, and the caller has already been told
+      // so via onProfiles(profiles, true). Surfacing the renderer's own
+      // TypeError here on top of that would put a developer's stack trace in
+      // front of a guitarist for a condition that isn't actually broken -
+      // it's a score with nothing to stage.
       console.debug("score-render: suppressed the predicted render failure for an unrenderable score.", e);
       return;
     }
@@ -724,8 +841,16 @@ export function createScoreView(host, opts = {}) {
     // score is on screen, and unlike the load's own first render, this call
     // is entirely ours to skip - re-attempting a render already known to
     // find zero drawable staves would just repeat the same suppressed
-    // failure on every window resize for no benefit.
-    if (unrenderable) return;
+    // failure on every window resize for no benefit. publish() still has to
+    // run first, though: setTheme/setPreset already updated `theme`/`preset`
+    // before calling this, and skipping publish() along with the render
+    // would leave dataset.scoreTheme/scorePreset reporting the *previous*
+    // theme or preset - stale, even though nothing about the (still
+    // unrenderable) view visibly changes either way.
+    if (unrenderable) {
+      publish();
+      return;
+    }
     // before anything measures it: the host carries the previous layout's
     // width when that layout was horizontal
     resetSurfaceFit();
@@ -789,7 +914,14 @@ export function createScoreView(host, opts = {}) {
     },
 
     setProfile(next) {
-      if (!scoreProfiles?.includes(next) || next === profile) return;
+      // Keyed on appliedProfile, not profile: profile is set eagerly, right
+      // below, the moment a switch is requested, whether or not it ever
+      // renders successfully. Keying on it would make a failed switch
+      // permanently unretriable - asking for the same profile again would
+      // look like a no-op ("next === profile" already true from the failed
+      // attempt) and skip reapply() entirely, with no way back to that
+      // profile except detouring through a third one first.
+      if (!scoreProfiles?.includes(next) || next === appliedProfile) return;
       profile = next;
       reapply();
     },

--- a/web/test-fixtures/environment-guard.mjs
+++ b/web/test-fixtures/environment-guard.mjs
@@ -1,0 +1,155 @@
+// Verifies score-render.js's delegation to alphaTab's Environment internals
+// degrades safely rather than answering silently wrong - see "How profile
+// support is actually decided" in tab-profile-selection.md. Not wired into
+// any runner (there isn't one yet - see that file's header), but plain
+// Node/ESM and runnable directly:
+//
+//   cd web && node test-fixtures/environment-guard.mjs
+//
+// Each case monkeypatches alphaTab.Environment *before* importing
+// score-render.js, since the module reads it once, at import time - this
+// only works because Node's ESM loader treats a fresh dynamic import() with
+// a cache-busting query as a new module instance, so each case gets its own
+// clean read of a differently-broken Environment.
+import * as alphaTab from "@coderline/alphatab";
+
+let failures = 0;
+
+function check(name, condition, detail) {
+  if (condition) {
+    console.log(`PASS: ${name}`);
+  } else {
+    failures += 1;
+    console.error(`FAIL: ${name}${detail ? " - " + detail : ""}`);
+  }
+}
+
+async function freshScoreRender() {
+  return import(`../src/lib/score-render.js?case=${Math.random()}`);
+}
+
+const notationStaff = {
+  showStandardNotation: true,
+  showTablature: false,
+  tuning: [],
+  showSlash: false,
+  showNumbered: false,
+};
+const tabStaff = {
+  showStandardNotation: false,
+  showTablature: true,
+  tuning: [0, 5, 10, 15, 19, 24],
+  showSlash: false,
+  showNumbered: false,
+};
+
+// ---------------------------------------------------------------- healthy
+{
+  const warnings = [];
+  const originalWarn = console.warn;
+  console.warn = (...args) => warnings.push(args[0]);
+  const mod = await freshScoreRender();
+  console.warn = originalWarn;
+
+  check("healthy library: no fallback warning at import", warnings.length === 0, JSON.stringify(warnings));
+  check(
+    "healthy library: notation-only staff -> [score, scoretab]",
+    JSON.stringify(mod.supportedProfiles([{ staves: [notationStaff] }])) === JSON.stringify(["score", "scoretab"]),
+  );
+  check(
+    "healthy library: tab-only staff -> [tab, scoretab]",
+    JSON.stringify(mod.supportedProfiles([{ staves: [tabStaff] }])) === JSON.stringify(["tab", "scoretab"]),
+  );
+  check(
+    "healthy library: one track, two staves -> all three",
+    JSON.stringify(mod.supportedProfiles([{ staves: [notationStaff, tabStaff] }])) ===
+      JSON.stringify(["score", "tab", "scoretab"]),
+  );
+  check("healthy library: no tracks -> []", JSON.stringify(mod.supportedProfiles([])) === "[]");
+}
+
+// ------------------------------------------------------- renamed staff ids
+// staveProfiles keeps the OLD ids; defaultRenderers now expose NEW ones -
+// every container-shape check (Map of Sets, array of {staffId, canCreate})
+// still passes, which is exactly what the shape-only guard used to miss.
+{
+  const original = alphaTab.Environment.defaultRenderers;
+  alphaTab.Environment.defaultRenderers = original.map((f) => ({
+    staffId: "renamed-" + f.staffId,
+    canCreate: (track, staff) => f.canCreate(track, staff),
+  }));
+
+  const warnings = [];
+  const originalWarn = console.warn;
+  console.warn = (...args) => warnings.push(args[0]);
+  const mod = await freshScoreRender();
+  console.warn = originalWarn;
+
+  check("renamed staff ids: a fallback warning fires", warnings.length > 0);
+  const result = mod.supportedProfiles([{ staves: [notationStaff] }]);
+  check(
+    "renamed staff ids: still answers correctly via the fallback, not []",
+    result.includes("score"),
+    JSON.stringify(result),
+  );
+
+  alphaTab.Environment.defaultRenderers = original;
+}
+
+// --------------------------------------------------------- throwing canCreate
+// Passes the shape guard (staffId is a string, canCreate is a function) but
+// throws when actually called - a changed parameter list or return contract.
+{
+  const original = alphaTab.Environment.defaultRenderers;
+  alphaTab.Environment.defaultRenderers = original.map((f) => ({
+    staffId: f.staffId,
+    canCreate: () => {
+      throw new TypeError("simulated signature change");
+    },
+  }));
+
+  const mod = await freshScoreRender();
+
+  const warningsFirst = [];
+  const originalWarn = console.warn;
+  console.warn = (...args) => warningsFirst.push(args[0]);
+  const result1 = mod.supportedProfiles([{ staves: [notationStaff] }]);
+  console.warn = originalWarn;
+
+  check("throwing canCreate: first call recovers instead of throwing", result1.includes("score"));
+  check("throwing canCreate: warns exactly once", warningsFirst.length === 1, JSON.stringify(warningsFirst));
+
+  const warningsSecond = [];
+  console.warn = (...args) => warningsSecond.push(args[0]);
+  const result2 = mod.supportedProfiles([{ staves: [notationStaff] }]);
+  console.warn = originalWarn;
+
+  check("throwing canCreate: second call still answers correctly", result2.includes("score"));
+  check("throwing canCreate: does not warn again (permanent, not re-armed)", warningsSecond.length === 0);
+
+  alphaTab.Environment.defaultRenderers = original;
+}
+
+// ------------------------------------------------- unrelated throw inside
+// supportedProfiles() itself (not from canCreate at all) must still degrade
+// to an array answer, never escape and strand the caller at "unknown".
+{
+  const mod = await freshScoreRender();
+  const malformedTrack = {
+    get staves() {
+      throw new Error("boom - unrelated to canCreate");
+    },
+  };
+  let threw = false;
+  let result;
+  try {
+    result = mod.supportedProfiles([malformedTrack]);
+  } catch {
+    threw = true;
+  }
+  check("unrelated throw inside supportedProfiles(): does not escape", !threw);
+  check("unrelated throw inside supportedProfiles(): still returns an array", Array.isArray(result));
+}
+
+console.log(failures === 0 ? "\nAll checks passed." : `\n${failures} check(s) failed.`);
+process.exit(failures === 0 ? 0 : 1);

--- a/web/test-fixtures/multi-staff.musicxml
+++ b/web/test-fixtures/multi-staff.musicxml
@@ -1,0 +1,177 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.musicxml.org/xsd/musicxml.xsd">
+  <work>
+    <work-title>Multi-staff example (notation staff + tab staff)</work-title>
+  </work>
+  <identification>
+    <encoding>
+      <software>Fermata test fixture</software>
+      <encoding-date>2026-08-20</encoding-date>
+    </encoding>
+  </identification>
+  <part-list>
+    <score-part id="P1">
+      <part-name>Piano and Guitar</part-name>
+    </score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>480</divisions>
+        <key>
+          <fifths>0</fifths>
+        </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+        </time>
+        <staves>2</staves>
+        <clef number="1">
+          <sign>G</sign>
+          <line>2</line>
+        </clef>
+        <clef number="2">
+          <sign>TAB</sign>
+          <line>5</line>
+        </clef>
+        <staff-details number="2">
+          <staff-lines>6</staff-lines>
+          <staff-tuning line="1">
+            <tuning-step>E</tuning-step>
+            <tuning-octave>2</tuning-octave>
+          </staff-tuning>
+          <staff-tuning line="2">
+            <tuning-step>A</tuning-step>
+            <tuning-octave>2</tuning-octave>
+          </staff-tuning>
+          <staff-tuning line="3">
+            <tuning-step>D</tuning-step>
+            <tuning-octave>3</tuning-octave>
+          </staff-tuning>
+          <staff-tuning line="4">
+            <tuning-step>G</tuning-step>
+            <tuning-octave>3</tuning-octave>
+          </staff-tuning>
+          <staff-tuning line="5">
+            <tuning-step>B</tuning-step>
+            <tuning-octave>3</tuning-octave>
+          </staff-tuning>
+          <staff-tuning line="6">
+            <tuning-step>E</tuning-step>
+            <tuning-octave>4</tuning-octave>
+          </staff-tuning>
+        </staff-details>
+      </attributes>
+      <!-- Staff 1: plain notation, no fret/string data at all. -->
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>480</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <staff>1</staff>
+      </note>
+      <note>
+        <pitch>
+          <step>D</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>480</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <staff>1</staff>
+      </note>
+      <note>
+        <pitch>
+          <step>E</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>480</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <staff>1</staff>
+      </note>
+      <note>
+        <pitch>
+          <step>F</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>480</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <staff>1</staff>
+      </note>
+      <backup>
+        <duration>1920</duration>
+      </backup>
+      <!-- Staff 2: tablature, every note carrying fret/string. -->
+      <note>
+        <pitch>
+          <step>E</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>480</duration>
+        <voice>2</voice>
+        <type>quarter</type>
+        <staff>2</staff>
+        <notations>
+          <technical>
+            <string>1</string>
+            <fret>0</fret>
+          </technical>
+        </notations>
+      </note>
+      <note>
+        <pitch>
+          <step>C</step>
+          <alter>1</alter>
+          <octave>4</octave>
+        </pitch>
+        <duration>480</duration>
+        <voice>2</voice>
+        <type>quarter</type>
+        <staff>2</staff>
+        <notations>
+          <technical>
+            <string>2</string>
+            <fret>2</fret>
+          </technical>
+        </notations>
+      </note>
+      <note>
+        <pitch>
+          <step>A</step>
+          <octave>3</octave>
+        </pitch>
+        <duration>480</duration>
+        <voice>2</voice>
+        <type>quarter</type>
+        <staff>2</staff>
+        <notations>
+          <technical>
+            <string>3</string>
+            <fret>2</fret>
+          </technical>
+        </notations>
+      </note>
+      <note>
+        <pitch>
+          <step>G</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>480</duration>
+        <voice>2</voice>
+        <type>quarter</type>
+        <staff>2</staff>
+        <notations>
+          <technical>
+            <string>1</string>
+            <fret>3</fret>
+          </technical>
+        </notations>
+      </note>
+    </measure>
+  </part>
+</score-partwise>

--- a/web/test-fixtures/notation-only.musicxml
+++ b/web/test-fixtures/notation-only.musicxml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.musicxml.org/xsd/musicxml.xsd">
+  <work>
+    <work-title>Notation-only example</work-title>
+  </work>
+  <identification>
+    <encoding>
+      <software>Fermata test fixture</software>
+      <encoding-date>2026-08-20</encoding-date>
+    </encoding>
+  </identification>
+  <part-list>
+    <score-part id="P1">
+      <part-name>Piano</part-name>
+      <score-instrument id="P1-I1">
+        <instrument-name>Piano</instrument-name>
+      </score-instrument>
+      <midi-instrument id="P1-I1">
+        <midi-channel>1</midi-channel>
+        <midi-program>1</midi-program>
+      </midi-instrument>
+    </score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>480</divisions>
+        <key>
+          <fifths>0</fifths>
+        </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+        </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+        </clef>
+      </attributes>
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>480</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+      </note>
+      <note>
+        <pitch>
+          <step>D</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>480</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+      </note>
+      <note>
+        <pitch>
+          <step>E</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>480</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+      </note>
+      <note>
+        <pitch>
+          <step>F</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>480</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+      </note>
+    </measure>
+  </part>
+</score-partwise>

--- a/web/test-fixtures/tab-profile-selection.md
+++ b/web/test-fixtures/tab-profile-selection.md
@@ -1,0 +1,212 @@
+# Tab profile selection — regression spec (issue #66)
+
+Written up because there is no frontend test runner in this repo yet (no
+`web/package.json` test script, no Playwright, no specs anywhere in the
+tree) - `feature/instruments` is bringing one, with a `Browser tests` CI
+job. This document is the three scenarios that verified the fix in
+[#69](https://github.com/sirged/fermata/pull/69), broken into fixture /
+setup / action / assertion so porting onto that harness is mechanical
+rather than a re-investigation. It was checked with Playwright against a
+real dev server + backend (not just a build); nothing below depends on
+Playwright specifically.
+
+## Fixtures
+
+1. **`web/test-fixtures/notation-only.musicxml`** (this file, new). A
+   minimal valid MusicXML 4.0 document: one part, one measure, G clef, four
+   quarter notes with `<pitch>` and **no** `<notations><technical>` at all -
+   no TAB clef, no `<staff-tuning>`. This is the exact repro condition from
+   issue #66: pitches, but nothing for a tab renderer to draw.
+
+   Deliberately **not** placed under `docs/examples/`, even though that
+   directory holds the repo's other committed MusicXML fixtures: it is
+   pinned by `server/tests/test_musicxml.py::test_the_published_examples_exist_and_conform`
+   to exactly `["monophonic.musicxml", "two-voice.musicxml"]`, and every
+   file there is validated against tab-profile-specific rules (TAB clef,
+   `<staff-tuning>`, Rule 8 measure arithmetic) that a notation-only file
+   does not, and should not, satisfy.
+
+2. **`docs/examples/monophonic.musicxml`** (already committed). One
+   monophonic bar, TAB clef, six-line `<staff-tuning>`, every note carrying
+   `<notations><technical><string>/<fret>`. This is a genuine *tab-only*
+   staff - see "Why alphaTab treats these differently" below - the mirror
+   image of fixture 1, and already validated by the server test suite (see
+   `docs/musicxml-tab-profile.md`).
+
+3. **No new fixture.** The bundled alphaTeX demo score is the `DEMO_TEX`
+   constant in `web/src/lib/TabViewer.svelte` (currently lines 68-76),
+   reachable at the `#/demo` route (`web/src/App.svelte` routes
+   `#/demo` to `<Viewer demo={true} />`, which passes `demo` through to
+   `TabViewer`). alphaTeX's default staff has both `showStandardNotation`
+   and `showTablature` true, so this is the one fixture here that genuinely
+   supports all three profiles - no MusicXML fixture in this repo does,
+   since Fermata's own MusicXML tab profile deliberately never pairs a tab
+   staff with a notation staff (`docs/musicxml-tab-profile.md`, "Out of
+   scope").
+
+## Why alphaTab treats these differently
+
+`score-render.js`'s `supportedProfiles()` (added in #69) filters
+`SCORE_PROFILES = ["score", "tab", "scoretab"]` by asking, per staff:
+does it have `showStandardNotation` ("score"), `showTablature && tuning.length > 0`
+("tab"), or any of those plus `showSlash`/`showNumbered` ("scoretab")? These
+mirror the renderer's own `ScoreBarRendererFactory` / `TabBarRendererFactory`
+`canCreate()` checks.
+
+For MusicXML specifically, alphaTab's importer sets these per
+`<clef><sign>`:
+
+- `sign=g` (or no clef at all): `showStandardNotation` stays at its class
+  default (`true`); `showTablature` stays `false` unless a later
+  `<staff-tuning>` is seen for that staff.
+- `sign=tab`: `showTablature = true`. The **first** `<staff-tuning>`
+  element parsed for that staff also flips `showStandardNotation` to
+  `false` (`MusicXmlImporter._parseStaffTuning` in
+  `@coderline/alphatab`'s bundle).
+
+That second rule is why fixture 2 offers only Tab/Both, never Notation - it
+is not a fixture bug, it is what a real Fermata transcription looks like
+today (a single TAB staff, never paired with a separate notation staff), so
+the regression spec has to assert exactly that, not "all three."
+
+## Environment
+
+Backend and frontend were run from a scratch checkout of the fix branch,
+isolated from any other running fermata instance on the machine.
+
+**Bind explicitly to `127.0.0.1` and a non-default port for both frontend
+and backend, and address them by that literal IP in the test client - not
+`localhost`.** On the machine this was verified on, `localhost` resolves to
+`::1` before `127.0.0.1`, and another already-running fermata instance (a
+different worktree's dev server, or a live instance) can already hold the
+default Vite/uvicorn ports on the IPv6 side. An early run of this spec
+against `localhost:5173`/`5174` silently hit that other instance's real
+250+-score library instead of the fixtures below - the giveaway was the
+scored count in the library view not matching the scratch library. Binding
+literally and checking `curl http://127.0.0.1:<PORT>/api/scores` returns
+exactly the scratch library's entries avoids this.
+
+Steps:
+
+1. `cd server && python -m venv .venv && .venv/Scripts/pip install -e .`
+   (the project requires Python >=3.12; use `py -3.13` if the default
+   `python` on the machine is older).
+2. Make a scratch library directory containing only fixture 1 (and, to
+   exercise scenario 2, a copy of `docs/examples/monophonic.musicxml`), and
+   an empty scratch config directory.
+3. `FERMATA_LIBRARY=<library dir> FERMATA_CONFIG=<config dir> .venv/Scripts/python -m uvicorn fermata.main:app --host 127.0.0.1 --port <PORT_A>`
+4. Once the backend is up: `curl -X POST http://127.0.0.1:<PORT_A>/api/scan`
+5. `cd web && npm install`, then either point `vite.config.js`'s
+   `server.proxy["/api"]` at `http://127.0.0.1:<PORT_A>` and set
+   `server.port = <PORT_B>` with `strictPort: true`, or otherwise confirm
+   the dev server under test really proxies to `PORT_A` (see the `curl`
+   check above) before running anything against it.
+6. Browser: Chromium via Playwright (`npx playwright install chromium`),
+   driven by a plain Node script against `http://127.0.0.1:<PORT_B>/` -
+   no browser-automation extension was available in the sandbox this was
+   verified in.
+
+## Scenario 1 — notation-only score: Tab must not be offered
+
+**Setup:** open the library card for fixture 1 ("Notation-only example").
+
+**Assertions (post-fix):**
+
+- `.seg button` texts are exactly `["Notation", "Both"]` - no "Tab" button
+  rendered at all.
+- The `.at-host` element's `dataset.scoreProfiles` equals `"score,scoretab"`.
+- `.at-host` contains at least one rendered `<svg>` (the score actually
+  drew, this isn't a silently-blank view).
+- Zero `console:error` and zero `pageerror` events across: page load,
+  clicking "Both", clicking back to "Notation", Play, Stop.
+
+**Failure before the fix** (`supportedProfiles()`/`onProfiles` did not
+exist, so all three buttons were offered and clicking "Tab" was possible).
+Clicking the then-offered "Tab" button produced this exact console output,
+and the view froze on its previous ("Both") render:
+
+```
+[AlphaTab][API] An unexpected error occurred
+TypeError: Cannot read properties of undefined (reading 'staves')
+    at StaffSystem.addBars (.../@coderline_alphatab.js:52929:32)
+    at PageViewLayout._createStaffSystem (.../@coderline_alphatab.js:54168:34)
+    at PageViewLayout._layoutAndRenderScore (.../@coderline_alphatab.js:54092:27)
+    at PageViewLayout.doLayoutAndRender (.../@coderline_alphatab.js:53902:14)
+    at PageViewLayout.layoutAndRender (.../@coderline_alphatab.js:53483:10)
+    at ScoreRenderer._layoutAndRender (.../@coderline_alphatab.js:37450:17)
+    at ScoreRenderer.render (.../@coderline_alphatab.js:37429:12)
+    at ScoreRenderer.renderScore (.../@coderline_alphatab.js:37375:12)
+    at ScoreRendererWrapper.renderScore (.../@coderline_alphatab.js:41186:21)
+    at _AlphaTabApi.render (.../@coderline_alphatab.js:42476:22)
+```
+
+The same message also appeared on the page itself, in `TabViewer`'s
+pre-existing `.error` paragraph (bound to `loadError`) - but the "Tab"
+button stayed visually selected (`.on`) even though the render behind it
+had failed and the old "Both" render was still on screen. That is the
+misleading half of the bug: the switcher lied about what was on screen. A
+**pre-fix** version of this test would assert `.seg button` texts include
+"Tab" and that clicking it produces the console error above; the **post-fix**
+version asserts "Tab" is simply absent (see above) - the crash can no
+longer be reached through the UI at all.
+
+## Scenario 2 — tab-only score (fixture 2): Notation must not be offered
+
+**Setup:** open the library card for "Monophonic example"
+(`docs/examples/monophonic.musicxml`).
+
+**Assertions:**
+
+- `.seg button` texts are exactly `["Tab", "Both"]`.
+- `.at-host` `dataset.scoreProfiles` equals `"tab,scoretab"`.
+- Clicking "Tab" then "Both": zero console errors either time; `.at-host`
+  keeps at least one rendered `<svg>` after each.
+- Player controls work: wait for `.player .primary` to become enabled
+  (`playerReady`), click it, its text becomes `"❚❚ Pause"`; click the
+  `.player button` with text `"■"` to stop.
+
+This scenario is the symmetric case the ticket also names ("a tab-only
+score should not offer a notation profile it cannot draw"), and it is not
+hypothetical - it is what every current Fermata transcription looks like
+(see "Why alphaTab treats these differently" above), so it is closer to
+"the common case" for real library content than scenario 3 is.
+
+## Scenario 3 — the bundled demo score: all three profiles work
+
+**Setup:** navigate directly to `#/demo` (no library entry needed).
+
+**Assertions:**
+
+- Zero console/page errors from navigation alone - this is also one of the
+  fix's own acceptance criteria.
+- `.seg button` texts are exactly `["Notation", "Tab", "Both"]`.
+- Clicking through all three, in any order: zero console errors per click;
+  `.at-host` keeps rendered `<svg>` content after each.
+- Wait for `.player .primary` to become enabled, then:
+  - click the `.practice button` with text "Loop" → gains class `on`.
+  - click the `.practice button` with text "Metronome" → gains class `on`.
+  - click the `.practice button` with text "Count-in" → gains class `on`.
+  - click the `.practice button` with text "Ladder" → gains class `on`,
+    and `.ladder-controls` becomes visible (Start/Step/Target number
+    inputs plus a `%` readout).
+  - click `.player .primary` → its text becomes `"❚❚ Pause"`.
+  - click the `.player button` with text `"■"` → stops without error.
+- Zero console errors across the whole playback sequence.
+
+## Notes for porting
+
+- Every assertion above was checked with Playwright's
+  `page.locator(...).allTextContents()`,
+  `page.locator(...).evaluate(el => ({...el.dataset}))`, and `console` /
+  `pageerror` event listeners on the page - none of it is
+  Playwright-specific and should translate directly to whatever
+  `feature/instruments` brings in.
+- `SCORE_PROFILES` and the button label order come from
+  `web/src/lib/score-render.js` (`SCORE_PROFILES = ["score", "tab", "scoretab"]`)
+  and `web/src/lib/TabViewer.svelte` (`PROFILE_LABELS`, mapping those to
+  "Notation"/"Tab"/"Both") - if either changes, the expected button-text
+  arrays above need to change with them; they are not independent
+  assertions.
+- `dataset.scoreProfiles` is written by `score-render.js`'s `publish()`,
+  added specifically in #69 so a test can assert on it directly rather than
+  parsing button text - prefer it once the harness exists.

--- a/web/test-fixtures/tab-profile-selection.md
+++ b/web/test-fixtures/tab-profile-selection.md
@@ -1,14 +1,15 @@
-# Tab profile selection — regression spec (issue #66)
+# Tab profile selection — a specification for tests (issue #66)
 
 Written up because there is no frontend test runner in this repo yet (no
 `web/package.json` test script, no Playwright, no specs anywhere in the
 tree) - `feature/instruments` is bringing one, with a `Browser tests` CI
-job. This document is the three scenarios that verified the fix in
-[#69](https://github.com/sirged/fermata/pull/69), broken into fixture /
-setup / action / assertion so porting onto that harness is mechanical
-rather than a re-investigation. It was checked with Playwright against a
-real dev server + backend (not just a build); nothing below depends on
-Playwright specifically.
+job. This document is not itself a test - nothing executes it, so no
+assertion in it can fail on its own - it is the five scenarios that verified
+the fix in [#69](https://github.com/sirged/fermata/pull/69), broken into
+fixture / setup / action / assertion so porting onto that harness is
+mechanical rather than a re-investigation. Each was checked with Playwright
+against a real dev server + backend (not just a build); nothing below
+depends on Playwright specifically.
 
 ## Fixtures
 
@@ -29,7 +30,7 @@ Playwright specifically.
 2. **`docs/examples/monophonic.musicxml`** (already committed). One
    monophonic bar, TAB clef, six-line `<staff-tuning>`, every note carrying
    `<notations><technical><string>/<fret>`. This is a genuine *tab-only*
-   staff - see "Why alphaTab treats these differently" below - the mirror
+   staff - see "How profile support is actually decided" below - the mirror
    image of fixture 1, and already validated by the server test suite (see
    `docs/musicxml-tab-profile.md`).
 
@@ -44,30 +45,158 @@ Playwright specifically.
    staff with a notation staff (`docs/musicxml-tab-profile.md`, "Out of
    scope").
 
-## Why alphaTab treats these differently
+4. **`web/test-fixtures/multi-staff.musicxml`** (new). One part, one
+   measure, `<staves>2</staves>`: staff 1 is plain notation (G clef, no
+   `<technical>`, same as fixture 1), staff 2 is tab-only (TAB clef,
+   six-line `<staff-tuning>`, every note carrying `<technical><string>/<fret>`,
+   same as fixture 2) - each note tagged `<staff>1</staff>` or
+   `<staff>2</staff>`, with a `<backup>` between the two staves' notes so
+   both start at the measure's beginning. See "A correctness bug to fix"
+   below: two staves in the one track that gets rendered by default, each
+   supporting a different single profile, neither supporting all three
+   alone.
 
-`score-render.js`'s `supportedProfiles()` (added in #69) filters
-`SCORE_PROFILES = ["score", "tab", "scoretab"]` by asking, per staff:
-does it have `showStandardNotation` ("score"), `showTablature && tuning.length > 0`
-("tab"), or any of those plus `showSlash`/`showNumbered` ("scoretab")? These
-mirror the renderer's own `ScoreBarRendererFactory` / `TabBarRendererFactory`
-`canCreate()` checks.
+5. **`web/test-fixtures/unrenderable.musicxml`** (new). One part, one
+   measure, a percussion clef *combined with* `<staff-details><staff-tuning>`.
+   `Staff.finish()` clears the tuning and forces `showTablature = false` for
+   any percussion staff regardless of what the tuning claimed, and a
+   percussion clef never sets `showStandardNotation`, `showSlash` or
+   `showNumbered` either - so this staff ends up unable to satisfy any of the
+   three profiles at all. See "A score that draws nothing" below.
 
-For MusicXML specifically, alphaTab's importer sets these per
-`<clef><sign>`:
+## How profile support is actually decided
 
-- `sign=g` (or no clef at all): `showStandardNotation` stays at its class
-  default (`true`); `showTablature` stays `false` unless a later
-  `<staff-tuning>` is seen for that staff.
-- `sign=tab`: `showTablature = true`. The **first** `<staff-tuning>`
-  element parsed for that staff also flips `showStandardNotation` to
-  `false` (`MusicXmlImporter._parseStaffTuning` in
-  `@coderline/alphatab`'s bundle).
+`score-render.js`'s `supportedProfiles(tracks)` decides, for each of
+`SCORE_PROFILES = ["score", "tab", "scoretab"]`, whether **any** `(track,
+staff)` pair in the given tracks can be drawn under it - not whether the
+first staff, or any one staff, can. The check for a single pair delegates to
+the renderer itself rather than reimplementing its rules:
 
-That second rule is why fixture 2 offers only Tab/Both, never Notation - it
-is not a fixture bug, it is what a real Fermata transcription looks like
-today (a single TAB staff, never paired with a separate notation staff), so
-the regression spec has to assert exactly that, not "all three."
+```js
+const staffIds = Environment.staveProfiles.get(STAVE_PROFILE[profileKey]);
+const drawable = Environment.defaultRenderers.some(
+  (f) => staffIds.has(f.staffId) && f.canCreate(track, staff),
+);
+```
+
+This is exactly `PageViewLayout.createEmptyStaffSystem`'s own test
+(`this.profile.has(factory.staffId) && factory.canCreate(track, staff)`)
+against `Environment.staveProfiles` / `Environment.defaultRenderers` - both
+plain public static class fields in 1.8.4 (`/** @internal */` only in the
+JSDoc, which is why they are absent from the shipped `.d.ts`). Calling the
+real `canCreate()` means this file cannot answer differently than the
+renderer that is about to be asked to draw - a hand-written mirror of the
+rules could only ever be *consistent with* the library at the time it was
+written, and would silently drift the day a rule changes.
+
+If `Environment.staveProfiles` or `Environment.defaultRenderers` are missing
+or not shaped as expected (an upgrade moved or renamed them),
+`environmentCanDraw()` in `score-render.js` returns `null`, one
+`console.warn` fires, and everything falls back to `mirroredCanDraw` - a
+kept-not-deleted hand-written version of the same per-staff rules this PR
+originally shipped with (`showStandardNotation` for "score", `showTablature
+&& tuning.length > 0` for "tab", either of those plus
+`showSlash`/`showNumbered` for "scoretab"). **This fallback path is verified
+by code inspection, not exercised here** - forcing it would mean breaking
+`Environment`'s shape at runtime, which isn't worth the complexity for a
+path whose only job is "fail loudly and degrade to today's behaviour, don't
+answer wrong silently." A test harness with the room to monkeypatch
+`alphaTab.Environment` before importing `score-render.js` could exercise it
+directly - assert the warning fires, and that `supportedProfiles()` still
+returns the fixture 1/2/3 answers below off `mirroredCanDraw` alone.
+
+For MusicXML specifically, what actually drives `showStandardNotation` /
+`showTablature` is **`<staff-tuning>`, not the clef sign** - this is worth
+stating precisely, because the natural-sounding guess (clef sign decides
+tab, staff-tuning decides notation) is backwards and does not match what
+alphaTab actually does. Verified by execution, not read off the clef-parsing
+code alone (which sets `showTablature = true` on a TAB clef sign by itself,
+but that gets overridden - see below):
+
+- A TAB clef with **no** `<staff-tuning>` at all gives
+  `showStandardNotation = true, showTablature = false`. `Staff.finish()`
+  clears `showTablature` back to `false` whenever a staff's tuning array
+  ended up empty, which is exactly what "no `<staff-tuning>` was ever
+  parsed" leaves it as - overriding whatever the clef parsing set.
+- A plain G clef **with** `<staff-tuning>` gives
+  `showStandardNotation = false, showTablature = true`. The **first**
+  `<staff-tuning>` element parsed for a staff sets both flags
+  (`MusicXmlImporter._parseStaffTuning` in `@coderline/alphatab`'s bundle),
+  regardless of what clef sign was declared.
+
+`<staff-tuning>`'s presence is the one thing driving both flags. This is why
+fixture 2 (TAB clef, `<staff-tuning>` present) offers only Tab/Both, never
+Notation - it is not a fixture bug, it is what a real Fermata transcription
+looks like today (a single tab staff, never paired with a separate notation
+staff), so the spec has to assert exactly that, not "all three."
+
+## A correctness bug to fix (caught before merge, not after)
+
+The crash `supportedProfiles()` exists to prevent only happens when **every**
+`(track, staff)` pair in the rendered set fails a profile's check - the
+renderer loops over all of them building one staff system, so it takes only
+one pair that can draw a profile to keep the system non-empty. A version of
+`supportedProfiles()` that decided from a single staff (e.g. only
+`tracks[0].staves[0]`) would answer wrong for exactly fixture 4: staff 1
+alone would say only "score" is supported, staff 2 alone would say only
+"tab" - either answer would incorrectly hide a profile the *other* staff
+can actually draw, once both are rendered together. `supportedProfiles()`
+therefore flattens every track's every staff into `(track, staff)` pairs
+first and ORs the per-pair check across all of them - see Scenario 4.
+
+## A score that draws nothing
+
+`supportedProfiles()` can legitimately return an empty array - fixture 5 is
+exactly that. An earlier version of this fix answered a wholly-unsupported
+score by offering every profile instead of none, which only moved the same
+crash from a click to page load: the permissive fallback would pass the
+`scoreProfiles.includes(profile)` check for whatever the default profile
+was, the renderer would still find zero drawable staves on its first
+attempt, and `StaffSystem.addBars` would still throw - now on load, with no
+click required to reach it, and the toolbar would have shown all three
+buttons for a score none of them could draw.
+
+There is no profile a caller can pick that fixes a score with nothing to
+draw, so `score-render.js` does not try to pick one. Instead:
+
+- `TabViewer` offers no profile buttons at all when `supportedProfiles()`
+  comes back empty, and shows `UNRENDERABLE_MESSAGE` ("This score has no
+  notation or tablature the staff view can draw.") in a `<p class="notice">`
+  instead - never the renderer's own error text. The `.score-scroll`
+  container stays in the DOM (`score-render.js`'s `host` binding needs a
+  stable element to attach to) but gets a `hidden` class so nothing broken
+  is visible inside it.
+- The renderer's own automatic first render, triggered by AlphaTabApi itself
+  immediately after `scoreLoaded`, cannot be cancelled from the `scoreLoaded`
+  handler - so it still runs. What happens next depends on timing that this
+  document does not treat as guaranteed: if the `.score-scroll.hidden` class
+  has already been applied to the DOM by the time that render executes, the
+  host measures 0 width and the renderer's own `render()` logs
+  `"AlphaTab skipped rendering because of width=0"` and returns without ever
+  reaching `addBars` - no crash, no `error` event, nothing to suppress. If it
+  has not (or `.score-scroll` is not hidden, as forced in the verification
+  below to check the other path directly), the render proceeds and throws
+  exactly as it always has - alphaTab's own `Logger.error` still writes the
+  raw `TypeError` to devtools (that call is inside the library, unconditional,
+  and not something this file can suppress), and the library's `error` event
+  fires with it. `score-render.js`'s `api.error` handler recognises this
+  specific, predicted failure (`unrenderable` was already true, and
+  `renderInFlight` shows a render actually started and never finished) and
+  swallows it - `console.debug`, not `onError` - rather than forwarding the
+  raw message to `loadError`/the page's `.error` paragraph. **Both paths are
+  safe for the person looking at the page**: either way, nothing renders,
+  nothing crashes past the library's own already-existing try/catch, and the
+  only thing shown is the plain sentence. Only devtools output differs.
+- `renderStarted` with no matching `postRenderFinished` since is a complete
+  failed-render detector - `ScoreRenderer.renderScore`'s own try/catch means
+  `postRenderFinished` never fires for a render that threw partway through.
+  `data-score-render-ok` reflects this per attempt; `data-score-render-ms` /
+  `data-score-renders` only ever advance on success and are not safe to read
+  as "did the last attempt succeed" on their own - check
+  `data-score-render-ok` first.
+
+See Scenario 5 for the exact assertions, and both the natural and forced
+verification of the two paths above.
 
 ## Environment
 
@@ -82,7 +211,7 @@ different worktree's dev server, or a live instance) can already hold the
 default Vite/uvicorn ports on the IPv6 side. An early run of this spec
 against `localhost:5173`/`5174` silently hit that other instance's real
 250+-score library instead of the fixtures below - the giveaway was the
-scored count in the library view not matching the scratch library. Binding
+score count in the library view not matching the scratch library. Binding
 literally and checking `curl http://127.0.0.1:<PORT>/api/scores` returns
 exactly the scratch library's entries avoids this.
 
@@ -91,9 +220,9 @@ Steps:
 1. `cd server && python -m venv .venv && .venv/Scripts/pip install -e .`
    (the project requires Python >=3.12; use `py -3.13` if the default
    `python` on the machine is older).
-2. Make a scratch library directory containing only fixture 1 (and, to
-   exercise scenario 2, a copy of `docs/examples/monophonic.musicxml`), and
-   an empty scratch config directory.
+2. Make a scratch library directory containing fixtures 1, 4 and 5, plus a
+   copy of `docs/examples/monophonic.musicxml` for fixture 2, and an empty
+   scratch config directory.
 3. `FERMATA_LIBRARY=<library dir> FERMATA_CONFIG=<config dir> .venv/Scripts/python -m uvicorn fermata.main:app --host 127.0.0.1 --port <PORT_A>`
 4. Once the backend is up: `curl -X POST http://127.0.0.1:<PORT_A>/api/scan`
 5. `cd web && npm install`, then either point `vite.config.js`'s
@@ -114,16 +243,15 @@ Steps:
 
 - `.seg button` texts are exactly `["Notation", "Both"]` - no "Tab" button
   rendered at all.
-- The `.at-host` element's `dataset.scoreProfiles` equals `"score,scoretab"`.
+- The `.at-host` element's `dataset.scoreProfiles` equals `"score,scoretab"`,
+  and `dataset.scoreRenderOk` equals `"true"`.
 - `.at-host` contains at least one rendered `<svg>` (the score actually
   drew, this isn't a silently-blank view).
 - Zero `console:error` and zero `pageerror` events across: page load,
   clicking "Both", clicking back to "Notation", Play, Stop.
 
-**Failure before the fix** (`supportedProfiles()`/`onProfiles` did not
-exist, so all three buttons were offered and clicking "Tab" was possible).
-Clicking the then-offered "Tab" button produced this exact console output,
-and the view froze on its previous ("Both") render:
+**Pre-fix**, this score's toolbar offered all three buttons, and clicking
+the (then-offered) "Tab" button produced this exact console output:
 
 ```
 [AlphaTab][API] An unexpected error occurred
@@ -140,15 +268,18 @@ TypeError: Cannot read properties of undefined (reading 'staves')
     at _AlphaTabApi.render (.../@coderline_alphatab.js:42476:22)
 ```
 
-The same message also appeared on the page itself, in `TabViewer`'s
-pre-existing `.error` paragraph (bound to `loadError`) - but the "Tab"
-button stayed visually selected (`.on`) even though the render behind it
-had failed and the old "Both" render was still on screen. That is the
-misleading half of the bug: the switcher lied about what was on screen. A
-**pre-fix** version of this test would assert `.seg button` texts include
-"Tab" and that clicking it produces the console error above; the **post-fix**
-version asserts "Tab" is simply absent (see above) - the crash can no
-longer be reached through the UI at all.
+This was **never console-only**: `score-render.js` already forwarded the
+renderer's `error` event to the viewer before this fix, so the same message
+also appeared on the page itself, in `TabViewer`'s pre-existing `.error`
+paragraph (bound to `loadError`). The full pre-fix experience was the raw
+`TypeError` text on the page, the console error, the stale previous ("Both")
+render frozen underneath it, and the "Tab" button still shown highlighted
+even though its render had failed and nothing behind it had changed - that
+mismatch between the highlighted button and what was actually on screen is
+the defect Scenario 1 and F4 (see PR #69's review) are both about. Post-fix,
+"Tab" is not offered at all, so none of the above is reachable through this
+score's UI - a score that draws *nothing at all* under *any* profile is a
+different case with its own failure mode; see Scenario 5, not this one.
 
 ## Scenario 2 — tab-only score (fixture 2): Notation must not be offered
 
@@ -168,7 +299,7 @@ longer be reached through the UI at all.
 This scenario is the symmetric case the ticket also names ("a tab-only
 score should not offer a notation profile it cannot draw"), and it is not
 hypothetical - it is what every current Fermata transcription looks like
-(see "Why alphaTab treats these differently" above), so it is closer to
+(see "How profile support is actually decided" above), so it is closer to
 "the common case" for real library content than scenario 3 is.
 
 ## Scenario 3 — the bundled demo score: all three profiles work
@@ -193,13 +324,73 @@ hypothetical - it is what every current Fermata transcription looks like
   - click the `.player button` with text `"■"` → stops without error.
 - Zero console errors across the whole playback sequence.
 
+## Scenario 4 — multi-staff score (fixture 4): OR across every pair, not one staff
+
+**Setup:** open the library card for "Multi-staff example".
+
+**Assertions:**
+
+- `.seg button` texts are exactly `["Notation", "Tab", "Both"]` - staff 1
+  alone would only justify "Notation", staff 2 alone only "Tab"; all three
+  are offered because `supportedProfiles()` ORs the check across both
+  `(track, staff)` pairs rather than answering from either staff on its own.
+- `.at-host` `dataset.scoreProfiles` equals `"score,tab,scoretab"`.
+- Clicking through all three: zero console errors per click; `.at-host`
+  keeps rendered `<svg>` content after each (both staves draw together
+  under "Both"; each individual profile still finds at least the one staff
+  that supports it).
+
+This is the scenario a single-staff answer would get wrong - see "A
+correctness bug to fix" above for why.
+
+## Scenario 5 — a score that draws nothing (fixture 5): no buttons, plain sentence, no crash reaches the page
+
+**Setup:** open the library card for "Unrenderable example".
+
+**Assertions:**
+
+- No `.seg` element is rendered at all (zero profile buttons).
+- A `<p class="notice">` is shown with exactly `UNRENDERABLE_MESSAGE`'s text:
+  "This score has no notation or tablature the staff view can draw."
+- No `.error` paragraph is shown (`loadError` never receives the renderer's
+  raw message for this predicted failure).
+- `.score-scroll` has class `hidden`.
+- `.at-host` `dataset.scoreProfiles` equals `""` (empty string, present -
+  distinct from the attribute being absent, which means no score has loaded
+  at all yet).
+- Verified twice, to cover both paths described in "A score that draws
+  nothing" above:
+  - **Natural**: open the score and wait. In this sandbox's Chromium, the
+    `.score-scroll.hidden` class was already applied by the time the
+    renderer's automatic first render ran, so it logged
+    `"AlphaTab skipped rendering because of width=0"` and returned - no
+    `error` event, no console error, `dataset.scoreRenderOk` stays at its
+    initial `"true"` (no render attempt ever completed or failed to update
+    it). Forcing a real window resize afterwards changes nothing:
+    `reapply()` skips outright while `unrenderable` is true, by design (see
+    `score-render.js`), so this state is stable rather than one accidental
+    early return away from the crash reappearing.
+  - **Forced**: with a stylesheet override neutralising `.score-scroll.hidden`
+    (`display: flex !important`) injected *before* opening the score, so the
+    host keeps real dimensions, the renderer's first render does proceed and
+    does throw the exact `TypeError` from Scenario 1's stack trace. alphaTab's
+    own `Logger.error` still writes that to devtools (unsuppressable from
+    outside the library) and a `console:debug` line
+    ("score-render: suppressed the predicted render failure…") appears - but
+    `.error` stays empty, `.notice` still shows the plain sentence, and
+    `dataset.scoreRenderOk` flips to `"false"`. This is the path that proves
+    the `api.error` + `unrenderable` + `renderInFlight` handling in
+    `score-render.js` actually works, independent of whichever path a given
+    browser's timing happens to take.
+
 ## Notes for porting
 
 - Every assertion above was checked with Playwright's
   `page.locator(...).allTextContents()`,
-  `page.locator(...).evaluate(el => ({...el.dataset}))`, and `console` /
-  `pageerror` event listeners on the page - none of it is
-  Playwright-specific and should translate directly to whatever
+  `page.locator(...).evaluate(el => ({...el.dataset}))`, `console` /
+  `pageerror` event listeners, `page.addStyleTag(...)` (Scenario 5's forced
+  path), and `page.setViewportSize(...)` (to trigger a real resize) - none of
+  it is Playwright-specific and should translate directly to whatever
   `feature/instruments` brings in.
 - `SCORE_PROFILES` and the button label order come from
   `web/src/lib/score-render.js` (`SCORE_PROFILES = ["score", "tab", "scoretab"]`)
@@ -207,6 +398,11 @@ hypothetical - it is what every current Fermata transcription looks like
   "Notation"/"Tab"/"Both") - if either changes, the expected button-text
   arrays above need to change with them; they are not independent
   assertions.
-- `dataset.scoreProfiles` is written by `score-render.js`'s `publish()`,
-  added specifically in #69 so a test can assert on it directly rather than
-  parsing button text - prefer it once the harness exists.
+- `dataset.scoreProfiles` and `dataset.scoreRenderOk` are written by
+  `score-render.js`'s `publish()` specifically so a test can assert on them
+  directly rather than parsing button text or guessing at render success -
+  prefer them once the harness exists. `dataset.scoreRenderMs` /
+  `dataset.scoreRenders` are not reset on a failed render and must not be
+  read without checking `dataset.scoreRenderOk` first.
+- `UNRENDERABLE_MESSAGE` is exported from `score-render.js` - import it
+  rather than hardcoding the sentence in a test, so the two cannot drift.

--- a/web/test-fixtures/tab-profile-selection.md
+++ b/web/test-fixtures/tab-profile-selection.md
@@ -4,16 +4,20 @@ Written up because there is no frontend test runner in this repo yet (no
 `web/package.json` test script, no Playwright, no specs anywhere in the
 tree) - `feature/instruments` is bringing one, with a `Browser tests` CI
 job. This document is not itself a test - nothing executes it, so no
-assertion in it can fail on its own - it is the five scenarios that verified
-the fix in [#69](https://github.com/sirged/fermata/pull/69), broken into
-fixture / setup / action / assertion so porting onto that harness is
-mechanical rather than a re-investigation. Each was checked with Playwright
-against a real dev server + backend (not just a build); nothing below
-depends on Playwright specifically.
+assertion in it can fail on its own - it is the five numbered scenarios
+(plus a few narrower behaviors called out in their own sections: async load
+timing, retryability after a failed switch, and dataset staleness across a
+score switch) that verified the fix in
+[#69](https://github.com/sirged/fermata/pull/69), broken into fixture /
+setup / action / assertion so porting onto that harness is mechanical rather
+than a re-investigation. Each was checked with Playwright against a real
+dev server + backend (not just a build), except the delegation-guard cases
+in `environment-guard.mjs`, which are plain Node and check `score-render.js`
+directly; nothing below depends on Playwright specifically.
 
 ## Fixtures
 
-1. **`web/test-fixtures/notation-only.musicxml`** (this file, new). A
+1. **`web/test-fixtures/notation-only.musicxml`** (new in this PR). A
    minimal valid MusicXML 4.0 document: one part, one measure, G clef, four
    quarter notes with `<pitch>` and **no** `<notations><technical>` at all -
    no TAB clef, no `<staff-tuning>`. This is the exact repro condition from
@@ -35,15 +39,18 @@ depends on Playwright specifically.
    `docs/musicxml-tab-profile.md`).
 
 3. **No new fixture.** The bundled alphaTeX demo score is the `DEMO_TEX`
-   constant in `web/src/lib/TabViewer.svelte` (currently lines 68-76),
+   constant in `web/src/lib/TabViewer.svelte` (currently lines 75-83),
    reachable at the `#/demo` route (`web/src/App.svelte` routes
    `#/demo` to `<Viewer demo={true} />`, which passes `demo` through to
    `TabViewer`). alphaTeX's default staff has both `showStandardNotation`
-   and `showTablature` true, so this is the one fixture here that genuinely
-   supports all three profiles - no MusicXML fixture in this repo does,
-   since Fermata's own MusicXML tab profile deliberately never pairs a tab
-   staff with a notation staff (`docs/musicxml-tab-profile.md`, "Out of
-   scope").
+   and `showTablature` true on the *same* staff, so this is the one fixture
+   here where a single staff genuinely supports all three profiles by
+   itself. That is a narrower claim than "no fixture offers all three" -
+   fixture 4, below, also offers all three, but only by combining two
+   staves that each support one; no *single* staff in any MusicXML fixture
+   in this repo does, since Fermata's own MusicXML tab profile deliberately
+   never pairs a tab staff with a notation staff on one staff
+   (`docs/musicxml-tab-profile.md`, "Out of scope").
 
 4. **`web/test-fixtures/multi-staff.musicxml`** (new). One part, one
    measure, `<staves>2</staves>`: staff 1 is plain notation (G clef, no
@@ -96,14 +103,46 @@ or not shaped as expected (an upgrade moved or renamed them),
 kept-not-deleted hand-written version of the same per-staff rules this PR
 originally shipped with (`showStandardNotation` for "score", `showTablature
 && tuning.length > 0` for "tab", either of those plus
-`showSlash`/`showNumbered` for "scoretab"). **This fallback path is verified
-by code inspection, not exercised here** - forcing it would mean breaking
-`Environment`'s shape at runtime, which isn't worth the complexity for a
-path whose only job is "fail loudly and degrade to today's behaviour, don't
-answer wrong silently." A test harness with the room to monkeypatch
-`alphaTab.Environment` before importing `score-render.js` could exercise it
-directly - assert the warning fires, and that `supportedProfiles()` still
-returns the fixture 1/2/3 answers below off `mirroredCanDraw` alone.
+`showSlash`/`showNumbered` for "scoretab").
+
+The guard checks more than field types. A shape check that only confirms
+"`staveProfiles` is a `Map` of `Set`s" and "every factory has a string
+`staffId` and a function `canCreate`" passes even when those two collections
+have quietly stopped referring to the same things - a release that renames
+every `staffId` consistently with itself (in both collections' *shape*, but
+not their *content*) would satisfy every field-type check while every
+profile matched zero factories, and `supportedProfiles()` would silently
+answer "nothing is drawable" for every score in the library, with no
+warning. `environmentCanDraw()` additionally requires the union of every
+stave profile's staff ids to actually intersect the renderers' ids
+somewhere, which a rename like that fails.
+
+The guard also cannot check that calling `canCreate` is *safe*, only that it
+*is a function* - a changed parameter list or return contract would pass the
+guard and throw on first use. That throw is caught where `canDraw()` calls
+the delegate, which permanently downgrades to `mirroredCanDraw` for the rest
+of the session (a structural incompatibility will not un-happen on the next
+call) and warns exactly once. `supportedProfiles()` itself is wrapped a
+second time, around that whole loop: without it, anything else going wrong
+in there (a malformed track, say) would throw out of the `scoreLoaded`
+handler in `createScoreView` entirely, skipping `publish()` and
+`onProfiles()` - `profileOptions` would stay `null` forever, showing neither
+buttons nor the unrenderable notice, while the renderer's own attempt to
+draw with whatever profile it already had still ran and surfaced its raw
+error. Both catches degrade to a checked answer instead of silence.
+
+**All four of these are exercised, not just inspected** - see
+`web/test-fixtures/environment-guard.mjs` (`node
+test-fixtures/environment-guard.mjs` from `web/`), a small monkeypatching
+script run directly with Node's own ESM loader rather than a browser: it
+imports `score-render.js` fresh (a cache-busting query on each dynamic
+`import()`) against four different states of `alphaTab.Environment` in
+turn - untouched, renamed staff ids, a throwing `canCreate`, and a
+malformed track passed straight to `supportedProfiles()` - and checks the
+warning fires (or doesn't, for the healthy case) and the answer is still
+correct in every case. This only works outside a browser because
+`score-render.js`'s module-level code only touches `alphaTab.Environment` at
+import time; everything DOM-dependent is inside functions, called later.
 
 For MusicXML specifically, what actually drives `showStandardNotation` /
 `showTablature` is **`<staff-tuning>`, not the clef sign** - this is worth
@@ -124,11 +163,37 @@ but that gets overridden - see below):
   (`MusicXmlImporter._parseStaffTuning` in `@coderline/alphatab`'s bundle),
   regardless of what clef sign was declared.
 
-`<staff-tuning>`'s presence is the one thing driving both flags. This is why
-fixture 2 (TAB clef, `<staff-tuning>` present) offers only Tab/Both, never
-Notation - it is not a fixture bug, it is what a real Fermata transcription
-looks like today (a single tab staff, never paired with a separate notation
-staff), so the spec has to assert exactly that, not "all three."
+`<staff-tuning>`'s presence is what drives both flags for a non-percussion
+staff - not the *only* thing that can affect them (a percussion clef
+overrides `showTablature` back to `false` regardless of tuning; see fixture
+5), but the one relevant to fixtures 1-4. This is why fixture 2 (TAB clef,
+`<staff-tuning>` present) offers only Tab/Both, never Notation - it is not a
+fixture bug, it is what a real Fermata transcription looks like today (a
+single tab staff, never paired with a separate notation staff), so the spec
+has to assert exactly that, not "all three."
+
+## Async load timing (the `score` prop's fetch window)
+
+`profileOptions` in `TabViewer.svelte` starts `null`, not `SCORE_PROFILES`,
+and the reason is specific to the `score` prop's load path, not just
+tidiness. `source()` for a `score` prop resolves to `{kind: "file", url}`,
+and `score-render.js`'s `load()` fetches that URL and only calls `api.load()`
+once the fetch resolves - `createScoreView` itself, and the `view` it
+returns, exist synchronously well before that. If `profileOptions` started
+permissive (every button offered), there would be a real window - however
+short - between mount and the fetch actually landing during which a click on
+"Tab" would reach `view.setProfile("tab")` for a score whose actual content
+is not yet known. Before this round's fix that click did not crash (the
+renderer's own `score`/`tracks` are still unset at that point, so `render()`
+takes its early "nothing to draw" branch and no-ops harmlessly), but the
+*internal* `profile` variable in `score-render.js` was still set to `"tab"`
+regardless - and once the fetch resolved and `scoreLoaded` ran its real
+check, a notation-only score would correct it right back, moving the
+highlighted button out from under a still-hovering pointer with no warning.
+Starting `profileOptions` at `null` (and resetting it to `null`, not to the
+previous score's list, on every new load - see `TabViewer.svelte`'s
+`$effect`) closes the window entirely: no button is clickable until the real
+answer is already known, so there is nothing to walk back.
 
 ## A correctness bug to fix (caught before merge, not after)
 
@@ -168,32 +233,71 @@ draw, so `score-render.js` does not try to pick one. Instead:
   is visible inside it.
 - The renderer's own automatic first render, triggered by AlphaTabApi itself
   immediately after `scoreLoaded`, cannot be cancelled from the `scoreLoaded`
-  handler - so it still runs. What happens next depends on timing that this
-  document does not treat as guaranteed: if the `.score-scroll.hidden` class
-  has already been applied to the DOM by the time that render executes, the
-  host measures 0 width and the renderer's own `render()` logs
-  `"AlphaTab skipped rendering because of width=0"` and returns without ever
-  reaching `addBars` - no crash, no `error` event, nothing to suppress. If it
-  has not (or `.score-scroll` is not hidden, as forced in the verification
-  below to check the other path directly), the render proceeds and throws
-  exactly as it always has - alphaTab's own `Logger.error` still writes the
-  raw `TypeError` to devtools (that call is inside the library, unconditional,
-  and not something this file can suppress), and the library's `error` event
-  fires with it. `score-render.js`'s `api.error` handler recognises this
-  specific, predicted failure (`unrenderable` was already true, and
-  `renderInFlight` shows a render actually started and never finished) and
-  swallows it - `console.debug`, not `onError` - rather than forwarding the
-  raw message to `loadError`/the page's `.error` paragraph. **Both paths are
-  safe for the person looking at the page**: either way, nothing renders,
-  nothing crashes past the library's own already-existing try/catch, and the
-  only thing shown is the plain sentence. Only devtools output differs.
+  handler - so it still runs, and can still throw exactly as it always has.
+  **Which of two paths that render takes is a font-load race, not a browser
+  quirk** - an earlier version of this document attributed it to this
+  sandbox's particular Chromium, which is wrong and would mislead whoever
+  ports it. AlphaTabApi defers the whole render while its fonts are still
+  loading. On a cold cache that deferral outlasts Svelte's reactivity flush
+  of the `hidden` class onto `.score-scroll`, so by the time the deferred
+  render actually runs, the host measures 0 width and the renderer's own
+  `render()` logs `"AlphaTab skipped rendering because of width=0"` and
+  returns without ever reaching `addBars` - no crash, no `error` event,
+  nothing to suppress. On a **warm** cache (fonts already cached - the
+  common case for a shipped app after the first load) there is no deferral:
+  the render runs synchronously inside `load()`, before the `hidden` class
+  has had any chance to apply, and it throws exactly as it always has.
+  **The forced path below is therefore the normal path for a warm cache, not
+  an exotic one** - it is what a real user hits on essentially every load of
+  an unrenderable score once the app has been open a moment. Either way,
+  alphaTab's own `Logger.error` still writes the raw `TypeError` to devtools
+  when it does throw (that call is inside the library, unconditional, and
+  not something this file can suppress); what differs between the two paths
+  is only whether devtools shows that line at all, never what the page
+  itself shows.
+- `score-render.js`'s `api.error` handler has to tell this specific,
+  predicted failure apart from an unrelated one - a soundfont load failure,
+  say - and **it cannot do that from timing alone**. An earlier version keyed
+  suppression on "a render is currently in flight" (`renderStarted` fired,
+  no matching `postRenderFinished` yet), which is not specific enough:
+  alphaTab registers its own resize handling unconditionally in the
+  `AlphaTabApi` constructor (see the `ResizeObserver` note in
+  `score-render.js`), and on an unrenderable score that internal path can
+  start and fail a render this file never even sees start -
+  `ScoreRenderer.resizeRender()`'s full-rerender branch calls `render()`
+  directly, with no try/catch around it, so it never reaches `api.error` for
+  its own failure, but it does still fire this file's `renderStarted`
+  listener on the way in and leaves nothing to ever clear it afterwards. The
+  in-flight flag stayed set until the *next* `api.error` of any kind, which
+  then got silently swallowed regardless of what actually caused it - a
+  reviewer reproduced this by injecting unrelated soundfont errors through
+  the library's own emitter after a resize and watching them alternate
+  shown, swallowed, shown, swallowed, one swallow armed per resize. The fix
+  keys suppression on the error itself instead: `e.stack` has to contain
+  both `"StaffSystem"` and `"addBars"` - the exact frames in Scenario 1's
+  trace - before anything is swallowed, in addition to `unrenderable` being
+  true. An unrelated error's stack never matches, regardless of what
+  `renderInFlight` (kept only for `data-score-render-ok` now, see below) is
+  doing at the time. **A known, accepted limitation**: `resizeRender()`'s own
+  failure for an unrenderable score still never reaches `api.error` at all
+  (it becomes an uncaught exception at `window.onerror`, which
+  `score-render.js` does not listen to), so it is not suppressed *or*
+  double-counted - it simply stays invisible to this file, the same as it
+  was before this fix, on every resize of an unrenderable score whose
+  container is not `display:none` for some reason.
 - `renderStarted` with no matching `postRenderFinished` since is a complete
-  failed-render detector - `ScoreRenderer.renderScore`'s own try/catch means
-  `postRenderFinished` never fires for a render that threw partway through.
-  `data-score-render-ok` reflects this per attempt; `data-score-render-ms` /
-  `data-score-renders` only ever advance on success and are not safe to read
-  as "did the last attempt succeed" on their own - check
-  `data-score-render-ok` first.
+  failed-render detector, used for `data-score-render-ok` only (not for the
+  suppression decision above) - `ScoreRenderer.renderScore`'s own try/catch
+  means `postRenderFinished` never fires for a render that threw partway
+  through. `data-score-render-ms` / `data-score-renders` only ever advance on
+  success and are not safe to read as "did the last attempt succeed" on
+  their own - check `data-score-render-ok` first, **and** that
+  `data-score-renders` actually incremented from its previous value:
+  `data-score-render-ok` reads `"true"` in two states where nothing was
+  drawn - before the first render ever runs, and when a render request was
+  silently dropped at width 0 or deferred by font loading (the natural path
+  above) - so it means "the last render that *reached* the renderer did not
+  throw", not "the last requested render actually produced something."
 
 See Scenario 5 for the exact assertions, and both the natural and forced
 verification of the two paths above.
@@ -359,38 +463,106 @@ correctness bug to fix" above for why.
   distinct from the attribute being absent, which means no score has loaded
   at all yet).
 - Verified twice, to cover both paths described in "A score that draws
-  nothing" above:
-  - **Natural**: open the score and wait. In this sandbox's Chromium, the
-    `.score-scroll.hidden` class was already applied by the time the
-    renderer's automatic first render ran, so it logged
-    `"AlphaTab skipped rendering because of width=0"` and returned - no
+  nothing" above - which one a given run takes is a font cache state
+  (cold/warm), not something to assert on directly; assert the *outcome*
+  (buttons, notice, `.error`, `dataset.scoreRenderOk`) the same way either
+  time:
+  - **Natural (cold cache)**: open the score and wait, on the first load
+    after starting the dev server. The `.score-scroll.hidden` class is
+    applied before alphaTab's font-load-deferred render runs, so it logs
+    `"AlphaTab skipped rendering because of width=0"` and returns - no
     `error` event, no console error, `dataset.scoreRenderOk` stays at its
     initial `"true"` (no render attempt ever completed or failed to update
-    it). Forcing a real window resize afterwards changes nothing:
-    `reapply()` skips outright while `unrenderable` is true, by design (see
-    `score-render.js`), so this state is stable rather than one accidental
-    early return away from the crash reappearing.
-  - **Forced**: with a stylesheet override neutralising `.score-scroll.hidden`
-    (`display: flex !important`) injected *before* opening the score, so the
-    host keeps real dimensions, the renderer's first render does proceed and
-    does throw the exact `TypeError` from Scenario 1's stack trace. alphaTab's
-    own `Logger.error` still writes that to devtools (unsuppressable from
-    outside the library) and a `console:debug` line
-    ("score-render: suppressed the predicted render failure…") appears - but
-    `.error` stays empty, `.notice` still shows the plain sentence, and
-    `dataset.scoreRenderOk` flips to `"false"`. This is the path that proves
-    the `api.error` + `unrenderable` + `renderInFlight` handling in
-    `score-render.js` actually works, independent of whichever path a given
-    browser's timing happens to take.
+    it; do not read that as "something rendered" - see the note on
+    `data-score-renders` above). Reloading and reopening the same score
+    again *without* restarting the server - warm cache now - takes the
+    forced path below instead, without needing the stylesheet override; the
+    override exists to make that path reachable on the very first (cold)
+    load too, for a deterministic single-run check.
+  - **Forced (or warm cache)**: with a stylesheet override neutralising
+    `.score-scroll.hidden` (`display: flex !important`) injected *before*
+    opening the score, so the host keeps real dimensions, the renderer's
+    first render does proceed and does throw the exact `TypeError` from
+    Scenario 1's stack trace. alphaTab's own `Logger.error` still writes
+    that to devtools (unsuppressable from outside the library) and a
+    `console:debug` line ("score-render: suppressed the predicted render
+    failure…") appears - but `.error` stays empty, `.notice` still shows the
+    plain sentence, and `dataset.scoreRenderOk` flips to `"false"`. This is
+    the path that proves the `api.error` handler's stack-based check (see
+    "A score that draws nothing" above) actually recognises and swallows
+    the specific crash, rather than merely never encountering it.
+
+## A profile switch has to survive failing (retry, and clearing the error)
+
+A render that fails - for *any* reason, not only the unsupported-profile
+case above - used to leave two traps, both reachable without any error at
+all (see the next paragraph):
+
+- **Permanently inert.** `score-render.js`'s `setProfile()` used to
+  de-duplicate against `profile`, the *requested* profile, set eagerly the
+  moment a switch is asked for whether or not it ever renders. Clicking the
+  same profile again after a failed switch then looked like a no-op
+  (`next === profile` already true from the failed attempt) and skipped
+  `reapply()` entirely - the only way out was detouring through a third
+  profile first. Fixed by keying the de-duplication on `appliedProfile`
+  instead - the profile a render has actually *finished* with successfully,
+  updated only from `postRenderFinished` - so asking again for a profile
+  that never actually rendered is never mistaken for "no change requested."
+- **A stale `loadError`.** Nothing cleared `loadError` on a later, unrelated
+  render succeeding, so an error from one failed switch could keep showing
+  (and keep the `.error` paragraph occupying space) after the view had
+  since recovered via a different profile. Fixed by clearing it from
+  `TabViewer`'s `onProfileApplied` handler - the same signal that moves the
+  highlighted button, since both represent "trust what's on screen now, not
+  what went wrong before."
+
+**Reachable with no error at all**, which is what makes it a real bug rather
+than a hypothetical one: switching profiles while the stage measures 0
+width (e.g. a hidden pane, mid-layout) hits the same "render silently
+skipped, nothing ever fires" path used by the natural cold-cache case above
+- `profile` (old code) or nothing (fixed code) advances, but no
+`postRenderFinished` ever runs to confirm it. Verified directly: open the
+multi-staff score, force `.at-host { width: 0 }` via a stylesheet override,
+click "Tab" (the request silently drops - the highlighted button correctly
+stays on whatever last actually rendered, `dataset.scoreProfile` shows
+`"tab"` requested but `data-score-renders` does not advance), remove the
+override, click "Tab" again - it renders successfully and the highlight
+moves, proving the second click was not blocked by the first.
+
+## A switch between scores must not leak the previous one's dataset
+
+`host` (the `.at-host` element) is the same DOM node across a score switch -
+`TabViewer`'s markup does not recreate it, only `createScoreView`'s closure
+is torn down and rebuilt. `publish()` explicitly deletes
+`dataset.scoreProfiles` when `scoreProfiles` is `null` (rather than simply
+not setting it) specifically so its very first call for a *new* score - made
+before anything about that score is known - wipes whatever the *previous*
+score left there, rather than letting it sit through the whole loading
+window and falsely read as the new score's answer. Verified directly:
+open a tab-only score (`dataset.scoreProfiles` = `"tab,scoretab"`), navigate
+back to the library and open the notation-only one, and confirm
+`dataset.scoreProfiles` reads `"score,scoretab"` promptly rather than
+briefly (or permanently, if something regresses) showing the tab-only
+score's stale value.
+
+Similarly, a theme or preset change on an *unrenderable* score still has to
+publish `dataset.scoreTheme` / `dataset.scorePreset` - `reapply()`'s early
+return for `unrenderable` runs `publish()` before returning, not just
+`return` outright, because `setTheme`/`setPreset` already updated their own
+variables before calling `reapply()`, and skipping `publish()` along with
+the (correctly) skipped render would leave those two attributes reporting
+the *previous* theme/preset instead of the one actually now in effect.
+Verified directly: open the unrenderable score, switch the theme picker to
+"White on black", and confirm `dataset.scoreTheme` reads `"noir"` promptly.
 
 ## Notes for porting
 
 - Every assertion above was checked with Playwright's
   `page.locator(...).allTextContents()`,
   `page.locator(...).evaluate(el => ({...el.dataset}))`, `console` /
-  `pageerror` event listeners, `page.addStyleTag(...)` (Scenario 5's forced
-  path), and `page.setViewportSize(...)` (to trigger a real resize) - none of
-  it is Playwright-specific and should translate directly to whatever
+  `pageerror` event listeners, and `page.addStyleTag(...)` (Scenario 5's
+  forced path, and the retry check's width-0 override) - none of it is
+  Playwright-specific and should translate directly to whatever
   `feature/instruments` brings in.
 - `SCORE_PROFILES` and the button label order come from
   `web/src/lib/score-render.js` (`SCORE_PROFILES = ["score", "tab", "scoretab"]`)
@@ -403,6 +575,14 @@ correctness bug to fix" above for why.
   directly rather than parsing button text or guessing at render success -
   prefer them once the harness exists. `dataset.scoreRenderMs` /
   `dataset.scoreRenders` are not reset on a failed render and must not be
-  read without checking `dataset.scoreRenderOk` first.
+  read without checking `dataset.scoreRenderOk` **and** that
+  `dataset.scoreRenders` itself incremented from its prior value - see "A
+  score that draws nothing" above for why `scoreRenderOk` alone is not
+  enough.
 - `UNRENDERABLE_MESSAGE` is exported from `score-render.js` - import it
   rather than hardcoding the sentence in a test, so the two cannot drift.
+- `web/test-fixtures/environment-guard.mjs` covers the delegation-guard
+  cases (renamed staff ids, a throwing `canCreate`, an unrelated throw
+  inside `supportedProfiles()`) directly with Node's own ESM loader, not
+  Playwright - see "How profile support is actually decided" above. Run it
+  with `node test-fixtures/environment-guard.mjs` from `web/`.

--- a/web/test-fixtures/unrenderable.musicxml
+++ b/web/test-fixtures/unrenderable.musicxml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.musicxml.org/xsd/musicxml.xsd">
+  <work>
+    <work-title>Unrenderable example (percussion clef + staff-tuning)</work-title>
+  </work>
+  <identification>
+    <encoding>
+      <software>Fermata test fixture</software>
+      <encoding-date>2026-08-20</encoding-date>
+    </encoding>
+  </identification>
+  <part-list>
+    <score-part id="P1">
+      <part-name>Drum Kit</part-name>
+    </score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>480</divisions>
+        <key>
+          <fifths>0</fifths>
+        </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+        </time>
+        <clef>
+          <sign>percussion</sign>
+          <line>2</line>
+        </clef>
+        <!-- A staff-tuning combined with a percussion clef: Staff.finish()
+             clears stringTuning and forces showTablature=false for a
+             percussion staff regardless of what staff-tuning claimed, and
+             the percussion clef never sets showStandardNotation either - so
+             this staff ends up with showStandardNotation=false,
+             showTablature=false, showSlash=false, showNumbered=false: no
+             profile can draw it. -->
+        <staff-details>
+          <staff-lines>6</staff-lines>
+          <staff-tuning line="1">
+            <tuning-step>E</tuning-step>
+            <tuning-octave>2</tuning-octave>
+          </staff-tuning>
+          <staff-tuning line="2">
+            <tuning-step>A</tuning-step>
+            <tuning-octave>2</tuning-octave>
+          </staff-tuning>
+          <staff-tuning line="3">
+            <tuning-step>D</tuning-step>
+            <tuning-octave>3</tuning-octave>
+          </staff-tuning>
+          <staff-tuning line="4">
+            <tuning-step>G</tuning-step>
+            <tuning-octave>3</tuning-octave>
+          </staff-tuning>
+          <staff-tuning line="5">
+            <tuning-step>B</tuning-step>
+            <tuning-octave>3</tuning-octave>
+          </staff-tuning>
+          <staff-tuning line="6">
+            <tuning-step>E</tuning-step>
+            <tuning-octave>4</tuning-octave>
+          </staff-tuning>
+        </staff-details>
+      </attributes>
+      <note>
+        <unpitched>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+        </unpitched>
+        <duration>1920</duration>
+        <voice>1</voice>
+        <type>whole</type>
+      </note>
+    </measure>
+  </part>
+</score-partwise>


### PR DESCRIPTION
## Summary

Fixes #66. Choosing the **Tab** profile on a score with no tablature data
(pitches but no `<technical><fret>/<string>`, i.e. no strung tuning) crashed
the renderer:

- The Tab bar-renderer factory refuses to create anything for a staff with no
  tuning, so when every staff of the rendered track fails a profile's check,
  the renderer builds a staff system with zero staves in it.
- `StaffSystem.addBars` then dereferences the group that was never built and
  throws `Cannot read properties of undefined (reading 'staves')`.
- This was never console-only: `score-render.js` already forwarded the
  renderer's `error` event to the viewer before this fix, so the raw
  `TypeError` text also appeared on the page itself, in `TabViewer`'s
  `.error` paragraph - on top of the stale previous render staying on screen
  and the just-clicked "Tab" button staying highlighted despite its render
  having failed.

## Fix

- `score-render.js` decides which of `score` / `tab` / `scoretab` a loaded
  score can actually be drawn under by delegating to the renderer's own
  `Environment.staveProfiles` / `Environment.defaultRenderers` and calling
  the real `canCreate(track, staff)` per `(track, staff)` pair - the same
  check `PageViewLayout.createEmptyStaffSystem` itself makes before building
  a staff system. This can't drift from the renderer's own rules the way a
  hand-written mirror of them could; a guarded fallback (`mirroredCanDraw`)
  covers the case where that internal shape moves in a future alphaTab
  version, with one `console.warn` if it's ever used. The check ORs across
  every `(track, staff)` pair being rendered, not just one staff, so a
  multi-track or multi-staff score is answered correctly even when only one
  staff of several supports a given profile.
- That result is reported to the caller once a score has loaded
  (`onProfiles`), and `TabViewer` only renders buttons for the profiles a
  score supports - starting with none shown at all until the real answer is
  known, rather than showing every button and walking one back once it
  isn't (see below).
- **A score that can draw nothing under any profile** (e.g. a percussion
  clef combined with `<staff-details><staff-tuning>`) is handled as its own
  case, not by falling back to offering everything: no profile buttons, and
  a plain sentence ("This score has no notation or tablature the staff view
  can draw.") in place of the staff area, never the renderer's raw error
  text. The renderer's own automatic first render still runs and can still
  throw internally (it can't be cancelled from here), but that specific,
  predicted failure is now recognised and swallowed at the source rather
  than surfaced.
- The highlighted profile button now follows what actually finished
  rendering (`onProfileApplied`, fired from a successful `postRenderFinished`),
  not what was most recently requested - a profile switch no longer moves
  the highlight until its render has actually succeeded, which is what
  fixes the "switcher lied about what was on screen" half of the original
  bug for good (it previously could recur for any render failure, not only
  an unsupported-profile one).
- A render that throws is now distinguished from one that succeeds via
  `renderStarted` with no matching `postRenderFinished` (`data-score-render-ok`
  in the host's dataset) - `data-score-render-ms` / `data-score-renders` only
  ever advance on success and would otherwise misreport a failed render's
  numbers as the previous successful one's.

## Test plan

Verified in a real browser (Playwright, against the dev server + backend) -
not just a build. Full scenario detail, fixtures, and exact assertions are
committed at `web/test-fixtures/tab-profile-selection.md` (there's no
frontend test runner in this repo yet for these to run as actual tests
against - `feature/instruments` is bringing one):

- [x] A notation-only MusicXML score: Tab is not offered, no console or page
      error, score renders.
- [x] A tab-only MusicXML score (Fermata's own tab profile - TAB clef, no
      separate notation staff): Notation is correctly not offered either;
      Tab/Both render and switch cleanly, playback works.
- [x] A multi-staff MusicXML score (one notation-only staff, one tab-only
      staff in the same track): all three profiles offered - the case a
      single-staff answer would get wrong - and all three render.
- [x] A score with nothing drawable under any profile (percussion clef +
      staff-tuning): no profile buttons, the plain sentence shown, no
      `.error` paragraph, `data-score-render-ok` correctly reflects the
      renderer's suppressed internal failure. Verified both with the
      renderer's first-render attempt naturally finding zero width (skips
      without erroring) and with that path forced to actually attempt (and
      fail) the render, to prove the suppression itself works rather than
      relying on the former.
- [x] The bundled alphaTeX demo (`#/demo`, has both notation and tab): all
      three profiles offered, all three render, and playback, loop,
      metronome, count-in and the tempo ladder all work; loads with zero
      console errors.

Console output for the notation-only score, before the fix, clicking Tab:

```
[AlphaTab][API] An unexpected error occurred
TypeError: Cannot read properties of undefined (reading 'staves')
    at StaffSystem.addBars ...
```

The same text also appeared on the page in `.error` at the time (see
Summary). After the fix, the same score's toolbar simply never offers "Tab".
