### PR TITLE
Say what ships, and what is missing rather than wrong

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,17 @@ them.
   stems do not separate still do not add up — that is now a stated conformance
   rule of the profile, so any MusicXML tool finds those bars too, and the count
   is reported either way. Scanned PDFs have nothing to read and are not
-  transcribed.
+  transcribed. Harmonics are currently dropped rather than read — a gap worth
+  knowing about separately, because a note that is missing does not announce
+  itself the way a note read wrongly does.
+- **Instruments** — define what you actually play: any number of strings, any
+  tuning including reentrant ones, a capo, and a reference pitch other than
+  A440. Each string shows the note and frequency it sounds and can be played,
+  because choosing between two positions for the same written note is done by
+  ear, and on an unfretted instrument a heard pitch is the reference rather
+  than a convenience. Presets cover guitars, basses, ukulele, violin, viola and
+  cello. Transcription does not yet use a score's instrument — it still assumes
+  a six-string guitar in standard tuning.
 - **Practice tracking** — a session timer per piece, with recently-practised
   and neglected views so the library reflects what you are actually working on.
 - **Gig mode** — fullscreen, screen kept awake, oversized tap targets and
@@ -134,9 +144,15 @@ demo*) if your library is PDF-only so far.
 
 ## Roadmap
 
+- **Harmonics when transcribing** — currently dropped entirely, which leaves a
+  hole in the music rather than a mistake in it, and shortens the bar they
+  belonged to
 - **Tuplets and ties when transcribing** — the largest remaining gap between a
   transcription and a score you could practise from, and the reason bars still
   overfill once voices have been separated
+- **Instrument-aware transcription** — reading a score against the instrument it
+  is written for, instead of assuming standard six-string tuning whatever the
+  score says
 - **Score creation and editing** — build a staff from scratch in the browser,
   instrument-agnostic with first-class guitar tablature support
 - **More import formats** — MIDI and plain-text tab in particular, since those


### PR DESCRIPTION
Two omissions in the public feature list, both in the direction of the README claiming a rosier picture than the code supports.

**Instruments ship and were not mentioned.** Any string count, any tuning including reentrant ones, a capo, a reference pitch other than A440, and a sounding pitch per string that can be played. Added with the limit that actually matters attached: transcription does not consult a score's instrument yet, so it still reads everything as a six-string guitar in standard tuning. Better to say that here than to let someone define a five-string bass and wonder why the transcription is wrong.

**Harmonics are dropped entirely and were mentioned nowhere.** The transcription bullet already said how much of the rhythm survives depends on the engraving, which honestly covers a note read *wrongly*. A note that was never emitted is a different kind of gap: nothing on the page shows it is absent, and the bar it belonged to comes out short. Someone deciding whether this is usable for their repertoire deserves that distinction up front rather than discovering it.

Both are on the roadmap too, with harmonics placed ahead of tuplets and ties — an inaccurate note is visible and correctable, a missing one is neither.

Docs only. No code changes.