### PR TITLE
Wait for the save to land before reading it back

### DIFF
--- a/web/tests/browser/instruments.spec.js
+++ b/web/tests/browser/instruments.spec.js
@@ -329,6 +329,14 @@ test("a reference pitch outside the bounds is refused rather than silently defau
   await expect(errors(page)).toHaveCount(0);
   await expect(editorRows(page).first().locator(".string-hz")).toHaveText("77.72 Hz");
   await page.locator(".actions button.primary").click();
+  // Wait for the save to have LANDED before reading it back, because the read
+  // below goes out of band - through the request context rather than the page -
+  // and so is not ordered against the click. Without this the read overtakes
+  // the POST often enough to fail roughly one run in ten, with an empty list
+  // and an error about reading a property of undefined. The two other tests
+  // that read the API this way each wait on the interface first for the same
+  // reason; those assertions are barriers, not only checks.
+  await expect(section(page)).toHaveAttribute("data-instrument-count", "1");
 
   const [saved] = await (await request.get("/api/instruments")).json();
   expect(saved.reference_pitch).toBe(415);


### PR DESCRIPTION
Fixes #82 — the reference-pitch bound test failing at random.

## It was not a state leak

The issue originally blamed state leaking between tests. It is not, and the fixes it proposed would not have helped: a `beforeEach` already deletes every existing definition, and the runner is pinned to one worker precisely because instruments are global to an install.

The cause is a missing synchronisation point. The test clicked Save and then read the API **out of band** — through the request context rather than the page — so the read was not ordered against the click:

```js
await page.locator(".actions button.primary").click();
const [saved] = await (await request.get("/api/instruments")).json();
```

`click()` resolves when the click is dispatched, not when the save it triggers has completed. An empty list makes `saved` undefined, which is the `Cannot read properties of undefined (reading 'reference_pitch')` seen in CI.

The two neighbouring tests that read the API the same way do not flake, and comparing them shows why: each waits on the interface first — one for the instrument count, the other for the saved rows to render — before reading out of band. Those assertions are barriers, not only checks. This test had no barrier.

## Proof, rather than reasoning

The race is timing-dependent, so it was made deterministic by delaying the page's POST by 1.5 s and running the test both ways:

- **Without the barrier** — reproduces the CI failure exactly: `TypeError: Cannot read properties of undefined (reading 'reference_pitch')`, at the same assertion.
- **With the barrier** — same delay, passes.

So the added line is load-bearing rather than decorative, which is the property that matters for a fix to a flake.

Full suite after the change: **49 passed**.

## Worth grepping for elsewhere

Any test that performs a user action and then reads state through a channel other than the page is exposed to the same race. That pattern is the thing to look for, not this one assertion.