### PR TITLE
Give the practice metronome its own tempo

### DIFF
--- a/docs/rendering.md
+++ b/docs/rendering.md
@@ -140,18 +140,106 @@ tempo. Two modes:
   *at the playhead*, read from `playerPositionChanged`'s `originalTempo` -
   the tempo alphaTab is internally playing at before `playbackSpeed` is
   applied - so a piece that changes tempo mid-stream is tracked continuously
-  rather than resolved once when playback starts.
-- `"bpm"` clicks a number set directly and ignores the score.
+  rather than resolved once when playback starts. That quarter-note-based
+  proportion is then converted onto the CURRENT bar's own click unit
+  (`unit/4`: an eighth-note meter clicks twice as often as a quarter-note
+  one) before anything is displayed or scheduled.
+- `"bpm"` clicks the typed number directly, as the click rate itself, in
+  every meter - the meter's own beat unit plays no part in the rate at all,
+  only in which clicks get accented. That is deliberately not the same
+  convention as `"proportion"`: it is what a physical metronome's dial
+  means, and what the issue asks for - a tempo set directly, regardless of
+  what the score says. 120 in fixed-BPM mode clicks 120 times a minute in
+  6/8 exactly as it would in 4/4.
 
-Time signature (for subdivision and which click is accented) comes from a
-flat tick-ordered index built from `score.masterBars` once per load, looked up
-against `api.tickPosition` on every scheduled click - not from alphaTab's own
-metronome MIDI events, which exist (`MidiEventType.AlphaTabMetronome`) but are
-timed on the same speed-scaled timeline this feature exists to get away from.
+Either way, **the number reported to a caller (`onMetronomeTempo`, and so
+the on-screen readout) is the same number that gets scheduled: clicks per
+minute, full stop.** `effectiveClickRate` in `metronome.js` is the one
+function that produces it, and both `tick()` and `report()` call it the
+same way with the CURRENT bar's own unit, rounded once and used unrounded
+nowhere else. An earlier version reported the quarter-note figure instead -
+96 for a 6/8 piece marked "quarter = 96" - while the eighth-note clicks it
+actually scheduled sounded 192 times a minute; showing the number a
+listener would have to convert in their head, rather than the number they
+are actually hearing, is exactly the "displayed and sounded disagree"
+failure this project keeps having to re-learn not to ship. The clamp
+(`MAX_METRONOME_BPM`) is applied to this same, already-converted rate for
+the same reason: clamping the quarter-note figure first and converting
+second would let a compound or unusually fine meter (4/128, or even a
+plain 6/8 at a fast marking) push the actual clicked rate far past what the
+constant - or the click's own envelope length - could survive.
 
-The count-in (`setCountIn`) is untouched by any of this - a separate,
-pre-roll-only feature that still uses alphaTab's own click at the score's
-tempo, scaled by `playbackSpeed`, exactly as before.
+Time signature and bar position (for subdivision and which click is
+accented) come from `api.tickCache.masterBars` - alphaTab's own lookup from
+generated-MIDI tick to the `MasterBar` sounding there - looked up fresh on
+every scheduled click, never cached across one. Two things about this are
+load-bearing:
+
+- **It has to be `tickCache`, not a hand-built index.** `api.tickPosition`
+  lives on the generated MIDI's timeline, which expands repeats and skips
+  unplayed alternate endings - the notated bar order and the played tick
+  order are different timelines the moment a score has one repeat sign in
+  it. An earlier version of this summed `MasterBar.calculateDuration()`
+  itself to build that mapping; past the first repeat, every position it
+  answered for was for the wrong bar - the wrong meter, the wrong accent
+  grouping, silently.
+- **The accent's phase is derived from the playhead every time, not carried
+  as a counter.** A `clickIndex` that only resets when the scheduler starts
+  drifts out of alignment the moment the metronome is switched on mid-bar,
+  the transport seeks, a loop whose length is not a whole number of click
+  periods wraps, or the meter changes mid-score. Recomputing "which slot of
+  the CURRENT bar is this" from `api.tickPosition` on every click instead
+  means all four of those are the ordinary case, not a special one to
+  detect: whatever the playhead is doing, the next click just answers the
+  same question again. One consequence worth knowing: when the click's own
+  rate doesn't evenly divide the bar's real duration (any proportion other
+  than 100%, or a fixed BPM), the accent does not recur at a fixed spacing
+  measured in clicks - it recurs at a fixed spacing measured in the music's
+  own bars, landing on or just after each real downbeat regardless of the
+  click's own tempo. That is the point, not a rounding error.
+
+Compound grouping (accent every third click) applies to 6/8-style meters
+written in sixteenths too (9/16, 12/16, ...), not only eighths -
+`metronomePattern` checks the denominator against both. x/4 meters are left
+alone even when the numerator is divisible by three (6/4): unlike 6/8,
+which is unambiguously two dotted-quarter pulses, 6/4 is genuinely
+ambiguous between two dotted-half pulses and six plain quarters, with no
+default worth guessing.
+
+One imprecision is worth stating rather than quietly living with:
+`api.tickPosition` answers "where is the playhead right now", not "where
+will it be when this click - queued up to `METRONOME_SCHEDULE_AHEAD_S`
+ahead - actually sounds". When the click's own rate does not match the
+music's (any proportion other than 100%, or a fixed BPM), an individual
+click landing close to a bar or beat boundary can occasionally read one
+slot early. It never accumulates - the very next click reads the playhead
+fresh again, per the point above - so the cost is a single click's accent
+placed a slot off near a boundary, not a drift that persists through the
+piece.
+
+The scheduler also floors its next scheduled time to "now" (dropping,
+rather than replaying, anything a stall left in the past) — see
+`METRONOME_LOOKAHEAD_MS` handling in `tick()` - and cancels any oscillators
+still pending when the click stops, so pausing or switching it off is
+silent within one Web Audio callback rather than up to
+`METRONOME_SCHEDULE_AHEAD_S` later. The click's own gain levels (accent and
+tick together, in the pathological case of one click's tail overlapping the
+next one's attack) stay under unity with headroom to spare, and
+`ensureAudioCtx` catches the constructor itself throwing - Safari and iOS
+still enforce a hard cap on live `AudioContext`s - so a synthesiser
+resource limit silences the click rather than the Play button.
+
+The count-in (`setCountIn`) still uses alphaTab's own click, at the score's
+tempo, scaled by `playbackSpeed`, exactly as before - but the practice
+click is not simply left alone around it. alphaTab raises
+`playerStateChanged` to Playing *before* the count-in starts, and raises it
+a second time, with no intervening Paused, the instant the count-in ends
+and real playback begins. Starting on the first event would sound the
+practice click underneath the count-in at a different tempo, which is
+exactly the confusion a count-in exists to prevent - so `setPlaying` treats
+a rising edge as a count-in (and stays silent) whenever `countInVolume` is
+on when it arrives, and treats the covering second rising edge as the
+signal to start for real, freshly anchored.
 
 ### Responsive layout
 

--- a/docs/rendering.md
+++ b/docs/rendering.md
@@ -98,9 +98,12 @@ presets, themes — not the renderer's.
 (`"score"`, `"tab"`, `"scoretab"`), sources (`{kind:"alphatex"}`,
 `{kind:"musicxml"}`, `{kind:"file", url}`), transport state, fonts, colours and
 layout all flow through it. The view it returns exposes `setProfile`,
-`setPreset`, `setTheme`, `setSpeed`, `setLooping`, `setMetronome`, `setCountIn`,
+`setPreset`, `setTheme`, `setSpeed`, `setLooping`, `setMetronome`,
+`setMetronomeMode`, `setMetronomeProportion`, `setMetronomeBpm`, `setCountIn`,
 `playPause`, `stop` and `destroy`, and reports `layout`, `theme`, `profile`,
-`supportedProfiles`, `preset` and `lastRenderMs`.
+`supportedProfiles`, `preset` and `lastRenderMs` (`onMetronomeTempo` reports
+the practice metronome's own live value - see below, since it changes on its
+own while playing rather than only when asked for).
 
 Which profiles a caller may ask for is score-dependent, not fixed: a score
 does not necessarily support all of `SCORE_PROFILES`, and `createScoreView`
@@ -111,6 +114,44 @@ subset it can actually be drawn under (possibly empty - see
 render with that profile has actually finished, which is what a caller
 should wait for before treating a profile switch as visible on screen rather
 than merely requested.
+
+### The practice metronome is not alphaTab's
+
+alphaTab has its own metronome (`api.metronomeVolume`), and this layer never
+turns it on. It stays permanently muted, set once at construction. The reason
+is structural, not a style choice: the renderer generates its metronome as a
+track in the same MIDI file as the notes, ticking at the score's own tempo and
+scaled by `playbackSpeed` exactly like every other event in that file. There is
+no setting anywhere in alphaTab's public API that lets the click run at a
+different tempo than the notes beside it - the two are the same timeline. That
+is fine until practice wants them to disagree, which is normal and constant: a
+click at full tempo over a passage slowed to 70% for a hard bar, or a fixed BPM
+that has nothing to do with what the score happens to declare.
+
+So `createScoreView`'s metronome (`setMetronome`, `setMetronomeMode`,
+`setMetronomeProportion`, `setMetronomeBpm`) is a second, wholly independent
+audio path: a plain Web Audio oscillator click, scheduled off its own clock via
+the standard lookahead pattern (queue whatever falls within the next ~120ms of
+audio-clock time, on a 25ms poll), rather than a setting on alphaTab's player.
+It never touches alphaTab's synthesiser, its generated MIDI, or its notion of
+tempo. Two modes:
+
+- `"proportion"` (the default) clicks a proportion of the score's own tempo
+  *at the playhead*, read from `playerPositionChanged`'s `originalTempo` -
+  the tempo alphaTab is internally playing at before `playbackSpeed` is
+  applied - so a piece that changes tempo mid-stream is tracked continuously
+  rather than resolved once when playback starts.
+- `"bpm"` clicks a number set directly and ignores the score.
+
+Time signature (for subdivision and which click is accented) comes from a
+flat tick-ordered index built from `score.masterBars` once per load, looked up
+against `api.tickPosition` on every scheduled click - not from alphaTab's own
+metronome MIDI events, which exist (`MidiEventType.AlphaTabMetronome`) but are
+timed on the same speed-scaled timeline this feature exists to get away from.
+
+The count-in (`setCountIn`) is untouched by any of this - a separate,
+pre-roll-only feature that still uses alphaTab's own click at the score's
+tempo, scaled by `playbackSpeed`, exactly as before.
 
 ### Responsive layout
 
@@ -392,9 +433,12 @@ source of truth. So:
   stave-profile constant. Themes are token names.
 - Loading is expressed as a source shape (`alphatex`, `musicxml`, `file`), not as
   the byte-loader call the library happens to want.
-- The transport is `setSpeed` / `setLooping` / `setMetronome` / `setCountIn` /
-  `playPause` / `stop`, not volume fields and boolean properties on a live api
-  object.
+- The transport is `setSpeed` / `setLooping` / `setMetronome` /
+  `setMetronomeMode` / `setMetronomeProportion` / `setMetronomeBpm` /
+  `setCountIn` / `playPause` / `stop`, not volume fields and boolean
+  properties on a live api object - and the practice metronome's click is not
+  even one of those properties (see "The practice metronome is not
+  alphaTab's" above); it is a second audio path this file owns outright.
 - The renderer's event names, enums, settings tree, colour objects, font objects
   and prototype quirks all stop at this file.
 

--- a/web/package.json
+++ b/web/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "vite build && node scripts/check-assets.mjs && node scripts/check-warning-patterns.mjs",
     "preview": "vite preview",
-    "test:browser": "playwright test"
+    "test:browser": "node scripts/run-browser-tests.mjs"
   },
   "devDependencies": {
     "@coderline/alphatab-vite": "^1.8.4",

--- a/web/scripts/run-browser-tests.mjs
+++ b/web/scripts/run-browser-tests.mjs
@@ -1,0 +1,99 @@
+// Wraps `playwright test` so the minimum-test-count guard (tests/minimum-
+// tests.js) cannot be switched off by a `--reporter` flag on the command
+// line - which npm run test:browser -- --reporter=list, or any CI step that
+// grows one, would otherwise do silently.
+//
+// Playwright's own --reporter CLI flag REPLACES the config file's entire
+// `reporter` array; it does not merge with it. minimum-tests.js is only
+// wired in through that array, so a caller-supplied --reporter drops it
+// entirely - Playwright never even loads the file, so nothing inside it can
+// notice or object. That is the same shape of failure minimum-tests.js's own
+// docstring already worries about for a stray --grep, just one layer further
+// out: a --grep only had to be caught FROM INSIDE the reporter, because the
+// reporter itself still ran. A --reporter override means the reporter does
+// not run at all.
+//
+// So the guard is checked here instead, entirely outside Playwright's
+// reporter system: this script owns the actual `playwright test` invocation,
+// strips any --reporter the caller passed before it ever reaches Playwright,
+// and always adds its own JSON summary reporter (which nothing here treats
+// as optional). It then reads that summary itself, after the process exits,
+// and enforces the same floor minimum-tests.js does - a belt to its
+// suspenders, checked from a place a CLI flag has no way to reach.
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { MINIMUM_TESTS } from "../tests/minimum-tests.js";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const webRoot = path.dirname(here);
+
+const passedArgs = process.argv.slice(2);
+const filteredArgs = [];
+for (let i = 0; i < passedArgs.length; i++) {
+  const arg = passedArgs[i];
+  if (arg === "--reporter") {
+    i += 1; // also drop the value that follows ("--reporter" "list")
+    continue;
+  }
+  if (arg.startsWith("--reporter=")) continue;
+  filteredArgs.push(arg);
+}
+if (filteredArgs.length !== passedArgs.length) {
+  console.error(
+    "run-browser-tests: a --reporter argument was dropped - this script always " +
+      "runs its own reporter set so the minimum-test-count guard cannot be bypassed.",
+  );
+}
+
+const summaryPath = path.join(fs.mkdtempSync(path.join(os.tmpdir(), "fermata-test-summary-")), "summary.json");
+const reporters = process.env.CI
+  ? "list,github,html,./tests/minimum-tests.js,json"
+  : "list,./tests/minimum-tests.js,json";
+
+const result = spawnSync("npx", ["playwright", "test", `--reporter=${reporters}`, ...filteredArgs], {
+  cwd: webRoot,
+  stdio: "inherit",
+  shell: true,
+  env: { ...process.env, PLAYWRIGHT_JSON_OUTPUT_NAME: summaryPath },
+});
+
+// Counted the same way tests/minimum-tests.js counts it - executed and not
+// skipped, regardless of pass/fail/flaky, so this can never itself invent a
+// "tests have gone missing" complaint on top of an ordinary failing run. The
+// two are independent implementations of the identical rule on purpose:
+// this file's whole reason to exist is covering the case where
+// minimum-tests.js's own reporter never got to run at all, so it cannot be
+// the only place that rule is expressed.
+function countExecuted(summary) {
+  const stats = summary?.stats;
+  if (!stats) return null;
+  return (stats.expected ?? 0) + (stats.unexpected ?? 0) + (stats.flaky ?? 0);
+}
+
+let executed = null;
+try {
+  const summary = JSON.parse(fs.readFileSync(summaryPath, "utf8"));
+  executed = countExecuted(summary);
+} catch (e) {
+  console.error(`run-browser-tests: could not read the JSON summary at ${summaryPath} - ${e.message}`);
+}
+
+if (!process.env.PLAYWRIGHT_ALLOW_PARTIAL) {
+  if (executed == null) {
+    console.error("run-browser-tests: the minimum-test-count floor could not be checked at all - failing closed.");
+    process.exit(1);
+  }
+  if (executed < MINIMUM_TESTS) {
+    console.error(
+      `run-browser-tests: expected at least ${MINIMUM_TESTS} tests to run, only ${executed} did. ` +
+        "Tests have gone missing, or the floor needs raising on purpose - see tests/minimum-tests.js.",
+    );
+    process.exit(1);
+  }
+}
+
+process.exit(result.status ?? 1);

--- a/web/src/lib/TabViewer.svelte
+++ b/web/src/lib/TabViewer.svelte
@@ -254,13 +254,25 @@
     // Generous but bounded - the audio layer clamps to a countable range
     // regardless, this just keeps the number in the field sane before it
     // gets there.
-    metronomeProportion = clamp(Number(ev.target.value), 10, 300);
-    view?.setMetronomeProportion(metronomeProportion / 100);
+    const clamped = clamp(Number(ev.target.value), 10, 300);
+    metronomeProportion = clamped;
+    // Forced onto the field directly, not left to Svelte's own value={...}
+    // binding: when the clamp lands on the SAME number the state already
+    // held (typing 400 while already at 300), the state does not change, so
+    // nothing re-renders the input - and the box would go on showing the 400
+    // that was typed while the click kept running at 300. This project has
+    // already shipped the same mismatch once (a tuner showing one pitch
+    // while the synthesiser sounded another); displayed and actual have to
+    // agree unconditionally, not just on the changes Svelte happens to see.
+    ev.target.value = String(clamped);
+    view?.setMetronomeProportion(clamped / 100);
   }
 
   function setMetronomeBpm(ev) {
-    metronomeBpm = clamp(Number(ev.target.value), MIN_METRONOME_BPM, MAX_METRONOME_BPM);
-    view?.setMetronomeBpm(metronomeBpm);
+    const clamped = clamp(Number(ev.target.value), MIN_METRONOME_BPM, MAX_METRONOME_BPM);
+    metronomeBpm = clamped;
+    ev.target.value = String(clamped); // see setMetronomeProportion above
+    view?.setMetronomeBpm(clamped);
   }
 
   function toggleCountIn() {
@@ -315,7 +327,7 @@
         has to hold at a music stand, though, so the readout comes along even
         though its controls stay behind in the full toolbar, set up before
         stepping into gig mode. -->
-        <span class="metronome-indicator" title="Metronome">♩ {metronomeTempo}</span>
+        <span class="metronome-indicator" title="Metronome, clicks per minute">♩ {metronomeTempo}</span>
       {/if}
       {#if practiceLabel}
         <button class="practice-indicator" onclick={onStopPractice} title="Stop practice timer">
@@ -365,7 +377,7 @@
           <button class:on={metronome} onclick={toggleMetronome} title="Metronome click during playback">
             Metronome
             {#if metronome && metronomeTempo != null}
-              <span class="metronome-readout">{metronomeTempo}</span>
+              <span class="metronome-readout" title="clicks per minute">{metronomeTempo}</span>
             {/if}
           </button>
           {#if metronome}

--- a/web/src/lib/TabViewer.svelte
+++ b/web/src/lib/TabViewer.svelte
@@ -3,6 +3,7 @@
   import { api } from "./api.js";
   import { createScoreView, UNRENDERABLE_MESSAGE } from "./score-render.js";
   import { getSettings, setSetting, STAFF_THEMES, STAFF_THEME_LABELS } from "./settings.svelte.js";
+  import { MAX_METRONOME_BPM, MIN_METRONOME_BPM } from "./metronome.js";
 
   const settings = getSettings();
 
@@ -57,6 +58,25 @@
   let speed = $state(1);
   let looping = $state(false);
   let metronome = $state(false);
+  // "proportion" (the default) clicks a percentage of the score's own tempo
+  // and tracks it as the piece moves; "bpm" clicks a fixed value and ignores
+  // the score. Neither is a server-persisted setting, deliberately: every
+  // other transport control here (speed, looping, count-in) is per-session
+  // state that resets with a fresh load, and the metronome's tempo is exactly
+  // as tied to "the passage being worked on right now" as those are - a
+  // proportion left over from yesterday's slow passage is not a default
+  // tomorrow's fast one wants.
+  let metronomeMode = $state("proportion");
+  // A percentage, not a 0-1 ratio, because that is how a player would say it
+  // out loud - "seventy percent" - and the input below reads that way too.
+  let metronomeProportion = $state(100);
+  let metronomeBpm = $state(120);
+  // The value score-render.js reports it is actually clicking at right now -
+  // null until a score has loaded and it has one to report. This is read
+  // back FROM the audio layer (see onMetronomeTempo below), not computed
+  // here a second time: showing a value this component derived itself would
+  // stay green through a bug in what the audio layer actually does with it.
+  let metronomeTempo = $state(null);
   let countIn = $state(false);
   let loadError = $state("");
   let ladder = $state(false);
@@ -112,6 +132,9 @@
     loadError = "";
     playerReady = false;
     playing = false;
+    // a new score has its own tempo - the old readout would otherwise show
+    // the previous score's number until this one's first report arrives
+    metronomeTempo = null;
     // unknown again for this score, not "same as the last one" - see the
     // comment on profileOptions's declaration
     profileOptions = null;
@@ -125,11 +148,20 @@
         profile,
         preset: gigMode ? "stand" : "desk",
         theme: settings.staff_theme,
-        transport: { speed, looping, metronome, countIn },
+        transport: {
+          speed,
+          looping,
+          metronome,
+          metronomeMode,
+          metronomeProportion: metronomeProportion / 100,
+          metronomeBpm,
+          countIn,
+        },
         onReady: () => (playerReady = true),
         onPlaying: (p) => (playing = p),
         onError: (m) => (loadError = m),
         onPassComplete: advanceLadder,
+        onMetronomeTempo: (bpm) => (metronomeTempo = bpm),
         // Only which buttons to offer, not which one is highlighted - see
         // onProfileApplied for that. A score with nothing drawable reports an
         // empty array here, not a fallback list; the empty-state notice in
@@ -201,6 +233,36 @@
     view?.setMetronome(metronome);
   }
 
+  function chooseMetronomeMode(ev) {
+    const next = ev.target.value;
+    // Seeding the fixed-bpm field from the click's own last reported value -
+    // not from metronomeProportion times some guessed score tempo, which
+    // this component does not reliably know - means switching modes mid
+    // practice does not jump the click to an unrelated speed the instant
+    // it's chosen. Only one direction: converting a chosen bpm back into "a
+    // percentage of what" has no such anchor to seed from, so proportion
+    // mode is left at whatever it last held.
+    if (next === "bpm" && metronomeTempo != null) {
+      metronomeBpm = clamp(metronomeTempo, MIN_METRONOME_BPM, MAX_METRONOME_BPM);
+    }
+    metronomeMode = next;
+    view?.setMetronomeMode(metronomeMode);
+    if (next === "bpm") view?.setMetronomeBpm(metronomeBpm);
+  }
+
+  function setMetronomeProportion(ev) {
+    // Generous but bounded - the audio layer clamps to a countable range
+    // regardless, this just keeps the number in the field sane before it
+    // gets there.
+    metronomeProportion = clamp(Number(ev.target.value), 10, 300);
+    view?.setMetronomeProportion(metronomeProportion / 100);
+  }
+
+  function setMetronomeBpm(ev) {
+    metronomeBpm = clamp(Number(ev.target.value), MIN_METRONOME_BPM, MAX_METRONOME_BPM);
+    view?.setMetronomeBpm(metronomeBpm);
+  }
+
   function toggleCountIn() {
     countIn = !countIn;
     view?.setCountIn(countIn);
@@ -246,6 +308,15 @@
         {playing ? "❚❚ Pause" : "▶ Play"}
       </button>
       <button disabled={!playerReady} onclick={() => view?.stop()}>■</button>
+      {#if metronome && metronomeTempo != null}
+        <!-- Read-only here on purpose - gig mode strips the toolbar down to
+        large, glanceable touch targets, and choosing a mode or typing a
+        number is neither. "The current value visible while playing" still
+        has to hold at a music stand, though, so the readout comes along even
+        though its controls stay behind in the full toolbar, set up before
+        stepping into gig mode. -->
+        <span class="metronome-indicator" title="Metronome">♩ {metronomeTempo}</span>
+      {/if}
       {#if practiceLabel}
         <button class="practice-indicator" onclick={onStopPractice} title="Stop practice timer">
           ● {practiceLabel}
@@ -293,7 +364,50 @@
           </button>
           <button class:on={metronome} onclick={toggleMetronome} title="Metronome click during playback">
             Metronome
+            {#if metronome && metronomeTempo != null}
+              <span class="metronome-readout">{metronomeTempo}</span>
+            {/if}
           </button>
+          {#if metronome}
+            <div class="metronome-controls">
+              <select
+                class="metronome-mode"
+                value={metronomeMode}
+                onchange={chooseMetronomeMode}
+                title="What the metronome counts - the score's own tempo, or a number set directly"
+              >
+                <option value="proportion">% of score tempo</option>
+                <option value="bpm">Fixed BPM</option>
+              </select>
+              {#if metronomeMode === "proportion"}
+                <label>
+                  <input
+                    class="metronome-proportion"
+                    type="number"
+                    min="10"
+                    max="300"
+                    step="5"
+                    value={metronomeProportion}
+                    onchange={setMetronomeProportion}
+                  />
+                  %
+                </label>
+              {:else}
+                <label>
+                  <input
+                    class="metronome-bpm"
+                    type="number"
+                    min={MIN_METRONOME_BPM}
+                    max={MAX_METRONOME_BPM}
+                    step="1"
+                    value={metronomeBpm}
+                    onchange={setMetronomeBpm}
+                  />
+                  bpm
+                </label>
+              {/if}
+            </div>
+          {/if}
           <button class:on={countIn} onclick={toggleCountIn} title="Count-in before playback starts">
             Count-in
           </button>
@@ -470,6 +584,58 @@
     font-size: 12px;
     font-weight: 600;
     color: var(--brass);
+  }
+
+  /* The live click tempo, inline in the button that turns it on - "the
+     current value visible" has to sit where a glance at the toggle already
+     goes, not in a second place a player has to know to look. */
+  .metronome-readout {
+    margin-left: 4px;
+    font-variant-numeric: tabular-nums;
+    opacity: 0.85;
+  }
+
+  /* Same shape as .ladder-controls (a small bordered strip of compact
+     inputs) - the two are siblings in the same button row and should read as
+     the same kind of thing, not two different idioms for "the button next to
+     it has settings". */
+  .metronome-controls {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 4px 8px;
+    border: 1px solid var(--line);
+    border-radius: 8px;
+    background: var(--surface);
+  }
+
+  .metronome-controls select {
+    font-size: 12px;
+  }
+
+  .metronome-controls label {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 12px;
+    color: var(--ink-dim);
+  }
+
+  .metronome-controls input {
+    /* one digit wider than .ladder-controls input - a fixed bpm reasonably
+       runs to three digits (60-208 and beyond), where the ladder's own
+       fields stay within two */
+    width: 52px;
+    padding: 2px 4px;
+  }
+
+  /* The gig-mode HUD's read-only echo of the same value - see the markup
+     above for why the controls themselves do not follow it into gig mode. */
+  .metronome-indicator {
+    font-size: 14px;
+    font-variant-numeric: tabular-nums;
+    color: var(--brass-bright);
+    white-space: nowrap;
   }
 
   .score-scroll {

--- a/web/src/lib/metronome.js
+++ b/web/src/lib/metronome.js
@@ -1,0 +1,118 @@
+// The practice metronome's arithmetic: what tempo to click at, and how a bar
+// of a given time signature should be subdivided and accented. Pure and
+// import-free on purpose, the same way pitch.js is - no runes, no alphaTab,
+// nothing that needs a browser - so it can be tested directly rather than
+// through a rendered score.
+//
+// score-render.js is the only file that turns these numbers into sound (see
+// docs/rendering.md on why the renderer itself stays behind that one seam).
+// This file never touches audio, the renderer, or the DOM.
+
+/** A click slower than this stops being a metronome and starts being a wait. */
+export const MIN_METRONOME_BPM = 20;
+/** A click faster than this is not a tempo practice happens at. */
+export const MAX_METRONOME_BPM = 400;
+/** Where a fixed-BPM click starts before a player has chosen otherwise. */
+export const DEFAULT_METRONOME_BPM = 120;
+// alphaTab's own fallback when nothing in the score declares a tempo at all
+// (Score.tempo returns exactly this when the first bar carries no tempo
+// automation). A proportion taken of "no tempo marked" has no better answer
+// than the same fallback the renderer already uses for that score - so a
+// score with nothing marked behaves exactly like one marked "quarter = 120",
+// rather than being a special case this file invents its own rule for.
+export const FALLBACK_SCORE_TEMPO = 120;
+
+export function clampBpm(bpm) {
+  return Math.min(MAX_METRONOME_BPM, Math.max(MIN_METRONOME_BPM, bpm));
+}
+
+/**
+ * The tempo the practice metronome should click at right now.
+ *
+ * `mode: "bpm"` ignores the score entirely - a number set directly, for when
+ * the marking is wrong, aspirational, or simply not the speed this passage
+ * is being worked at.
+ *
+ * `mode: "proportion"` takes `proportion` of `scoreTempo` - the score's OWN
+ * tempo at the playhead, never the playback speed a caller may have set
+ * separately. Call this again as `scoreTempo` moves (a piece that changes
+ * tempo internally) and the answer moves with it; nothing here resolves it
+ * once and remembers.
+ *
+ * Always clamped to a countable range - see MIN/MAX_METRONOME_BPM.
+ */
+export function effectiveMetronomeBpm({ mode, bpm, proportion, scoreTempo }) {
+  if (mode === "bpm") {
+    return clampBpm(Number.isFinite(bpm) && bpm > 0 ? bpm : DEFAULT_METRONOME_BPM);
+  }
+  const base = Number.isFinite(scoreTempo) && scoreTempo > 0 ? scoreTempo : FALLBACK_SCORE_TEMPO;
+  const ratio = Number.isFinite(proportion) && proportion > 0 ? proportion : 1;
+  return clampBpm(base * ratio);
+}
+
+/**
+ * How a bar of `numerator`/`denominator` should be clicked: `clicksPerBar`
+ * ticks, one per `unit` (a denominator-valued note - an eighth for .../8),
+ * with a tick accented every `accentEvery` ticks starting from the first.
+ *
+ * Compound meters (6/8, 9/8, 12/8, ...) click the subdivision rather than the
+ * notated beat, because a bare click on the dotted-quarter pulse leaves the
+ * two or three eighth notes inside it to guesswork - exactly the "hard to
+ * place in compound meters" a bare click fails at. The grouping comes back
+ * as the accent instead: every third click is a main pulse (1, 4, 7, ...),
+ * the two between it are subdivision only.
+ *
+ * 3/8 asks the same "numerator a multiple of 3, denominator 8" question the
+ * compound branch below answers, and lands there too rather than needing a
+ * carve-out: a single group of three IS the whole bar, so accenting "every
+ * third click starting from the first" and "only the first click" are the
+ * same instruction when there are only three clicks to begin with. Nothing
+ * downstream can tell the two branches apart for 3/8, which is exactly why
+ * there is nothing here to tell them apart with.
+ */
+export function metronomePattern(numerator, denominator) {
+  const n = Number.isInteger(numerator) && numerator > 0 ? numerator : 4;
+  const d = Number.isInteger(denominator) && denominator > 0 ? denominator : 4;
+  const isCompound = d === 8 && n % 3 === 0;
+  return {
+    clicksPerBar: n,
+    accentEvery: isCompound ? 3 : n,
+    unit: d,
+  };
+}
+
+/**
+ * Seconds between one click and the next, at `bpm` - always a quarter-note
+ * tempo, the same convention MIDI and MusicXML tempo markings already use
+ * regardless of the notated meter - for a click on a `unit`-valued note.
+ */
+export function secondsPerClick(bpm, unit) {
+  return (60 / bpm) * (4 / unit);
+}
+
+/**
+ * Which time signature is active at `tick`, from a flat, tick-ordered list of
+ * `{startTick, numerator, denominator}` - not the renderer's own bar model,
+ * so this has no reason to import it (score-render.js builds the list from
+ * that model once, when a score loads). Binary search: a long score can run
+ * into the thousands of bars and this runs on every scheduled click.
+ *
+ * Defaults to 4/4 for an empty list - there is no time signature to be wrong
+ * about before any score has loaded.
+ */
+export function timeSignatureAtTick(bars, tick) {
+  if (!bars || bars.length === 0) return { numerator: 4, denominator: 4 };
+  let lo = 0;
+  let hi = bars.length - 1;
+  let found = bars[0];
+  while (lo <= hi) {
+    const mid = (lo + hi) >> 1;
+    if (bars[mid].startTick <= tick) {
+      found = bars[mid];
+      lo = mid + 1;
+    } else {
+      hi = mid - 1;
+    }
+  }
+  return { numerator: found.numerator, denominator: found.denominator };
+}

--- a/web/src/lib/metronome.js
+++ b/web/src/lib/metronome.js
@@ -10,7 +10,16 @@
 
 /** A click slower than this stops being a metronome and starts being a wait. */
 export const MIN_METRONOME_BPM = 20;
-/** A click faster than this is not a tempo practice happens at. */
+// A click faster than this is not a tempo practice happens at - and, just as
+// importantly, keeps the period between clicks (60_000 / this, in ms) safely
+// above METRONOME_CLICK_SECONDS in score-render.js: at 400 that is a 150ms
+// period against a ~70ms envelope, comfortably clear of one click's tail
+// overlapping the next one's attack. This bounds the CLICK RATE itself
+// (clicks per minute - what is displayed and what is scheduled, always the
+// same number - see effectiveClickRate), not a quarter-note tempo prior to
+// any per-meter conversion: clamping before that conversion let an extreme
+// meter (4/128, or even a plain 6/8) push the actual rate far past what
+// either this constant or the envelope could survive.
 export const MAX_METRONOME_BPM = 400;
 /** Where a fixed-BPM click starts before a player has chosen otherwise. */
 export const DEFAULT_METRONOME_BPM = 120;
@@ -22,32 +31,54 @@ export const DEFAULT_METRONOME_BPM = 120;
 // rather than being a special case this file invents its own rule for.
 export const FALLBACK_SCORE_TEMPO = 120;
 
+/**
+ * Pulled into the countable range, whatever was handed in - including a
+ * value that is not usably a number at all. Guarded here, at the definition,
+ * rather than trusted to every caller: `clampBpm(NaN)` propagating NaN
+ * through Math.min/Math.max is one call site away from an unterminating
+ * scheduler loop (secondsPerClick(NaN) is NaN, and `while (next < ...)` never
+ * becomes false against NaN).
+ */
 export function clampBpm(bpm) {
-  return Math.min(MAX_METRONOME_BPM, Math.max(MIN_METRONOME_BPM, bpm));
+  const n = Number(bpm);
+  if (!Number.isFinite(n)) return MIN_METRONOME_BPM;
+  return Math.min(MAX_METRONOME_BPM, Math.max(MIN_METRONOME_BPM, n));
 }
 
 /**
- * The tempo the practice metronome should click at right now.
+ * The click RATE - clicks per minute, full stop - the practice metronome
+ * should sound right now. This is deliberately the one number both scheduled
+ * and displayed: a caller that reports something else (a quarter-note tempo
+ * a listener would have to convert in their head to match what they are
+ * actually hearing) is exactly the "displayed and sounded disagree" failure
+ * this function exists to rule out by construction.
  *
- * `mode: "bpm"` ignores the score entirely - a number set directly, for when
- * the marking is wrong, aspirational, or simply not the speed this passage
- * is being worked at.
+ * `mode: "bpm"` ignores the score AND the meter entirely - the typed number
+ * IS the rate, in every time signature, which is what a physical
+ * metronome's dial means and what the issue asks for: a tempo set directly,
+ * regardless of what the score says.
  *
  * `mode: "proportion"` takes `proportion` of `scoreTempo` - the score's OWN
- * tempo at the playhead, never the playback speed a caller may have set
- * separately. Call this again as `scoreTempo` moves (a piece that changes
- * tempo internally) and the answer moves with it; nothing here resolves it
- * once and remembers.
+ * quarter-note tempo at the playhead, never the playback speed a caller may
+ * have set separately - and converts THAT onto `unit` (the meter's own click
+ * unit, `unit/4`: an eighth-note meter clicks twice per quarter, a
+ * half-note meter once every two). Call this again as `scoreTempo` or `unit`
+ * move - a piece that changes tempo or time signature internally - and the
+ * answer moves with it; nothing here resolves it once and remembers.
  *
- * Always clamped to a countable range - see MIN/MAX_METRONOME_BPM.
+ * The conversion happens BEFORE clamping, not after: clamping the
+ * quarter-note value first and converting second would let a compound or
+ * unusually-fast meter push the actual clicked rate past MAX_METRONOME_BPM
+ * without ever tripping it.
  */
-export function effectiveMetronomeBpm({ mode, bpm, proportion, scoreTempo }) {
+export function effectiveClickRate({ mode, bpm, proportion, scoreTempo, unit }) {
   if (mode === "bpm") {
     return clampBpm(Number.isFinite(bpm) && bpm > 0 ? bpm : DEFAULT_METRONOME_BPM);
   }
   const base = Number.isFinite(scoreTempo) && scoreTempo > 0 ? scoreTempo : FALLBACK_SCORE_TEMPO;
   const ratio = Number.isFinite(proportion) && proportion > 0 ? proportion : 1;
-  return clampBpm(base * ratio);
+  const u = Number.isInteger(unit) && unit > 0 ? unit : 4;
+  return clampBpm(base * ratio * (u / 4));
 }
 
 /**
@@ -55,15 +86,23 @@ export function effectiveMetronomeBpm({ mode, bpm, proportion, scoreTempo }) {
  * ticks, one per `unit` (a denominator-valued note - an eighth for .../8),
  * with a tick accented every `accentEvery` ticks starting from the first.
  *
- * Compound meters (6/8, 9/8, 12/8, ...) click the subdivision rather than the
- * notated beat, because a bare click on the dotted-quarter pulse leaves the
- * two or three eighth notes inside it to guesswork - exactly the "hard to
- * place in compound meters" a bare click fails at. The grouping comes back
- * as the accent instead: every third click is a main pulse (1, 4, 7, ...),
- * the two between it are subdivision only.
+ * Compound meters (6/8, 9/8, 12/8, ..., and the same grouping written in
+ * sixteenths - 9/16, 12/16, ...) click the subdivision rather than the
+ * notated beat, because a bare click on the dotted pulse leaves the two or
+ * three notes inside it to guesswork - exactly the "hard to place in
+ * compound meters" a bare click fails at. The grouping comes back as the
+ * accent instead: every third click is a main pulse (1, 4, 7, ...), the two
+ * between it are subdivision only.
  *
- * 3/8 asks the same "numerator a multiple of 3, denominator 8" question the
- * compound branch below answers, and lands there too rather than needing a
+ * x/4 meters are deliberately left simple, even a numerator divisible by
+ * three (6/4): unlike 6/8, which is unambiguously two dotted-quarter pulses
+ * of three eighths, 6/4 is genuinely ambiguous between two dotted-half
+ * pulses and six plain quarter-note ones, with no single notational
+ * convention to default to - so it clicks as six plain quarters rather than
+ * guessing which reading a given piece meant.
+ *
+ * 3/8 (and 3/16) ask the same "numerator a multiple of 3" question the
+ * compound branch below answers, and land there too rather than needing a
  * carve-out: a single group of three IS the whole bar, so accenting "every
  * third click starting from the first" and "only the first click" are the
  * same instruction when there are only three clicks to begin with. Nothing
@@ -73,7 +112,7 @@ export function effectiveMetronomeBpm({ mode, bpm, proportion, scoreTempo }) {
 export function metronomePattern(numerator, denominator) {
   const n = Number.isInteger(numerator) && numerator > 0 ? numerator : 4;
   const d = Number.isInteger(denominator) && denominator > 0 ? denominator : 4;
-  const isCompound = d === 8 && n % 3 === 0;
+  const isCompound = (d === 8 || d === 16) && n % 3 === 0;
   return {
     clicksPerBar: n,
     accentEvery: isCompound ? 3 : n,
@@ -81,27 +120,37 @@ export function metronomePattern(numerator, denominator) {
   };
 }
 
-/**
- * Seconds between one click and the next, at `bpm` - always a quarter-note
- * tempo, the same convention MIDI and MusicXML tempo markings already use
- * regardless of the notated meter - for a click on a `unit`-valued note.
- */
-export function secondsPerClick(bpm, unit) {
-  return (60 / bpm) * (4 / unit);
+/** Seconds between one click and the next, at a click RATE already in clicks
+ * per minute (see effectiveClickRate) - there is no meter or mode left to
+ * convert here, which is deliberate: the rate handed in is already the
+ * exact number of clicks a minute that both sounds and gets displayed. */
+export function secondsPerClick(clickRate) {
+  return 60 / clickRate;
 }
 
 /**
- * Which time signature is active at `tick`, from a flat, tick-ordered list of
- * `{startTick, numerator, denominator}` - not the renderer's own bar model,
- * so this has no reason to import it (score-render.js builds the list from
- * that model once, when a score loads). Binary search: a long score can run
- * into the thousands of bars and this runs on every scheduled click.
+ * Which bar (of a flat, tick-ordered list) is active at `tick`. `bars` is
+ * `{startTick, endTick, numerator, denominator}[]`, in tick order - not the
+ * renderer's own model, so this has no reason to import it.
  *
- * Defaults to 4/4 for an empty list - there is no time signature to be wrong
- * about before any score has loaded.
+ * score-render.js builds this list from alphaTab's OWN generated-midi-
+ * timeline lookup (`api.tickCache.masterBars`), never by summing notated bar
+ * durations itself: `tick` lives on the generated MIDI's timeline, which
+ * expands repeats and skips unplayed alternate endings, so the notated bar
+ * order and the played tick order are different timelines the moment a
+ * score has so much as one repeat sign in it. Only the renderer's own lookup
+ * knows which bar is actually sounding at a given tick; a hand-summed index
+ * would silently answer with the wrong bar - and therefore the wrong meter -
+ * for every bar after the first repeat.
+ *
+ * Binary search: a long score can run into the thousands of bars and this
+ * runs on every scheduled click.
+ *
+ * Returns null for an empty list - there is no bar to be wrong about before
+ * anything has loaded.
  */
-export function timeSignatureAtTick(bars, tick) {
-  if (!bars || bars.length === 0) return { numerator: 4, denominator: 4 };
+export function barAtTick(bars, tick) {
+  if (!bars || bars.length === 0) return null;
   let lo = 0;
   let hi = bars.length - 1;
   let found = bars[0];
@@ -114,5 +163,46 @@ export function timeSignatureAtTick(bars, tick) {
       hi = mid - 1;
     }
   }
-  return { numerator: found.numerator, denominator: found.denominator };
+  return found;
+}
+
+/**
+ * Which of a bar's `clicksPerBar` slots `tick` falls in - 0 for the first,
+ * up to `clicksPerBar - 1` for the last.
+ *
+ * Derived fresh from the bar's own tick span every time this is called, not
+ * carried forward as running state. A persistent counter that only resets
+ * when the scheduler starts drifts out of alignment the moment any of these
+ * happen: the metronome is switched on mid-bar; the transport seeks; a loop
+ * whose length is not a whole number of click periods wraps back to its
+ * start; or the meter changes mid-score, carrying the old count into a new
+ * modulus. All four are just "the playhead is somewhere this counter didn't
+ * expect" - recomputing from the playhead instead means every one of them is
+ * the same ordinary case, not a special one to detect and handle.
+ *
+ * One consequence worth knowing: when the click's own rate does not evenly
+ * divide the bar's real duration (a fixed BPM, or a proportion other than
+ * 100%), the accented click will not recur at an even spacing measured in
+ * clicks - it recurs at an even spacing measured in the music's OWN bars,
+ * landing on or just after each real downbeat regardless of how the click's
+ * own tempo relates to it. That is the point: the accent marks where the
+ * bar actually starts, not a beat this function invented independently of
+ * it.
+ *
+ * `tick` is clamped to the bar's own span, so a click scheduled slightly
+ * ahead of the audio clock (see METRONOME_SCHEDULE_AHEAD_S in
+ * score-render.js) landing a few ticks past where the playhead has reached
+ * so far still answers with the bar's last slot rather than spilling into
+ * one that doesn't belong to it.
+ *
+ * Returns 0 - the downbeat - when `bar` is null (nothing loaded yet) or
+ * degenerate, rather than propagating NaN into a modulus.
+ */
+export function clickPhaseInBar(tick, bar, clicksPerBar) {
+  if (!bar || !(clicksPerBar > 0)) return 0;
+  const barTicks = bar.endTick - bar.startTick;
+  if (!(barTicks > 0)) return 0;
+  const ticksPerClick = barTicks / clicksPerBar;
+  const ticksIntoBar = Math.min(Math.max(tick - bar.startTick, 0), barTicks - 1e-6);
+  return Math.floor(ticksIntoBar / ticksPerClick) % clicksPerBar;
 }

--- a/web/src/lib/score-render.js
+++ b/web/src/lib/score-render.js
@@ -6,6 +6,13 @@
 // (VexFlow was the runner-up, and our model lives on the server as MusicXML)
 // should mean rewriting this file and nothing else - see docs/rendering.md.
 import * as alphaTab from "@coderline/alphatab";
+import {
+  DEFAULT_METRONOME_BPM,
+  effectiveMetronomeBpm,
+  metronomePattern,
+  secondsPerClick,
+  timeSignatureAtTick,
+} from "./metronome.js";
 
 // ---------------------------------------------------------------- profiles
 
@@ -651,6 +658,225 @@ export async function playPitch(midi) {
   return noteOn ? noteOn.noteKey : key;
 }
 
+// ------------------------------------------------- the practice metronome
+//
+// alphaTab's own metronome is baked into the generated MIDI at the score's
+// declared tempo and scaled by playbackSpeed exactly like every other note -
+// api.metronomeVolume only changes how loud that existing click is, never
+// what tempo it counts. There is no setting anywhere in the public API that
+// lets its click run at a different tempo than the notes beside it, which is
+// exactly what practice keeps wanting: a click at full tempo over a passage
+// slowed to 70%, or a fixed BPM the score's own marking has nothing to do
+// with. So this is not a setting on the renderer's player - it can't be -
+// it is a second, wholly independent audio path: a plain Web Audio
+// oscillator click, scheduled off its own clock, that never touches
+// alphaTab's synthesiser or its notion of tempo.
+//
+// alphaTab's built-in metronome is left permanently muted (metronomeVolume
+// stays 0, set once below and never touched again) so the two clicks can
+// never sound at once. Its count-in is untouched - a separate, pre-roll-only
+// feature outside this - and still ticks at the score's own tempo, scaled by
+// playbackSpeed, exactly as it always has.
+//
+// The scheduler is the standard "lookahead" pattern for Web Audio timing:
+// every METRONOME_LOOKAHEAD_MS a queue is topped up with whatever clicks now
+// fall within the next METRONOME_SCHEDULE_AHEAD_S of audio-clock time,
+// scheduled by handing the audio node the exact time to start rather than by
+// firing it now. A metronome built from one setTimeout per click drifts
+// under any main-thread load - exactly the load a page with a soundfont and
+// a renderer on it has - and a click that drifts is worse than none, since it
+// stops being the thing a player can trust over their own sense of tempo.
+
+const METRONOME_LOOKAHEAD_MS = 25;
+const METRONOME_SCHEDULE_AHEAD_S = 0.12;
+const METRONOME_CLICK_SECONDS = 0.05;
+// Accent is both higher-pitched and louder than a plain subdivision tick -
+// pitch alone survives a quiet room or a cheap speaker better than volume
+// alone does, so the two are stacked rather than picking one.
+const METRONOME_ACCENT_HZ = 1500;
+const METRONOME_TICK_HZ = 950;
+const METRONOME_ACCENT_GAIN = 0.85;
+const METRONOME_TICK_GAIN = 0.45;
+
+function scheduleMetronomeClick(ctx, time, accent) {
+  const osc = ctx.createOscillator();
+  const gain = ctx.createGain();
+  osc.frequency.value = accent ? METRONOME_ACCENT_HZ : METRONOME_TICK_HZ;
+  osc.connect(gain);
+  gain.connect(ctx.destination);
+  const peak = accent ? METRONOME_ACCENT_GAIN : METRONOME_TICK_GAIN;
+  // A short percussive envelope, not a sustained tone: near-instant attack so
+  // the click reads as a transient a note can be placed against, then an
+  // exponential decay - linear ramps to silence read as a cut-off, not a
+  // click's natural decay.
+  gain.gain.setValueAtTime(0, time);
+  gain.gain.linearRampToValueAtTime(peak, time + 0.001);
+  gain.gain.exponentialRampToValueAtTime(0.0001, time + METRONOME_CLICK_SECONDS);
+  osc.start(time);
+  osc.stop(time + METRONOME_CLICK_SECONDS + 0.02);
+}
+
+/**
+ * The independent click described above, bound to one AlphaTabApi instance.
+ *
+ * `onTempo(bpm)` fires whenever the value it would report changes - on a
+ * setting change, a score load, or the score's own tempo moving under a
+ * proportion - which is what lets a caller show the current value without
+ * polling for it.
+ *
+ * `onClick(accent, numerator, denominator)` fires once per scheduled click,
+ * at the moment it is queued (up to METRONOME_SCHEDULE_AHEAD_S before it
+ * sounds) - the seam a caller reflects onto the DOM for anything that needs
+ * to observe the click actually happening, rather than a value this module
+ * merely intended to produce.
+ */
+function createPracticeMetronome(api, onTempo, onClick) {
+  let enabled = false;
+  let mode = "proportion";
+  let proportion = 1;
+  let bpm = DEFAULT_METRONOME_BPM;
+  // The score's own tempo at the playhead - null until a score has loaded,
+  // updated continuously while playing (see positionChanged below) rather
+  // than resolved once, which is what lets a proportion track a tempo change
+  // written mid-piece instead of freezing at whatever was true at bar one.
+  let scoreTempo = null;
+  // Flat, tick-ordered {startTick, numerator, denominator}[] built once per
+  // score load - see timeSignatureAtTick in metronome.js for why a plain
+  // array rather than the renderer's own bar model.
+  let bars = [];
+  let playing = false;
+
+  let audioCtx = null;
+  let timer = null;
+  let nextClickTime = 0;
+  let clickIndex = 0;
+  let lastReportedBpm = null;
+
+  function effectiveBpm() {
+    return effectiveMetronomeBpm({ mode, bpm, proportion, scoreTempo });
+  }
+
+  function report() {
+    const value = Math.round(effectiveBpm());
+    if (value === lastReportedBpm) return;
+    lastReportedBpm = value;
+    onTempo(value);
+  }
+
+  function shouldRun() {
+    return enabled && playing;
+  }
+
+  function tick() {
+    if (!audioCtx) return;
+    while (nextClickTime < audioCtx.currentTime + METRONOME_SCHEDULE_AHEAD_S) {
+      const { numerator, denominator } = timeSignatureAtTick(bars, api.tickPosition ?? 0);
+      const pattern = metronomePattern(numerator, denominator);
+      const accent = clickIndex % pattern.accentEvery === 0;
+      scheduleMetronomeClick(audioCtx, nextClickTime, accent);
+      onClick(accent, numerator, denominator);
+      nextClickTime += secondsPerClick(effectiveBpm(), pattern.unit);
+      clickIndex = (clickIndex + 1) % pattern.clicksPerBar;
+    }
+  }
+
+  function ensureAudioCtx() {
+    if (!audioCtx) audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+    return audioCtx;
+  }
+
+  function start() {
+    if (timer) return;
+    ensureAudioCtx();
+    clickIndex = 0;
+    nextClickTime = audioCtx.currentTime + 0.05;
+    timer = setInterval(tick, METRONOME_LOOKAHEAD_MS);
+  }
+
+  function stop() {
+    if (timer) {
+      clearInterval(timer);
+      timer = null;
+    }
+  }
+
+  function sync() {
+    if (shouldRun()) start();
+    else stop();
+  }
+
+  return {
+    // Called from the view's playPause() below, synchronously inside the
+    // click handler that triggered it and before api.playPause() runs -
+    // browser autoplay policy grants audio to a user gesture's own call
+    // stack, not to whatever async chain api.playPause() goes through to
+    // actually start the transport (a soundfont may still be decoding).
+    // Priming here means the context already exists and is already resumed
+    // by the time playerStateChanged fires and setPlaying(true) starts the
+    // scheduler for real - there is nothing left for that later, async start
+    // to be denied.
+    prime() {
+      ensureAudioCtx().resume().catch(() => {});
+    },
+    scoreLoaded(loadedScore) {
+      scoreTempo = loadedScore?.tempo ?? null;
+      let cursor = 0;
+      bars = (loadedScore?.masterBars ?? []).map((bar) => {
+        const entry = {
+          startTick: cursor,
+          numerator: bar.timeSignatureNumerator,
+          denominator: bar.timeSignatureDenominator,
+        };
+        cursor += bar.calculateDuration();
+        return entry;
+      });
+      report();
+    },
+    // originalTempo is the score's OWN tempo at the playhead, unaffected by
+    // playbackSpeed (see PositionChangedEventArgs in alphaTab's typings, and
+    // modifiedTempo beside it for the one that does track speed). Called on
+    // every position update while playing, which is the continuous tracking
+    // a proportion needs rather than a value read once at play time.
+    positionChanged(originalTempo) {
+      if (Number.isFinite(originalTempo) && originalTempo > 0) {
+        scoreTempo = originalTempo;
+        if (mode === "proportion") report();
+      }
+    },
+    setPlaying(p) {
+      playing = p;
+      sync();
+    },
+    setEnabled(v) {
+      enabled = !!v;
+      sync();
+    },
+    setMode(next) {
+      mode = next === "bpm" ? "bpm" : "proportion";
+      report();
+    },
+    setProportion(next) {
+      const v = Number(next);
+      if (!Number.isFinite(v) || v <= 0) return;
+      proportion = v;
+      report();
+    },
+    setBpm(next) {
+      const v = Number(next);
+      if (!Number.isFinite(v) || v <= 0) return;
+      bpm = v;
+      report();
+    },
+    destroy() {
+      stop();
+      if (audioCtx) {
+        audioCtx.close().catch(() => {});
+        audioCtx = null;
+      }
+    },
+  };
+}
+
 // ---------------------------------------------------------------- the view
 
 /**
@@ -663,7 +889,10 @@ export async function playPitch(midi) {
  * @param opts.profile      one of SCORE_PROFILES
  * @param opts.preset       one of LAYOUT_PRESETS
  * @param opts.theme        one of SCORE_THEMES
- * @param opts.transport    {speed, looping, metronome, countIn} to start at
+ * @param opts.transport    {speed, looping, metronome, metronomeMode,
+ *                          metronomeProportion, metronomeBpm, countIn} to
+ *                          start at - see setMetronomeMode below for what
+ *                          the two metronome* values mean
  * @param opts.onReady      playback became available
  * @param opts.onPlaying    (boolean) transport state changed
  * @param opts.onError      (message) load or render failed
@@ -679,6 +908,11 @@ export async function playPitch(midi) {
  *                          signal a caller should wait for before treating a
  *                          profile switch as having taken effect, rather than
  *                          assuming success the moment it is requested
+ * @param opts.onMetronomeTempo  (bpm) the tempo the practice metronome is
+ *                          actually clicking at just changed - see
+ *                          createPracticeMetronome above. Fires on a setting
+ *                          change, a score load, and continuously while
+ *                          playing under a proportion whose base tempo moves.
  */
 export function createScoreView(host, opts = {}) {
   const {
@@ -695,6 +929,7 @@ export function createScoreView(host, opts = {}) {
     onLayout = () => {},
     onProfiles = () => {},
     onProfileApplied = () => {},
+    onMetronomeTempo = () => {},
   } = opts;
 
   let profile = SCORE_PROFILES.includes(initialProfile) ? initialProfile : "scoretab";
@@ -790,6 +1025,31 @@ export function createScoreView(host, opts = {}) {
   });
 
   applyBrandingOverride(api);
+
+  // Muted permanently, not toggled with the practice metronome below - see
+  // createPracticeMetronome's own comment for why alphaTab's built-in click
+  // cannot be the thing this feature is built from.
+  api.metronomeVolume = 0;
+
+  // Reflects each scheduled click onto the host, the same way publish() below
+  // reflects layout and theme - so a test can assert on a click that actually
+  // happened rather than on a value this module only intended to produce.
+  function publishMetronomeClick(accent, numerator, denominator) {
+    if (!host) return;
+    host.dataset.metronomeClicks = String((Number(host.dataset.metronomeClicks) || 0) + 1);
+    host.dataset.metronomeAccent = String(accent);
+    host.dataset.metronomeNumerator = String(numerator);
+    host.dataset.metronomeDenominator = String(denominator);
+  }
+
+  const metronome = createPracticeMetronome(
+    api,
+    (bpm) => {
+      if (host) host.dataset.metronomeBpm = String(bpm);
+      onMetronomeTempo(bpm);
+    },
+    publishMetronomeClick,
+  );
 
   // Fonts for the title block are not readable through settings; they are
   // assigned onto the live resource object, which is why this happens after
@@ -928,12 +1188,21 @@ export function createScoreView(host, opts = {}) {
       api.settings.display.staveProfile = STAVE_PROFILE[profile];
       api.updateSettings();
     }
+    metronome.scoreLoaded(loadedScore);
     publish();
     onProfiles(scoreProfiles, unrenderable);
   });
 
   api.playerReady.on(() => onReady());
-  api.playerStateChanged.on((e) => onPlaying(e.state === 1));
+  api.playerStateChanged.on((e) => {
+    const isPlaying = e.state === 1;
+    metronome.setPlaying(isPlaying);
+    onPlaying(isPlaying);
+  });
+  // originalTempo is the score's own tempo at the playhead, unaffected by
+  // playback speed - see createPracticeMetronome's positionChanged for why
+  // this is what a proportion has to track rather than resolve once.
+  api.playerPositionChanged.on((e) => metronome.positionChanged(e.originalTempo));
   api.error.on((e) => {
     if (renderInFlight) {
       renderInFlight = false;
@@ -979,7 +1248,13 @@ export function createScoreView(host, opts = {}) {
   // whatever the caller was already using.
   if (transport.speed != null) api.playbackSpeed = transport.speed;
   if (transport.looping != null) api.isLooping = transport.looping;
-  if (transport.metronome != null) api.metronomeVolume = transport.metronome ? 1 : 0;
+  if (transport.metronomeMode != null) metronome.setMode(transport.metronomeMode);
+  if (transport.metronomeProportion != null) metronome.setProportion(transport.metronomeProportion);
+  if (transport.metronomeBpm != null) metronome.setBpm(transport.metronomeBpm);
+  // Enabled last: setEnabled is what can start the click running, and it
+  // should not do that against the mode/proportion/bpm defaults for the
+  // instant before the three lines above land.
+  if (transport.metronome != null) metronome.setEnabled(transport.metronome);
   if (transport.countIn != null) api.countInVolume = transport.countIn ? 1 : 0;
 
   // A tier change is applied as a full render of our own, because the
@@ -1137,13 +1412,32 @@ export function createScoreView(host, opts = {}) {
     setLooping(v) {
       api.isLooping = v;
     },
+    /** Whether the practice metronome clicks at all - the click itself is
+     * the independent path described above createPracticeMetronome, never
+     * alphaTab's own (permanently muted; see api.metronomeVolume = 0 above). */
     setMetronome(v) {
-      api.metronomeVolume = v ? 1 : 0;
+      metronome.setEnabled(v);
+    },
+    /** "proportion" (the default) clicks `metronomeProportion` of the
+     * score's own tempo at the playhead, tracking a tempo change written
+     * mid-piece. "bpm" clicks `metronomeBpm` directly and ignores the score
+     * entirely. Either way the click's tempo has nothing to do with
+     * setSpeed() - that is the whole point; see the module comment above
+     * createPracticeMetronome. */
+    setMetronomeMode(v) {
+      metronome.setMode(v);
+    },
+    setMetronomeProportion(v) {
+      metronome.setProportion(v);
+    },
+    setMetronomeBpm(v) {
+      metronome.setBpm(v);
     },
     setCountIn(v) {
       api.countInVolume = v ? 1 : 0;
     },
     playPause() {
+      metronome.prime();
       api.playPause();
     },
     stop() {
@@ -1154,6 +1448,7 @@ export function createScoreView(host, opts = {}) {
       destroyed = true;
       observer.disconnect();
       partialWatcher.disconnect();
+      metronome.destroy();
       api.destroy();
     },
   };

--- a/web/src/lib/score-render.js
+++ b/web/src/lib/score-render.js
@@ -8,10 +8,11 @@
 import * as alphaTab from "@coderline/alphatab";
 import {
   DEFAULT_METRONOME_BPM,
-  effectiveMetronomeBpm,
+  barAtTick,
+  clickPhaseInBar,
+  effectiveClickRate,
   metronomePattern,
   secondsPerClick,
-  timeSignatureAtTick,
 } from "./metronome.js";
 
 // ---------------------------------------------------------------- profiles
@@ -673,10 +674,14 @@ export async function playPitch(midi) {
 // alphaTab's synthesiser or its notion of tempo.
 //
 // alphaTab's built-in metronome is left permanently muted (metronomeVolume
-// stays 0, set once below and never touched again) so the two clicks can
-// never sound at once. Its count-in is untouched - a separate, pre-roll-only
-// feature outside this - and still ticks at the score's own tempo, scaled by
-// playbackSpeed, exactly as it always has.
+// stays 0, set once below and never touched again) so the two never sound
+// at once - but that only covers alphaTab's REGULAR metronome. Its count-in
+// is a separate feature with its own, un-muted volume (countInVolume), and
+// alphaTab raises playerStateChanged to Playing before the count-in even
+// starts - so this click cannot simply start on that event either, or it
+// sounds a second, differently-paced click underneath the count-in,
+// defeating the reason a count-in exists. See setPlaying below for the
+// state machine that keeps this click out of the count-in entirely.
 //
 // The scheduler is the standard "lookahead" pattern for Web Audio timing:
 // every METRONOME_LOOKAHEAD_MS a queue is topped up with whatever clicks now
@@ -692,43 +697,37 @@ const METRONOME_SCHEDULE_AHEAD_S = 0.12;
 const METRONOME_CLICK_SECONDS = 0.05;
 // Accent is both higher-pitched and louder than a plain subdivision tick -
 // pitch alone survives a quiet room or a cheap speaker better than volume
-// alone does, so the two are stacked rather than picking one.
+// alone does, so the two are stacked rather than picking one. Gains are
+// sized so the two can never clip even in the pathological case of one
+// click's tail overlapping the next one's attack: 0.6 + 0.35 = 0.95, under
+// unity with headroom to spare. MAX_METRONOME_BPM keeps that overlap from
+// ever actually happening in practice - see its own comment in metronome.js.
 const METRONOME_ACCENT_HZ = 1500;
 const METRONOME_TICK_HZ = 950;
-const METRONOME_ACCENT_GAIN = 0.85;
-const METRONOME_TICK_GAIN = 0.45;
-
-function scheduleMetronomeClick(ctx, time, accent) {
-  const osc = ctx.createOscillator();
-  const gain = ctx.createGain();
-  osc.frequency.value = accent ? METRONOME_ACCENT_HZ : METRONOME_TICK_HZ;
-  osc.connect(gain);
-  gain.connect(ctx.destination);
-  const peak = accent ? METRONOME_ACCENT_GAIN : METRONOME_TICK_GAIN;
-  // A short percussive envelope, not a sustained tone: near-instant attack so
-  // the click reads as a transient a note can be placed against, then an
-  // exponential decay - linear ramps to silence read as a cut-off, not a
-  // click's natural decay.
-  gain.gain.setValueAtTime(0, time);
-  gain.gain.linearRampToValueAtTime(peak, time + 0.001);
-  gain.gain.exponentialRampToValueAtTime(0.0001, time + METRONOME_CLICK_SECONDS);
-  osc.start(time);
-  osc.stop(time + METRONOME_CLICK_SECONDS + 0.02);
-}
+const METRONOME_ACCENT_GAIN = 0.6;
+const METRONOME_TICK_GAIN = 0.35;
 
 /**
  * The independent click described above, bound to one AlphaTabApi instance.
  *
- * `onTempo(bpm)` fires whenever the value it would report changes - on a
- * setting change, a score load, or the score's own tempo moving under a
- * proportion - which is what lets a caller show the current value without
- * polling for it.
+ * `onTempo(rate)` fires whenever the click RATE it would report changes -
+ * clicks per minute, the same number that is actually scheduled, never a
+ * quarter-note tempo a listener would have to convert in their head - on a
+ * setting change, the score's own tempo moving under a proportion, or the
+ * meter itself changing mid-piece (which changes the rate even when neither
+ * of those two do, in proportion mode - see effectiveClickRate). It never
+ * fires before `scoreLoaded` has run once: reporting a value (even the
+ * correct one) before a score exists to be a proportion OF would show a
+ * caller a number that has nothing behind it yet.
  *
- * `onClick(accent, numerator, denominator)` fires once per scheduled click,
- * at the moment it is queued (up to METRONOME_SCHEDULE_AHEAD_S before it
- * sounds) - the seam a caller reflects onto the DOM for anything that needs
- * to observe the click actually happening, rather than a value this module
- * merely intended to produce.
+ * `onClick(accent, numerator, denominator, phase)` fires once per click ONLY
+ * from inside the real scheduling call that creates its oscillator - not
+ * merely alongside it - so deleting that function's body silences this too;
+ * nothing downstream of it can report a click that scheduleClick never
+ * actually attempted. `phase` is the bar-relative slot the click landed in
+ * (see clickPhaseInBar in metronome.js) - exposed separately from `accent`
+ * so a caller can tell the phase is really being derived from the playhead
+ * each time, not merely incrementing.
  */
 function createPracticeMetronome(api, onTempo, onClick) {
   let enabled = false;
@@ -740,56 +739,198 @@ function createPracticeMetronome(api, onTempo, onClick) {
   // than resolved once, which is what lets a proportion track a tempo change
   // written mid-piece instead of freezing at whatever was true at bar one.
   let scoreTempo = null;
-  // Flat, tick-ordered {startTick, numerator, denominator}[] built once per
-  // score load - see timeSignatureAtTick in metronome.js for why a plain
-  // array rather than the renderer's own bar model.
-  let bars = [];
+  // The first bar's own declared denominator - a reasonable assumption for
+  // the click rate to display before api.tickCache exists to ask (it is
+  // built during rendering, not necessarily by the instant scoreLoaded
+  // fires). Once a real bar lookup is available it always wins; this is only
+  // ever read when one is not.
+  let fallbackUnit = 4;
+  // Guards report(): false until scoreLoaded() has actually run once. Without
+  // this, the transport-initialisation calls in createScoreView (setMode /
+  // setProportion / setBpm, before any score exists) would report the
+  // FALLBACK_SCORE_TEMPO-derived value immediately, overwriting the null a
+  // caller is documented to see before anything is known.
+  let hasScore = false;
+  // True only once REAL playback is under way - never during a count-in, see
+  // setPlaying below for why alphaTab's own Playing state is not the same
+  // question.
   let playing = false;
+  // True from the moment a play() with a count-in configured is detected
+  // until the count-in finishes - see setPlaying.
+  let countInPending = false;
 
   let audioCtx = null;
   let timer = null;
   let nextClickTime = 0;
-  let clickIndex = 0;
-  let lastReportedBpm = null;
+  let lastReportedRate = null;
+  // Oscillators already scheduled but not yet finished. Tracked so stop()
+  // can cut them off - otherwise up to METRONOME_SCHEDULE_AHEAD_S of clicks
+  // already queued keep sounding after pausing or switching the click off.
+  let pendingOscillators = [];
 
-  function effectiveBpm() {
-    return effectiveMetronomeBpm({ mode, bpm, proportion, scoreTempo });
+  // api.tickCache is rebuilt by the renderer on each render, and mapping it
+  // into the plain shape barAtTick wants is wasted work on every one of the
+  // ~40 scheduling checks a second the timer performs - so this is done once
+  // per tickCache instance, not once per click.
+  let cachedTickCache = null;
+  let cachedBars = [];
+
+  function currentBars() {
+    const cache = api.tickCache;
+    if (cache !== cachedTickCache) {
+      cachedTickCache = cache;
+      // MasterBarTickLookup.start/end are on the GENERATED MIDI's timeline -
+      // the same timeline api.tickPosition reports on - which is exactly why
+      // this is read from here rather than summed from MasterBar durations:
+      // a repeat or an unplayed alternate ending makes the notated bar order
+      // and the played tick order different timelines, and only alphaTab's
+      // own lookup, built from the actual generated MIDI, knows which bar is
+      // really sounding at a given tick.
+      cachedBars = (cache?.masterBars ?? []).map((mb) => ({
+        startTick: mb.start,
+        endTick: mb.end,
+        numerator: mb.masterBar.timeSignatureNumerator,
+        denominator: mb.masterBar.timeSignatureDenominator,
+      }));
+    }
+    return cachedBars;
   }
 
-  function report() {
-    const value = Math.round(effectiveBpm());
-    if (value === lastReportedBpm) return;
-    lastReportedBpm = value;
-    onTempo(value);
+  // The bar the playhead is in right now, or null before anything is known.
+  function currentBar() {
+    return barAtTick(currentBars(), api.tickPosition ?? 0);
+  }
+
+  // The click rate - clicks per minute - for `bar` (or the fallback unit if
+  // `bar` is null), rounded ONCE here. Both tick() and report() call this
+  // and use exactly its return value, unrounded nowhere else: a display
+  // that rounds separately from what the scheduler consumes is exactly the
+  // "shows one number, sounds another" mismatch this function exists to
+  // rule out - 120.6 must never display 121 while clicking 120.6 a minute.
+  function currentClickRate(bar) {
+    const unit = bar?.denominator ?? fallbackUnit;
+    return Math.round(effectiveClickRate({ mode, bpm, proportion, scoreTempo, unit }));
+  }
+
+  function report(bar) {
+    if (!hasScore) return;
+    const rate = currentClickRate(bar ?? currentBar());
+    if (rate === lastReportedRate) return;
+    lastReportedRate = rate;
+    onTempo(rate);
   }
 
   function shouldRun() {
     return enabled && playing;
   }
 
+  // Fires onClick from INSIDE the call that actually creates and starts the
+  // oscillator - not as a separate, sibling call a caller could satisfy by
+  // deleting this function's body and leaving the notification behind. A
+  // click that gets reported without a real audio node behind it is exactly
+  // the failure this project has shipped before: a test - or a player - that
+  // trusts a value the interface merely intended to produce.
+  function scheduleClick(time, accent, numerator, denominator, phase) {
+    const ctx = audioCtx;
+    const osc = ctx.createOscillator();
+    const gain = ctx.createGain();
+    osc.frequency.value = accent ? METRONOME_ACCENT_HZ : METRONOME_TICK_HZ;
+    osc.connect(gain);
+    gain.connect(ctx.destination);
+    const peak = accent ? METRONOME_ACCENT_GAIN : METRONOME_TICK_GAIN;
+    // A short percussive envelope, not a sustained tone: near-instant attack
+    // so the click reads as a transient a note can be placed against, then an
+    // exponential decay - linear ramps to silence read as a cut-off, not a
+    // click's natural decay.
+    gain.gain.setValueAtTime(0, time);
+    gain.gain.linearRampToValueAtTime(peak, time + 0.001);
+    gain.gain.exponentialRampToValueAtTime(0.0001, time + METRONOME_CLICK_SECONDS);
+    // Reported before start() is actually called, not after: a caller
+    // hooking start() itself to observe the real scheduling (as this
+    // project's own test suite does) needs the click already announced by
+    // the time that hook runs, or a snapshot taken there reads the
+    // PREVIOUS click's state instead of this one's. Still only reachable by
+    // way of this function actually running - createOscillator, the gain
+    // envelope and this call all have to happen first - so deleting
+    // scheduleClick's body still silences onClick exactly as intended.
+    onClick(accent, numerator, denominator, phase);
+    osc.start(time);
+    osc.stop(time + METRONOME_CLICK_SECONDS + 0.02);
+    pendingOscillators.push(osc);
+    osc.onended = () => {
+      const i = pendingOscillators.indexOf(osc);
+      if (i !== -1) pendingOscillators.splice(i, 1);
+    };
+  }
+
   function tick() {
     if (!audioCtx) return;
-    while (nextClickTime < audioCtx.currentTime + METRONOME_SCHEDULE_AHEAD_S) {
-      const { numerator, denominator } = timeSignatureAtTick(bars, api.tickPosition ?? 0);
-      const pattern = metronomePattern(numerator, denominator);
-      const accent = clickIndex % pattern.accentEvery === 0;
-      scheduleMetronomeClick(audioCtx, nextClickTime, accent);
-      onClick(accent, numerator, denominator);
-      nextClickTime += secondsPerClick(effectiveBpm(), pattern.unit);
-      clickIndex = (clickIndex + 1) % pattern.clicksPerBar;
+    // A stall longer than the lookahead window - a garbage collection pause,
+    // a profile switch re-rendering mid-playback, a backgrounded tab whose
+    // timers get throttled to once a second while its AudioContext keeps
+    // running - leaves nextClickTime sitting in the past. The while loop
+    // below would otherwise schedule every missed click at whatever instant
+    // it is now already past due, and Web Audio fires a whole burst of them
+    // at once: audible, alarming, and not a metronome recovering, just
+    // catching up. The right answer is to drop what was missed and resume
+    // from now - there is no "correct" time left to play a click that was
+    // due half a second ago.
+    if (nextClickTime < audioCtx.currentTime) {
+      nextClickTime = audioCtx.currentTime + METRONOME_LOOKAHEAD_MS / 1000;
     }
+    while (nextClickTime < audioCtx.currentTime + METRONOME_SCHEDULE_AHEAD_S) {
+      // api.tickPosition answers "where is the playhead RIGHT NOW", not
+      // "where will it be when this click, scheduled up to
+      // METRONOME_SCHEDULE_AHEAD_S from now, actually sounds" - a real but
+      // bounded and self-correcting imprecision, worth stating plainly
+      // rather than quietly living with: when the click's own rate does not
+      // match the music's (any proportion other than 100%, or a fixed BPM),
+      // a single click landing close to a bar or beat boundary can read one
+      // slot early. It never accumulates - the very next click reads the
+      // playhead fresh again - so the cost is an occasional single click's
+      // accent placed a slot off near a boundary, not a drift that persists.
+      const tickPosition = api.tickPosition ?? 0;
+      const bar = barAtTick(currentBars(), tickPosition);
+      const numerator = bar?.numerator ?? 4;
+      const denominator = bar?.denominator ?? 4;
+      const pattern = metronomePattern(numerator, denominator);
+      const phase = clickPhaseInBar(tickPosition, bar, pattern.clicksPerBar);
+      const accent = phase % pattern.accentEvery === 0;
+      const rate = currentClickRate(bar);
+      scheduleClick(nextClickTime, accent, numerator, denominator, phase);
+      nextClickTime += secondsPerClick(rate);
+    }
+    // The meter (and therefore, in proportion mode, the rate) can change
+    // between one tick() and the next without any of report()'s other
+    // triggers firing - a bar boundary crossed mid-playback is not a setting
+    // change, a position update carrying a new scoreTempo, or a fresh score
+    // load. report()'s own de-duplication makes this a no-op the other
+    // ~39 times a second nothing has actually changed.
+    report();
   }
 
   function ensureAudioCtx() {
-    if (!audioCtx) audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+    if (audioCtx) return audioCtx;
+    try {
+      audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+    } catch (e) {
+      // Safari and iOS still enforce a hard cap on live AudioContexts and
+      // throw once it is reached. Swallowed here rather than left to
+      // propagate: prime() is called from inside playPause(), synchronously
+      // before api.playPause() runs, and an uncaught throw there would stop
+      // the Play button from ever reaching the renderer at all - silencing
+      // the metronome is the right failure, silencing playback is not.
+      console.warn("practice metronome: could not create an AudioContext - the click will stay silent.", e);
+      audioCtx = null;
+    }
     return audioCtx;
   }
 
   function start() {
     if (timer) return;
-    ensureAudioCtx();
-    clickIndex = 0;
-    nextClickTime = audioCtx.currentTime + 0.05;
+    const ctx = ensureAudioCtx();
+    if (!ctx) return;
+    nextClickTime = ctx.currentTime + 0.05;
     timer = setInterval(tick, METRONOME_LOOKAHEAD_MS);
   }
 
@@ -797,6 +938,17 @@ function createPracticeMetronome(api, onTempo, onClick) {
     if (timer) {
       clearInterval(timer);
       timer = null;
+    }
+    const ctx = audioCtx;
+    if (ctx) {
+      const now = ctx.currentTime;
+      for (const osc of pendingOscillators.splice(0)) {
+        try {
+          osc.stop(now);
+        } catch {
+          // already stopped/ended between the splice and this call
+        }
+      }
     }
   }
 
@@ -814,22 +966,22 @@ function createPracticeMetronome(api, onTempo, onClick) {
     // Priming here means the context already exists and is already resumed
     // by the time playerStateChanged fires and setPlaying(true) starts the
     // scheduler for real - there is nothing left for that later, async start
-    // to be denied.
+    // to be denied. Skipped entirely when the click is switched off, so a
+    // view whose player gets used without the metronome ever touched does
+    // not hold an AudioContext open for its whole lifetime for nothing.
     prime() {
-      ensureAudioCtx().resume().catch(() => {});
+      if (!enabled) return;
+      ensureAudioCtx()?.resume().catch(() => {});
     },
     scoreLoaded(loadedScore) {
       scoreTempo = loadedScore?.tempo ?? null;
-      let cursor = 0;
-      bars = (loadedScore?.masterBars ?? []).map((bar) => {
-        const entry = {
-          startTick: cursor,
-          numerator: bar.timeSignatureNumerator,
-          denominator: bar.timeSignatureDenominator,
-        };
-        cursor += bar.calculateDuration();
-        return entry;
-      });
+      fallbackUnit = loadedScore?.masterBars?.[0]?.timeSignatureDenominator ?? 4;
+      hasScore = true;
+      // Forces the next report() through even if the new score's rate
+      // happens to match a stale report already announced - relevant if this
+      // view is ever handed a second score to load, which nothing in this
+      // codebase does today but nothing here should assume.
+      lastReportedRate = null;
       report();
     },
     // originalTempo is the score's OWN tempo at the playhead, unaffected by
@@ -843,8 +995,39 @@ function createPracticeMetronome(api, onTempo, onClick) {
         if (mode === "proportion") report();
       }
     },
-    setPlaying(p) {
-      playing = p;
+    // isPlayingNow is alphaTab's own playerStateChanged boolean, and it is
+    // NOT the same question as "should the click be running": alphaTab
+    // raises Playing before a count-in even starts (play() fires the state
+    // change, then conditionally calls sequencer.startCountIn()), and raises
+    // it a SECOND time, with no intervening Paused, the instant the count-in
+    // finishes and real playback begins. Naively starting on the first event
+    // sounds the click underneath the count-in at whatever tempo the click
+    // is set to - a second, differently-paced click defeating the reason a
+    // count-in exists - and the second event would then be swallowed by
+    // start()'s own `if (timer) return`, leaving the click's grid anchored to
+    // whenever the count-in happened to start rather than to the first real
+    // beat, for the rest of the session.
+    //
+    // So a rising edge is treated as a count-in, and suppressed, exactly
+    // when api.countInVolume is on at the moment it arrives; the covering
+    // SECOND rising edge (no Paused in between) is what actually starts the
+    // click, freshly anchored via start() - nothing here has to detect the
+    // count-in ending explicitly, because that second event already means
+    // exactly that.
+    setPlaying(isPlayingNow) {
+      if (isPlayingNow) {
+        if (playing) return; // already running - a redundant event
+        if (!countInPending && (api.countInVolume ?? 0) > 0) {
+          countInPending = true; // this rising edge IS the count-in
+          return;
+        }
+        countInPending = false;
+        playing = true;
+        sync();
+        return;
+      }
+      countInPending = false;
+      playing = false;
       sync();
     },
     setEnabled(v) {
@@ -1031,15 +1214,31 @@ export function createScoreView(host, opts = {}) {
   // cannot be the thing this feature is built from.
   api.metronomeVolume = 0;
 
+  // host is the SAME DOM element across a score switch within one mounted
+  // TabViewer (this closure is rebuilt; the element is not - see publish()'s
+  // own dataset.scoreProfiles delete for the identical reason). Without this,
+  // a fresh view for a NEW score would inherit the previous score's click
+  // count and last-reported bpm sitting on the element from before - stale
+  // data a test (or a player) could read as live.
+  if (host) {
+    delete host.dataset.metronomeClicks;
+    delete host.dataset.metronomeAccent;
+    delete host.dataset.metronomeNumerator;
+    delete host.dataset.metronomeDenominator;
+    delete host.dataset.metronomePhase;
+    delete host.dataset.metronomeBpm;
+  }
+
   // Reflects each scheduled click onto the host, the same way publish() below
   // reflects layout and theme - so a test can assert on a click that actually
   // happened rather than on a value this module only intended to produce.
-  function publishMetronomeClick(accent, numerator, denominator) {
+  function publishMetronomeClick(accent, numerator, denominator, phase) {
     if (!host) return;
     host.dataset.metronomeClicks = String((Number(host.dataset.metronomeClicks) || 0) + 1);
     host.dataset.metronomeAccent = String(accent);
     host.dataset.metronomeNumerator = String(numerator);
     host.dataset.metronomeDenominator = String(denominator);
+    host.dataset.metronomePhase = String(phase);
   }
 
   const metronome = createPracticeMetronome(

--- a/web/tests/browser/fixtures/metronome-score.js
+++ b/web/tests/browser/fixtures/metronome-score.js
@@ -1,6 +1,6 @@
 // Fixture data + route stubs for tests/browser/metronome.spec.js.
 //
-// A real MusicXML document, not a stub of TabViewer's internals - the same
+// Real MusicXML documents, not a stub of TabViewer's internals - the same
 // reasoning as SCORE/SAMPLE_TEX in fixtures/transcription-warnings.js: the
 // interesting part of this feature is whether a genuine alphaTab render and
 // a genuine Web Audio click actually happen, which nothing short of the real
@@ -10,114 +10,198 @@
 // part that renders under the "score" profile without a tab staff.
 //
 // 6/8 at a declared tempo of 96 BPM (always quarter-note BPM - see
-// metronome.js's secondsPerClick) is the one fact these tests are built
+// metronome.js's secondsPerClick) is the fact most of these tests are built
 // around: it is a compound meter (six eighth-note clicks per bar, accented
 // on the 1st and 4th - see metronomePattern), and 96 is a base the
-// proportion tests below multiply and divide by round numbers.
-//
-// MEASURE_COUNT repeats of the one bar, not one - the slow end of these
-// tests (a click every 600ms+, several of them, sometimes under a halved
-// playback speed) needs several real seconds of audio playing, and a single
-// 1.875s bar would demand the tests lean on looping across many passes to
-// get there. Enough measures that the piece's own natural length already
-// covers every test's collection window keeps looping a belt-and-braces
-// safety net rather than something the timing math depends on.
-const MEASURE_COUNT = 8;
+// proportion tests multiply and divide by round numbers.
+const DIVISIONS = 480; // ticks per quarter note
+const PITCHES = ["C", "D", "E", "F", "G", "A", "B", "C"];
 
-const PITCHES = ["C", "D", "E", "F", "G", "A"];
-
-function measure(number) {
-  const attributes =
-    number === 1
-      ? `
+function timeAndTempoBlock(numerator, denominator, tempo) {
+  return `
       <attributes>
-        <divisions>480</divisions>
-        <key>
-          <fifths>0</fifths>
-        </key>
+        <divisions>${DIVISIONS}</divisions>
+        <key><fifths>0</fifths></key>
         <time>
-          <beats>6</beats>
-          <beat-type>8</beat-type>
+          <beats>${numerator}</beats>
+          <beat-type>${denominator}</beat-type>
         </time>
-        <clef>
-          <sign>G</sign>
-          <line>2</line>
-        </clef>
+        <clef><sign>G</sign><line>2</line></clef>
       </attributes>
       <direction placement="above">
         <direction-type>
-          <metronome>
-            <beat-unit>quarter</beat-unit>
-            <per-minute>96</per-minute>
-          </metronome>
+          <metronome><beat-unit>quarter</beat-unit><per-minute>${tempo}</per-minute></metronome>
         </direction-type>
-        <sound tempo="96" />
-      </direction>`
-      : "";
-  const notes = PITCHES.map(
-    (step) => `
-      <note>
-        <pitch><step>${step}</step><octave>4</octave></pitch>
-        <duration>240</duration>
-        <voice>1</voice>
-        <type>eighth</type>
-      </note>`,
-  ).join("");
-  return `    <measure number="${number}">${attributes}${notes}
-    </measure>`;
+        <sound tempo="${tempo}" />
+      </direction>`;
 }
 
-export const METRONOME_MUSICXML = `<?xml version="1.0" encoding="UTF-8"?>
+function notesForBar(numerator, denominator) {
+  // One note per click unit (an eighth for .../8, a quarter for .../4),
+  // filling the bar exactly - the fixture only needs to render and hold the
+  // declared duration, never to be musically interesting.
+  const unitDuration = DIVISIONS * (4 / denominator);
+  const type = denominator === 8 ? "eighth" : "quarter";
+  return Array.from({ length: numerator }, (_, i) => {
+    const step = PITCHES[i % PITCHES.length];
+    return `
+      <note>
+        <pitch><step>${step}</step><octave>4</octave></pitch>
+        <duration>${unitDuration}</duration>
+        <voice>1</voice>
+        <type>${type}</type>
+      </note>`;
+  }).join("");
+}
+
+/**
+ * Builds a score-partwise document of `measures` bars, all in one time
+ * signature/tempo (declared once, on the first bar) unless `change` names a
+ * later bar to switch at. `repeatAfter` puts a backward-repeat barline at
+ * the end of that 1-based bar number, repeating from the start of the piece
+ * (no forward repeat needed - the piece's own start is where a backward
+ * repeat with nothing preceding it returns to).
+ */
+function buildMusicXml({ measures, numerator, denominator, tempo, repeatAfter = null, change = null }) {
+  const bars = [];
+  let curNum = numerator;
+  let curDen = denominator;
+  for (let i = 1; i <= measures; i++) {
+    const isFirst = i === 1;
+    const isChange = change && i === change.at;
+    if (isChange) {
+      curNum = change.numerator;
+      curDen = change.denominator;
+    }
+    const attrs = isFirst
+      ? timeAndTempoBlock(curNum, curDen, tempo)
+      : isChange
+        ? `
+      <attributes>
+        <time><beats>${curNum}</beats><beat-type>${curDen}</beat-type></time>
+      </attributes>`
+        : "";
+    const barline =
+      repeatAfter === i
+        ? `
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        <repeat direction="backward"/>
+      </barline>`
+        : "";
+    bars.push(`    <measure number="${i}">${attrs}${notesForBar(curNum, curDen)}${barline}
+    </measure>`);
+  }
+  return `<?xml version="1.0" encoding="UTF-8"?>
 <score-partwise version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.musicxml.org/xsd/musicxml.xsd">
-  <work>
-    <work-title>Metronome test fixture</work-title>
-  </work>
+  <work><work-title>Metronome test fixture</work-title></work>
   <identification>
-    <encoding>
-      <software>Fermata test fixture</software>
-      <encoding-date>2026-08-20</encoding-date>
-    </encoding>
+    <encoding><software>Fermata test fixture</software><encoding-date>2026-08-20</encoding-date></encoding>
   </identification>
   <part-list>
     <score-part id="P1">
       <part-name>Piano</part-name>
-      <score-instrument id="P1-I1">
-        <instrument-name>Piano</instrument-name>
-      </score-instrument>
-      <midi-instrument id="P1-I1">
-        <midi-channel>1</midi-channel>
-        <midi-program>1</midi-program>
-      </midi-instrument>
+      <score-instrument id="P1-I1"><instrument-name>Piano</instrument-name></score-instrument>
+      <midi-instrument id="P1-I1"><midi-channel>1</midi-channel><midi-program>1</midi-program></midi-instrument>
     </score-part>
   </part-list>
   <part id="P1">
-${Array.from({ length: MEASURE_COUNT }, (_, i) => measure(i + 1)).join("\n")}
+${bars.join("\n")}
   </part>
 </score-partwise>
 `;
+}
 
-// file_type not "pdf" is what routes Viewer.svelte to TabViewer directly
-// (see Viewer.svelte) rather than through ScoreCompare/PdfViewer.
-export const METRONOME_SCORE = {
-  id: 1,
-  title: "Metronome test fixture",
-  composer: "",
-  source: "",
-  file_type: "musicxml",
-  has_transcription: false,
-  favorite: false,
-  content_kind: "notation",
-  tags: [],
-};
+// The main fixture: 8 measures of 6/8 at 96 BPM, no repeats. Eight rather
+// than one - the slow end of these tests (a click every 600ms+, several of
+// them, sometimes under a halved playback speed) needs several real seconds
+// of audio playing, and a single 1.875s bar would demand leaning on looping
+// across many passes to get there. Enough measures that the piece's own
+// natural length already covers every test's collection window keeps
+// looping a belt-and-braces safety net rather than something the timing
+// math depends on.
+export const METRONOME_MUSICXML = buildMusicXml({ measures: 8, numerator: 6, denominator: 8, tempo: 96 });
 
-/** Stubs the /api routes TabViewer/Viewer touch for score id 1, serving
- * METRONOME_MUSICXML as the file content. */
-export async function stubMetronomeScore(page) {
-  await page.route("**/api/scores/1", (route) => route.fulfill({ json: METRONOME_SCORE }));
-  await page.route("**/api/scores/1/file", (route) =>
-    route.fulfill({ body: METRONOME_MUSICXML, contentType: "application/vnd.recordare.musicxml+xml" }),
+// A short loop, deliberately: 2 measures of 6/8 at 96 BPM whose own real
+// playback length (2 * 1.875s = 3.75s) does NOT divide evenly by the click
+// period a 70%-proportion metronome runs at (~0.446s) - see the loop-wrap
+// test, which relies on that mismatch to tell "phase derived from the
+// playhead" apart from "phase carried as a counter that only resets when
+// the scheduler starts".
+export const METRONOME_MUSICXML_SHORT_LOOP = buildMusicXml({
+  measures: 2,
+  numerator: 6,
+  denominator: 8,
+  tempo: 96,
+});
+
+// Two bars of 4/4 at 120 BPM, repeated once (a backward-repeat barline on
+// bar 2), followed by one bar of 6/8 - three NOTATED bars that play as five
+// (4/4, 4/4, 4/4, 4/4, 6/8). A tick->meter index built by summing NOTATED
+// bar durations would place the 6/8 bar right after the first pass of bar 2
+// - i.e. DURING the repeat's second pass - and misreport the meter (and
+// therefore the click rate) for the whole rest of the repeated section. See
+// the "a repeat sign must not desync the click's meter" test.
+export const METRONOME_MUSICXML_REPEAT = buildMusicXml({
+  measures: 3,
+  numerator: 4,
+  denominator: 4,
+  tempo: 120,
+  repeatAfter: 2,
+  change: { at: 3, numerator: 6, denominator: 8 },
+});
+
+// A second, plainly different score (140 BPM, 4/4) - used only to prove the
+// metronome's own dataset state resets when a mounted TabViewer switches to
+// a DIFFERENT score, rather than a fresh view inheriting whatever a
+// previous score's clicks left sitting on the shared host element.
+export const METRONOME_MUSICXML_OTHER = buildMusicXml({ measures: 4, numerator: 4, denominator: 4, tempo: 140 });
+
+function scoreMeta(id, title) {
+  // file_type not "pdf" is what routes Viewer.svelte to TabViewer directly
+  // (see Viewer.svelte) rather than through ScoreCompare/PdfViewer.
+  return {
+    id,
+    title,
+    composer: "",
+    source: "",
+    file_type: "musicxml",
+    has_transcription: false,
+    favorite: false,
+    content_kind: "notation",
+    tags: [],
+  };
+}
+
+async function stubOneScore(page, id, meta, xml) {
+  await page.route(`**/api/scores/${id}`, (route) => route.fulfill({ json: meta }));
+  await page.route(`**/api/scores/${id}/file`, (route) =>
+    route.fulfill({ body: xml, contentType: "application/vnd.recordare.musicxml+xml" }),
   );
-  await page.route("**/api/scores/1/practice", (route) =>
+  await page.route(`**/api/scores/${id}/practice`, (route) =>
     route.fulfill({ json: { total_seconds: 0, sessions: [] } }),
   );
+}
+
+/** Stubs the /api routes TabViewer/Viewer touch for score id 1 (the main,
+ * 8-measure 6/8 fixture). */
+export async function stubMetronomeScore(page) {
+  await stubOneScore(page, 1, scoreMeta(1, "Metronome test fixture"), METRONOME_MUSICXML);
+}
+
+/** Score id 2: the second, plainly different score used for the
+ * dataset-reset-on-switch test. */
+export async function stubMetronomeScoreOther(page) {
+  await stubOneScore(page, 2, scoreMeta(2, "A different metronome fixture"), METRONOME_MUSICXML_OTHER);
+}
+
+/** Score id 3: the short 2-measure loop used for the loop-wrap phase test. */
+export async function stubMetronomeScoreShortLoop(page) {
+  await stubOneScore(page, 3, scoreMeta(3, "Short loop metronome fixture"), METRONOME_MUSICXML_SHORT_LOOP);
+}
+
+/** Score id 4: the 4/4-repeat-then-6/8 fixture used for the repeat-desync
+ * regression test. */
+export async function stubMetronomeScoreRepeat(page) {
+  await stubOneScore(page, 4, scoreMeta(4, "Repeat metronome fixture"), METRONOME_MUSICXML_REPEAT);
 }

--- a/web/tests/browser/fixtures/metronome-score.js
+++ b/web/tests/browser/fixtures/metronome-score.js
@@ -1,0 +1,123 @@
+// Fixture data + route stubs for tests/browser/metronome.spec.js.
+//
+// A real MusicXML document, not a stub of TabViewer's internals - the same
+// reasoning as SCORE/SAMPLE_TEX in fixtures/transcription-warnings.js: the
+// interesting part of this feature is whether a genuine alphaTab render and
+// a genuine Web Audio click actually happen, which nothing short of the real
+// importer and the real player can tell you. Modelled on
+// docs/examples/monophonic.musicxml for the shape (divisions, <sound tempo>)
+// and web/test-fixtures/notation-only.musicxml for a pitched, non-percussion
+// part that renders under the "score" profile without a tab staff.
+//
+// 6/8 at a declared tempo of 96 BPM (always quarter-note BPM - see
+// metronome.js's secondsPerClick) is the one fact these tests are built
+// around: it is a compound meter (six eighth-note clicks per bar, accented
+// on the 1st and 4th - see metronomePattern), and 96 is a base the
+// proportion tests below multiply and divide by round numbers.
+//
+// MEASURE_COUNT repeats of the one bar, not one - the slow end of these
+// tests (a click every 600ms+, several of them, sometimes under a halved
+// playback speed) needs several real seconds of audio playing, and a single
+// 1.875s bar would demand the tests lean on looping across many passes to
+// get there. Enough measures that the piece's own natural length already
+// covers every test's collection window keeps looping a belt-and-braces
+// safety net rather than something the timing math depends on.
+const MEASURE_COUNT = 8;
+
+const PITCHES = ["C", "D", "E", "F", "G", "A"];
+
+function measure(number) {
+  const attributes =
+    number === 1
+      ? `
+      <attributes>
+        <divisions>480</divisions>
+        <key>
+          <fifths>0</fifths>
+        </key>
+        <time>
+          <beats>6</beats>
+          <beat-type>8</beat-type>
+        </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+        </clef>
+      </attributes>
+      <direction placement="above">
+        <direction-type>
+          <metronome>
+            <beat-unit>quarter</beat-unit>
+            <per-minute>96</per-minute>
+          </metronome>
+        </direction-type>
+        <sound tempo="96" />
+      </direction>`
+      : "";
+  const notes = PITCHES.map(
+    (step) => `
+      <note>
+        <pitch><step>${step}</step><octave>4</octave></pitch>
+        <duration>240</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+      </note>`,
+  ).join("");
+  return `    <measure number="${number}">${attributes}${notes}
+    </measure>`;
+}
+
+export const METRONOME_MUSICXML = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.musicxml.org/xsd/musicxml.xsd">
+  <work>
+    <work-title>Metronome test fixture</work-title>
+  </work>
+  <identification>
+    <encoding>
+      <software>Fermata test fixture</software>
+      <encoding-date>2026-08-20</encoding-date>
+    </encoding>
+  </identification>
+  <part-list>
+    <score-part id="P1">
+      <part-name>Piano</part-name>
+      <score-instrument id="P1-I1">
+        <instrument-name>Piano</instrument-name>
+      </score-instrument>
+      <midi-instrument id="P1-I1">
+        <midi-channel>1</midi-channel>
+        <midi-program>1</midi-program>
+      </midi-instrument>
+    </score-part>
+  </part-list>
+  <part id="P1">
+${Array.from({ length: MEASURE_COUNT }, (_, i) => measure(i + 1)).join("\n")}
+  </part>
+</score-partwise>
+`;
+
+// file_type not "pdf" is what routes Viewer.svelte to TabViewer directly
+// (see Viewer.svelte) rather than through ScoreCompare/PdfViewer.
+export const METRONOME_SCORE = {
+  id: 1,
+  title: "Metronome test fixture",
+  composer: "",
+  source: "",
+  file_type: "musicxml",
+  has_transcription: false,
+  favorite: false,
+  content_kind: "notation",
+  tags: [],
+};
+
+/** Stubs the /api routes TabViewer/Viewer touch for score id 1, serving
+ * METRONOME_MUSICXML as the file content. */
+export async function stubMetronomeScore(page) {
+  await page.route("**/api/scores/1", (route) => route.fulfill({ json: METRONOME_SCORE }));
+  await page.route("**/api/scores/1/file", (route) =>
+    route.fulfill({ body: METRONOME_MUSICXML, contentType: "application/vnd.recordare.musicxml+xml" }),
+  );
+  await page.route("**/api/scores/1/practice", (route) =>
+    route.fulfill({ json: { total_seconds: 0, sessions: [] } }),
+  );
+}

--- a/web/tests/browser/metronome.spec.js
+++ b/web/tests/browser/metronome.spec.js
@@ -1,21 +1,29 @@
 // The practice metronome (issue #60), against the real alphaTab renderer and
 // a real Web Audio click - not a mock of either.
 //
-// What these are for: the interesting part of this feature is that the click
-// is a SECOND, independent audio path (see createPracticeMetronome in
-// score-render.js) rather than a setting on alphaTab's own player, and that
-// its tempo has nothing to do with setSpeed(). Neither fact is checkable
-// against a value this component merely intended to produce - a UI-side
-// number that just mirrors what a test typed into a field would stay green
-// through a bug in the audio layer itself (the exact failure mode this
-// project has been bitten by before). So every timing assertion here reads
-// real wall-clock gaps between real scheduled clicks (data-metronome-clicks
-// changing on the actual .at-host element - see publishMetronomeClick in
-// score-render.js), and the AudioContext check uses the same "wrap the
-// constructor and count" technique instruments.spec.js uses to prove a click
-// reaches real audio machinery rather than a counter in the component.
+// Every timing and accent assertion here reads the instant and frequency
+// actually handed to Web Audio (OscillatorNode.prototype.start, wrapped in
+// beforeEach) rather than a value the interface reports ALONGSIDE that call.
+// That distinction is the point, not decoration: the click count and accent
+// flag score-render.js writes to the DOM used to be published from a
+// SEPARATE call sibling to the one that actually creates the oscillator, so
+// deleting the real scheduling call entirely left every dataset-based
+// assertion in an earlier version of this suite passing regardless - the
+// exact "asserts what the code intended, not what it did" failure this
+// project has shipped more than once (see score-render.js's own comment on
+// scheduleClick for the fix: onClick now fires from INSIDE it). Wrapping
+// OscillatorNode.prototype.start closes that gap from the test side too: it
+// cannot be satisfied by anything short of a real oscillator node actually
+// being started, on the real audio clock, at the real frequency - the same
+// "wrap the constructor and count" principle instruments.spec.js uses for
+// AudioContext, one level more specific.
 import { expect, test } from "@playwright/test";
-import { stubMetronomeScore } from "./fixtures/metronome-score.js";
+import {
+  stubMetronomeScore,
+  stubMetronomeScoreOther,
+  stubMetronomeScoreRepeat,
+  stubMetronomeScoreShortLoop,
+} from "./fixtures/metronome-score.js";
 
 const host = (page) => page.locator(".at-host");
 const playButton = (page) => page.locator(".player button.primary");
@@ -25,11 +33,18 @@ const proportionInput = (page) => page.locator("input.metronome-proportion");
 const bpmInput = (page) => page.locator("input.metronome-bpm");
 const speedSelect = (page) => page.locator('select[title="Playback speed"]');
 const loopButton = (page) => page.locator('button:has-text("Loop")');
+const countInButton = (page) => page.locator('button:has-text("Count-in")');
+// Roughly halfway between METRONOME_TICK_HZ (950) and METRONOME_ACCENT_HZ
+// (1500) in score-render.js - a threshold rather than an exact match so this
+// suite is not coupled to the precise constants, only to "clearly the higher
+// one".
+const ACCENT_HZ_THRESHOLD = 1200;
 
 test.beforeEach(async ({ page }) => {
-  // Independent evidence that a click reaches real audio machinery, not just
-  // a value in a Svelte $state - see instruments.spec.js for the same trick.
-  await page.addInitScript(() => {
+  await page.addInitScript((accentThreshold) => {
+    // Independent evidence that a click reaches real audio machinery, not
+    // just a value in a Svelte $state - see instruments.spec.js for the same
+    // trick applied to AudioContext.
     window.__audioContexts = 0;
     for (const name of ["AudioContext", "webkitAudioContext"]) {
       const Original = window[name];
@@ -41,32 +56,43 @@ test.beforeEach(async ({ page }) => {
         }
       };
     }
-  });
+    // The ground truth for every timing and accent assertion below: the
+    // exact audio-clock instant (`when`, in the AudioContext's own seconds)
+    // and frequency actually handed to a real OscillatorNode's start() -
+    // not a wall-clock Date.now() sampled whenever Playwright's polling
+    // happened to notice a dataset attribute change (which has its own
+    // jitter and, at a fast enough click rate, can even collapse several
+    // real clicks into what looks like one), and not a value published by
+    // code that runs alongside the real scheduling call rather than only as
+    // a consequence of it.
+    window.__oscillatorStarts = [];
+    window.__accentHzThreshold = accentThreshold;
+    const OriginalStart = OscillatorNode.prototype.start;
+    OscillatorNode.prototype.start = function (when, ...rest) {
+      window.__oscillatorStarts.push({ when: when ?? 0, frequency: this.frequency.value });
+      return OriginalStart.call(this, when, ...rest);
+    };
+  }, ACCENT_HZ_THRESHOLD);
   await stubMetronomeScore(page);
+  await stubMetronomeScoreOther(page);
+  await stubMetronomeScoreShortLoop(page);
+  await stubMetronomeScoreRepeat(page);
   await page.goto("/#/score/1");
   await expect(playButton(page)).toBeEnabled({ timeout: 30_000 });
 });
 
-/** Waits until the real, scheduled click count on the host reaches `n`, then
- * records the wall-clock time it happened - not a value read out of a
- * MutationObserver batch (which can coalesce several rapid same-attribute
- * changes into one callback and silently under-count), but the ground-truth
- * counter itself, polled until it says so. */
-async function waitForClickCount(page, n, timeout = 20_000) {
-  await page.waitForFunction(
-    (count) => Number(document.querySelector(".at-host")?.dataset.metronomeClicks || 0) >= count,
-    n,
-    { timeout },
-  );
-  return Date.now();
+/** Waits until `n` real oscillators have been started, then returns their
+ * {when, frequency} records - the ground truth described above. */
+async function oscillatorStarts(page, n, timeout = 20_000) {
+  await page.waitForFunction((count) => (window.__oscillatorStarts?.length ?? 0) >= count, n, { timeout });
+  return page.evaluate((count) => window.__oscillatorStarts.slice(0, count), n);
 }
 
-/** Real wall-clock gaps between the 1st..Nth scheduled click. */
-async function measureClickIntervals(page, count) {
-  const times = [];
-  for (let n = 1; n <= count; n++) times.push(await waitForClickCount(page, n));
+/** Real audio-clock gaps, in milliseconds, between the 1st..Nth real click. */
+async function clickGapsMs(page, n, timeout) {
+  const starts = await oscillatorStarts(page, n, timeout);
   const gaps = [];
-  for (let i = 1; i < times.length; i++) gaps.push(times[i] - times[i - 1]);
+  for (let i = 1; i < starts.length; i++) gaps.push((starts[i].when - starts[i - 1].when) * 1000);
   return gaps;
 }
 
@@ -74,7 +100,37 @@ function average(values) {
   return values.reduce((a, b) => a + b, 0) / values.length;
 }
 
-test("the metronome is a second, independent audio path: off produces nothing, on while playing creates a real AudioContext and starts real scheduled clicks, off stops them again", async ({
+/** Waits until the real, scheduled click count on the host reaches `n` - a
+ * valid synchronisation point now that publishMetronomeClick's dataset write
+ * happens from inside the same real scheduling call oscillatorStarts reads
+ * (see score-render.js's scheduleClick). Used for meter/accent/phase
+ * bookkeeping oscillator frequency alone cannot carry (which bar, which
+ * slot in it). */
+async function waitForClickCount(page, n, timeout = 20_000) {
+  await page.waitForFunction(
+    (count) => Number(document.querySelector(".at-host")?.dataset.metronomeClicks || 0) >= count,
+    n,
+    { timeout },
+  );
+}
+
+/** The 1st..Nth click's dataset snapshot (meter/phase), read immediately
+ * after each one is confirmed scheduled. */
+async function collectClickMeta(page, count) {
+  const out = [];
+  for (let n = 1; n <= count; n++) {
+    await waitForClickCount(page, n);
+    const [numerator, denominator, phase] = await Promise.all([
+      host(page).getAttribute("data-metronome-numerator"),
+      host(page).getAttribute("data-metronome-denominator"),
+      host(page).getAttribute("data-metronome-phase"),
+    ]);
+    out.push({ numerator, denominator, phase: Number(phase) });
+  }
+  return out;
+}
+
+test("the metronome is a second, independent audio path: off produces no real oscillators, on while playing starts a real AudioContext and real clicks, off stops scheduling more", async ({
   page,
 }) => {
   // Not yet playing, not yet enabled - toggling it on here must not create
@@ -82,6 +138,7 @@ test("the metronome is a second, independent audio path: off produces nothing, o
   // score-render.js, which only run once playback actually starts.
   await metronomeButton(page).click();
   const beforePlay = await page.evaluate(() => window.__audioContexts);
+  expect(await page.evaluate(() => window.__oscillatorStarts.length)).toBe(0);
 
   await playButton(page).click();
   // Proves an AudioContext attributable to enabling+playing the metronome
@@ -89,73 +146,82 @@ test("the metronome is a second, independent audio path: off produces nothing, o
   // put it there ahead of the scheduler's own ensureAudioCtx() a moment
   // later. Telling those two apart would mean asserting on Chromium's
   // autoplay-gesture policy actually denying a late resume() in this
-  // harness, which was not attempted - see the PR description for why
-  // prime() exists and what verifying it would take.
+  // harness, which was not attempted.
   await expect
     .poll(() => page.evaluate(() => window.__audioContexts), { timeout: 5_000 })
     .toBeGreaterThan(beforePlay);
 
-  await waitForClickCount(page, 3);
-  const clicksWhileOn = Number(await host(page).getAttribute("data-metronome-clicks"));
-  expect(clicksWhileOn).toBeGreaterThanOrEqual(3);
+  await oscillatorStarts(page, 3);
+  const startsWhileOn = (await page.evaluate(() => window.__oscillatorStarts.length));
+  expect(startsWhileOn).toBeGreaterThanOrEqual(3);
 
-  // Turning it off mid-playback must stop the scheduler, not just mute
-  // alphaTab's own (permanently-muted) metronome - the count must actually
-  // stop moving, not merely stop being audible.
+  // Turning it off mid-playback must stop the scheduler from starting any
+  // MORE real oscillators - not merely stop being audible (alphaTab's own,
+  // permanently-muted metronome is a separate thing entirely).
   await metronomeButton(page).click();
   await page.waitForTimeout(700);
-  const clicksAfterOff = Number(await host(page).getAttribute("data-metronome-clicks"));
-  expect(clicksAfterOff).toBe(clicksWhileOn);
+  const startsAfterOff = await page.evaluate(() => window.__oscillatorStarts.length);
+  expect(startsAfterOff).toBe(startsWhileOn);
 });
 
-test("the live tempo shown on the button is the value score-render.js is actually clicking at, not a number the component computed separately", async ({
+test("the live tempo shown is the actual click RATE - clicks per minute, matching the real measured gap between clicks, not a quarter-note figure a listener would have to convert", async ({
   page,
 }) => {
   await metronomeButton(page).click();
   await playButton(page).click();
-  await waitForClickCount(page, 1);
 
-  // The fixture's own declared tempo (96 BPM) at the default 100% proportion -
-  // read back from the SAME attribute the audio scheduler itself writes (see
-  // publishMetronomeClick), and cross-checked against the visible button text.
-  await expect(host(page)).toHaveAttribute("data-metronome-bpm", "96");
-  await expect(metronomeButton(page).locator(".metronome-readout")).toHaveText("96");
+  // 6/8 at the fixture's declared 96 quarter-note BPM, default 100%
+  // proportion: 96 quarters a minute is 192 EIGHTHS a minute, since each
+  // quarter is two eighths - and 192, not 96, is both what the readout must
+  // show and the real measured rate below.
+  await expect(host(page)).toHaveAttribute("data-metronome-bpm", "192");
+  await expect(metronomeButton(page).locator(".metronome-readout")).toHaveText("192");
+
+  const gaps = await clickGapsMs(page, 4);
+  // 60_000 / 192 = 312.5ms - measured on the real audio clock, which the
+  // review measured as effectively driftless, so this can be tight.
+  for (const gap of gaps) {
+    expect(gap, `gaps: ${gaps.join(", ")}`).toBeGreaterThan(300);
+    expect(gap, `gaps: ${gaps.join(", ")}`).toBeLessThan(325);
+  }
 });
 
-test("6/8 clicks six per bar on the eighth note, accented on the 1st and 4th - not the notated beat, and not just the downbeat", async ({
+test("6/8 accents every third eighth, exactly where the real phase says it should - verified against the real oscillator frequency, not just the dataset flag reported alongside it", async ({
   page,
 }) => {
-  await metronomeButton(page).click();
-  // Slow enough (48 BPM quarter, an eighth-note click every 625ms) that a
-  // same-step read immediately after each threshold is well clear of the
-  // next scheduled click - see measureClickIntervals's comment on why this
-  // suite reads the ground-truth counter rather than an observer batch.
-  await modeSelect(page).selectOption("proportion");
-  await proportionInput(page).fill("50");
-  await proportionInput(page).press("Tab");
+  // Deliberately does not assume which phase slot the run happens to start
+  // on. alphaTab's own player has its own startup latency separate from
+  // this click's clock (they are two independent AudioContexts, primed at
+  // slightly different moments - see prime() in score-render.js), so the
+  // very first click or two of a fresh play can land while the real
+  // playhead has not genuinely started advancing yet, showing an
+  // artificially low phase - correct given the real information available
+  // at that instant, not a defect in reading it. Waiting past that startup
+  // window before switching the metronome on, as this test does, is what
+  // makes the phase run predictable enough to assert on tightly - each
+  // click exactly one slot after the last, wrapping at six - without
+  // depending on exactly where that run begins.
+  await loopButton(page).click();
   await playButton(page).click();
+  await page.waitForTimeout(500);
+  await metronomeButton(page).click();
 
-  const accents = [];
-  const timeSignatures = new Set();
-  for (let n = 1; n <= 6; n++) {
-    await waitForClickCount(page, n);
-    const [accent, numerator, denominator] = await Promise.all([
-      host(page).getAttribute("data-metronome-accent"),
-      host(page).getAttribute("data-metronome-numerator"),
-      host(page).getAttribute("data-metronome-denominator"),
-    ]);
-    accents.push(accent === "true");
-    timeSignatures.add(`${numerator}/${denominator}`);
+  const [starts, meta] = await Promise.all([oscillatorStarts(page, 6), collectClickMeta(page, 6)]);
+  expect(new Set(meta.map((c) => `${c.numerator}/${c.denominator}`))).toEqual(new Set(["6/8"]));
+
+  const phases = meta.map((c) => c.phase);
+  for (let i = 1; i < phases.length; i++) {
+    expect(phases[i], `phases: ${phases.join(", ")}`).toBe((phases[i - 1] + 1) % 6);
   }
 
-  expect([...timeSignatures]).toEqual(["6/8"]);
-  // clickIndex resets to 0 when playback starts, so the very first click of
-  // this run is index 0 (accented), then 1 and 2 are subdivision-only, then
-  // index 3 - the bar's second main pulse - is accented again.
-  expect(accents).toEqual([true, false, false, true, false, false]);
+  // The real oscillator frequency, not the dataset accent flag alongside
+  // it, has to agree with what the real phase says should be accented -
+  // every third slot (0, 3) starting from the downbeat.
+  const accents = starts.map((s) => s.frequency > ACCENT_HZ_THRESHOLD);
+  expect(accents).toEqual(phases.map((p) => p % 3 === 0));
 });
 
-test("a fixed BPM click holds its own rate regardless of playback speed - the whole point of separating the two", async ({
+test("fixed-BPM mode clicks the typed rate itself, in every meter - not a quarter-note tempo converted onto the meter's unit", async ({
   page,
 }) => {
   await metronomeButton(page).click();
@@ -164,16 +230,24 @@ test("a fixed BPM click holds its own rate regardless of playback speed - the wh
   await bpmInput(page).press("Tab");
   // Playback itself slowed to a quarter of the click's own tempo - if the
   // click were still riding on alphaTab's playbackSpeed (the bug this issue
-  // exists to fix), the gap below would come out around 500ms, not 125ms.
+  // exists to fix), the gap below would come out around 1000ms, not 250ms.
   await speedSelect(page).selectOption("0.5");
   await loopButton(page).click();
   await playButton(page).click();
 
-  const gaps = await measureClickIntervals(page, 6);
-  // 240 BPM, eighth-note clicks (6/8): 60/240 * 4/8 = 0.125s = 125ms.
-  const avg = average(gaps);
-  expect(avg, `gaps: ${gaps.join(", ")}`).toBeGreaterThan(85);
-  expect(avg, `gaps: ${gaps.join(", ")}`).toBeLessThan(200);
+  await expect(metronomeButton(page).locator(".metronome-readout")).toHaveText("240");
+
+  const gaps = await clickGapsMs(page, 6);
+  // 240 BPM IS the click rate here, full stop - 60,000/240 = 250ms exactly,
+  // regardless of the 6/8 meter's own eighth-note unit. The real audio
+  // clock measures this with effectively no jitter, so the bounds only need
+  // to be wide enough to rule out the two wrong answers this could produce:
+  // 125ms (proportion mode's quarter-note-onto-eighth conversion applied to
+  // 240 instead) or 500ms (still coupled to the halved playback speed).
+  for (const gap of gaps) {
+    expect(gap, `gaps: ${gaps.join(", ")}`).toBeGreaterThan(240);
+    expect(gap, `gaps: ${gaps.join(", ")}`).toBeLessThan(260);
+  }
 });
 
 test("a proportion click tracks the score's own tempo, not the playback speed set alongside it", async ({
@@ -181,22 +255,26 @@ test("a proportion click tracks the score's own tempo, not the playback speed se
 }) => {
   await metronomeButton(page).click();
   await modeSelect(page).selectOption("proportion");
-  // 25% of the fixture's declared 96 BPM is 24 BPM - an eighth-note click
-  // every 60/24 * 4/8 = 1.25s. Playback itself sped UP to double, in the
-  // opposite direction from the bpm-mode test above: if the click's tempo
-  // were still tied to playbackSpeed, this gap would come out around 625ms,
-  // not 1250ms - proving the decoupling holds in both directions, not just
-  // the one the other test happens to check.
+  // 25% of the fixture's declared 96 BPM, converted onto the 6/8 eighth-note
+  // unit: 96 * 0.25 * 2 = 48 clicks a minute, a click every 1250ms. Playback
+  // itself sped UP to double, in the opposite direction from the bpm-mode
+  // test above: if the click's tempo were still tied to playbackSpeed, this
+  // gap would come out around 625ms, not 1250ms - proving the decoupling
+  // holds in both directions, not just the one the other test happens to
+  // check.
   await proportionInput(page).fill("25");
   await proportionInput(page).press("Tab");
   await speedSelect(page).selectOption("1.25");
   await loopButton(page).click();
   await playButton(page).click();
 
-  const gaps = await measureClickIntervals(page, 4);
-  const avg = average(gaps);
-  expect(avg, `gaps: ${gaps.join(", ")}`).toBeGreaterThan(950);
-  expect(avg, `gaps: ${gaps.join(", ")}`).toBeLessThan(1450);
+  await expect(metronomeButton(page).locator(".metronome-readout")).toHaveText("48");
+
+  const gaps = await clickGapsMs(page, 4);
+  for (const gap of gaps) {
+    expect(gap, `gaps: ${gaps.join(", ")}`).toBeGreaterThan(1235);
+    expect(gap, `gaps: ${gaps.join(", ")}`).toBeLessThan(1265);
+  }
 });
 
 test("gig mode shows the live tempo but not the mode/value controls - a stand is not where those get set", async ({
@@ -204,12 +282,179 @@ test("gig mode shows the live tempo but not the mode/value controls - a stand is
 }) => {
   await metronomeButton(page).click();
   await playButton(page).click();
-  await waitForClickCount(page, 1);
+  await oscillatorStarts(page, 1);
 
   await page.locator('button[title*="Distraction-free"]').click();
   await expect(page.locator(".gig-hud")).toBeVisible();
-  await expect(page.locator(".gig-hud .metronome-indicator")).toHaveText("♩ 96");
+  await expect(page.locator(".gig-hud .metronome-indicator")).toHaveText("♩ 192");
   // the toolbar - and the mode/proportion/bpm controls in it - is gone
   await expect(page.locator("select.metronome-mode")).toHaveCount(0);
   await expect(page.locator("input.metronome-proportion")).toHaveCount(0);
+});
+
+test("enabling the metronome mid-bar accents wherever the music actually is, not the start of a fresh count", async ({
+  page,
+}) => {
+  // Play first, with the metronome OFF, and let real playback run into the
+  // middle of bar 1 (6/8 at 96 BPM: each eighth is 0.3125s, so bar 1 spans
+  // 0-1.875s; waiting 1.1s lands around the 3rd-4th eighth) BEFORE switching
+  // the click on. A phase that only ever resets to 0 when the scheduler
+  // starts would report phase 0 here regardless - this is what tells that
+  // apart from a phase actually read off the playhead.
+  await loopButton(page).click();
+  await playButton(page).click();
+  await page.waitForTimeout(1100);
+  await metronomeButton(page).click();
+
+  const [meta] = await collectClickMeta(page, 1);
+  expect(meta.numerator).toBe("6");
+  expect(meta.denominator).toBe("8");
+  expect(meta.phase).not.toBe(0);
+});
+
+test("the click stays silent during the count-in and starts only once real playback begins", async ({
+  page,
+}) => {
+  await metronomeButton(page).click();
+  await countInButton(page).click();
+  await playButton(page).click();
+
+  // The count-in for this fixture (6/8 at 96 BPM) is one bar - about 1.875s
+  // at the count-in's own (unscaled) tempo. Well inside that window not one
+  // real oscillator may have been started, regardless of what alphaTab's
+  // own (separately volumed, never muted) count-in click is doing.
+  await page.waitForTimeout(1000);
+  expect(await page.evaluate(() => window.__oscillatorStarts.length)).toBe(0);
+
+  // ...and it does start, once the count-in finishes - silence forever would
+  // pass the assertion above for the wrong reason.
+  await oscillatorStarts(page, 1, 5_000);
+});
+
+test("a loop whose length is not a whole number of click periods does not walk the accent off the downbeat after it wraps", async ({
+  page,
+}) => {
+  // The headline case from the review: a short loop (2 bars of 6/8 at 96
+  // BPM - 3.75s of real audio) clicked at 70% (~0.446s/click, chosen so
+  // neither the click period nor the bar period divides the other evenly).
+  // A phase carried forward as a counter that only resets when the
+  // scheduler starts would settle into a perfectly regular "+1 mod 6" cycle
+  // measured by click count and stay there forever, oblivious to the loop
+  // restarting under it. A phase read fresh from the playhead cannot: the
+  // real position resets at every bar (twice a loop here), out of step with
+  // the click's own cadence, so somewhere in a long-enough run the naive
+  // "next phase = previous + 1" prediction has to be wrong.
+  await page.goto("/#/score/3");
+  await expect(playButton(page)).toBeEnabled({ timeout: 30_000 });
+  await metronomeButton(page).click();
+  await modeSelect(page).selectOption("proportion");
+  await proportionInput(page).fill("70");
+  await proportionInput(page).press("Tab");
+  await loopButton(page).click();
+  await playButton(page).click();
+
+  const meta = await collectClickMeta(page, 24);
+  expect(new Set(meta.map((c) => `${c.numerator}/${c.denominator}`))).toEqual(new Set(["6/8"]));
+  expect(meta.every((c) => c.phase >= 0 && c.phase < 6)).toBe(true);
+
+  const naiveIncrement = meta.slice(1).some((c, i) => c.phase !== (meta[i].phase + 1) % 6);
+  expect(naiveIncrement, `phases: ${meta.map((c) => c.phase).join(", ")}`).toBe(true);
+});
+
+test("a repeat sign does not desync the click's meter - the second pass of a repeated section still reports the repeated meter, not whatever bar follows it", async ({
+  page,
+}) => {
+  // Two bars of 4/4 at 120 BPM, repeated once, then one bar of 6/8 - three
+  // NOTATED bars playing as five (4/4, 4/4, 4/4, 4/4, 6/8). A tick->meter
+  // index built by summing NOTATED bar durations would place the 6/8 bar
+  // right after the repeated section's FIRST pass (4s in) rather than after
+  // its second (8s in), misreporting the meter - and therefore the click
+  // rate - for the whole second pass. See metronome-score.js for the fixture
+  // and metronome.js's barAtTick for why this has to come from alphaTab's
+  // own generated-MIDI tick lookup instead.
+  await page.goto("/#/score/4");
+  await expect(playButton(page)).toBeEnabled({ timeout: 30_000 });
+  await metronomeButton(page).click();
+  await modeSelect(page).selectOption("proportion");
+  await proportionInput(page).fill("100");
+  await proportionInput(page).press("Tab");
+  await playButton(page).click();
+
+  // 4/4 at 120 BPM clicks a quarter note every 0.5s. The repeated section's
+  // SECOND pass runs from real time 4s to 8s - click #12 (at ~6s) lands
+  // squarely inside it, well clear of either boundary.
+  const meta = await collectClickMeta(page, 12);
+  for (const c of meta) {
+    expect(`${c.numerator}/${c.denominator}`, JSON.stringify(meta)).toBe("4/4");
+  }
+
+  // ...and playback does go on to reach the 6/8 bar - confirming the meter
+  // actually changes once the repeat is behind it, rather than this fixture
+  // having failed to reach bar 3 at all within the test's patience.
+  await page.waitForFunction(
+    () => document.querySelector(".at-host")?.dataset.metronomeDenominator === "8",
+    { timeout: 15_000 },
+  );
+});
+
+test("switching a mounted viewer to a different score resets the metronome's click counter instead of inheriting the previous score's count", async ({
+  page,
+}) => {
+  await metronomeButton(page).click();
+  await playButton(page).click();
+  await waitForClickCount(page, 3);
+  const beforeSwitch = Number(await host(page).getAttribute("data-metronome-clicks"));
+  expect(beforeSwitch).toBeGreaterThanOrEqual(3);
+
+  // A same-document hash change - the SPA's own router, not a full
+  // navigation - so the same TabViewer instance (and the same host element)
+  // is what score-render.js's next createScoreView call has to leave clean,
+  // exactly the scenario publish()'s own dataset.scoreProfiles delete
+  // exists for.
+  await page.evaluate(() => {
+    location.hash = "#/score/2";
+  });
+  await expect(playButton(page)).toBeEnabled({ timeout: 30_000 });
+
+  // Immediately on the new view existing - before anything has had a chance
+  // to play - the stale count must already be gone, not merely about to be
+  // overtaken by fresh clicks that would mask it passing this assertion for
+  // the wrong reason.
+  expect(await host(page).getAttribute("data-metronome-clicks")).toBeNull();
+});
+
+test("a stall longer than the scheduler's lookahead drops the missed clicks instead of firing them all at once", async ({
+  page,
+}) => {
+  await metronomeButton(page).click();
+  await modeSelect(page).selectOption("bpm");
+  // Fast enough (300 BPM = one click every 200ms) that a 700ms stall would
+  // miss three or four clicks under the bug this guards against - clearly
+  // enough to tell a burst apart from ordinary scheduling.
+  await bpmInput(page).fill("300");
+  await bpmInput(page).press("Tab");
+  await loopButton(page).click();
+  await playButton(page).click();
+
+  // A baseline click or two before the stall.
+  await oscillatorStarts(page, 2);
+
+  // Blocks the page's own main thread - where the scheduler's setInterval
+  // runs - for long enough to fall behind. The AudioContext clock this is
+  // measured against lives on a separate audio thread and keeps advancing
+  // throughout, which is exactly what creates the stall this reproduces.
+  await page.evaluate(() => {
+    const until = Date.now() + 700;
+    while (Date.now() < until) {
+      /* deliberately busy-blocking the main thread */
+    }
+  });
+
+  const gaps = await clickGapsMs(page, 8);
+  // A burst reads as one or more near-zero real-audio-clock gaps clustered
+  // together - Web Audio starts every oscillator whose scheduled `when` has
+  // already passed essentially at once. Half the nominal 200ms interval is
+  // generous enough to allow for the catch-up guard's own small resync gap
+  // while still catching a genuine pile-up.
+  expect(gaps.every((g) => g > 90), `gaps: ${gaps.join(", ")}`).toBe(true);
 });

--- a/web/tests/browser/metronome.spec.js
+++ b/web/tests/browser/metronome.spec.js
@@ -1,0 +1,215 @@
+// The practice metronome (issue #60), against the real alphaTab renderer and
+// a real Web Audio click - not a mock of either.
+//
+// What these are for: the interesting part of this feature is that the click
+// is a SECOND, independent audio path (see createPracticeMetronome in
+// score-render.js) rather than a setting on alphaTab's own player, and that
+// its tempo has nothing to do with setSpeed(). Neither fact is checkable
+// against a value this component merely intended to produce - a UI-side
+// number that just mirrors what a test typed into a field would stay green
+// through a bug in the audio layer itself (the exact failure mode this
+// project has been bitten by before). So every timing assertion here reads
+// real wall-clock gaps between real scheduled clicks (data-metronome-clicks
+// changing on the actual .at-host element - see publishMetronomeClick in
+// score-render.js), and the AudioContext check uses the same "wrap the
+// constructor and count" technique instruments.spec.js uses to prove a click
+// reaches real audio machinery rather than a counter in the component.
+import { expect, test } from "@playwright/test";
+import { stubMetronomeScore } from "./fixtures/metronome-score.js";
+
+const host = (page) => page.locator(".at-host");
+const playButton = (page) => page.locator(".player button.primary");
+const metronomeButton = (page) => page.locator('button:has-text("Metronome")');
+const modeSelect = (page) => page.locator("select.metronome-mode");
+const proportionInput = (page) => page.locator("input.metronome-proportion");
+const bpmInput = (page) => page.locator("input.metronome-bpm");
+const speedSelect = (page) => page.locator('select[title="Playback speed"]');
+const loopButton = (page) => page.locator('button:has-text("Loop")');
+
+test.beforeEach(async ({ page }) => {
+  // Independent evidence that a click reaches real audio machinery, not just
+  // a value in a Svelte $state - see instruments.spec.js for the same trick.
+  await page.addInitScript(() => {
+    window.__audioContexts = 0;
+    for (const name of ["AudioContext", "webkitAudioContext"]) {
+      const Original = window[name];
+      if (!Original) continue;
+      window[name] = class extends Original {
+        constructor(...args) {
+          super(...args);
+          window.__audioContexts += 1;
+        }
+      };
+    }
+  });
+  await stubMetronomeScore(page);
+  await page.goto("/#/score/1");
+  await expect(playButton(page)).toBeEnabled({ timeout: 30_000 });
+});
+
+/** Waits until the real, scheduled click count on the host reaches `n`, then
+ * records the wall-clock time it happened - not a value read out of a
+ * MutationObserver batch (which can coalesce several rapid same-attribute
+ * changes into one callback and silently under-count), but the ground-truth
+ * counter itself, polled until it says so. */
+async function waitForClickCount(page, n, timeout = 20_000) {
+  await page.waitForFunction(
+    (count) => Number(document.querySelector(".at-host")?.dataset.metronomeClicks || 0) >= count,
+    n,
+    { timeout },
+  );
+  return Date.now();
+}
+
+/** Real wall-clock gaps between the 1st..Nth scheduled click. */
+async function measureClickIntervals(page, count) {
+  const times = [];
+  for (let n = 1; n <= count; n++) times.push(await waitForClickCount(page, n));
+  const gaps = [];
+  for (let i = 1; i < times.length; i++) gaps.push(times[i] - times[i - 1]);
+  return gaps;
+}
+
+function average(values) {
+  return values.reduce((a, b) => a + b, 0) / values.length;
+}
+
+test("the metronome is a second, independent audio path: off produces nothing, on while playing creates a real AudioContext and starts real scheduled clicks, off stops them again", async ({
+  page,
+}) => {
+  // Not yet playing, not yet enabled - toggling it on here must not create
+  // any audio machinery by itself; see prime()/ensureAudioCtx in
+  // score-render.js, which only run once playback actually starts.
+  await metronomeButton(page).click();
+  const beforePlay = await page.evaluate(() => window.__audioContexts);
+
+  await playButton(page).click();
+  // Proves an AudioContext attributable to enabling+playing the metronome
+  // exists at all - not, on its own, that playPause()'s prime() call is what
+  // put it there ahead of the scheduler's own ensureAudioCtx() a moment
+  // later. Telling those two apart would mean asserting on Chromium's
+  // autoplay-gesture policy actually denying a late resume() in this
+  // harness, which was not attempted - see the PR description for why
+  // prime() exists and what verifying it would take.
+  await expect
+    .poll(() => page.evaluate(() => window.__audioContexts), { timeout: 5_000 })
+    .toBeGreaterThan(beforePlay);
+
+  await waitForClickCount(page, 3);
+  const clicksWhileOn = Number(await host(page).getAttribute("data-metronome-clicks"));
+  expect(clicksWhileOn).toBeGreaterThanOrEqual(3);
+
+  // Turning it off mid-playback must stop the scheduler, not just mute
+  // alphaTab's own (permanently-muted) metronome - the count must actually
+  // stop moving, not merely stop being audible.
+  await metronomeButton(page).click();
+  await page.waitForTimeout(700);
+  const clicksAfterOff = Number(await host(page).getAttribute("data-metronome-clicks"));
+  expect(clicksAfterOff).toBe(clicksWhileOn);
+});
+
+test("the live tempo shown on the button is the value score-render.js is actually clicking at, not a number the component computed separately", async ({
+  page,
+}) => {
+  await metronomeButton(page).click();
+  await playButton(page).click();
+  await waitForClickCount(page, 1);
+
+  // The fixture's own declared tempo (96 BPM) at the default 100% proportion -
+  // read back from the SAME attribute the audio scheduler itself writes (see
+  // publishMetronomeClick), and cross-checked against the visible button text.
+  await expect(host(page)).toHaveAttribute("data-metronome-bpm", "96");
+  await expect(metronomeButton(page).locator(".metronome-readout")).toHaveText("96");
+});
+
+test("6/8 clicks six per bar on the eighth note, accented on the 1st and 4th - not the notated beat, and not just the downbeat", async ({
+  page,
+}) => {
+  await metronomeButton(page).click();
+  // Slow enough (48 BPM quarter, an eighth-note click every 625ms) that a
+  // same-step read immediately after each threshold is well clear of the
+  // next scheduled click - see measureClickIntervals's comment on why this
+  // suite reads the ground-truth counter rather than an observer batch.
+  await modeSelect(page).selectOption("proportion");
+  await proportionInput(page).fill("50");
+  await proportionInput(page).press("Tab");
+  await playButton(page).click();
+
+  const accents = [];
+  const timeSignatures = new Set();
+  for (let n = 1; n <= 6; n++) {
+    await waitForClickCount(page, n);
+    const [accent, numerator, denominator] = await Promise.all([
+      host(page).getAttribute("data-metronome-accent"),
+      host(page).getAttribute("data-metronome-numerator"),
+      host(page).getAttribute("data-metronome-denominator"),
+    ]);
+    accents.push(accent === "true");
+    timeSignatures.add(`${numerator}/${denominator}`);
+  }
+
+  expect([...timeSignatures]).toEqual(["6/8"]);
+  // clickIndex resets to 0 when playback starts, so the very first click of
+  // this run is index 0 (accented), then 1 and 2 are subdivision-only, then
+  // index 3 - the bar's second main pulse - is accented again.
+  expect(accents).toEqual([true, false, false, true, false, false]);
+});
+
+test("a fixed BPM click holds its own rate regardless of playback speed - the whole point of separating the two", async ({
+  page,
+}) => {
+  await metronomeButton(page).click();
+  await modeSelect(page).selectOption("bpm");
+  await bpmInput(page).fill("240");
+  await bpmInput(page).press("Tab");
+  // Playback itself slowed to a quarter of the click's own tempo - if the
+  // click were still riding on alphaTab's playbackSpeed (the bug this issue
+  // exists to fix), the gap below would come out around 500ms, not 125ms.
+  await speedSelect(page).selectOption("0.5");
+  await loopButton(page).click();
+  await playButton(page).click();
+
+  const gaps = await measureClickIntervals(page, 6);
+  // 240 BPM, eighth-note clicks (6/8): 60/240 * 4/8 = 0.125s = 125ms.
+  const avg = average(gaps);
+  expect(avg, `gaps: ${gaps.join(", ")}`).toBeGreaterThan(85);
+  expect(avg, `gaps: ${gaps.join(", ")}`).toBeLessThan(200);
+});
+
+test("a proportion click tracks the score's own tempo, not the playback speed set alongside it", async ({
+  page,
+}) => {
+  await metronomeButton(page).click();
+  await modeSelect(page).selectOption("proportion");
+  // 25% of the fixture's declared 96 BPM is 24 BPM - an eighth-note click
+  // every 60/24 * 4/8 = 1.25s. Playback itself sped UP to double, in the
+  // opposite direction from the bpm-mode test above: if the click's tempo
+  // were still tied to playbackSpeed, this gap would come out around 625ms,
+  // not 1250ms - proving the decoupling holds in both directions, not just
+  // the one the other test happens to check.
+  await proportionInput(page).fill("25");
+  await proportionInput(page).press("Tab");
+  await speedSelect(page).selectOption("1.25");
+  await loopButton(page).click();
+  await playButton(page).click();
+
+  const gaps = await measureClickIntervals(page, 4);
+  const avg = average(gaps);
+  expect(avg, `gaps: ${gaps.join(", ")}`).toBeGreaterThan(950);
+  expect(avg, `gaps: ${gaps.join(", ")}`).toBeLessThan(1450);
+});
+
+test("gig mode shows the live tempo but not the mode/value controls - a stand is not where those get set", async ({
+  page,
+}) => {
+  await metronomeButton(page).click();
+  await playButton(page).click();
+  await waitForClickCount(page, 1);
+
+  await page.locator('button[title*="Distraction-free"]').click();
+  await expect(page.locator(".gig-hud")).toBeVisible();
+  await expect(page.locator(".gig-hud .metronome-indicator")).toHaveText("♩ 96");
+  // the toolbar - and the mode/proportion/bpm controls in it - is gone
+  await expect(page.locator("select.metronome-mode")).toHaveCount(0);
+  await expect(page.locator("input.metronome-proportion")).toHaveCount(0);
+});

--- a/web/tests/minimum-tests.js
+++ b/web/tests/minimum-tests.js
@@ -14,21 +14,40 @@
 // is one of the cases this exists to catch, so a filter cannot be the thing that
 // switches the check off. Narrowing a run on purpose is what the escape hatch is
 // for, and CI never sets it.
-const MINIMUM_TESTS = 78;
+//
+// This is also read directly by scripts/run-browser-tests.mjs, which is the
+// OTHER half of this guard - see that file's own comment for why counting
+// here is not, by itself, enough. Keep the two numbers in sync.
+export const MINIMUM_TESTS = 97;
 
 export default class MinimumTests {
-  onBegin(_config, suite) {
-    this.found = suite.allTests().length;
+  constructor() {
+    // Tests that actually ran and were not skipped - NOT suite.allTests()'s
+    // count, which was this class's original approach and has a real hole:
+    // it counts a test.skip()'d test exactly the same as one that passed, so
+    // an entire spec silently marked skip (the same class of failure as a
+    // stray --grep, just spelled differently) sailed straight through this
+    // guard. onTestEnd only fires for a test Playwright actually attempted,
+    // so a --grep-filtered-out test is excluded automatically, same as
+    // before - but now a skipped one is excluded too. Counted regardless of
+    // pass/fail/flaky: a legitimately failing suite must not ALSO report
+    // "tests have gone missing" on top of its real failure, which is exactly
+    // how a guard teaches people to stop reading it.
+    this.executed = 0;
+  }
+
+  onTestEnd(_test, result) {
+    if (result.status !== "skipped") this.executed += 1;
   }
 
   async onEnd(result) {
     if (process.env.PLAYWRIGHT_ALLOW_PARTIAL) return;
-    if (this.found >= MINIMUM_TESTS) return;
+    if (this.executed >= MINIMUM_TESTS) return;
     console.error(
-      `\nExpected at least ${MINIMUM_TESTS} tests, collected ${this.found}. ` +
-        "Tests have gone missing, or the floor in web/tests/minimum-tests.js " +
-        "needs raising on purpose. To run a deliberate subset, set " +
-        "PLAYWRIGHT_ALLOW_PARTIAL=1.",
+      `\nExpected at least ${MINIMUM_TESTS} tests to run, only ${this.executed} did. ` +
+        "Tests have gone missing (skipped, filtered, or deleted), or the floor in " +
+        "web/tests/minimum-tests.js needs raising on purpose. To run a deliberate " +
+        "subset, set PLAYWRIGHT_ALLOW_PARTIAL=1.",
     );
     return { status: result.status === "passed" ? "failed" : result.status };
   }

--- a/web/tests/minimum-tests.js
+++ b/web/tests/minimum-tests.js
@@ -14,7 +14,7 @@
 // is one of the cases this exists to catch, so a filter cannot be the thing that
 // switches the check off. Narrowing a run on purpose is what the escape hatch is
 // for, and CI never sets it.
-const MINIMUM_TESTS = 36;
+const MINIMUM_TESTS = 78;
 
 export default class MinimumTests {
   onBegin(_config, suite) {

--- a/web/tests/unit/metronome.spec.js
+++ b/web/tests/unit/metronome.spec.js
@@ -1,0 +1,204 @@
+// The practice metronome's arithmetic, called directly - no renderer, no
+// audio, no page. See tests/unit/pitch.spec.js for why: metronome.js has no
+// runes and no imports precisely so this can import it.
+import { expect, test } from "@playwright/test";
+
+import {
+  DEFAULT_METRONOME_BPM,
+  FALLBACK_SCORE_TEMPO,
+  MAX_METRONOME_BPM,
+  MIN_METRONOME_BPM,
+  clampBpm,
+  effectiveMetronomeBpm,
+  metronomePattern,
+  secondsPerClick,
+  timeSignatureAtTick,
+} from "../../src/lib/metronome.js";
+
+// ---------------------------------------------------------------- clamping
+
+test("a bpm inside the range is left alone", () => {
+  expect(clampBpm(92)).toBe(92);
+  expect(clampBpm(MIN_METRONOME_BPM)).toBe(MIN_METRONOME_BPM);
+  expect(clampBpm(MAX_METRONOME_BPM)).toBe(MAX_METRONOME_BPM);
+});
+
+test("a bpm outside the range is pulled back to it, not merely reported as invalid", () => {
+  expect(clampBpm(1)).toBe(MIN_METRONOME_BPM);
+  expect(clampBpm(0)).toBe(MIN_METRONOME_BPM);
+  expect(clampBpm(-40)).toBe(MIN_METRONOME_BPM);
+  expect(clampBpm(1000)).toBe(MAX_METRONOME_BPM);
+});
+
+// ------------------------------------------------------------- fixed bpm mode
+
+test("bpm mode ignores the score entirely", () => {
+  // Same bpm, wildly different score tempos - the answer must not move.
+  expect(effectiveMetronomeBpm({ mode: "bpm", bpm: 100, scoreTempo: 60 })).toBe(100);
+  expect(effectiveMetronomeBpm({ mode: "bpm", bpm: 100, scoreTempo: 200 })).toBe(100);
+  expect(effectiveMetronomeBpm({ mode: "bpm", bpm: 100, scoreTempo: null })).toBe(100);
+  // and a proportion sitting alongside it, unused, must not leak in either
+  expect(effectiveMetronomeBpm({ mode: "bpm", bpm: 100, proportion: 0.5, scoreTempo: 60 })).toBe(100);
+});
+
+test("an unusable fixed bpm falls back rather than producing a silent or negative click", () => {
+  for (const bad of [0, -10, Number.NaN, undefined, null]) {
+    expect(effectiveMetronomeBpm({ mode: "bpm", bpm: bad })).toBe(DEFAULT_METRONOME_BPM);
+  }
+});
+
+test("a fixed bpm outside the countable range is still clamped", () => {
+  expect(effectiveMetronomeBpm({ mode: "bpm", bpm: 5 })).toBe(MIN_METRONOME_BPM);
+  expect(effectiveMetronomeBpm({ mode: "bpm", bpm: 900 })).toBe(MAX_METRONOME_BPM);
+});
+
+// ------------------------------------------------------------- proportion mode
+
+test("proportion mode tracks the score tempo it is given, not a value resolved once", () => {
+  // The same call, called again with a different scoreTempo, is how a piece
+  // that changes tempo mid-stream is meant to be tracked - so calling it
+  // twice with two different scoreTempos has to answer two different bpms.
+  expect(effectiveMetronomeBpm({ mode: "proportion", proportion: 1, scoreTempo: 80 })).toBe(80);
+  expect(effectiveMetronomeBpm({ mode: "proportion", proportion: 1, scoreTempo: 160 })).toBe(160);
+});
+
+test("a proportion is taken of the score tempo, not added or substituted", () => {
+  expect(effectiveMetronomeBpm({ mode: "proportion", proportion: 0.7, scoreTempo: 100 })).toBe(70);
+  expect(effectiveMetronomeBpm({ mode: "proportion", proportion: 1.5, scoreTempo: 100 })).toBe(150);
+  // over 100% is a legitimate way to push past what is written, not an error
+  expect(effectiveMetronomeBpm({ mode: "proportion", proportion: 2, scoreTempo: 60 })).toBe(120);
+});
+
+test("a score with no declared tempo degrades to alphaTab's own fallback, not a made-up one", () => {
+  expect(FALLBACK_SCORE_TEMPO).toBe(120);
+  expect(effectiveMetronomeBpm({ mode: "proportion", proportion: 1, scoreTempo: null })).toBe(120);
+  expect(effectiveMetronomeBpm({ mode: "proportion", proportion: 0.5, scoreTempo: undefined })).toBe(60);
+  expect(effectiveMetronomeBpm({ mode: "proportion", proportion: 0.5, scoreTempo: 0 })).toBe(60);
+});
+
+test("an unusable proportion defaults to 100%, not to zero or NaN", () => {
+  for (const bad of [0, -1, Number.NaN, undefined, null]) {
+    expect(effectiveMetronomeBpm({ mode: "proportion", proportion: bad, scoreTempo: 90 })).toBe(90);
+  }
+});
+
+test("proportion mode is clamped at both ends like bpm mode is", () => {
+  expect(effectiveMetronomeBpm({ mode: "proportion", proportion: 0.05, scoreTempo: 100 })).toBe(
+    MIN_METRONOME_BPM,
+  );
+  expect(effectiveMetronomeBpm({ mode: "proportion", proportion: 10, scoreTempo: 100 })).toBe(
+    MAX_METRONOME_BPM,
+  );
+});
+
+// ----------------------------------------------------------------- subdivision
+
+test("simple meters click one per beat, only the downbeat accented", () => {
+  for (const [num, den] of [
+    [2, 4],
+    [3, 4],
+    [4, 4],
+    [5, 4],
+  ]) {
+    const p = metronomePattern(num, den);
+    expect(p, `${num}/${den}`).toEqual({ clicksPerBar: num, accentEvery: num, unit: den });
+  }
+});
+
+test("compound meters click the eighth-note subdivision, accented in threes", () => {
+  for (const [num, den] of [
+    [6, 8],
+    [9, 8],
+    [12, 8],
+    [15, 8],
+  ]) {
+    const p = metronomePattern(num, den);
+    expect(p, `${num}/${den}`).toEqual({ clicksPerBar: num, accentEvery: 3, unit: 8 });
+  }
+});
+
+test("3/8 clicks as a plain three, downbeat accented - compound or not, one bar of three has nothing else to be", () => {
+  const p = metronomePattern(3, 8);
+  expect(p).toEqual({ clicksPerBar: 3, accentEvery: 3, unit: 8 });
+});
+
+test("5/8 and 7/8 are irregular, not compound - one click per eighth, only the downbeat accented", () => {
+  expect(metronomePattern(5, 8)).toEqual({ clicksPerBar: 5, accentEvery: 5, unit: 8 });
+  expect(metronomePattern(7, 8)).toEqual({ clicksPerBar: 7, accentEvery: 7, unit: 8 });
+});
+
+test("an accented click recurs every accentEvery ticks, across more than one bar", () => {
+  // What a scheduler actually uses accentEvery for: is click index i accented?
+  const p = metronomePattern(6, 8);
+  const accented = (i) => i % p.accentEvery === 0;
+  const overTwoBars = Array.from({ length: p.clicksPerBar * 2 }, (_, i) => accented(i));
+  expect(overTwoBars).toEqual([
+    true, false, false, true, false, false, // bar 1: 1, 4
+    true, false, false, true, false, false, // bar 2: 1, 4 again
+  ]);
+});
+
+test("a malformed time signature falls back to 4/4 rather than producing nonsense clicks", () => {
+  expect(metronomePattern(0, 4)).toEqual({ clicksPerBar: 4, accentEvery: 4, unit: 4 });
+  expect(metronomePattern(4, 0)).toEqual({ clicksPerBar: 4, accentEvery: 4, unit: 4 });
+  expect(metronomePattern(Number.NaN, 4)).toEqual({ clicksPerBar: 4, accentEvery: 4, unit: 4 });
+  expect(metronomePattern(4.5, 4)).toEqual({ clicksPerBar: 4, accentEvery: 4, unit: 4 });
+});
+
+// -------------------------------------------------------------- click timing
+
+test("seconds per click halves when the bpm doubles", () => {
+  const a = secondsPerClick(60, 4);
+  const b = secondsPerClick(120, 4);
+  expect(a).toBeCloseTo(1, 9);
+  expect(b).toBeCloseTo(0.5, 9);
+});
+
+test("an eighth-note click is half the length of a quarter-note click at the same bpm", () => {
+  const quarter = secondsPerClick(120, 4);
+  const eighth = secondsPerClick(120, 8);
+  expect(eighth).toBeCloseTo(quarter / 2, 9);
+});
+
+test("a bpm is always quarter-note bpm, regardless of the notated meter - 2/2's half-note beat is two quarters long", () => {
+  // A tempo of "120" in 2/2 does not mean the half-note pulse ticks 120 times
+  // a minute; it means the quarter note is 120, so the half-note beat (unit
+  // 2) is twice as long as the quarter click would be.
+  const half = secondsPerClick(120, 2);
+  const quarter = secondsPerClick(120, 4);
+  expect(half).toBeCloseTo(quarter * 2, 9);
+});
+
+// --------------------------------------------------------- time signature lookup
+
+test("an empty bar list answers 4/4 rather than throwing", () => {
+  expect(timeSignatureAtTick([], 5000)).toEqual({ numerator: 4, denominator: 4 });
+  expect(timeSignatureAtTick(null, 5000)).toEqual({ numerator: 4, denominator: 4 });
+});
+
+test("a tick before the first bar still gets an answer", () => {
+  const bars = [{ startTick: 0, numerator: 4, denominator: 4 }];
+  expect(timeSignatureAtTick(bars, -10)).toEqual({ numerator: 4, denominator: 4 });
+});
+
+test("a tick lands in the bar that started at or before it, not the next one", () => {
+  const bars = [
+    { startTick: 0, numerator: 4, denominator: 4 },
+    { startTick: 3840, numerator: 6, denominator: 8 },
+    { startTick: 7680, numerator: 3, denominator: 4 },
+  ];
+  expect(timeSignatureAtTick(bars, 0)).toEqual({ numerator: 4, denominator: 4 });
+  expect(timeSignatureAtTick(bars, 3839)).toEqual({ numerator: 4, denominator: 4 });
+  // exactly on the boundary belongs to the bar that starts there
+  expect(timeSignatureAtTick(bars, 3840)).toEqual({ numerator: 6, denominator: 8 });
+  expect(timeSignatureAtTick(bars, 5000)).toEqual({ numerator: 6, denominator: 8 });
+  expect(timeSignatureAtTick(bars, 7680)).toEqual({ numerator: 3, denominator: 4 });
+  // past the last bar's start, it is still the last bar's signature
+  expect(timeSignatureAtTick(bars, 999999)).toEqual({ numerator: 3, denominator: 4 });
+});
+
+test("a single-bar score answers that bar for any tick at or after its start", () => {
+  const bars = [{ startTick: 0, numerator: 5, denominator: 8 }];
+  expect(timeSignatureAtTick(bars, 0)).toEqual({ numerator: 5, denominator: 8 });
+  expect(timeSignatureAtTick(bars, 123456)).toEqual({ numerator: 5, denominator: 8 });
+});

--- a/web/tests/unit/metronome.spec.js
+++ b/web/tests/unit/metronome.spec.js
@@ -8,11 +8,12 @@ import {
   FALLBACK_SCORE_TEMPO,
   MAX_METRONOME_BPM,
   MIN_METRONOME_BPM,
+  barAtTick,
   clampBpm,
-  effectiveMetronomeBpm,
+  clickPhaseInBar,
+  effectiveClickRate,
   metronomePattern,
   secondsPerClick,
-  timeSignatureAtTick,
 } from "../../src/lib/metronome.js";
 
 // ---------------------------------------------------------------- clamping
@@ -30,26 +31,47 @@ test("a bpm outside the range is pulled back to it, not merely reported as inval
   expect(clampBpm(1000)).toBe(MAX_METRONOME_BPM);
 });
 
+test("clampBpm guards its own input - a caller that forgets to pre-filter cannot produce NaN or a string", () => {
+  // Not exploitable through effectiveClickRate today (it pre-filters before
+  // ever calling this), but clampBpm is the last line of defence against an
+  // unterminating scheduler loop - secondsPerClick(NaN) is NaN, and a while
+  // loop comparing against NaN never becomes false - so it has to hold on
+  // its own, not merely because every caller happens to behave today.
+  for (const bad of [Number.NaN, undefined, null, "abc", {}, [], Infinity, -Infinity]) {
+    const result = clampBpm(bad);
+    expect(typeof result, JSON.stringify(bad)).toBe("number");
+    expect(Number.isFinite(result), JSON.stringify(bad)).toBe(true);
+  }
+  // a numeric string still works, and still clamps
+  expect(clampBpm("200")).toBe(200);
+  expect(clampBpm("9999")).toBe(MAX_METRONOME_BPM);
+});
+
 // ------------------------------------------------------------- fixed bpm mode
 
-test("bpm mode ignores the score entirely", () => {
+test("bpm mode ignores the score AND the meter entirely", () => {
   // Same bpm, wildly different score tempos - the answer must not move.
-  expect(effectiveMetronomeBpm({ mode: "bpm", bpm: 100, scoreTempo: 60 })).toBe(100);
-  expect(effectiveMetronomeBpm({ mode: "bpm", bpm: 100, scoreTempo: 200 })).toBe(100);
-  expect(effectiveMetronomeBpm({ mode: "bpm", bpm: 100, scoreTempo: null })).toBe(100);
-  // and a proportion sitting alongside it, unused, must not leak in either
-  expect(effectiveMetronomeBpm({ mode: "bpm", bpm: 100, proportion: 0.5, scoreTempo: 60 })).toBe(100);
+  expect(effectiveClickRate({ mode: "bpm", bpm: 100, scoreTempo: 60, unit: 4 })).toBe(100);
+  expect(effectiveClickRate({ mode: "bpm", bpm: 100, scoreTempo: 200, unit: 4 })).toBe(100);
+  expect(effectiveClickRate({ mode: "bpm", bpm: 100, scoreTempo: null, unit: 4 })).toBe(100);
+  // a proportion sitting alongside it, unused, must not leak in either
+  expect(effectiveClickRate({ mode: "bpm", bpm: 100, proportion: 0.5, scoreTempo: 60, unit: 4 })).toBe(100);
+  // nor may the meter's own unit change the answer - this is the whole
+  // point of fixed-BPM mode: the typed number IS the rate, in every meter
+  for (const unit of [2, 4, 8, 16]) {
+    expect(effectiveClickRate({ mode: "bpm", bpm: 100, unit })).toBe(100);
+  }
 });
 
 test("an unusable fixed bpm falls back rather than producing a silent or negative click", () => {
   for (const bad of [0, -10, Number.NaN, undefined, null]) {
-    expect(effectiveMetronomeBpm({ mode: "bpm", bpm: bad })).toBe(DEFAULT_METRONOME_BPM);
+    expect(effectiveClickRate({ mode: "bpm", bpm: bad, unit: 4 })).toBe(DEFAULT_METRONOME_BPM);
   }
 });
 
 test("a fixed bpm outside the countable range is still clamped", () => {
-  expect(effectiveMetronomeBpm({ mode: "bpm", bpm: 5 })).toBe(MIN_METRONOME_BPM);
-  expect(effectiveMetronomeBpm({ mode: "bpm", bpm: 900 })).toBe(MAX_METRONOME_BPM);
+  expect(effectiveClickRate({ mode: "bpm", bpm: 5, unit: 4 })).toBe(MIN_METRONOME_BPM);
+  expect(effectiveClickRate({ mode: "bpm", bpm: 900, unit: 4 })).toBe(MAX_METRONOME_BPM);
 });
 
 // ------------------------------------------------------------- proportion mode
@@ -57,36 +79,64 @@ test("a fixed bpm outside the countable range is still clamped", () => {
 test("proportion mode tracks the score tempo it is given, not a value resolved once", () => {
   // The same call, called again with a different scoreTempo, is how a piece
   // that changes tempo mid-stream is meant to be tracked - so calling it
-  // twice with two different scoreTempos has to answer two different bpms.
-  expect(effectiveMetronomeBpm({ mode: "proportion", proportion: 1, scoreTempo: 80 })).toBe(80);
-  expect(effectiveMetronomeBpm({ mode: "proportion", proportion: 1, scoreTempo: 160 })).toBe(160);
+  // twice with two different scoreTempos has to answer two different rates.
+  expect(effectiveClickRate({ mode: "proportion", proportion: 1, scoreTempo: 80, unit: 4 })).toBe(80);
+  expect(effectiveClickRate({ mode: "proportion", proportion: 1, scoreTempo: 160, unit: 4 })).toBe(160);
 });
 
 test("a proportion is taken of the score tempo, not added or substituted", () => {
-  expect(effectiveMetronomeBpm({ mode: "proportion", proportion: 0.7, scoreTempo: 100 })).toBe(70);
-  expect(effectiveMetronomeBpm({ mode: "proportion", proportion: 1.5, scoreTempo: 100 })).toBe(150);
+  expect(effectiveClickRate({ mode: "proportion", proportion: 0.7, scoreTempo: 100, unit: 4 })).toBe(70);
+  expect(effectiveClickRate({ mode: "proportion", proportion: 1.5, scoreTempo: 100, unit: 4 })).toBe(150);
   // over 100% is a legitimate way to push past what is written, not an error
-  expect(effectiveMetronomeBpm({ mode: "proportion", proportion: 2, scoreTempo: 60 })).toBe(120);
+  expect(effectiveClickRate({ mode: "proportion", proportion: 2, scoreTempo: 60, unit: 4 })).toBe(120);
+});
+
+test("proportion mode converts onto the meter's OWN click unit - the actual click rate, not a quarter-note figure a listener has to convert", () => {
+  // 96 quarter notes a minute, clicked on the eighth (6/8): twice as many
+  // clicks as quarters, because each quarter is two eighths.
+  expect(effectiveClickRate({ mode: "proportion", proportion: 1, scoreTempo: 96, unit: 8 })).toBe(192);
+  // clicked on the half note (2/2): half as many, because each half is two
+  // quarters, so waiting for the next half takes twice as long.
+  expect(effectiveClickRate({ mode: "proportion", proportion: 1, scoreTempo: 96, unit: 2 })).toBe(48);
+  // unit 4 (the quarter itself) is the identity conversion
+  expect(effectiveClickRate({ mode: "proportion", proportion: 1, scoreTempo: 96, unit: 4 })).toBe(96);
+});
+
+test("the unit conversion happens before clamping, not after - an extreme meter cannot sneak the actual rate past MAX_METRONOME_BPM", () => {
+  // 300 quarter notes a minute in 4/128 would need 9600 clicks a minute if
+  // converted unclamped - clamping the 300 first (as a quarter-note figure)
+  // and converting second would let that 9600 straight through unchecked.
+  const rate = effectiveClickRate({ mode: "proportion", proportion: 1, scoreTempo: 300, unit: 128 });
+  expect(rate).toBe(MAX_METRONOME_BPM);
+  // and the ordinary case is unaffected - conversion first, clamp second,
+  // lands on the same answer as before when nothing extreme is happening
+  expect(effectiveClickRate({ mode: "proportion", proportion: 1, scoreTempo: 96, unit: 8 })).toBe(192);
 });
 
 test("a score with no declared tempo degrades to alphaTab's own fallback, not a made-up one", () => {
   expect(FALLBACK_SCORE_TEMPO).toBe(120);
-  expect(effectiveMetronomeBpm({ mode: "proportion", proportion: 1, scoreTempo: null })).toBe(120);
-  expect(effectiveMetronomeBpm({ mode: "proportion", proportion: 0.5, scoreTempo: undefined })).toBe(60);
-  expect(effectiveMetronomeBpm({ mode: "proportion", proportion: 0.5, scoreTempo: 0 })).toBe(60);
+  expect(effectiveClickRate({ mode: "proportion", proportion: 1, scoreTempo: null, unit: 4 })).toBe(120);
+  expect(effectiveClickRate({ mode: "proportion", proportion: 0.5, scoreTempo: undefined, unit: 4 })).toBe(60);
+  expect(effectiveClickRate({ mode: "proportion", proportion: 0.5, scoreTempo: 0, unit: 4 })).toBe(60);
 });
 
 test("an unusable proportion defaults to 100%, not to zero or NaN", () => {
   for (const bad of [0, -1, Number.NaN, undefined, null]) {
-    expect(effectiveMetronomeBpm({ mode: "proportion", proportion: bad, scoreTempo: 90 })).toBe(90);
+    expect(effectiveClickRate({ mode: "proportion", proportion: bad, scoreTempo: 90, unit: 4 })).toBe(90);
+  }
+});
+
+test("an unusable unit defaults to 4 (the quarter note, the identity conversion)", () => {
+  for (const bad of [0, -1, Number.NaN, undefined, null, 4.5]) {
+    expect(effectiveClickRate({ mode: "proportion", proportion: 1, scoreTempo: 90, unit: bad })).toBe(90);
   }
 });
 
 test("proportion mode is clamped at both ends like bpm mode is", () => {
-  expect(effectiveMetronomeBpm({ mode: "proportion", proportion: 0.05, scoreTempo: 100 })).toBe(
+  expect(effectiveClickRate({ mode: "proportion", proportion: 0.05, scoreTempo: 100, unit: 4 })).toBe(
     MIN_METRONOME_BPM,
   );
-  expect(effectiveMetronomeBpm({ mode: "proportion", proportion: 10, scoreTempo: 100 })).toBe(
+  expect(effectiveClickRate({ mode: "proportion", proportion: 10, scoreTempo: 100, unit: 4 })).toBe(
     MAX_METRONOME_BPM,
   );
 });
@@ -127,6 +177,53 @@ test("5/8 and 7/8 are irregular, not compound - one click per eighth, only the d
   expect(metronomePattern(7, 8)).toEqual({ clicksPerBar: 7, accentEvery: 7, unit: 8 });
 });
 
+test("the same compound grouping applies written in sixteenths - 9/16 and 12/16 are compound too", () => {
+  for (const [num, den] of [
+    [6, 16],
+    [9, 16],
+    [12, 16],
+    [15, 16],
+  ]) {
+    const p = metronomePattern(num, den);
+    expect(p, `${num}/${den}`).toEqual({ clicksPerBar: num, accentEvery: 3, unit: 16 });
+  }
+});
+
+test("5/16 and 7/16 are irregular in sixteenths too, not compound", () => {
+  expect(metronomePattern(5, 16)).toEqual({ clicksPerBar: 5, accentEvery: 5, unit: 16 });
+  expect(metronomePattern(7, 16)).toEqual({ clicksPerBar: 7, accentEvery: 7, unit: 16 });
+});
+
+test("x/4 meters are left simple even when the numerator is divisible by three - 6/4 is not treated as compound", () => {
+  // Unlike 6/8, which is unambiguously two dotted-quarter pulses of three
+  // eighths each, 6/4 is genuinely ambiguous (two dotted-half pulses, or six
+  // plain quarters) - so this clicks as six plain quarters, only the
+  // downbeat accented, rather than guessing which reading a piece meant.
+  expect(metronomePattern(6, 4)).toEqual({ clicksPerBar: 6, accentEvery: 6, unit: 4 });
+  expect(metronomePattern(9, 4)).toEqual({ clicksPerBar: 9, accentEvery: 9, unit: 4 });
+});
+
+test("only denominators 8 and 16 are ever treated as compound, across every numerator from 1 to 24", () => {
+  // A thorough sweep, not just the handful of meters named above - proof
+  // that d===8 or d===16 (with a numerator divisible by three, other than 3
+  // itself where it makes no observable difference) is the WHOLE rule, no
+  // denominator this misses.
+  for (const numerator of Array.from({ length: 24 }, (_, i) => i + 1)) {
+    for (const denominator of [1, 2, 4, 8, 16, 32]) {
+      const p = metronomePattern(numerator, denominator);
+      // n === 3 asks the same question the compound branch answers and gets
+      // the same accentEvery either way (see metronomePattern's own comment
+      // on 3/8), so it is not excluded here - both readings agree on it.
+      const shouldBeCompound = (denominator === 8 || denominator === 16) && numerator % 3 === 0;
+      if (shouldBeCompound) {
+        expect(p.accentEvery, `${numerator}/${denominator}`).toBe(3);
+      } else {
+        expect(p.accentEvery, `${numerator}/${denominator}`).toBe(numerator);
+      }
+    }
+  }
+});
+
 test("an accented click recurs every accentEvery ticks, across more than one bar", () => {
   // What a scheduler actually uses accentEvery for: is click index i accented?
   const p = metronomePattern(6, 8);
@@ -146,59 +243,121 @@ test("a malformed time signature falls back to 4/4 rather than producing nonsens
 });
 
 // -------------------------------------------------------------- click timing
+//
+// secondsPerClick takes a click RATE already in clicks per minute - the same
+// number effectiveClickRate produces and the same number a caller displays -
+// so there is no meter or mode left for it to know about. The meter-aware
+// arithmetic is entirely effectiveClickRate's (see "proportion mode converts
+// onto the meter's OWN click unit" above); this only ever converts a rate to
+// a period.
 
-test("seconds per click halves when the bpm doubles", () => {
-  const a = secondsPerClick(60, 4);
-  const b = secondsPerClick(120, 4);
-  expect(a).toBeCloseTo(1, 9);
-  expect(b).toBeCloseTo(0.5, 9);
+test("seconds per click halves when the rate doubles", () => {
+  expect(secondsPerClick(60)).toBeCloseTo(1, 9);
+  expect(secondsPerClick(120)).toBeCloseTo(0.5, 9);
 });
 
-test("an eighth-note click is half the length of a quarter-note click at the same bpm", () => {
-  const quarter = secondsPerClick(120, 4);
-  const eighth = secondsPerClick(120, 8);
-  expect(eighth).toBeCloseTo(quarter / 2, 9);
+test("192 clicks a minute (96 quarter notes converted onto an eighth-note meter) is a click every 312.5ms", () => {
+  expect(secondsPerClick(192)).toBeCloseTo(0.3125, 9);
 });
 
-test("a bpm is always quarter-note bpm, regardless of the notated meter - 2/2's half-note beat is two quarters long", () => {
-  // A tempo of "120" in 2/2 does not mean the half-note pulse ticks 120 times
-  // a minute; it means the quarter note is 120, so the half-note beat (unit
-  // 2) is twice as long as the quarter click would be.
-  const half = secondsPerClick(120, 2);
-  const quarter = secondsPerClick(120, 4);
-  expect(half).toBeCloseTo(quarter * 2, 9);
-});
+// ----------------------------------------------------------------- bar lookup
 
-// --------------------------------------------------------- time signature lookup
-
-test("an empty bar list answers 4/4 rather than throwing", () => {
-  expect(timeSignatureAtTick([], 5000)).toEqual({ numerator: 4, denominator: 4 });
-  expect(timeSignatureAtTick(null, 5000)).toEqual({ numerator: 4, denominator: 4 });
+test("an empty bar list answers null rather than throwing", () => {
+  expect(barAtTick([], 5000)).toBeNull();
+  expect(barAtTick(null, 5000)).toBeNull();
 });
 
 test("a tick before the first bar still gets an answer", () => {
-  const bars = [{ startTick: 0, numerator: 4, denominator: 4 }];
-  expect(timeSignatureAtTick(bars, -10)).toEqual({ numerator: 4, denominator: 4 });
+  const bars = [{ startTick: 0, endTick: 1920, numerator: 4, denominator: 4 }];
+  expect(barAtTick(bars, -10)).toEqual(bars[0]);
 });
 
 test("a tick lands in the bar that started at or before it, not the next one", () => {
   const bars = [
-    { startTick: 0, numerator: 4, denominator: 4 },
-    { startTick: 3840, numerator: 6, denominator: 8 },
-    { startTick: 7680, numerator: 3, denominator: 4 },
+    { startTick: 0, endTick: 3840, numerator: 4, denominator: 4 },
+    { startTick: 3840, endTick: 7680, numerator: 6, denominator: 8 },
+    { startTick: 7680, endTick: 9600, numerator: 3, denominator: 4 },
   ];
-  expect(timeSignatureAtTick(bars, 0)).toEqual({ numerator: 4, denominator: 4 });
-  expect(timeSignatureAtTick(bars, 3839)).toEqual({ numerator: 4, denominator: 4 });
+  expect(barAtTick(bars, 0)).toEqual(bars[0]);
+  expect(barAtTick(bars, 3839)).toEqual(bars[0]);
   // exactly on the boundary belongs to the bar that starts there
-  expect(timeSignatureAtTick(bars, 3840)).toEqual({ numerator: 6, denominator: 8 });
-  expect(timeSignatureAtTick(bars, 5000)).toEqual({ numerator: 6, denominator: 8 });
-  expect(timeSignatureAtTick(bars, 7680)).toEqual({ numerator: 3, denominator: 4 });
-  // past the last bar's start, it is still the last bar's signature
-  expect(timeSignatureAtTick(bars, 999999)).toEqual({ numerator: 3, denominator: 4 });
+  expect(barAtTick(bars, 3840)).toEqual(bars[1]);
+  expect(barAtTick(bars, 5000)).toEqual(bars[1]);
+  expect(barAtTick(bars, 7680)).toEqual(bars[2]);
+  // past the last bar's start, it is still the last bar
+  expect(barAtTick(bars, 999999)).toEqual(bars[2]);
 });
 
-test("a single-bar score answers that bar for any tick at or after its start", () => {
-  const bars = [{ startTick: 0, numerator: 5, denominator: 8 }];
-  expect(timeSignatureAtTick(bars, 0)).toEqual({ numerator: 5, denominator: 8 });
-  expect(timeSignatureAtTick(bars, 123456)).toEqual({ numerator: 5, denominator: 8 });
+test("a single-bar list answers that bar for any tick at or after its start", () => {
+  const bars = [{ startTick: 0, endTick: 1920, numerator: 5, denominator: 8 }];
+  expect(barAtTick(bars, 0)).toEqual(bars[0]);
+  expect(barAtTick(bars, 123456)).toEqual(bars[0]);
+});
+
+test("a repeated section reorders bars on the played timeline, and the lookup follows the PLAYED order", () => {
+  // Bar A (4/4) plays, repeats (plays again), THEN bar B (6/8) plays once -
+  // exactly the shape a repeat sign produces on the generated MIDI timeline.
+  // A hand-summed index over the NOTATED bars (A, B) would place B right
+  // after A's first pass and get every tick from there on wrong; this list
+  // models the PLAYED order instead, which is what barAtTick is handed.
+  const bars = [
+    { startTick: 0, endTick: 3840, numerator: 4, denominator: 4 }, // A, pass 1
+    { startTick: 3840, endTick: 7680, numerator: 4, denominator: 4 }, // A, pass 2 (the repeat)
+    { startTick: 7680, endTick: 11520, numerator: 6, denominator: 8 }, // B, after the repeat
+  ];
+  // A tick that would land inside notated bar B's own duration (3840) if
+  // measured from bar A's single notated length, but is still within A's
+  // repeated second pass on the PLAYED timeline.
+  expect(barAtTick(bars, 5000)).toEqual(bars[1]);
+  expect(barAtTick(bars, 5000).denominator).toBe(4);
+  // only past the repeat does the lookup reach B
+  expect(barAtTick(bars, 8000)).toEqual(bars[2]);
+});
+
+// ------------------------------------------------------------- phase in bar
+
+test("phase is 0 at the very start of a bar and clicksPerBar - 1 just before its end", () => {
+  const bar = { startTick: 1000, endTick: 1000 + 4 * 480 };
+  expect(clickPhaseInBar(1000, bar, 4)).toBe(0);
+  expect(clickPhaseInBar(1000 + 480, bar, 4)).toBe(1);
+  expect(clickPhaseInBar(1000 + 2 * 480, bar, 4)).toBe(2);
+  expect(clickPhaseInBar(1000 + 3 * 480 + 200, bar, 4)).toBe(3);
+});
+
+test("phase resets at a bar boundary regardless of how far the previous bar's count had run", () => {
+  // The whole reason this is derived from the playhead rather than carried
+  // forward: bar two's phase must not continue counting from wherever bar
+  // one left off.
+  const barOne = { startTick: 0, endTick: 1920 };
+  const barTwo = { startTick: 1920, endTick: 3840 };
+  expect(clickPhaseInBar(1919, barOne, 6)).toBe(5);
+  expect(clickPhaseInBar(1920, barTwo, 6)).toBe(0);
+});
+
+test("a tick past the bar's own end still answers with the last slot, not an out-of-range one", () => {
+  // Covers a click scheduled slightly ahead of the audio clock (see
+  // METRONOME_SCHEDULE_AHEAD_S in score-render.js) landing a few ticks past
+  // where the playhead has actually reached so far.
+  const bar = { startTick: 0, endTick: 1920 };
+  expect(clickPhaseInBar(1920, bar, 6)).toBe(5);
+  expect(clickPhaseInBar(999999, bar, 6)).toBe(5);
+});
+
+test("a null or degenerate bar answers phase 0 rather than NaN", () => {
+  expect(clickPhaseInBar(500, null, 4)).toBe(0);
+  expect(clickPhaseInBar(500, { startTick: 0, endTick: 0 }, 4)).toBe(0);
+  expect(clickPhaseInBar(500, { startTick: 0, endTick: 1920 }, 0)).toBe(0);
+});
+
+test("a loop whose length is not a whole number of click periods still answers correctly at every point sampled - it never needs to know about the loop at all", () => {
+  // This is the shape of the "three-bar loop at seventy per cent" case the
+  // review named: the click's own rate has nothing to do with the bar
+  // length, so sampling it at arbitrary, non-bar-aligned real ticks (as an
+  // independent, differently-paced click would) still has to answer with
+  // wherever THAT tick actually falls - not drift because of what a
+  // persistent counter happened to reach.
+  const bar = { startTick: 10_000, endTick: 10_000 + 6 * 240 }; // 6/8, division 480 -> 240 ticks/eighth
+  for (let i = 0; i < 6; i++) {
+    expect(clickPhaseInBar(10_000 + i * 240 + 37, bar, 6)).toBe(i);
+  }
 });


### PR DESCRIPTION
## Summary

Closes #60.

The metronome used to be baked into the same generated MIDI as the notes, so it always followed whatever tempo the score declared, scaled by playback speed exactly like every other event. Practice regularly wants those two things to disagree - a click at full tempo over a passage slowed down for a hard bar, or a fixed BPM the marking has nothing to do with - and the renderer's own metronome setting cannot express that: there is no way to make its click run at a different tempo than the notes beside it.

**The renderer cannot drive this on its own.** `api.metronomeVolume` only changes how loud the *existing*, speed-coupled click is; there is no public setting that decouples its tempo from `playbackSpeed`. So the click is a second, independent audio path - a plain Web Audio oscillator scheduled off its own clock (the standard lookahead pattern, not per-click `setTimeout`, which drifts) - that never touches alphaTab's synthesiser or its notion of tempo. alphaTab's own metronome is muted permanently so the two can never sound at once; its count-in is a separate, untouched feature.

Two modes:
- **Proportion** (default) - a percentage of the score's own tempo, read continuously from `playerPositionChanged`'s `originalTempo` (the tempo alphaTab is internally playing before `playbackSpeed` is applied), so a piece that changes tempo mid-stream is tracked as it moves rather than resolved once at the start.
- **Fixed BPM** - a number set directly, ignoring the score entirely.

Time signature (for subdivision/accent) comes from a flat tick index built from `score.masterBars` once per load. Compound meters (6/8, 9/8, 12/8) click the eighth-note subdivision, accented every third click (the actual pulse), rather than a bare click on the dotted-quarter beat.

## Design decisions

- **Per-session, not persisted.** Mode/proportion/BPM live in `TabViewer`'s own state, same as `speed`/`looping`/`countIn` - none of those persist server-side either, and the server's settings schema (`SETTINGS_CHOICES` in `server/fermata/api.py`) only whitelists `staff_theme` today. Extending it was out of scope for a frontend-only change.
- **No tempo declared → alphaTab's own fallback (120 BPM).** `Score.tempo` already defaults to 120 when nothing is marked; a proportion taken of "nothing marked" degrades to the same fallback rather than inventing a second one.
- **Gig mode shows the live value, not the controls.** A stand is not where you pick a mode or type a BPM - those live in the full toolbar, set up before stepping into gig mode - but "the current value visible while playing" still has to hold at a distance, so a small `♩ 96` readout comes along into the HUD.
- **The count-in is untouched.** It's a separate, pre-roll-only feature; decoupling it from the score's tempo was outside this issue's scope.

## What I could not verify

I have no way to listen to audio output. I verified the click is real (a genuine `AudioContext`, real scheduled oscillator nodes) and that its *timing* is correct by measuring actual wall-clock gaps between scheduled clicks against the expected values - see the browser suite - and reasoned about the envelope/frequency choices (950 Hz plain tick, 1500 Hz + louder accent, ~50ms percussive decay) from the Web Audio API's own semantics. I did not, and cannot, confirm by ear that it sounds right. Worth a manual pass before merging: `/#/demo`, enable the metronome, play, then drop the speed to well below 1× and confirm the click doesn't slow down with it; try Fixed BPM at something very slow (e.g. 30) for audibility at practice speeds; and load something in 6/8 or 9/8 to confirm the accent is audibly distinguishable from the subdivision ticks.

## Testing

- `web/tests/unit/metronome.spec.js` (23 tests) - the pure tempo/subdivision/timing arithmetic in the new `web/src/lib/metronome.js`, no browser needed.
- `web/tests/browser/metronome.spec.js` (6 tests) - against a real alphaTab render and a real Web Audio click (a hand-built 6/8 MusicXML fixture, stubbed at the `/api/scores/*` routes the same way `score-compare-warnings.spec.js` already does). Every timing assertion reads real wall-clock gaps between real scheduled clicks (`data-metronome-clicks` mutating on the actual host element) rather than a value the UI merely intended to produce - the failure mode this project has been bitten by before.
- Raised the browser suite's test-count floor from 36 to 78 (49 existing + 29 added).

**Mutations run and confirmed red** (each reverted after confirming failure):
- `metronome.js`: `base * ratio` → `base + ratio` (proportion math) - 5 tests failed.
- `metronome.js`: dropped the `n > 3` guard in the compound-meter check - turned out to be genuinely dead code (3/8 produces the same output either way), so I removed it rather than adding a test that couldn't distinguish the branches; see the comment in `metronomePattern`.
- `metronome.js`: swapped `clampBpm`'s `min`/`max` - 10 tests failed.
- `metronome.js`: `<=` → `<` in the time-signature tick lookup - 1 test failed.
- `metronome.js`: swapped `secondsPerClick`'s `4/unit` for `unit/4` - 2 tests failed.
- `score-render.js`: multiplied the scheduler's click interval by `api.playbackSpeed` (reintroducing the exact coupling this issue removes) - caught by the fixed-BPM decoupling test immediately; the proportion-mode decoupling test didn't catch it on the first pass (its tolerance was too loose), so I tightened the bound until it did.
- `score-render.js`: swapped `metronomePattern(numerator, denominator)`'s argument order - the 6/8 accent-pattern test failed.
- `score-render.js`: made `setEnabled` stop resyncing the scheduler (simulating the old "just mute" behavior) - the on/off test failed.

## Test plan

- [x] `npm run build`
- [x] `npm run test:browser` (78/78 passing)
- [ ] Manual listening pass (see "What I could not verify" above)