### PR TITLE
Persist the bar conformance figures

### DIFF
--- a/server/fermata/api.py
+++ b/server/fermata/api.py
@@ -363,13 +363,37 @@ def _transcription_row(conn, score_id: int):
     ).fetchone()
 
 
+# Keys a caller reads at the top level of a transcription however it arrived.
+# POST /transcribe builds them from the extraction result it still holds; GET
+# has only the stored blob, so it lifts the same names back out. Without this
+# the two endpoints describe the same transcription in two different shapes,
+# and a client that reloads a score has to reconstruct what POST told it -
+# which, for the bar figures, cannot be done. See the note in transcribe().
+_BLOB_TOP_LEVEL = (
+    "warnings",
+    "bars_overfull",
+    "bars_short",
+    "bars_defective",
+    "bars_measured",
+)
+
+
 def _transcription_dict(row) -> dict:
     d = dict(row)
-    if d.get("confidence"):
-        try:
-            d["confidence"] = json.loads(d["confidence"])
-        except (TypeError, ValueError):
-            pass
+    if not d.get("confidence"):
+        return d
+    try:
+        blob = json.loads(d["confidence"])
+    except (TypeError, ValueError):
+        return d
+    d["confidence"] = blob
+    if isinstance(blob, dict):
+        # Absent rather than zero for a row written before these were stored:
+        # a missing key means "not recorded", and zero would claim every bar
+        # was measured and every one of them was fine.
+        for key in _BLOB_TOP_LEVEL:
+            if key in blob:
+                d[key] = blob[key]
     return d
 
 
@@ -451,7 +475,25 @@ def transcribe(score_id: int, body: TranscribeIn | None = Body(default=None)):
     # written before this change keep rendering as the alphaTex they are, and
     # a hand-edited row stays in whichever format it was edited in until its
     # author edits it again.
-    confidence_json = json.dumps({"warnings": result.warnings, "confidence": result.confidence})
+    # The Rule 8 figures are STORED, not only echoed on this response, because
+    # they cannot be recovered later from the warning prose. A polyphonic bar
+    # can hold one voice over its meter and another under it, so it counts into
+    # both `overfull` and `short`: their sum double-counts such a bar and can
+    # exceed the number of bars measured. `defective` counts each wrong bar
+    # once and is the only figure safe to compare against `measured`, and no
+    # arithmetic over the two warning sentences recovers it. A reader that
+    # reloads a transcription and has only the prose can therefore either say
+    # nothing about bars or say something untrue - so it gets the numbers.
+    confidence_json = json.dumps(
+        {
+            "warnings": result.warnings,
+            "confidence": result.confidence,
+            "bars_overfull": result.bars_overfull,
+            "bars_short": result.bars_short,
+            "bars_defective": result.bars_defective,
+            "bars_measured": result.bars_measured,
+        }
+    )
     with tx() as tx_conn:
         tx_conn.execute(
             """INSERT INTO transcriptions(score_id, format, content, source, confidence, updated_at)

--- a/server/fermata/api.py
+++ b/server/fermata/api.py
@@ -363,37 +363,44 @@ def _transcription_row(conn, score_id: int):
     ).fetchone()
 
 
-# Keys a caller reads at the top level of a transcription however it arrived.
-# POST /transcribe builds them from the extraction result it still holds; GET
-# has only the stored blob, so it lifts the same names back out. Without this
-# the two endpoints describe the same transcription in two different shapes,
-# and a client that reloads a score has to reconstruct what POST told it -
-# which, for the bar figures, cannot be done. See the note in transcribe().
-_BLOB_TOP_LEVEL = (
-    "warnings",
-    "bars_overfull",
-    "bars_short",
-    "bars_defective",
-    "bars_measured",
-)
+# Rule 8 conformance, as the top level of every transcription response.
+#
+# These are STATED on every response rather than included only when known,
+# and that is the whole point of them. A hand edit stores no confidence at
+# all, so on the omitting version of this a client that merged the PUT
+# response over the transcription it already held kept the figures from
+# BEFORE the edit - and went on reporting bars as defective after the edit
+# that fixed them, which is the one thing this project must never do. An
+# explicit "not recorded" overwrites such a merge; a missing key is silently
+# preserved by it.
+#
+# None means not recorded: a row stored before these were persisted, or a
+# hand edit, whose content nothing has measured. It does NOT mean zero -
+# zero would claim every bar was measured and every one of them added up,
+# which is a far stronger statement than either row can support. Anything
+# wanting real figures for edited content has to measure that content; it
+# cannot inherit them from the extraction it replaced.
+_BAR_KEYS = ("bars_overfull", "bars_short", "bars_defective", "bars_measured")
 
 
 def _transcription_dict(row) -> dict:
     d = dict(row)
-    if not d.get("confidence"):
-        return d
-    try:
-        blob = json.loads(d["confidence"])
-    except (TypeError, ValueError):
-        return d
-    d["confidence"] = blob
-    if isinstance(blob, dict):
-        # Absent rather than zero for a row written before these were stored:
-        # a missing key means "not recorded", and zero would claim every bar
-        # was measured and every one of them was fine.
-        for key in _BLOB_TOP_LEVEL:
-            if key in blob:
-                d[key] = blob[key]
+    blob = None
+    if d.get("confidence"):
+        try:
+            blob = json.loads(d["confidence"])
+        except (TypeError, ValueError):
+            blob = None  # leave the column as the raw text it turned out to be
+        else:
+            d["confidence"] = blob
+    stored = blob if isinstance(blob, dict) else {}
+
+    warnings = stored.get("warnings")
+    d["warnings"] = warnings if isinstance(warnings, list) else []
+    for key in _BAR_KEYS:
+        value = stored.get(key)
+        # bool is a subclass of int and would otherwise pass as a count.
+        d[key] = value if isinstance(value, int) and not isinstance(value, bool) else None
     return d
 
 
@@ -508,8 +515,12 @@ def transcribe(score_id: int, body: TranscribeIn | None = Body(default=None)):
     saved = conn.execute(
         "SELECT * FROM transcriptions WHERE score_id = ? AND source = 'extracted'", (score_id,)
     ).fetchone()
+    # `warnings` and the Rule 8 conformance figures are NOT set from `result`
+    # here. They come back out of the row that was just written, so that this
+    # response and a later GET of the same row are answered from one source
+    # rather than two that could drift. Everything below is extraction detail
+    # that is genuinely only available on this response.
     d = _transcription_dict(saved)
-    d["warnings"] = result.warnings
     d["bars"] = result.bars
     d["beats"] = result.beats
     d["notes"] = result.notes
@@ -520,12 +531,6 @@ def transcribe(score_id: int, body: TranscribeIn | None = Body(default=None)):
     d["time_signature_source"] = result.time_signature_source
     d["key_fifths"] = result.key_fifths
     d["key_signature_source"] = result.key_signature_source
-    # Rule 8 conformance as data, not only as prose in the warning list, so a
-    # caller can compare it against what its own MusicXML tooling reports.
-    d["bars_overfull"] = result.bars_overfull
-    d["bars_short"] = result.bars_short
-    d["bars_defective"] = result.bars_defective
-    d["bars_measured"] = result.bars_measured
     return d
 
 

--- a/server/tests/test_tabextract.py
+++ b/server/tests/test_tabextract.py
@@ -1340,3 +1340,33 @@ def test_reported_conformance_matches_the_emitted_measures(zanarkand_pdf):
     # than summing to it
     assert result.bars_defective <= result.bars_overfull + result.bars_short
     assert max(result.bars_overfull, result.bars_short) <= result.bars_defective
+
+
+def test_a_bar_wrong_in_both_directions_is_counted_once():
+    """The case the whole reporting contract rests on, which no real score in
+    the library exhibits.
+
+    Two voices sound concurrently: one runs over the meter, the other falls
+    short of it. That is ONE bar that plays wrong, and `defective` says so -
+    while `overfull` and `short` each count it, so their sum exceeds the
+    number of bars there are. Anything comparing that sum against the total
+    reports more defective bars than the music has, which is why `defective`
+    is the only figure a reader may put over `measured`.
+
+    Constructed rather than extracted on purpose: no score in the library is
+    wrong in both directions at once, so this is the only place the behaviour
+    is pinned. If it were deleted the fault would not be rediscovered.
+    """
+    from fermata.tabextract import _bar_conformance
+
+    over = [(4, 0, None)] * 5  # five quarter notes
+    under = [(4, 0, None)] * 3  # three quarter notes
+    counts = _bar_conformance([([over, under], (4, 4))])  # a 4/4 bar wants four
+
+    assert counts.counted == 1
+    assert counts.defective == 1, "one bar plays wrong, however many ways it is wrong"
+    assert counts.overfull == 1
+    assert counts.short == 1
+    assert counts.overfull + counts.short > counts.counted, (
+        "the sum overstates the music - this is the arithmetic no reader may do"
+    )

--- a/server/tests/test_transcription_api.py
+++ b/server/tests/test_transcription_api.py
@@ -1,3 +1,5 @@
+import json
+
 import pytest
 from fastapi import HTTPException
 
@@ -280,3 +282,55 @@ def test_edit_format_is_read_off_the_content(content, expected):
     backslash and beats with a colon or a fret number - so the leading
     character settles it."""
     assert api._sniff_transcription_format(content) == expected
+
+
+# ---------------------------------------------------------------------------
+# Rule 8 conformance survives a reload
+# ---------------------------------------------------------------------------
+
+
+BAR_KEYS = ("bars_overfull", "bars_short", "bars_defective", "bars_measured")
+
+
+def test_bar_conformance_survives_a_reload(app_env, zanarkand_pdf, monkeypatch, insert_score):
+    """A reloaded transcription must report the same bar figures the extraction
+    did. They are not derivable from the warning prose - a bar wrong in both
+    directions at once counts into overfull AND short, so their sum can exceed
+    the bars measured - which means a client without these numbers can only
+    guess. It must not have to."""
+    monkeypatch.setattr(api, "LIBRARY_DIR", zanarkand_pdf.parent)
+    conn = db.connect()
+    score_id = insert_score(conn, zanarkand_pdf.name)
+
+    posted = api.transcribe(score_id, body=None)
+    fetched = api.get_transcription(score_id)
+
+    for key in BAR_KEYS:
+        assert posted[key] == fetched[key], key
+    assert fetched["bars_measured"] > 0
+    # The invariant that makes `defective` the only figure comparable against
+    # the total: it never exceeds the bars measured, whereas overfull + short
+    # may. A client comparing the wrong pair can print "13 of 12 bars".
+    assert fetched["bars_defective"] <= fetched["bars_measured"]
+    assert max(fetched["bars_overfull"], fetched["bars_short"]) <= fetched["bars_defective"]
+    assert fetched["warnings"] == posted["warnings"]
+
+
+def test_a_row_stored_before_the_bar_figures_omits_them(app_env, insert_score):
+    """Rows written before these were persisted carry a blob without them.
+    Absent must read as absent: defaulting to zero would claim every bar was
+    measured and every one of them added up, which is a stronger statement
+    than the row can support."""
+    conn = db.connect()
+    score_id = insert_score(conn, "legacy.pdf")
+    conn.execute(
+        """INSERT INTO transcriptions(score_id, format, content, source, confidence, updated_at)
+           VALUES (?, 'alphatex', ':4 0.1 |', 'extracted', ?, datetime('now'))""",
+        (score_id, json.dumps({"warnings": ["something was odd"], "confidence": {"rhythm": "low"}})),
+    )
+    conn.commit()
+
+    fetched = api.get_transcription(score_id)
+    assert fetched["warnings"] == ["something was odd"]
+    for key in BAR_KEYS:
+        assert key not in fetched, key

--- a/server/tests/test_transcription_api.py
+++ b/server/tests/test_transcription_api.py
@@ -316,9 +316,9 @@ def test_bar_conformance_survives_a_reload(app_env, zanarkand_pdf, monkeypatch, 
     assert fetched["warnings"] == posted["warnings"]
 
 
-def test_a_row_stored_before_the_bar_figures_omits_them(app_env, insert_score):
+def test_a_row_stored_before_the_bar_figures_reports_them_unrecorded(app_env, insert_score):
     """Rows written before these were persisted carry a blob without them.
-    Absent must read as absent: defaulting to zero would claim every bar was
+    Unrecorded must read as None, not as zero: zero would claim every bar was
     measured and every one of them added up, which is a stronger statement
     than the row can support."""
     conn = db.connect()
@@ -333,4 +333,71 @@ def test_a_row_stored_before_the_bar_figures_omits_them(app_env, insert_score):
     fetched = api.get_transcription(score_id)
     assert fetched["warnings"] == ["something was odd"]
     for key in BAR_KEYS:
-        assert key not in fetched, key
+        assert key in fetched, key
+        assert fetched[key] is None, key
+
+
+def test_an_edit_states_that_nothing_measured_it(app_env, zanarkand_pdf, monkeypatch, insert_score):
+    """A hand edit replaces the content the figures describe, so it has none of
+    its own - and it must SAY so rather than leave the keys out.
+
+    A client that merges this response over the transcription it already held
+    would keep the pre-edit figures if they were merely absent, and go on
+    reporting bars as defective after the edit that fixed them. Carrying the
+    extraction's figures forward would be worse still: it would assert
+    measurements of content that nothing has measured."""
+    monkeypatch.setattr(api, "LIBRARY_DIR", zanarkand_pdf.parent)
+    conn = db.connect()
+    score_id = insert_score(conn, zanarkand_pdf.name)
+
+    extracted = api.transcribe(score_id, body=None)
+    assert extracted["bars_measured"] > 0
+    assert extracted["warnings"]
+
+    edited = api.save_transcription(
+        score_id, api.TranscriptionEditIn(content=":4 0.1 |", format="alphatex")
+    )
+    for state in (edited, api.get_transcription(score_id)):
+        assert state["source"] == "edited"
+        assert state["warnings"] == []
+        for key in BAR_KEYS:
+            assert key in state, key
+            assert state[key] is None, key
+
+    # Reverting restores the extracted row, and with it the real figures.
+    api.delete_transcription(score_id)
+    reverted = api.get_transcription(score_id)
+    assert reverted["bars_measured"] == extracted["bars_measured"]
+    assert reverted["bars_defective"] == extracted["bars_defective"]
+
+
+def test_a_corrupt_blob_does_not_yield_a_bar_count(app_env, insert_score):
+    """The figures are only ever numbers. A blob carrying something else in
+    those keys must read as unrecorded rather than passing a string or a bool
+    through to a caller that will do arithmetic on it."""
+    conn = db.connect()
+    score_id = insert_score(conn, "odd.pdf")
+    conn.execute(
+        """INSERT INTO transcriptions(score_id, format, content, source, confidence, updated_at)
+           VALUES (?, 'alphatex', ':4 0.1 |', 'extracted', ?, datetime('now'))""",
+        (
+            score_id,
+            json.dumps(
+                {
+                    "warnings": "not a list",
+                    "bars_measured": "twelve",
+                    "bars_defective": None,
+                    "bars_overfull": True,
+                    "bars_short": 2,
+                }
+            ),
+        ),
+    )
+    conn.commit()
+
+    fetched = api.get_transcription(score_id)
+    assert fetched["warnings"] == []
+    assert fetched["bars_measured"] is None
+    assert fetched["bars_defective"] is None
+    assert fetched["bars_overfull"] is None, "a bool is not a bar count"
+    assert fetched["bars_short"] == 2


### PR DESCRIPTION
The four Rule 8 conformance counts were echoed on the `POST /transcribe` response and then discarded — the stored `confidence` blob held only the warnings and the prose confidence, so a client reloading a score had to recover the numbers by parsing the warning sentences.

That parse cannot be made correct. A bar with one voice over its meter and another under it counts into **both** `overfull` and `short`, so their sum double-counts it and can exceed the bars measured:

```
constructed two-voice bar, one voice over and one under, in 4/4:
  _BarConformance(overfull=1, short=1, defective=1, counted=1)
  naive overfull+short = 2  vs measured = 1
```

Read off the prose that becomes "2 of 1 bars don't add up". `defective` counts each wrong bar once and is the only figure comparable against the total, and no arithmetic over the two sentences recovers it — as `docs/musicxml-tab-profile.md` already states.

Measured across the library: 144 extractable scores, **0** where the naive sum overstates `defective`. No score currently engraves a bar wrong in both directions at once, so the fault is latent rather than visible — but it is reachable, as above, and is now pinned by a constructed test since no real score will ever pin it.

## What changed

- `transcribe()` stores `bars_overfull`, `bars_short`, `bars_defective`, `bars_measured` alongside the warnings.
- `_transcription_dict()` **states all five keys on every transcription response**, whether or not the row records them: `warnings` as a list, the four counts as an integer or `None`.
- `transcribe()` no longer restates those five from the extraction result, so this response and a later `GET` of the same row are answered from one source rather than two that could drift.
- A non-integer count in the blob reads as `None` rather than passing a string, a null or a bool through to a caller that will do arithmetic on it.

### Why *stated* rather than *only when known*

The first version of this lifted the keys only when the row recorded them, which introduced a worse fault than it fixed. A hand edit stores no confidence at all, so the keys were absent from the `PUT` response — and a client merging that response over the transcription it already held **kept the pre-edit values**. The panel went on reporting "4 of 50 bars don't add up", with warnings about notes that no longer existed, immediately after the edit that fixed them; reloading then cleared it. One state, two different wrong answers.

An absent key is silently preserved by a merge. An explicit "not recorded" overwrites it.

`None` means nothing has measured this content — a row stored before these were persisted, or a hand edit. It does **not** mean zero, which would claim every bar was measured and every one of them added up.

Carrying the extraction's figures onto the edited row would also have silenced the merge, and is the one fix that must not be chosen: it would assert measurements of content that nothing has measured. Real figures for edited content require measuring that content, which is separate work.

## Scope, stated accurately

This does **not** make `GET` and `POST` return the same shape. Ten keys remain `POST`-only, because they are extraction detail that is genuinely unavailable on a reload: `bars`, `beats`, `notes`, `tempo`, `tuning`, `tuning_label`, `time_signature`, `time_signature_source`, `key_fifths`, `key_signature_source`. What this closes is the divergence in the five keys a client needs on every load.

The four counts are also still present nested inside `confidence`, since that is how they are stored. **The top level is the contract**; the nested copy is a storage detail and should not be read.

## Tests

Six, each verified to fail with the relevant half of the change reverted:

- the figures a reload reports match the ones the extraction reported, with `defective <= measured` asserted
- an edited row states all five keys, and reverting restores the real ones
- a legacy row reports `None` rather than zero
- a blob carrying a string, a null or a bool in those keys yields no count
- the two-voice bar the whole reporting contract rests on: one defective bar, counted by both `overfull` and `short`, whose sum exceeds the number of bars there are

`213 passed, 3 skipped` for the full server suite with `FERMATA_TEST_LIBRARY` set (the 3 skips need `FERMATA_MUSICXML_XSD` and a built `web/`).