### PR TITLE
Record what practice was, and what it was meant to be

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,15 @@ them.
   a six-string guitar in standard tuning.
 - **Practice tracking** — a session timer per piece, with recently-practised
   and neglected views so the library reflects what you are actually working on.
+  A session can record what the work was: which bars or pages, at what tempo,
+  section work or a run-through, and how it went. Practice that is not a piece
+  at all — technique, ear training, simply playing — is recorded the same way
+  and in the same history ([the data model](docs/practice-data.md)).
+- **Weekly goals, and an honest review** — how many days you mean to practise
+  and for how long, on what. While the week runs it says where you stand so the
+  goal can still change it; afterwards it states plainly what happened and asks
+  whether the goal was realistic. No streaks, no comparison with a better week,
+  and nothing that grades you for a week that did not go to plan.
 - **Gig mode** — fullscreen, screen kept awake, oversized tap targets and
   half-page turns for a tablet on a music stand.
 - **Organize** — collections (from your folder layout), free-form tags,
@@ -159,7 +168,7 @@ demo*) if your library is PDF-only so far.
   accompany most freely-licensed sheet music you can download
 - **A fretboard trainer** — note finding, chord flash cards and reach drills,
   scoped to the strings and frets you are working on
-- Setlists and practice sessions with per-piece progress
+- Setlists, and recognition for what you have accomplished over time
 - Annotations on PDFs (fingerings, markings)
 - Reverse proxy authentication, then multi-user accounts
 - Splitting compilation books into individual pieces

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -167,9 +167,11 @@ docker compose up --build -d
 ```
 
 Fermata's database applies its own schema changes automatically on startup —
-new tables or columns an upgrade needs are created the first time the new
-version starts, and so far this has never required a manual step. You do not
-need to run a migration command.
+new tables and columns an upgrade needs are created the first time the new
+version starts, and a change too large for that (rebuilding a table to carry
+its rows into a new shape) runs then too, once, inside a single transaction. It
+has never required a manual step, and you do not need to run a migration
+command.
 
 That said, take a backup first anyway, the same way you would before any
 software upgrade you can't easily undo:
@@ -192,8 +194,8 @@ recognises — but if the newer version changed the schema, the older one refuse
 to start rather than write to a database it does not understand, and says so:
 
 ```
-RuntimeError: this database is at schema version 2, but this version of
-Fermata understands 1. It was written by a newer release - upgrade, or
+RuntimeError: this database is at schema version 3, but this version of
+Fermata understands 2. It was written by a newer release - upgrade, or
 restore a backup taken before it.
 ```
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -194,8 +194,8 @@ recognises — but if the newer version changed the schema, the older one refuse
 to start rather than write to a database it does not understand, and says so:
 
 ```
-RuntimeError: this database is at schema version 3, but this version of
-Fermata understands 2. It was written by a newer release - upgrade, or
+RuntimeError: this database is at schema version 4, but this version of
+Fermata understands 3. It was written by a newer release - upgrade, or
 restore a backup taken before it.
 ```
 

--- a/docs/practice-data.md
+++ b/docs/practice-data.md
@@ -1,0 +1,240 @@
+# The practice data model
+
+What Fermata records about practice, how it is stored, and how to ask it
+questions. Two things live here: a **session**, which is a fact about work that
+was done, and a **goal**, which is an intention with a period attached.
+
+Practice history is the only data in Fermata that cannot be regenerated. A
+score row can be rebuilt by rescanning the library and a transcription by
+re-extracting, but nothing on disk remembers that somebody sat down and
+practised for forty minutes. Everything below is designed around that.
+
+## Sessions
+
+One table, `practice_sessions`, for every kind of practice.
+
+| Column | Meaning |
+| --- | --- |
+| `id` | Stable for the life of the row, including across schema upgrades. |
+| `owner` | `'local'` until real accounts exist. |
+| `score_id` | The piece, when the work was against one. `NULL` otherwise. |
+| `activity` | What kind of work it was. See the vocabulary below. |
+| `mode` | `section`, `run_through`, or `NULL` for unstated. |
+| `started_at` | UTC timestamp of when the session was **recorded**. |
+| `local_date` | The calendar day the practice **happened** on, in the practiser's own time. |
+| `seconds` | How long, 1 to 86400. |
+| `from_bar`, `to_bar` | The bars worked. |
+| `from_page`, `to_page` | The pages worked - for a PDF, where bar numbers are not addressable. |
+| `tempo_bpm` | The tempo actually practised at. |
+| `target_tempo_bpm` | The tempo being worked towards. |
+| `rating` | 1-5, the player's own sense of how it went. `NULL` for not rated. |
+| `note` | Free text, up to 2000 characters. |
+
+### Why there is one table and not one per kind
+
+Practice is not only pieces. The exercises that come next - fret-to-note, ear
+training, chord drills - produce practice in exactly the way a piece does, and
+so does sitting down and playing. A table per kind would mean every history
+view and every goal calculation growing another special case with each of
+them, forever. So `activity` says what a row was, and `score_id` is present
+when there was a piece behind it.
+
+`activity` is one of: `piece`, `technique`, `sight_reading`, `ear_training`,
+`fretboard`, `chords`, `improvisation`, `theory`, `free`, `other`. `piece` is
+the only value that requires a `score_id`; `free` is unstructured playing.
+
+### Why the practice day is stored rather than derived
+
+`started_at` is UTC. West of Greenwich an evening session falls on the next UTC
+day, so "how many days did I practise this week" would be wrong by one for
+exactly the sessions somebody is most likely to have - and at a week boundary
+it would land in the wrong week entirely, against a goal counting days. So the
+client sends `local_date`, and every day-based query counts that.
+
+A back-dated session is a first-class thing rather than a contradiction:
+`started_at` is when it was **recorded** and `local_date` is when the practice
+**happened**. Somebody entering yesterday's forgotten hour is lying about
+neither.
+
+Rows written before this column existed hold `NULL`, and are attributed to
+`date(started_at)` because that is the only day they ever recorded. Every
+session response carries `local_date_source`, which is `recorded` or `utc_date`,
+so a reader is never handed an inferred day as though it were a recorded one.
+
+### What is derived rather than stored
+
+- `reached_target` is `tempo_bpm >= target_tempo_bpm`, computed on read. A
+  stored answer is one that can end up contradicting the two numbers it came
+  from. `null` means one of them is missing, which is not the same as "did not
+  reach it".
+- Totals, day counts and goal progress are all counted from sessions when
+  asked. Nothing anywhere caches them.
+
+### What deletes a session
+
+`score_id` is `ON DELETE CASCADE`, so removing a score removes its practice.
+That is deliberate and narrower than it sounds: the scanner re-links a renamed
+or moved file to its existing score row by content hash precisely so a rename
+never reaches this cascade, and a score row that genuinely goes means the file
+has left the library. `DELETE /api/practice/sessions/{id}` is the only other
+way, and exists because a timer left running by accident is otherwise
+permanent.
+
+## Goals
+
+One table, `practice_goals`. A goal says how many days somebody means to
+practise and for how long in total, over one period, optionally scoped to one
+piece or one kind of work.
+
+| Column | Meaning |
+| --- | --- |
+| `period` | `'week'`. Nothing else is implemented. |
+| `period_start`, `period_end` | Inclusive dates. Stored, not derived. |
+| `target_days` | Days with practice in them, 1 to 7. |
+| `target_minutes` | Total minutes across the period. |
+| `scope` | `all`, `score`, or `activity`. |
+| `score_id`, `activity` | Whichever the scope names. The other is `NULL`. |
+| `intent` | What they mean to work on, in their words. |
+| `reflection`, `realistic` | Written afterwards, by them, and by nothing else. |
+
+At least one target is required: a goal has to be concrete enough to be either
+met or missed, which is the point of setting one. There is **one goal per
+period per owner** - setting another for the same week replaces it, because
+changing your mind about the week is the ordinary case and a period with two
+goals in it is a scorecard.
+
+The period is stored as its two dates rather than as a week number, so a goal
+keeps meaning exactly what it meant when it was set even after the
+`week_starts_on` preference changes underneath it.
+
+**There is no column recording whether a goal was met, and there will not be
+one.** Progress is counted from the sessions inside the period every time it is
+asked for. That is what keeps a goal and the history it is about from ever
+disagreeing, and it is the only version of this that stays true when an hour is
+remembered and logged three days late.
+
+### What happens when a period ends
+
+Nothing. No archiving, no closing, no grading, no deletion. The goal stays with
+its targets and whatever was written about it, because a record of what
+somebody meant to do is what makes the next goal a better one. A finished
+period gains one question - *was this goal realistic?* - whose answer is
+`realistic` and whose detail is `reflection`.
+
+### What is deliberately absent
+
+- **No streaks, and no run of anything.** Missing a week because of a busy job
+  is information, not a moral failure.
+- **No comparison between periods.** No best week, no average, no ranking. A
+  best week is the mechanism by which a good month becomes the standard a bad
+  month is measured against. No query here returns one and no field invites
+  one.
+- **No pace advice.** A running period reports the days left in it and nothing
+  about what is needed per day to catch up, which is a verdict wearing
+  arithmetic.
+- **No verdict vocabulary.** The interface states counts - "3 of 4 planned
+  days" - and stops. `web/src/lib/practice.js` owns the phrasing and carries
+  the word list its tests check it against.
+
+## Asking questions
+
+Every field is readable over the REST API, and the endpoints are shaped around
+the questions rather than around the tables.
+
+### Sessions
+
+- `POST /api/scores/{id}/practice` - log practice against a piece. Only
+  `seconds` is required; the response carries the new session's `id` so detail
+  can be added afterwards.
+- `POST /api/practice/sessions` - log practice that need not be against a
+  piece.
+- `PATCH /api/practice/sessions/{id}` - add or correct detail. The whole record
+  is re-checked, so a patch cannot reach a state a fresh log would be refused.
+  An explicit `null` clears a field.
+- `DELETE /api/practice/sessions/{id}`
+- `GET /api/practice/sessions?start=&end=&score_id=&activity=&limit=` - the raw
+  record across every piece and every kind of work, filtered by practice day.
+  *What did I actually do this week.*
+
+### Aggregates
+
+- `GET /api/practice/history?days=&today=` - per-day totals, per-piece totals
+  and per-activity totals over a window of up to a year. *Where has the time
+  gone over three months.*
+- `GET /api/scores?practiced=recent|neglected` - the library's own views.
+  *Which pieces have I neglected.* These use rolling windows over `started_at`
+  rather than the practice day, because "in the last 14 days" is a question
+  about elapsed time rather than about calendar days.
+- `GET /api/practice/summary` - the last seven days, for the library header.
+
+### Goals and the review
+
+- `GET /api/practice/goals/current?today=` - the goal covering today, with
+  progress. `goal: null` is an answer, not an error.
+- `GET /api/practice/goals?limit=&today=`
+- `POST /api/practice/goals?today=` - set or replace the goal for a period.
+  Omit `period_start` for the week containing `today`.
+- `PATCH /api/practice/goals/{id}?today=` - adjust targets while the period
+  runs, or write the reflection after it ends.
+- `DELETE /api/practice/goals/{id}` - deletes the intention, never the
+  practice.
+- `GET /api/practice/review?weeks=&today=` - recent weeks, each with its goal
+  if it had one, its own facts either way, and where its time went. *What did
+  they plan versus what did they do.*
+
+### `today`, on every endpoint that needs a date
+
+The server's own date is UTC, and whether a period is still running must not be
+an accident of the hour: west of Greenwich the UTC date is already tomorrow
+while somebody still has their evening. So a client passes its own date as
+`today`, and a client that passes nothing gets the server's UTC date.
+
+### Progress, as reported
+
+`progress` on a goal carries `days_practised`, `minutes`, `seconds`,
+`sessions`, a `days` array covering **every** day in the period including the
+empty ones, `status` (`upcoming`, `running` or `past`), `days_left`, and
+`met_days` / `met_minutes` / `met`.
+
+A `met_*` value is `null` when that target was not set, which is not the same
+as unmet - a goal with no minutes target has nothing to say about minutes, and
+`false` there would read as a shortfall against a target nobody chose.
+
+## Schema changes
+
+`server/fermata/db.py` holds two mechanisms, and they are not interchangeable.
+
+`COLUMN_ADDITIONS` expresses `ADD COLUMN` and nothing else. It runs on every
+startup, so idempotence is its only safety property, and a change that can be
+expressed there still belongs there - it repairs a database that half-upgraded.
+
+`MIGRATIONS` is the real runner: ordered steps, each taking a database from the
+version below its key to that key, run once and then stamped into `PRAGMA
+user_version`. A step may do anything SQLite can do, because it is not re-run.
+All pending steps share one transaction and each stamps its own version as it
+completes, so an interrupted upgrade resumes from the last step that actually
+landed, and the work and its stamp cannot disagree.
+
+Version 2 is the first step: it rebuilds `practice_sessions` so `score_id` can
+be `NULL`, which SQLite cannot express as an alteration in place. Every
+existing row is carried across with its id intact.
+`server/tests/test_practice_migration.py` builds a real version 0 and version 1
+database, with real practice rows in them, and checks the rows survive - and
+compares the upgraded table against a freshly created one so the two
+definitions cannot drift apart.
+
+There is no down direction. A database written by a newer release is refused
+outright at startup rather than written to blind; restoring a backup is the way
+back. See the Backups section of [deployment.md](deployment.md).
+
+## What is not here yet
+
+- **Per-attempt trainer results** - which positions or intervals were missed,
+  and response times. That belongs beside the trainer that produces it, and
+  inventing its shape before one exists would be guessing. What the `activity`
+  vocabulary guarantees is that when a trainer arrives, the time it accounts
+  for lands in the same history and the same goals as everything else.
+- **Key, tempo and difficulty per score** - musical metadata about the piece
+  rather than about the practice.
+- **Achievements** - looking back at what has been accomplished, where a goal
+  looks forward from an intention. Designed to share this surface.

--- a/docs/practice-data.md
+++ b/docs/practice-data.md
@@ -72,13 +72,28 @@ so a reader is never handed an inferred day as though it were a recorded one.
 
 ### What deletes a session
 
-`score_id` is `ON DELETE CASCADE`, so removing a score removes its practice.
-That is deliberate and narrower than it sounds: the scanner re-links a renamed
-or moved file to its existing score row by content hash precisely so a rename
-never reaches this cascade, and a score row that genuinely goes means the file
-has left the library. `DELETE /api/practice/sessions/{id}` is the only other
-way, and exists because a timer left running by accident is otherwise
-permanent.
+Almost nothing. `score_id` is `ON DELETE SET NULL`: removing a score forgets
+which piece the practice was about and keeps the practice. The hours were spent
+whether or not the file is still on disk, and the record of them belongs to the
+person rather than to the file - which is the whole premise of this feature and
+the reason these rows are the one thing here that cannot be regenerated.
+
+A session that outlives its score keeps `activity = 'piece'` with no
+`score_id`, and that pair is what identifies it: every other activity may
+legitimately have no score, and a `piece` session cannot be *created* without
+one. Every session response carries `score_missing` for exactly this, so a
+reader can name it as practice on a piece that has gone rather than showing a
+blank where a title belongs. Nothing filters these rows out of any total, any
+day count or any goal.
+
+`DELETE /api/practice/sessions/{id}` is the only way to remove a session, and
+exists because a timer left running by accident is otherwise permanent.
+
+A dangling `score_id` - a reference to a score that is not in the table, which
+this application cannot produce but the `sqlite3` command line produces
+trivially, since its default is `foreign_keys` off - is repaired to `NULL` on
+the next startup and announced in the log. That is what the reference's own `ON
+DELETE SET NULL` would have done had the deletion gone through the database.
 
 ## Goals
 
@@ -98,14 +113,35 @@ piece or one kind of work.
 | `reflection`, `realistic` | Written afterwards, by them, and by nothing else. |
 
 At least one target is required: a goal has to be concrete enough to be either
-met or missed, which is the point of setting one. There is **one goal per
-period per owner** - setting another for the same week replaces it, because
-changing your mind about the week is the ordinary case and a period with two
-goals in it is a scorecard.
+met or missed, which is the point of setting one. Setting another goal for the
+same period replaces it - changing your mind about the week is the ordinary
+case, and a period with two goals in it is a scorecard. The reflection is
+cleared when that happens: it was written about the intention being replaced,
+and carrying it over would have the review ask whether a goal was realistic and
+answer with words about a different one.
 
-The period is stored as its two dates rather than as a week number, so a goal
-keeps meaning exactly what it meant when it was set even after the
-`week_starts_on` preference changes underneath it.
+**No two goals may share a day.** Not merely no two with the same start date:
+overlap is refused with a 409 naming the period that clashes. Overlapping goals
+are how the same practice gets counted against two intentions, and it becomes
+reachable through the ordinary interface the moment `week_starts_on` changes,
+because the new grid's weeks are offset from the old grid's rather than being
+different weeks.
+
+The period is stored as its two dates rather than as a week number, and those
+dates are what everything reads. A goal therefore keeps meaning exactly what it
+meant when it was set, and changing `week_starts_on` afterwards cannot re-slice
+it: the review lists each goal's **own** period rather than matching goals to
+slots on today's grid. Matching by grid slot meant the same history reported a
+different result after a preference change, and a past week carrying somebody's
+own intent and reflection rendered as "no goal was set" - a false statement
+about their own record.
+
+A goal about a piece that has since left the library reports
+`progress.countable = false` with `met` as `null`. Its sessions are still in the
+history but no longer identifiable as being about that piece, so it cannot be
+counted - and saying so is the only honest answer. Reporting zero days would
+turn a week somebody practised into a shortfall, and a goal already reached into
+one that was not.
 
 **There is no column recording whether a goal was met, and there will not be
 one.** Progress is counted from the sessions inside the period every time it is
@@ -154,7 +190,11 @@ the questions rather than around the tables.
 - `DELETE /api/practice/sessions/{id}`
 - `GET /api/practice/sessions?start=&end=&score_id=&activity=&limit=` - the raw
   record across every piece and every kind of work, filtered by practice day.
-  *What did I actually do this week.*
+  *What did I actually do this week.* Returns `total` and `truncated` beside the
+  rows: a list that stops at the limit and says nothing looks identical to a
+  complete one, and a reader totalling it would report less practice than there
+  was. `/practice/history` does the same for its by-piece breakdown, with
+  `scores_worked` and `by_score_truncated`.
 
 ### Aggregates
 
@@ -162,9 +202,11 @@ the questions rather than around the tables.
   and per-activity totals over a window of up to a year. *Where has the time
   gone over three months.*
 - `GET /api/scores?practiced=recent|neglected` - the library's own views.
-  *Which pieces have I neglected.* These use rolling windows over `started_at`
-  rather than the practice day, because "in the last 14 days" is a question
-  about elapsed time rather than about calendar days.
+  *Which pieces have I neglected.* Windowed on the practice day, like
+  everything else: the library is the view a person sees first, so it must not
+  disagree with the practice page about when they last played something, and a
+  back-dated session counts from the day it says it happened. `last_practiced`
+  on a score is that day, not a timestamp.
 - `GET /api/practice/summary` - the last seven days, for the library header.
 
 ### Goals and the review
@@ -189,12 +231,27 @@ an accident of the hour: west of Greenwich the UTC date is already tomorrow
 while somebody still has their evening. So a client passes its own date as
 `today`, and a client that passes nothing gets the server's UTC date.
 
+It is bounded to the same window a practice day may name - roughly a year back
+and a day forward. Unbounded, `today=2099-01-01` was answered with a
+plausible-looking empty week, which is the worst kind of wrong answer because
+nothing in the response marks it as suspect. The window is deliberately as wide
+as the back-dating window rather than as narrow as a timezone: reasoning about a
+period that has already ended is a legitimate use of the parameter, and the
+thing that makes every period rule here testable without waiting for the
+calendar.
+
 ### Progress, as reported
 
 `progress` on a goal carries `days_practised`, `minutes`, `seconds`,
 `sessions`, a `days` array covering **every** day in the period including the
-empty ones, `status` (`upcoming`, `running` or `past`), `days_left`, and
-`met_days` / `met_minutes` / `met`.
+empty ones, `status` (`upcoming`, `running` or `past`), `days_left`,
+`countable`, and `met_days` / `met_minutes` / `met`.
+
+It also carries `sessions_inferred`: how many of the sessions behind those
+totals had no recorded practice day and were attributed to their UTC one. A
+single session already says which it is; a total said nothing, so a window
+spanning the upgrade quietly added two kinds of day together. Zero on any
+install that has only ever run this version.
 
 A `met_*` value is `null` when that target was not set, which is not the same
 as unmet - a goal with no minutes target has nothing to say about minutes, and
@@ -215,13 +272,28 @@ All pending steps share one transaction and each stamps its own version as it
 completes, so an interrupted upgrade resumes from the last step that actually
 landed, and the work and its stamp cannot disagree.
 
-Version 2 is the first step: it rebuilds `practice_sessions` so `score_id` can
-be `NULL`, which SQLite cannot express as an alteration in place. Every
-existing row is carried across with its id intact.
-`server/tests/test_practice_migration.py` builds a real version 0 and version 1
-database, with real practice rows in them, and checks the rows survive - and
-compares the upgraded table against a freshly created one so the two
-definitions cannot drift apart.
+Steps run **before** the schema script and before `COLUMN_ADDITIONS`, so a step
+sees the database exactly as the previous version left it: no table `SCHEMA`
+would have created, and no column `COLUMN_ADDITIONS` would have added. A step
+that needs such a column has to add it itself. The order matters the other way
+too: `SCHEMA` creates indexes over columns that only exist once a rebuild has
+happened.
+
+A step that rebuilds a table runs with foreign keys **off**, as SQLite's own
+table-rebuild recipe says to. With them on, one pre-existing row whose reference
+had come loose would be rejected on the copy and take startup down on every
+subsequent boot. Consistency is checked rather than assumed: dangling practice
+references are repaired to `NULL`, anything else remaining is reported, and both
+are announced in the log.
+
+Version 2 rebuilds `practice_sessions` so `score_id` can be `NULL`; version 3
+rebuilds both practice tables so a deleted score sets that reference to `NULL`
+rather than cascading the practice away. Every existing row is carried across
+with its id intact, by name rather than by position.
+`server/tests/test_practice_migration.py` builds real version 0, 1 and 2
+databases with real practice rows in them - including a hand-edited one with a
+dangling reference - and checks the rows survive, then compares each upgraded
+table against a freshly created one so the two definitions cannot drift apart.
 
 There is no down direction. A database written by a newer release is refused
 outright at startup rather than written to blind; restoring a backup is the way

--- a/server/fermata/api.py
+++ b/server/fermata/api.py
@@ -1,14 +1,22 @@
 import json
 import re
 import shutil
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Annotated
 
-from fastapi import APIRouter, Body, HTTPException, Path as PathParam, UploadFile
+from fastapi import (
+    APIRouter,
+    Body,
+    HTTPException,
+    Path as PathParam,
+    Query,
+    UploadFile,
+)
 from fastapi.responses import FileResponse
 from pydantic import BaseModel, Field
 
-from . import instruments, scanner
+from . import instruments, practice, scanner
 from .config import FILE_TYPES, LIBRARY_DIR
 from .db import DEFAULT_OWNER, connect, tx, write_tx
 from .glyph_rhythm import VALID_TS_DENOMINATORS
@@ -37,8 +45,19 @@ VALID_PRACTICED = {"recent", "neglected"}
 # web/src/lib/score-render.js - test_settings_api.py's
 # test_staff_theme_choices_match_the_frontends_score_themes parses that file
 # and fails if the two ever disagree.
-SETTINGS_DEFAULTS = {"staff_theme": "parchment"}
-SETTINGS_CHOICES = {"staff_theme": {"parchment", "noir", "print"}}
+#
+# week_starts_on decides which seven days "this week" means when a goal is set
+# without naming its period, and which weeks a review walks back through. It is
+# a preference and not a fact - half the world starts a week on Sunday - and a
+# goal counted over the wrong seven days is counted against days its owner did
+# not think were part of the week. It only ever decides a DEFAULT: a goal
+# stores the two dates it was actually set for, so changing this never moves a
+# goal that already exists.
+SETTINGS_DEFAULTS = {"staff_theme": "parchment", "week_starts_on": practice.DEFAULT_WEEK_START}
+SETTINGS_CHOICES = {
+    "staff_theme": {"parchment", "noir", "print"},
+    "week_starts_on": set(practice.WEEK_STARTS),
+}
 # MusicXML is a good deal more verbose than alphaTex for the same music: across
 # the sampled library it runs about 44x the characters, and the longest score
 # comes out around 660 KB. This leaves room for a compilation several times
@@ -464,9 +483,46 @@ def patch_score(score_id: RowId, patch: ScorePatch):
     return _with_tags(conn, [_score_row(conn, score_id)])[0]
 
 
-class PracticeIn(BaseModel):
-    seconds: int
-    note: str | None = Field(default=None, max_length=2000)
+# ---------------------------------------------------------------------------
+# Practice: sessions (what happened) and goals (what was intended).
+#
+# The rules live in fermata/practice.py, including why a session records the
+# practiser's own calendar day and why nothing stores whether a goal was met.
+# This layer does routing, ownership and 404s, and nothing else - so a session
+# logged from the per-score path and one logged from the general path are the
+# same row obeying the same rules.
+# ---------------------------------------------------------------------------
+
+
+def _server_today():
+    """Today as the server sees it, in UTC.
+
+    UTC and not the host's local time, because started_at is UTC and the two
+    disagreeing would mean a session recorded 'today' landing outside the
+    period a goal was told today was in. Every endpoint that needs a date
+    accepts `today` to override this - see _today().
+    """
+    return datetime.now(timezone.utc).date()
+
+
+def _today(today: str | None):
+    """The date an endpoint should treat as today.
+
+    Passed in by a client that knows its own timezone, because the server's UTC
+    date is not the practiser's date - and whether a period is still running is
+    exactly the sort of thing that must not be an hour-of-day accident. A
+    client that sends nothing gets the server's UTC date.
+    """
+    if not today:
+        return _server_today()
+    try:
+        return practice.parse_day(today, "today")
+    except ValueError as e:
+        raise HTTPException(422, str(e)) from None
+
+
+def _week_starts_on() -> str:
+    return get_settings()["week_starts_on"]
 
 
 def _practice_totals(conn, score_id: int):
@@ -479,17 +535,125 @@ def _practice_totals(conn, score_id: int):
     return dict(row)
 
 
+class PracticeIn(BaseModel):
+    """A session as logged against a score whose id is already in the path.
+
+    Everything but `seconds` is optional, and that is deliberate: the timer can
+    stop and store the one thing it knows, and the detail - how it felt, at
+    what tempo, which bars - can arrive afterwards through the PATCH below
+    rather than standing between a player and a stopped clock.
+    """
+
+    seconds: int
+    activity: str | None = None
+    mode: str | None = None
+    # The practiser's own calendar day. Omitted means "attribute this to the
+    # UTC day", which is what a client that does not know its timezone should
+    # say rather than guess.
+    local_date: str | None = None
+    from_bar: int | None = None
+    to_bar: int | None = None
+    from_page: int | None = None
+    to_page: int | None = None
+    tempo_bpm: int | None = None
+    target_tempo_bpm: int | None = None
+    rating: int | None = None
+    note: str | None = Field(default=None, max_length=practice.MAX_NOTE_CHARS)
+
+
+class SessionIn(PracticeIn):
+    """A session that names its own score, or names none at all."""
+
+    score_id: int | None = Field(default=None, ge=1, le=SQLITE_MAX_INTEGER)
+
+
+class SessionPatch(BaseModel):
+    """Detail added to, or corrected on, a session already stored.
+
+    Every field including `seconds` is optional, and an explicit null CLEARS
+    the field rather than being ignored - a rating entered by mistake has to be
+    removable. The merged record is then re-checked in full, so a patch cannot
+    reach a state a fresh log would have been refused.
+    """
+
+    seconds: int | None = None
+    activity: str | None = None
+    mode: str | None = None
+    local_date: str | None = None
+    from_bar: int | None = None
+    to_bar: int | None = None
+    from_page: int | None = None
+    to_page: int | None = None
+    tempo_bpm: int | None = None
+    target_tempo_bpm: int | None = None
+    rating: int | None = None
+    note: str | None = Field(default=None, max_length=practice.MAX_NOTE_CHARS)
+
+
+_SESSION_COLUMNS = (
+    "score_id",
+    "activity",
+    "mode",
+    "seconds",
+    "local_date",
+    "from_bar",
+    "to_bar",
+    "from_page",
+    "to_page",
+    "tempo_bpm",
+    "target_tempo_bpm",
+    "rating",
+    "note",
+)
+
+
+def _normalise_session(conn, fields: dict) -> dict:
+    if fields.get("score_id") is not None:
+        _score_row(conn, fields["score_id"])
+    try:
+        return practice.normalise_session(recorded_on=_server_today(), **fields)
+    except ValueError as e:
+        raise HTTPException(422, str(e)) from None
+
+
+def _insert_session(conn, values: dict) -> int:
+    columns = ", ".join(_SESSION_COLUMNS)
+    placeholders = ", ".join("?" * len(_SESSION_COLUMNS))
+    cur = conn.execute(
+        f"""INSERT INTO practice_sessions(owner, started_at, {columns})
+            VALUES (?, datetime('now'), {placeholders})""",
+        [DEFAULT_OWNER, *(values[c] for c in _SESSION_COLUMNS)],
+    )
+    return cur.lastrowid
+
+
+def _session_row(conn, session_id: int):
+    row = conn.execute(
+        "SELECT * FROM practice_sessions WHERE id = ? AND owner = ?",
+        (session_id, DEFAULT_OWNER),
+    ).fetchone()
+    if not row:
+        raise HTTPException(404, "practice session not found")
+    return row
+
+
 @router.post("/scores/{score_id}/practice")
 def log_practice(score_id: RowId, body: PracticeIn):
-    if not 0 < body.seconds <= 86400:
-        raise HTTPException(422, "seconds must be between 1 and 86400")
-    with tx() as conn:
+    with write_tx() as conn:
         _score_row(conn, score_id)
-        conn.execute(
-            "INSERT INTO practice_sessions(score_id, started_at, seconds, note) VALUES (?, datetime('now'), ?, ?)",
-            (score_id, body.seconds, body.note),
-        )
-    return get_practice(score_id)
+        fields = body.model_dump()
+        fields["score_id"] = score_id
+        values = _normalise_session(conn, fields)
+        session_id = _insert_session(conn, values)
+    # The stored row, read back, rather than the request echoed: the id is what
+    # a client needs to add detail to what it just logged, and the row is the
+    # only place the attributed practice day exists once the server has
+    # decided it.
+    conn = connect()
+    return {
+        "session": practice.session_dict(_session_row(conn, session_id)),
+        **get_practice(score_id),
+    }
 
 
 @router.get("/scores/{score_id}/practice")
@@ -500,7 +664,110 @@ def get_practice(score_id: RowId):
         "SELECT * FROM practice_sessions WHERE score_id = ? ORDER BY started_at DESC, id DESC LIMIT 50",
         (score_id,),
     ).fetchall()
-    return {"sessions": [dict(r) for r in sessions], **_practice_totals(conn, score_id)}
+    return {
+        "sessions": [practice.session_dict(r) for r in sessions],
+        **_practice_totals(conn, score_id),
+    }
+
+
+@router.post("/practice/sessions")
+def log_session(body: SessionIn):
+    """Log practice that is not necessarily against a piece.
+
+    The general form of the per-score endpoint above, and the one an exercise
+    or a stretch of unstructured playing uses: `score_id` may be omitted for
+    every activity except 'piece', which is defined by having one.
+    """
+    with write_tx() as conn:
+        values = _normalise_session(conn, body.model_dump())
+        session_id = _insert_session(conn, values)
+    conn = connect()
+    return practice.session_dict(_session_row(conn, session_id))
+
+
+@router.patch("/practice/sessions/{session_id}")
+def patch_session(session_id: RowId, patch: SessionPatch):
+    with write_tx() as conn:
+        row = _session_row(conn, session_id)
+        # The whole record is rebuilt and re-checked, not just the changed
+        # fields: `to_bar` alone is meaningless without the `from_bar` already
+        # stored, and validating a fragment would let a patch produce a row a
+        # fresh log could not have created.
+        fields = {c: row[c] for c in _SESSION_COLUMNS}
+        for name in patch.model_fields_set:
+            fields[name] = getattr(patch, name)
+        values = _normalise_session(conn, fields)
+        assignments = ", ".join(f"{c} = ?" for c in _SESSION_COLUMNS)
+        conn.execute(
+            f"UPDATE practice_sessions SET {assignments} WHERE id = ? AND owner = ?",
+            [*(values[c] for c in _SESSION_COLUMNS), session_id, DEFAULT_OWNER],
+        )
+    conn = connect()
+    return practice.session_dict(_session_row(conn, session_id))
+
+
+@router.delete("/practice/sessions/{session_id}")
+def delete_session(session_id: RowId):
+    """Remove a session that should not be in the record.
+
+    Practice history cannot be regenerated from anything on disk, so this is
+    the one destructive operation here and it exists only because a timer left
+    running by accident is otherwise permanent - and a record with an invented
+    two-hour session in it is not an honest record either.
+    """
+    with write_tx() as conn:
+        _session_row(conn, session_id)
+        conn.execute(
+            "DELETE FROM practice_sessions WHERE id = ? AND owner = ?",
+            (session_id, DEFAULT_OWNER),
+        )
+    return {"deleted": session_id}
+
+
+@router.get("/practice/sessions")
+def list_sessions(
+    start: str = "",
+    end: str = "",
+    score_id: Annotated[int | None, Query(ge=1, le=SQLITE_MAX_INTEGER)] = None,
+    activity: str = "",
+    limit: int = practice.DEFAULT_SESSION_LIMIT,
+):
+    """Sessions themselves, across every piece and every kind of practice.
+
+    The raw record, filtered by practice day: this is what answers "what did I
+    actually do this week" without a reader having to reconstruct it from
+    per-score endpoints one score at a time.
+    """
+    if not 1 <= limit <= practice.MAX_SESSION_LIMIT:
+        raise HTTPException(422, f"limit must be between 1 and {practice.MAX_SESSION_LIMIT}")
+    if activity and activity not in practice.ACTIVITIES:
+        raise HTTPException(422, f"activity must be one of {sorted(practice.ACTIVITIES)}")
+    where = ["p.owner = ?"]
+    params: list = [DEFAULT_OWNER]
+    for value, field, comparison in ((start, "start", ">="), (end, "end", "<=")):
+        if value:
+            try:
+                day = practice.parse_day(value, field)
+            except ValueError as e:
+                raise HTTPException(422, str(e)) from None
+            where.append(f"{practice.LOCAL_DATE_SQL} {comparison} ?")
+            params.append(day.isoformat())
+    if score_id is not None:
+        where.append("p.score_id = ?")
+        params.append(score_id)
+    if activity:
+        where.append("p.activity = ?")
+        params.append(activity)
+    conn = connect()
+    rows = conn.execute(
+        f"""SELECT p.*, s.title AS score_title
+              FROM practice_sessions p LEFT JOIN scores s ON s.id = p.score_id
+             WHERE {" AND ".join(where)}
+          ORDER BY {practice.LOCAL_DATE_SQL} DESC, p.started_at DESC, p.id DESC
+             LIMIT ?""",
+        [*params, limit],
+    ).fetchall()
+    return {"sessions": [practice.session_dict(r) for r in rows]}
 
 
 @router.get("/practice/summary")
@@ -521,6 +788,282 @@ def practice_summary():
         "week_sessions": week["session_count"],
         "top_scores": [dict(r) for r in top],
     }
+
+
+@router.get("/practice/history")
+def practice_history(days: int = practice.DEFAULT_HISTORY_DAYS, today: str | None = None):
+    """Where the time went over a stretch of days.
+
+    A day at a time, a piece at a time, and a kind of work at a time, over a
+    window as long as three months - which is the shape of question a reader
+    has otherwise had to reassemble score by score. It states totals and never
+    a trend, a streak, or a comparison between one stretch and another.
+    """
+    if not 1 <= days <= practice.MAX_HISTORY_DAYS:
+        raise HTTPException(422, f"days must be between 1 and {practice.MAX_HISTORY_DAYS}")
+    end = _today(today)
+    start = end - timedelta(days=days - 1)
+    conn = connect()
+    return {
+        "start": start.isoformat(),
+        "end": end.isoformat(),
+        **practice.period_facts(conn, start.isoformat(), end.isoformat()),
+        **practice.time_spent(conn, start.isoformat(), end.isoformat()),
+    }
+
+
+class GoalIn(BaseModel):
+    """A whole goal. Replaces any goal already set for the same period.
+
+    `period_start` may be omitted, in which case the goal is for the week
+    containing `today` under the week_starts_on setting - which is what "set a
+    goal for this week" means and what saves a client doing calendar
+    arithmetic the server can do once.
+    """
+
+    period: str | None = None
+    period_start: str | None = None
+    target_days: int | None = None
+    target_minutes: int | None = None
+    scope: str | None = None
+    score_id: int | None = Field(default=None, ge=1, le=SQLITE_MAX_INTEGER)
+    activity: str | None = None
+    intent: str | None = Field(default=None, max_length=practice.MAX_INTENT_CHARS)
+
+
+class GoalPatch(BaseModel):
+    """A change to a goal already set.
+
+    Targets are editable while the period runs, on purpose: seeing where you
+    stand is only useful if the goal can still change the week rather than
+    only judge it afterwards. `reflection` and `realistic` are the person's
+    own account of how it went, and nothing else ever writes them.
+    """
+
+    target_days: int | None = None
+    target_minutes: int | None = None
+    scope: str | None = None
+    score_id: int | None = Field(default=None, ge=1, le=SQLITE_MAX_INTEGER)
+    activity: str | None = None
+    intent: str | None = Field(default=None, max_length=practice.MAX_INTENT_CHARS)
+    reflection: str | None = Field(default=None, max_length=practice.MAX_REFLECTION_CHARS)
+    realistic: str | None = None
+
+
+# What a caller may state about a goal, which is what practice.normalise_goal
+# takes. period_end is absent on purpose: it is derived from the start and the
+# period length, so it can never be given as something other than what the
+# period means.
+_GOAL_INPUT_FIELDS = (
+    "period",
+    "period_start",
+    "target_days",
+    "target_minutes",
+    "scope",
+    "score_id",
+    "activity",
+    "intent",
+)
+
+# The stored columns, which is the above plus the derived period_end.
+_GOAL_COLUMNS = (*_GOAL_INPUT_FIELDS, "period_end")
+
+
+def _goal_row(conn, goal_id: int):
+    row = conn.execute(
+        "SELECT * FROM practice_goals WHERE id = ? AND owner = ?",
+        (goal_id, DEFAULT_OWNER),
+    ).fetchone()
+    if not row:
+        raise HTTPException(404, "goal not found")
+    return row
+
+
+def _normalise_goal(conn, fields: dict) -> dict:
+    if fields.get("score_id") is not None:
+        _score_row(conn, fields["score_id"])
+    try:
+        return practice.normalise_goal(**fields)
+    except ValueError as e:
+        raise HTTPException(422, str(e)) from None
+
+
+@router.post("/practice/goals")
+def set_goal(body: GoalIn, today: str | None = None):
+    day = _today(today)
+    fields = body.model_dump()
+    if not fields.get("period_start"):
+        fields["period_start"] = practice.week_start(day, _week_starts_on()).isoformat()
+    with write_tx() as conn:
+        values = _normalise_goal(conn, fields)
+        # Setting a goal for a period that already has one REPLACES its
+        # targets rather than adding a second goal or refusing. Changing your
+        # mind about the week is the ordinary case, and a period with two
+        # goals in it is a scorecard.
+        columns = ", ".join(_GOAL_COLUMNS)
+        placeholders = ", ".join("?" * len(_GOAL_COLUMNS))
+        updates = ", ".join(f"{c} = excluded.{c}" for c in _GOAL_COLUMNS if c != "period_start")
+        conn.execute(
+            f"""INSERT INTO practice_goals(owner, {columns})
+                VALUES (?, {placeholders})
+                ON CONFLICT(owner, period_start) DO UPDATE SET
+                    {updates}, updated_at = datetime('now')""",
+            [DEFAULT_OWNER, *(values[c] for c in _GOAL_COLUMNS)],
+        )
+        row = conn.execute(
+            "SELECT * FROM practice_goals WHERE owner = ? AND period_start = ?",
+            (DEFAULT_OWNER, values["period_start"]),
+        ).fetchone()
+        goal_id = row["id"]
+    conn = connect()
+    return practice.goal_dict(conn, _goal_row(conn, goal_id), day)
+
+
+# Declared before the {goal_id} routes so "current" is not parsed as an id -
+# FastAPI matches in declaration order.
+@router.get("/practice/goals/current")
+def current_goal(today: str | None = None):
+    """The goal covering today, or nothing.
+
+    `goal: null` is an answer, not an error: having no goal set is an ordinary
+    state and a perfectly good week can happen inside it.
+    """
+    day = _today(today)
+    conn = connect()
+    row = conn.execute(
+        """SELECT * FROM practice_goals
+            WHERE owner = ? AND period_start <= ? AND period_end >= ?
+         ORDER BY period_start DESC LIMIT 1""",
+        (DEFAULT_OWNER, day.isoformat(), day.isoformat()),
+    ).fetchone()
+    week = practice.week_start(day, _week_starts_on())
+    return {
+        "goal": practice.goal_dict(conn, row, day) if row else None,
+        "today": day.isoformat(),
+        # What a goal set right now would be for, so a client offering to set
+        # one does not have to work out the week itself.
+        "week_starts_on": _week_starts_on(),
+        "week_start": week.isoformat(),
+        "week_end": (week + timedelta(days=6)).isoformat(),
+    }
+
+
+@router.get("/practice/goals")
+def list_goals(limit: int = practice.MAX_REVIEW_WEEKS, today: str | None = None):
+    day = _today(today)
+    if not 1 <= limit <= practice.MAX_REVIEW_WEEKS:
+        raise HTTPException(422, f"limit must be between 1 and {practice.MAX_REVIEW_WEEKS}")
+    conn = connect()
+    rows = conn.execute(
+        """SELECT * FROM practice_goals WHERE owner = ?
+        ORDER BY period_start DESC LIMIT ?""",
+        (DEFAULT_OWNER, limit),
+    ).fetchall()
+    return {"goals": [practice.goal_dict(conn, r, day) for r in rows]}
+
+
+@router.patch("/practice/goals/{goal_id}")
+def patch_goal(goal_id: RowId, patch: GoalPatch, today: str | None = None):
+    day = _today(today)
+    with write_tx() as conn:
+        row = _goal_row(conn, goal_id)
+        fields = {c: row[c] for c in _GOAL_INPUT_FIELDS}
+        for name in patch.model_fields_set:
+            if name in fields:
+                fields[name] = getattr(patch, name)
+        # period_start is not patchable: it is the goal's identity under the
+        # unique index, and moving it would silently re-point a goal at a
+        # different week's practice. Setting a goal for the other week is what
+        # POST does.
+        values = _normalise_goal(conn, fields)
+        try:
+            reflection = practice.normalise_reflection(
+                reflection=patch.reflection
+                if "reflection" in patch.model_fields_set
+                else row["reflection"],
+                realistic=patch.realistic
+                if "realistic" in patch.model_fields_set
+                else row["realistic"],
+            )
+        except ValueError as e:
+            raise HTTPException(422, str(e)) from None
+        assignments = ", ".join(f"{c} = ?" for c in _GOAL_COLUMNS if c != "period_start")
+        conn.execute(
+            f"""UPDATE practice_goals
+                   SET {assignments}, reflection = ?, realistic = ?,
+                       updated_at = datetime('now')
+                 WHERE id = ? AND owner = ?""",
+            [
+                *(values[c] for c in _GOAL_COLUMNS if c != "period_start"),
+                reflection["reflection"],
+                reflection["realistic"],
+                goal_id,
+                DEFAULT_OWNER,
+            ],
+        )
+    conn = connect()
+    return practice.goal_dict(conn, _goal_row(conn, goal_id), day)
+
+
+@router.delete("/practice/goals/{goal_id}")
+def delete_goal(goal_id: RowId):
+    """Forget a goal.
+
+    Deleting a goal deletes an intention, never the practice: the sessions in
+    its period are untouched and the week still shows what was done. A goal
+    whose week has ended is NOT deleted by anything automatic - it stays with
+    whatever was written about it, because a record of what someone meant to do
+    is the only thing that makes the next goal a better one.
+    """
+    with write_tx() as conn:
+        _goal_row(conn, goal_id)
+        conn.execute(
+            "DELETE FROM practice_goals WHERE id = ? AND owner = ?", (goal_id, DEFAULT_OWNER)
+        )
+    return {"deleted": goal_id}
+
+
+@router.get("/practice/review")
+def practice_review(weeks: int = practice.DEFAULT_REVIEW_WEEKS, today: str | None = None):
+    """Recent weeks, each stating what happened in it.
+
+    Every week in the window appears, whether or not a goal was set for it -
+    a week with no goal is not a gap in a record, and a week whose goal was not
+    reached is reported with the same fields and in the same order as one whose
+    goal was. Nothing here compares one week to another, and nothing carries a
+    best or a run of anything: that is the machinery by which a good month
+    becomes the standard a bad month is punished against.
+    """
+    if not 1 <= weeks <= practice.MAX_REVIEW_WEEKS:
+        raise HTTPException(422, f"weeks must be between 1 and {practice.MAX_REVIEW_WEEKS}")
+    day = _today(today)
+    starts_on = _week_starts_on()
+    this_week = practice.week_start(day, starts_on)
+    conn = connect()
+    periods = []
+    for back in range(weeks):
+        start = this_week - timedelta(days=7 * back)
+        end = start + timedelta(days=6)
+        row = conn.execute(
+            "SELECT * FROM practice_goals WHERE owner = ? AND period_start = ?",
+            (DEFAULT_OWNER, start.isoformat()),
+        ).fetchone()
+        periods.append(
+            {
+                "period": "week",
+                "period_start": start.isoformat(),
+                "period_end": end.isoformat(),
+                "status": "running" if start <= day <= end else "past",
+                "goal": practice.goal_dict(conn, row, day) if row else None,
+                # The week's own facts, unscoped, even when the goal was about
+                # one piece: "I did not reach the goal but I practised four
+                # days" is true and is the sort of thing a scoped-only view
+                # hides.
+                "facts": practice.period_facts(conn, start.isoformat(), end.isoformat()),
+                **practice.time_spent(conn, start.isoformat(), end.isoformat()),
+            }
+        )
+    return {"today": day.isoformat(), "week_starts_on": starts_on, "weeks": periods}
 
 
 @router.get("/scores/{score_id}/file")

--- a/server/fermata/api.py
+++ b/server/fermata/api.py
@@ -14,7 +14,7 @@ from fastapi import (
     UploadFile,
 )
 from fastapi.responses import FileResponse
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, StrictInt
 
 from . import instruments, practice, scanner
 from .config import FILE_TYPES, LIBRARY_DIR
@@ -32,6 +32,13 @@ router = APIRouter(prefix="/api")
 # negatives are equally impossible.
 SQLITE_MAX_INTEGER = 2**63 - 1
 RowId = Annotated[int, PathParam(ge=1, le=SQLITE_MAX_INTEGER)]
+
+# A whole number and nothing that merely converts to one. Pydantic's default
+# mode coerces before any validator sees the value, so `true` arrived as 1 -
+# and {"target_days": true} set a one-day goal, cheerfully, past a guard
+# written specifically to reject bools. Every numeric field a client sends
+# below uses this.
+Count = Annotated[StrictInt, Field()]
 
 VALID_KINDS = {"notation", "tab", "both", "unknown"}
 VALID_PRACTICED = {"recent", "neglected"}
@@ -91,9 +98,17 @@ def _with_tags(conn, rows):
             ids,
         ):
             tag_map[r["score_id"]].append(r["name"])
+        # last_practiced is the practice DAY (YYYY-MM-DD), not the timestamp it
+        # used to be. The library's "practised 3 days ago" is a calendar
+        # statement, and reading it off a UTC timestamp put an evening's
+        # practice on the wrong day for anyone west of Greenwich - the same
+        # reason the practice day is stored at all. Compared as text, which is
+        # chronological for this format.
         for r in conn.execute(
-            f"""SELECT score_id, SUM(seconds) AS practice_seconds, MAX(started_at) AS last_practiced
-                FROM practice_sessions WHERE score_id IN ({placeholders}) GROUP BY score_id""",
+            f"""SELECT p.score_id, SUM(p.seconds) AS practice_seconds,
+                       MAX({practice.LOCAL_DATE_SQL}) AS last_practiced
+                FROM practice_sessions p WHERE p.score_id IN ({placeholders})
+                GROUP BY p.score_id""",
             ids,
         ):
             practice_map[r["score_id"]] = {
@@ -369,16 +384,39 @@ def list_scores(
         params.append(kind)
     if favorite:
         where.append("s.favorite = 1")
+    # Windowed on the practice DAY, not on the UTC timestamp. These two views
+    # and the practice page have to agree about when a piece was last worked
+    # on, and the library is the view a person sees first - so "practised
+    # recently" here and "practised on Tuesday" there cannot be answered from
+    # different clocks. A back-dated session counts from the day it says it
+    # happened, which is the whole point of being able to enter one.
     if practiced == "recent":
         where.append(
-            """s.id IN (SELECT score_id FROM practice_sessions
-                        GROUP BY score_id HAVING MAX(started_at) >= datetime('now', '-14 days'))"""
+            f"""s.id IN (SELECT p.score_id FROM practice_sessions p
+                         GROUP BY p.score_id
+                         HAVING MAX({practice.LOCAL_DATE_SQL}) >= date('now', '-14 days'))"""
         )
     elif practiced == "neglected":
         where.append(
-            """(s.id NOT IN (SELECT score_id FROM practice_sessions)
-                OR s.id IN (SELECT score_id FROM practice_sessions
-                            GROUP BY score_id HAVING MAX(started_at) < datetime('now', '-30 days')))"""
+            # NOT EXISTS, not NOT IN, and this is not a style preference. A
+            # session can now have no score at all - a trainer, or a piece
+            # since deleted - and SQL's NOT IN against a set containing NULL
+            # is never true, for any row. So the version of this that read
+            # `s.id NOT IN (SELECT score_id FROM practice_sessions)` returned
+            # NOTHING the moment one score-less session existed anywhere,
+            # which is precisely what the nullable column was added for:
+            # "needs attention" went from listing every unpractised score to
+            # listing none, with nothing failing. NOT EXISTS asks the question
+            # this filter means and is unaffected by NULLs.
+            #
+            # Worth knowing as a pattern rather than an instance: nothing about
+            # that query was wrong when it was written. It rested on an
+            # assumption the schema had been guaranteeing, and this change
+            # stopped guaranteeing it.
+            f"""(NOT EXISTS (SELECT 1 FROM practice_sessions p WHERE p.score_id = s.id)
+                 OR s.id IN (SELECT p.score_id FROM practice_sessions p
+                             GROUP BY p.score_id
+                             HAVING MAX({practice.LOCAL_DATE_SQL}) < date('now', '-30 days')))"""
         )
     if where:
         sql += " WHERE " + " AND ".join(where)
@@ -512,13 +550,29 @@ def _today(today: str | None):
     date is not the practiser's date - and whether a period is still running is
     exactly the sort of thing that must not be an hour-of-day accident. A
     client that sends nothing gets the server's UTC date.
+
+    Bounded to the same window a practice day may name - see the comment on
+    practice.MAX_BACKDATE_DAYS. Unbounded, a read endpoint answered
+    `today=2099-01-01` with a plausible-looking empty week rather than an error,
+    which is the worst kind of wrong answer: nothing in the response marks it as
+    suspect. Writes were already bounded; reads were not.
     """
     if not today:
         return _server_today()
     try:
-        return practice.parse_day(today, "today")
+        day = practice.parse_day(today, "today")
     except ValueError as e:
         raise HTTPException(422, str(e)) from None
+    server_day = _server_today()
+    earliest = server_day - timedelta(days=practice.MAX_BACKDATE_DAYS)
+    latest = server_day + timedelta(days=practice.MAX_FUTURE_DAYS)
+    if not earliest <= day <= latest:
+        raise HTTPException(
+            422,
+            f"today must be between {earliest.isoformat()} and {latest.isoformat()} - "
+            "no practice this instance could hold falls outside that",
+        )
+    return day
 
 
 def _week_starts_on() -> str:
@@ -527,9 +581,9 @@ def _week_starts_on() -> str:
 
 def _practice_totals(conn, score_id: int):
     row = conn.execute(
-        """SELECT COUNT(*) AS session_count, COALESCE(SUM(seconds), 0) AS practice_seconds,
-                  MAX(started_at) AS last_practiced
-           FROM practice_sessions WHERE score_id = ?""",
+        f"""SELECT COUNT(*) AS session_count, COALESCE(SUM(p.seconds), 0) AS practice_seconds,
+                   MAX({practice.LOCAL_DATE_SQL}) AS last_practiced
+            FROM practice_sessions p WHERE p.score_id = ?""",
         (score_id,),
     ).fetchone()
     return dict(row)
@@ -544,27 +598,27 @@ class PracticeIn(BaseModel):
     rather than standing between a player and a stopped clock.
     """
 
-    seconds: int
+    seconds: Count
     activity: str | None = None
     mode: str | None = None
     # The practiser's own calendar day. Omitted means "attribute this to the
     # UTC day", which is what a client that does not know its timezone should
     # say rather than guess.
     local_date: str | None = None
-    from_bar: int | None = None
-    to_bar: int | None = None
-    from_page: int | None = None
-    to_page: int | None = None
-    tempo_bpm: int | None = None
-    target_tempo_bpm: int | None = None
-    rating: int | None = None
+    from_bar: Count | None = None
+    to_bar: Count | None = None
+    from_page: Count | None = None
+    to_page: Count | None = None
+    tempo_bpm: Count | None = None
+    target_tempo_bpm: Count | None = None
+    rating: Count | None = None
     note: str | None = Field(default=None, max_length=practice.MAX_NOTE_CHARS)
 
 
 class SessionIn(PracticeIn):
     """A session that names its own score, or names none at all."""
 
-    score_id: int | None = Field(default=None, ge=1, le=SQLITE_MAX_INTEGER)
+    score_id: Count | None = Field(default=None, ge=1, le=SQLITE_MAX_INTEGER)
 
 
 class SessionPatch(BaseModel):
@@ -576,17 +630,17 @@ class SessionPatch(BaseModel):
     reach a state a fresh log would have been refused.
     """
 
-    seconds: int | None = None
+    seconds: Count | None = None
     activity: str | None = None
     mode: str | None = None
     local_date: str | None = None
-    from_bar: int | None = None
-    to_bar: int | None = None
-    from_page: int | None = None
-    to_page: int | None = None
-    tempo_bpm: int | None = None
-    target_tempo_bpm: int | None = None
-    rating: int | None = None
+    from_bar: Count | None = None
+    to_bar: Count | None = None
+    from_page: Count | None = None
+    to_page: Count | None = None
+    tempo_bpm: Count | None = None
+    target_tempo_bpm: Count | None = None
+    rating: Count | None = None
     note: str | None = Field(default=None, max_length=practice.MAX_NOTE_CHARS)
 
 
@@ -607,24 +661,38 @@ _SESSION_COLUMNS = (
 )
 
 
-def _normalise_session(conn, fields: dict) -> dict:
+def _normalise_session(
+    conn, fields: dict, allow_missing_score: bool = False, check_day_window: bool = True
+) -> dict:
     if fields.get("score_id") is not None:
         _score_row(conn, fields["score_id"])
     try:
-        return practice.normalise_session(recorded_on=_server_today(), **fields)
+        return practice.normalise_session(
+            recorded_on=_server_today(),
+            allow_missing_score=allow_missing_score,
+            check_day_window=check_day_window,
+            **fields,
+        )
     except ValueError as e:
         raise HTTPException(422, str(e)) from None
 
 
-def _insert_session(conn, values: dict) -> int:
+def _insert_session(conn, values: dict):
+    """Store a session and return the stored row.
+
+    Returned rather than looked up again afterwards: reading it back on a
+    second connection - or after the transaction closed - lets a delete land in
+    the gap and turn a successful write into a 404 about a row this call had
+    just created.
+    """
     columns = ", ".join(_SESSION_COLUMNS)
     placeholders = ", ".join("?" * len(_SESSION_COLUMNS))
-    cur = conn.execute(
+    return conn.execute(
         f"""INSERT INTO practice_sessions(owner, started_at, {columns})
-            VALUES (?, datetime('now'), {placeholders})""",
+            VALUES (?, datetime('now'), {placeholders})
+            RETURNING *""",
         [DEFAULT_OWNER, *(values[c] for c in _SESSION_COLUMNS)],
-    )
-    return cur.lastrowid
+    ).fetchone()
 
 
 def _session_row(conn, session_id: int):
@@ -644,28 +712,33 @@ def log_practice(score_id: RowId, body: PracticeIn):
         fields = body.model_dump()
         fields["score_id"] = score_id
         values = _normalise_session(conn, fields)
-        session_id = _insert_session(conn, values)
-    # The stored row, read back, rather than the request echoed: the id is what
-    # a client needs to add detail to what it just logged, and the row is the
-    # only place the attributed practice day exists once the server has
-    # decided it.
-    conn = connect()
-    return {
-        "session": practice.session_dict(_session_row(conn, session_id)),
-        **get_practice(score_id),
-    }
+        # The stored row, not the request echoed: the id is what a client needs
+        # to add detail to what it just logged, and the row is the only place
+        # the attributed practice day exists once the server has decided it.
+        session = practice.session_dict(_insert_session(conn, values))
+        totals = {
+            "sessions": [
+                practice.session_dict(r) for r in _recent_sessions(conn, score_id)
+            ],
+            **_practice_totals(conn, score_id),
+        }
+    return {"session": session, **totals}
+
+
+def _recent_sessions(conn, score_id: int):
+    return conn.execute(
+        """SELECT * FROM practice_sessions WHERE score_id = ?
+        ORDER BY started_at DESC, id DESC LIMIT 50""",
+        (score_id,),
+    ).fetchall()
 
 
 @router.get("/scores/{score_id}/practice")
 def get_practice(score_id: RowId):
     conn = connect()
     _score_row(conn, score_id)
-    sessions = conn.execute(
-        "SELECT * FROM practice_sessions WHERE score_id = ? ORDER BY started_at DESC, id DESC LIMIT 50",
-        (score_id,),
-    ).fetchall()
     return {
-        "sessions": [practice.session_dict(r) for r in sessions],
+        "sessions": [practice.session_dict(r) for r in _recent_sessions(conn, score_id)],
         **_practice_totals(conn, score_id),
     }
 
@@ -680,9 +753,7 @@ def log_session(body: SessionIn):
     """
     with write_tx() as conn:
         values = _normalise_session(conn, body.model_dump())
-        session_id = _insert_session(conn, values)
-    conn = connect()
-    return practice.session_dict(_session_row(conn, session_id))
+        return practice.session_dict(_insert_session(conn, values))
 
 
 @router.patch("/practice/sessions/{session_id}")
@@ -696,14 +767,30 @@ def patch_session(session_id: RowId, patch: SessionPatch):
         fields = {c: row[c] for c in _SESSION_COLUMNS}
         for name in patch.model_fields_set:
             fields[name] = getattr(patch, name)
-        values = _normalise_session(conn, fields)
-        assignments = ", ".join(f"{c} = ?" for c in _SESSION_COLUMNS)
-        conn.execute(
-            f"UPDATE practice_sessions SET {assignments} WHERE id = ? AND owner = ?",
-            [*(values[c] for c in _SESSION_COLUMNS), session_id, DEFAULT_OWNER],
+        # A session whose score has since been deleted is still a true record
+        # and has to stay editable - somebody adding a note to it is not making
+        # a claim about a piece, they are annotating practice that happened.
+        # The allowance is granted from the STORED row, so a patch cannot use
+        # it to create that state deliberately.
+        values = _normalise_session(
+            conn,
+            fields,
+            allow_missing_score=practice.is_orphaned(row["activity"], row["score_id"]),
+            # How far back a practice day may be is a rule about what somebody
+            # may claim NOW. Re-applying it to the date already stored made a
+            # session permanently uneditable once it was old enough - so a
+            # rating on last year's practice could not be corrected, for a
+            # reason that has nothing to do with the rating. Checked only when
+            # the date is what is being written.
+            check_day_window="local_date" in patch.model_fields_set,
         )
-    conn = connect()
-    return practice.session_dict(_session_row(conn, session_id))
+        assignments = ", ".join(f"{c} = ?" for c in _SESSION_COLUMNS)
+        updated = conn.execute(
+            f"""UPDATE practice_sessions SET {assignments}
+                 WHERE id = ? AND owner = ? RETURNING *""",
+            [*(values[c] for c in _SESSION_COLUMNS), session_id, DEFAULT_OWNER],
+        ).fetchone()
+        return practice.session_dict(updated)
 
 
 @router.delete("/practice/sessions/{session_id}")
@@ -759,29 +846,58 @@ def list_sessions(
         where.append("p.activity = ?")
         params.append(activity)
     conn = connect()
+    filters = " AND ".join(where)
     rows = conn.execute(
         f"""SELECT p.*, s.title AS score_title
               FROM practice_sessions p LEFT JOIN scores s ON s.id = p.score_id
-             WHERE {" AND ".join(where)}
+             WHERE {filters}
           ORDER BY {practice.LOCAL_DATE_SQL} DESC, p.started_at DESC, p.id DESC
              LIMIT ?""",
         [*params, limit],
     ).fetchall()
-    return {"sessions": [practice.session_dict(r) for r in rows]}
+    # How many matched, not just how many came back. A list that stops at the
+    # limit and says nothing looks identical to a complete one, and a reader
+    # totalling it would report less practice than there was - which is the one
+    # direction this must never be wrong in.
+    total = conn.execute(
+        f"SELECT COUNT(*) AS n FROM practice_sessions p WHERE {filters}", params
+    ).fetchone()["n"]
+    return {
+        "sessions": [practice.session_dict(r) for r in rows],
+        "total": total,
+        "truncated": total > len(rows),
+    }
 
 
 @router.get("/practice/summary")
 def practice_summary():
+    """The last seven days, for the library header.
+
+    Counted over practice DAYS - today and the six before it - rather than over
+    a rolling 168 hours of UTC timestamps, so this and the practice page cannot
+    disagree about which sessions were "this week". `date('now')` is UTC, which
+    can put the window's edge a few hours out for somebody far from Greenwich;
+    over seven days that moves nothing anybody would notice, and unlike the
+    goal endpoints this one has no period whose end has to be got exactly right.
+    """
     conn = connect()
+    # Scoped to the owner like every other practice query. Nothing else exists
+    # to aggregate across today, but the day accounts arrive this is a site
+    # that would silently total somebody else's practice into this one's - and
+    # the schema's own comments ask for these to stay greppable and consistent
+    # rather than correct by accident.
     week = conn.execute(
-        """SELECT COALESCE(SUM(seconds), 0) AS total_seconds, COUNT(*) AS session_count
-           FROM practice_sessions WHERE started_at >= datetime('now', '-7 days')"""
+        f"""SELECT COALESCE(SUM(p.seconds), 0) AS total_seconds, COUNT(*) AS session_count
+            FROM practice_sessions p
+            WHERE p.owner = ? AND {practice.LOCAL_DATE_SQL} >= date('now', '-6 days')""",
+        (DEFAULT_OWNER,),
     ).fetchone()
     top = conn.execute(
-        """SELECT s.id, s.title, SUM(p.seconds) AS practice_seconds
-           FROM practice_sessions p JOIN scores s ON s.id = p.score_id
-           WHERE p.started_at >= datetime('now', '-7 days')
-           GROUP BY p.score_id ORDER BY practice_seconds DESC LIMIT 5"""
+        f"""SELECT s.id, s.title, SUM(p.seconds) AS practice_seconds
+            FROM practice_sessions p JOIN scores s ON s.id = p.score_id
+            WHERE p.owner = ? AND {practice.LOCAL_DATE_SQL} >= date('now', '-6 days')
+            GROUP BY p.score_id ORDER BY practice_seconds DESC LIMIT 5""",
+        (DEFAULT_OWNER,),
     ).fetchall()
     return {
         "week_seconds": week["total_seconds"],
@@ -823,10 +939,10 @@ class GoalIn(BaseModel):
 
     period: str | None = None
     period_start: str | None = None
-    target_days: int | None = None
-    target_minutes: int | None = None
+    target_days: Count | None = None
+    target_minutes: Count | None = None
     scope: str | None = None
-    score_id: int | None = Field(default=None, ge=1, le=SQLITE_MAX_INTEGER)
+    score_id: Count | None = Field(default=None, ge=1, le=SQLITE_MAX_INTEGER)
     activity: str | None = None
     intent: str | None = Field(default=None, max_length=practice.MAX_INTENT_CHARS)
 
@@ -840,10 +956,10 @@ class GoalPatch(BaseModel):
     own account of how it went, and nothing else ever writes them.
     """
 
-    target_days: int | None = None
-    target_minutes: int | None = None
+    target_days: Count | None = None
+    target_minutes: Count | None = None
     scope: str | None = None
-    score_id: int | None = Field(default=None, ge=1, le=SQLITE_MAX_INTEGER)
+    score_id: Count | None = Field(default=None, ge=1, le=SQLITE_MAX_INTEGER)
     activity: str | None = None
     intent: str | None = Field(default=None, max_length=practice.MAX_INTENT_CHARS)
     reflection: str | None = Field(default=None, max_length=practice.MAX_REFLECTION_CHARS)
@@ -879,11 +995,11 @@ def _goal_row(conn, goal_id: int):
     return row
 
 
-def _normalise_goal(conn, fields: dict) -> dict:
+def _normalise_goal(conn, fields: dict, allow_missing_score: bool = False) -> dict:
     if fields.get("score_id") is not None:
         _score_row(conn, fields["score_id"])
     try:
-        return practice.normalise_goal(**fields)
+        return practice.normalise_goal(allow_missing_score=allow_missing_score, **fields)
     except ValueError as e:
         raise HTTPException(422, str(e)) from None
 
@@ -896,27 +1012,51 @@ def set_goal(body: GoalIn, today: str | None = None):
         fields["period_start"] = practice.week_start(day, _week_starts_on()).isoformat()
     with write_tx() as conn:
         values = _normalise_goal(conn, fields)
+        # No two goals may share a day. The unique index below covers an
+        # identical period; this covers a period that merely overlaps one,
+        # which becomes reachable the moment the week-start preference changes
+        # - the new grid's weeks are offset from the old grid's rather than
+        # being different weeks. Overlapping goals are how the same practice
+        # gets counted against two intentions and how two panels of one page
+        # come to disagree about which goal this week has.
+        clash = practice.overlapping_goal(
+            conn,
+            DEFAULT_OWNER,
+            values["period_start"],
+            values["period_end"],
+            ignore_start=values["period_start"],
+        )
+        if clash is not None:
+            raise HTTPException(
+                409,
+                f"a goal is already set for {clash['period_start']} to {clash['period_end']}, "
+                f"which shares days with {values['period_start']} to {values['period_end']}. "
+                "Adjust or remove that one first.",
+            )
         # Setting a goal for a period that already has one REPLACES its
         # targets rather than adding a second goal or refusing. Changing your
         # mind about the week is the ordinary case, and a period with two
         # goals in it is a scorecard.
+        #
+        # The reflection goes with it. It was written about the intention being
+        # replaced, and carrying it over would have the review ask whether a
+        # goal was realistic and answer with words about a different one.
         columns = ", ".join(_GOAL_COLUMNS)
         placeholders = ", ".join("?" * len(_GOAL_COLUMNS))
         updates = ", ".join(f"{c} = excluded.{c}" for c in _GOAL_COLUMNS if c != "period_start")
-        conn.execute(
+        row = conn.execute(
             f"""INSERT INTO practice_goals(owner, {columns})
                 VALUES (?, {placeholders})
                 ON CONFLICT(owner, period_start) DO UPDATE SET
-                    {updates}, updated_at = datetime('now')""",
+                    {updates}, reflection = NULL, realistic = NULL,
+                    updated_at = datetime('now')
+                RETURNING *""",
             [DEFAULT_OWNER, *(values[c] for c in _GOAL_COLUMNS)],
-        )
-        row = conn.execute(
-            "SELECT * FROM practice_goals WHERE owner = ? AND period_start = ?",
-            (DEFAULT_OWNER, values["period_start"]),
         ).fetchone()
-        goal_id = row["id"]
-    conn = connect()
-    return practice.goal_dict(conn, _goal_row(conn, goal_id), day)
+        # Read back inside the transaction that wrote it. Outside, a delete
+        # landing in the gap turns a successful write into a 404 about a row
+        # this call had just created.
+        return practice.goal_dict(conn, row, day)
 
 
 # Declared before the {goal_id} routes so "current" is not parsed as an id -
@@ -975,7 +1115,15 @@ def patch_goal(goal_id: RowId, patch: GoalPatch, today: str | None = None):
         # unique index, and moving it would silently re-point a goal at a
         # different week's practice. Setting a goal for the other week is what
         # POST does.
-        values = _normalise_goal(conn, fields)
+        #
+        # A goal whose piece has since been deleted can no longer be counted,
+        # but its reflection can still be written - a deleted file must not
+        # lock the record of an intention that was genuinely formed.
+        values = _normalise_goal(
+            conn,
+            fields,
+            allow_missing_score=row["scope"] == "score" and row["score_id"] is None,
+        )
         try:
             reflection = practice.normalise_reflection(
                 reflection=patch.reflection
@@ -988,11 +1136,11 @@ def patch_goal(goal_id: RowId, patch: GoalPatch, today: str | None = None):
         except ValueError as e:
             raise HTTPException(422, str(e)) from None
         assignments = ", ".join(f"{c} = ?" for c in _GOAL_COLUMNS if c != "period_start")
-        conn.execute(
+        updated = conn.execute(
             f"""UPDATE practice_goals
                    SET {assignments}, reflection = ?, realistic = ?,
                        updated_at = datetime('now')
-                 WHERE id = ? AND owner = ?""",
+                 WHERE id = ? AND owner = ? RETURNING *""",
             [
                 *(values[c] for c in _GOAL_COLUMNS if c != "period_start"),
                 reflection["reflection"],
@@ -1000,9 +1148,8 @@ def patch_goal(goal_id: RowId, patch: GoalPatch, today: str | None = None):
                 goal_id,
                 DEFAULT_OWNER,
             ],
-        )
-    conn = connect()
-    return practice.goal_dict(conn, _goal_row(conn, goal_id), day)
+        ).fetchone()
+        return practice.goal_dict(conn, updated, day)
 
 
 @router.delete("/practice/goals/{goal_id}")
@@ -1038,32 +1185,35 @@ def practice_review(weeks: int = practice.DEFAULT_REVIEW_WEEKS, today: str | Non
         raise HTTPException(422, f"weeks must be between 1 and {practice.MAX_REVIEW_WEEKS}")
     day = _today(today)
     starts_on = _week_starts_on()
-    this_week = practice.week_start(day, starts_on)
     conn = connect()
-    periods = []
-    for back in range(weeks):
-        start = this_week - timedelta(days=7 * back)
-        end = start + timedelta(days=6)
-        row = conn.execute(
-            "SELECT * FROM practice_goals WHERE owner = ? AND period_start = ?",
-            (DEFAULT_OWNER, start.isoformat()),
-        ).fetchone()
-        periods.append(
+    out = []
+    for period in practice.review_periods(
+        conn, DEFAULT_OWNER, practice.week_start(day, starts_on), weeks, starts_on
+    ):
+        start, end, row = period["period_start"], period["period_end"], period["goal"]
+        # The week's own facts, unscoped, even when the goal was about one
+        # piece: "I did not reach the goal but I practised four days" is true
+        # and is the sort of thing a scoped-only view hides. Reused as the
+        # goal's progress when the goal counts everything, because then the two
+        # are the same query asked twice.
+        facts = practice.period_facts(conn, start, end)
+        goal = None
+        if row is not None:
+            goal = practice.goal_dict(
+                conn, row, day, facts=facts if row["scope"] == "all" else None
+            )
+        out.append(
             {
                 "period": "week",
-                "period_start": start.isoformat(),
-                "period_end": end.isoformat(),
-                "status": "running" if start <= day <= end else "past",
-                "goal": practice.goal_dict(conn, row, day) if row else None,
-                # The week's own facts, unscoped, even when the goal was about
-                # one piece: "I did not reach the goal but I practised four
-                # days" is true and is the sort of thing a scoped-only view
-                # hides.
-                "facts": practice.period_facts(conn, start.isoformat(), end.isoformat()),
-                **practice.time_spent(conn, start.isoformat(), end.isoformat()),
+                "period_start": start,
+                "period_end": end,
+                "status": "running" if start <= day.isoformat() <= end else "past",
+                "goal": goal,
+                "facts": facts,
+                **practice.time_spent(conn, start, end),
             }
         )
-    return {"today": day.isoformat(), "week_starts_on": starts_on, "weeks": periods}
+    return {"today": day.isoformat(), "week_starts_on": starts_on, "weeks": out}
 
 
 @router.get("/scores/{score_id}/file")

--- a/server/fermata/db.py
+++ b/server/fermata/db.py
@@ -1,3 +1,4 @@
+import logging
 import sqlite3
 import threading
 from contextlib import contextmanager
@@ -5,6 +6,11 @@ from contextlib import contextmanager
 from .config import DB_PATH
 
 _local = threading.local()
+
+# Startup is the one place in this application that has something to say and no
+# person watching, so it says it through the logger uvicorn has already
+# configured rather than into a response nobody asked for.
+log = logging.getLogger("fermata.db")
 
 # The only owner that exists until real accounts do. Kept as a named constant
 # rather than the literal 'local' scattered wherever a write means "this
@@ -44,10 +50,31 @@ DEFAULT_OWNER = "local"
 # Whether a tempo ladder reached its target is NOT stored: it is
 # tempo_bpm >= target_tempo_bpm, and a stored answer is one that can end up
 # contradicting the two numbers it was computed from.
+#
+# ON DELETE SET NULL, AND WHY IT IS NOT CASCADE. Deleting a score means the
+# file has left the library. It does not mean the hours were not spent. The
+# practice happened, and the record of it is a property of the person's
+# history rather than of a file on disk - which is the entire premise of this
+# feature and the reason these rows are the one thing here that cannot be
+# regenerated. Cascade also made this project inconsistent with itself: the
+# scanner goes to real lengths to re-link a renamed file to its existing score
+# row by content hash SPECIFICALLY so that a rename does not destroy practice
+# history through this reference, and score management is an explicit upcoming
+# feature (#56), so a person deleting a score while tidying up is not
+# hypothetical. Protecting history from a rename while surrendering it to a
+# delete is not a position worth holding.
+#
+# A session that outlives its score keeps activity='piece' with no score_id,
+# and that pair is exactly what identifies it: every other activity may
+# legitimately have no score, and a 'piece' session cannot be CREATED without
+# one (see practice.normalise_session). Nothing filters these rows out - they
+# carry their day, their length, their tempo, their bars and their note, which
+# is enough to be practice that happened. See practice.session_dict's
+# `score_missing`.
 _PRACTICE_SESSIONS_COLUMNS = """(
     id INTEGER PRIMARY KEY,
     owner TEXT NOT NULL DEFAULT 'local',
-    score_id INTEGER REFERENCES scores(id) ON DELETE CASCADE,
+    score_id INTEGER REFERENCES scores(id) ON DELETE SET NULL,
     activity TEXT NOT NULL DEFAULT 'piece',
     mode TEXT,
     started_at TEXT NOT NULL,
@@ -66,9 +93,21 @@ _PRACTICE_SESSIONS_COLUMNS = """(
 # Kept as separate statements rather than one script so SCHEMA can be
 # assembled from them, and so a future migration that needs to build this table
 # under another name has the index set to hand without restating it.
+#
+# idx_practice_day is an index on the EXPRESSION every day-based query filters
+# and groups by, not on the column - because the column alone cannot serve
+# them. A row written before local_date existed is attributed to its UTC day,
+# so every such query reads COALESCE(local_date, date(started_at)) (see
+# practice.LOCAL_DATE_SQL), and a plain index on local_date cannot be used for
+# a wrapped column: SQLite would scan the owner's entire practice history to
+# answer a question about seven days of it. The expression here must stay
+# character-identical to LOCAL_DATE_SQL apart from the table alias, or the
+# planner silently stops using it - test_practice_model.py checks the query
+# plan rather than trusting that.
 _PRACTICE_SESSIONS_INDEXES = (
     "CREATE INDEX IF NOT EXISTS idx_practice_score ON practice_sessions(score_id)",
-    "CREATE INDEX IF NOT EXISTS idx_practice_day ON practice_sessions(owner, local_date)",
+    "CREATE INDEX IF NOT EXISTS idx_practice_day ON practice_sessions"
+    "(owner, COALESCE(local_date, date(started_at)))",
     "CREATE INDEX IF NOT EXISTS idx_practice_started ON practice_sessions(started_at)",
     "CREATE INDEX IF NOT EXISTS idx_practice_activity ON practice_sessions(owner, activity)",
 )
@@ -98,11 +137,16 @@ _PRACTICE_SESSIONS_INDEXES = (
 # deleted, and a plain INTEGER PRIMARY KEY hands a deleted row's id to the
 # next one, so a reflection typed into an open tab could land on a different
 # goal than the one on screen.
-_PRACTICE_SCHEMA = (
-    "CREATE TABLE IF NOT EXISTS practice_sessions " + _PRACTICE_SESSIONS_COLUMNS + ";\n"
-    + "".join(f"{statement};\n" for statement in _PRACTICE_SESSIONS_INDEXES)
-    + """
-CREATE TABLE IF NOT EXISTS practice_goals (
+#
+# ON DELETE SET NULL on score_id, for the same reason the session table has it.
+# A goal is a record of an intention, and tidying a file out of the library is
+# not a reason to forget having formed one. What it CANNOT do is go on being
+# counted: the sessions that were about that piece are still in the history but
+# no longer identifiable as being about it, so the goal becomes uncountable
+# rather than unmet - see practice.goal_progress's `countable`, which exists so
+# that a goal already reached cannot be turned into a shortfall by a file being
+# deleted afterwards.
+_PRACTICE_GOALS_COLUMNS = """(
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     owner TEXT NOT NULL DEFAULT 'local',
     period TEXT NOT NULL DEFAULT 'week',
@@ -111,17 +155,25 @@ CREATE TABLE IF NOT EXISTS practice_goals (
     target_days INTEGER,
     target_minutes INTEGER,
     scope TEXT NOT NULL DEFAULT 'all',
-    score_id INTEGER REFERENCES scores(id) ON DELETE CASCADE,
+    score_id INTEGER REFERENCES scores(id) ON DELETE SET NULL,
     activity TEXT,
     intent TEXT,
     reflection TEXT,
     realistic TEXT,
     created_at TEXT NOT NULL DEFAULT (datetime('now')),
     updated_at TEXT NOT NULL DEFAULT (datetime('now'))
-);
-CREATE UNIQUE INDEX IF NOT EXISTS idx_practice_goals_period
-    ON practice_goals(owner, period_start);
-"""
+)"""
+
+_PRACTICE_GOALS_INDEXES = (
+    "CREATE UNIQUE INDEX IF NOT EXISTS idx_practice_goals_period"
+    " ON practice_goals(owner, period_start)",
+)
+
+_PRACTICE_SCHEMA = (
+    "CREATE TABLE IF NOT EXISTS practice_sessions " + _PRACTICE_SESSIONS_COLUMNS + ";\n"
+    + "".join(f"{statement};\n" for statement in _PRACTICE_SESSIONS_INDEXES)
+    + "CREATE TABLE IF NOT EXISTS practice_goals " + _PRACTICE_GOALS_COLUMNS + ";\n"
+    + "".join(f"{statement};\n" for statement in _PRACTICE_GOALS_INDEXES)
 )
 
 SCHEMA = """
@@ -252,7 +304,7 @@ CREATE INDEX IF NOT EXISTS idx_instruments_owner ON instruments(owner);
 #
 # Version 2 is the first change this file's ADD COLUMN mechanism could not
 # express, which is what the stamp was recorded for - see MIGRATIONS.
-SCHEMA_VERSION = 2
+SCHEMA_VERSION = 3
 
 # Columns added to a table that had already shipped. CREATE TABLE IF NOT EXISTS
 # does nothing at all to a table that exists, so SCHEMA alone reaches only fresh
@@ -362,9 +414,164 @@ def _migrate_to_2_any_practice(conn) -> None:
     # one's in test_practice_migration.py either way.
 
 
+def _table_exists(conn, table: str) -> bool:
+    return (
+        conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?", (table,)
+        ).fetchone()
+        is not None
+    )
+
+
+def _on_delete_action(conn, table: str, column: str) -> str | None:
+    """What SQLite will do to this column when the row it points at is deleted.
+
+    PRAGMA foreign_key_list is the only way to read it back - the action is not
+    in table_info - and reading it is what lets a migration check its own work
+    instead of assuming it. None means the column carries no foreign key at all.
+    """
+    for row in conn.execute(f"PRAGMA foreign_key_list({table})"):
+        if row["from"] == column:
+            return row["on_delete"]
+    return None
+
+
+def _rebuild_carrying_rows(conn, table: str, columns: str) -> None:
+    """Rebuild one table from `columns`, carrying every existing row across.
+
+    SQLite cannot alter a constraint in place, so this is the documented
+    table-rebuild recipe: a new table under a temporary name, the rows copied,
+    the old table dropped, the new one renamed into its place. It runs inside
+    the caller's transaction, so it either lands completely or not at all.
+
+    The columns carried are the ones the two tables have IN COMMON, worked out
+    by name from PRAGMA table_info on both - never a positional copy, and never
+    SELECT *. A column the old table did not have takes its default; a column
+    it had and the new definition does not is dropped, which is the only way a
+    rebuild can remove one. Discovering the list rather than restating it is
+    what stops this from silently dropping a column that was added between the
+    step being written and the step being run.
+
+    Indexes are NOT recreated here. init_db runs SCHEMA immediately after the
+    migrations, and SCHEMA's CREATE INDEX IF NOT EXISTS statements are the one
+    place they are defined; the index set an upgraded install ends up with is
+    asserted against a fresh one's in test_practice_migration.py.
+
+    CALLERS MUST HAVE FOREIGN KEYS DISABLED. _run_migrations does that, and it
+    is not optional: with them on, a single practice row whose score_id no
+    longer matches a score - which the sqlite3 command line, whose default is
+    foreign_keys OFF, will happily leave behind - is rejected on the copy, and
+    the application then fails to start on every boot with no way out but hand
+    SQL or deleting the rows this migration exists to protect. SQLite's own
+    table-rebuild recipe opens by saying to turn them off for this reason.
+    _repair_dangling_practice_references is what then puts such a row right
+    instead of refusing to carry it.
+    """
+    temp = f"{table}_rebuilt"
+    conn.execute(f"CREATE TABLE {temp} {columns}")
+    old = {row["name"] for row in conn.execute(f"PRAGMA table_info({table})")}
+    carried = [
+        row["name"]
+        for row in conn.execute(f"PRAGMA table_info({temp})")
+        if row["name"] in old
+    ]
+    names = ", ".join(carried)
+    conn.execute(f"INSERT INTO {temp} ({names}) SELECT {names} FROM {table}")
+    conn.execute(f"DROP TABLE {table}")
+    conn.execute(f"ALTER TABLE {temp} RENAME TO {table}")
+
+
+def _repair_dangling_practice_references(conn) -> int:
+    """Point a practice row at nothing rather than at a score that is not there.
+
+    A row whose score_id names a missing score is not something this
+    application can produce - the reference has always been enforced - but it
+    is something the sqlite3 command line produces trivially, because its
+    default is foreign_keys OFF. Before this schema such a row was inert. Now
+    that a rebuild has to copy it, it has to be dealt with, and there are only
+    three options: refuse to start, drop the row, or put it right.
+
+    Putting it right means NULL, which is exactly what the reference's own ON
+    DELETE SET NULL would have done had the deletion gone through the database
+    in the first place. The practice is kept, the database is left consistent,
+    and the change is announced rather than made quietly - it is somebody's
+    history, and a row that stops naming a piece is a visible difference.
+    """
+    repaired = 0
+    for table in ("practice_sessions", "practice_goals"):
+        if not _table_exists(conn, table):
+            # A fresh install, where SCHEMA has not run yet. Nothing to repair,
+            # and nothing to raise about either.
+            continue
+        cur = conn.execute(
+            f"""UPDATE {table} SET score_id = NULL
+                 WHERE score_id IS NOT NULL
+                   AND score_id NOT IN (SELECT id FROM scores)"""
+        )
+        if cur.rowcount > 0:
+            repaired += cur.rowcount
+            log.warning(
+                "%s row(s) in %s referred to a score that is no longer in the database, "
+                "which normal use cannot produce - most likely the file was edited by "
+                "hand with foreign keys off. The practice itself is kept; those rows now "
+                "record practice with no piece named, which is what deleting the score "
+                "through Fermata would have done.",
+                cur.rowcount,
+                table,
+            )
+    return repaired
+
+
+def _migrate_to_3_keep_practice_when_a_score_goes(conn) -> None:
+    """Stop deleting a score from deleting the evidence somebody practised it.
+
+    Both practice tables referenced scores(id) ON DELETE CASCADE. Removing one
+    score therefore removed every session against it - hours of somebody's own
+    record of their own work, and the one thing in this application that cannot
+    be rebuilt from the files on disk. This makes both references ON DELETE SET
+    NULL. See _PRACTICE_SESSIONS_COLUMNS and _PRACTICE_GOALS_COLUMNS for why
+    that is the right trade and what an orphaned row then means.
+
+    WHY THIS IS A SEPARATE STEP FROM 2, when 2 has never shipped. Migration 2
+    builds practice_sessions from the shared column definition, which now says
+    SET NULL - so a database arriving from version 0 or 1 gets the right table
+    from that step alone and this one finds nothing to do. What this step is
+    for is a database already stamped 2: the branch that introduced both ran in
+    other people's working copies before the cascade was reversed, and a
+    database stamped 2 can never be re-offered step 2. Folding the fix into
+    step 2 silently would leave those databases cascading for ever.
+
+    That is also the general rule for a step here: a step brings a database to
+    the CURRENT definition, and its guard checks the one property it owns. So
+    an earlier step may well already satisfy a later one, and every step is
+    safe to reach in any order that respects the stamps.
+    """
+    for table, columns in (
+        ("practice_sessions", _PRACTICE_SESSIONS_COLUMNS),
+        ("practice_goals", _PRACTICE_GOALS_COLUMNS),
+    ):
+        info = conn.execute(f"PRAGMA table_info({table})").fetchall()
+        if not info:
+            continue  # SCHEMA is about to create it in its current shape
+        if _on_delete_action(conn, table, "score_id") == "SET NULL":
+            continue  # already carries the reference this step is here to fix
+        _rebuild_carrying_rows(conn, table, columns)
+
+
 # The real migration runner the ADD COLUMN mechanism above deliberately is not:
 # ordered steps, each taking a database from the version below its key to that
 # key, run once and then stamped.
+#
+# ORDERING, WHICH A STEP AUTHOR HAS TO KNOW. init_db runs these BEFORE the
+# SCHEMA script and before _add_missing_columns, so a step sees the database
+# exactly as the previous version left it: no table SCHEMA would have created,
+# and NO COLUMN COLUMN_ADDITIONS WOULD HAVE ADDED. On a version 0 database,
+# step 2 therefore runs against a `scores` table with no instrument_id at all -
+# which is fine because it does not touch it, and would not be fine for a step
+# that did. A step needing a column from COLUMN_ADDITIONS has to add it itself,
+# or be written not to need it. This is exactly the trap the version stamp
+# exists to prevent: such a step works on the author's already-upgraded
+# database and fails on a genuinely old one.
 #
 # A step may do anything SQLite can do - rebuild a table, backfill, drop a
 # column - because unlike COLUMN_ADDITIONS it is NOT re-run on every startup,
@@ -382,6 +589,7 @@ def _migrate_to_2_any_practice(conn) -> None:
 # Backups section of docs/deployment.md.
 MIGRATIONS = {
     2: _migrate_to_2_any_practice,
+    3: _migrate_to_3_keep_practice_when_a_score_goes,
 }
 
 
@@ -390,7 +598,27 @@ def connect() -> sqlite3.Connection:
     if conn is None:
         conn = sqlite3.connect(DB_PATH, timeout=30)
         conn.row_factory = sqlite3.Row
-        conn.execute("PRAGMA journal_mode=WAL")
+        try:
+            # WAL is a write to the database header, so this is the first thing
+            # that touches a read-only file - and "attempt to write a readonly
+            # database" from a pragma is not a diagnosis anybody can act on.
+            # Read-only is a real deployment mistake: a config volume mounted
+            # :ro, or a file owned by another user after a container's user id
+            # changed.
+            conn.execute("PRAGMA journal_mode=WAL")
+        except sqlite3.OperationalError as exc:
+            raise RuntimeError(
+                f"Fermata cannot start: its database at {DB_PATH} cannot be written to "
+                f"({exc}).\n"
+                "\n"
+                "Fermata needs write access to the config folder - it keeps your library "
+                "index, your practice history and your settings there. Check that the "
+                "folder is not mounted read-only, and that the user Fermata runs as owns "
+                "it. In Docker that is the volume mapped to /config; see "
+                "docs/deployment.md.\n"
+                "\n"
+                "Your sheet music is not affected: the library folder is only ever read."
+            ) from None
         conn.execute("PRAGMA foreign_keys=ON")
         _local.conn = conn
     return conn
@@ -463,24 +691,60 @@ def _run_migrations(conn) -> None:
     """
     if not any(version > _stored_version(conn) for version in MIGRATIONS):
         return
-    conn.execute("BEGIN IMMEDIATE")
+    # Off for the duration, and restored afterwards whatever happens. A step
+    # may rebuild a table, and a rebuild copies rows - so an existing row whose
+    # reference is already dangling would be REJECTED with them on, taking
+    # startup down permanently rather than being carried across and put right.
+    # The pragma is a no-op inside a transaction, so it has to be set here,
+    # outside the BEGIN. Consistency is not taken on trust in exchange: it is
+    # checked below, before the commit.
+    conn.execute("PRAGMA foreign_keys=OFF")
     try:
-        # Re-read inside the lock: another instance starting at the same moment
-        # may have applied these already, and applying a rebuild twice would
-        # not be a no-op if the step's own guard were the only thing stopping
-        # it. Re-checked for a newer writer too, for the same reason init_db
-        # checks twice.
-        _check_schema_version(conn)
-        stored = _stored_version(conn)
-        for version in sorted(MIGRATIONS):
-            if version <= stored:
-                continue
-            MIGRATIONS[version](conn)
-            conn.execute(f"PRAGMA user_version = {version}")
-        conn.commit()
-    except Exception:
-        conn.rollback()
-        raise
+        conn.execute("BEGIN IMMEDIATE")
+        try:
+            # Re-read inside the lock: another instance starting at the same
+            # moment may have applied these already, and applying a rebuild
+            # twice would not be a no-op if the step's own guard were the only
+            # thing stopping it. Re-checked for a newer writer too, for the
+            # same reason init_db checks twice.
+            _check_schema_version(conn)
+            stored = _stored_version(conn)
+            for version in sorted(MIGRATIONS):
+                if version <= stored:
+                    continue
+                MIGRATIONS[version](conn)
+                conn.execute(f"PRAGMA user_version = {version}")
+            _repair_dangling_practice_references(conn)
+            _report_remaining_violations(conn)
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            raise
+    finally:
+        conn.execute("PRAGMA foreign_keys=ON")
+
+
+def _report_remaining_violations(conn) -> None:
+    """Say so if the database is still inconsistent after a migration.
+
+    The rebuilds above run with foreign keys off, so nothing is checking them
+    while they work. This is the check - not to refuse the upgrade, which would
+    strand somebody on an unstartable application over rows they cannot see,
+    but so that a real inconsistency is stated once, plainly, in the log rather
+    than surfacing later as a query that quietly returns the wrong thing.
+    """
+    violations = conn.execute("PRAGMA foreign_key_check").fetchall()
+    if not violations:
+        return
+    tables = sorted({row[0] for row in violations})
+    log.warning(
+        "after the schema upgrade, %s reference(s) in %s still point at rows that are "
+        "not there. Fermata will start and your practice history is intact, but this is "
+        "not a state normal use produces - please report it, with the version you "
+        "upgraded from.",
+        len(violations),
+        ", ".join(tables),
+    )
 
 
 def init_db() -> None:
@@ -496,7 +760,31 @@ def init_db() -> None:
     # the INDEX exists - against the pre-migration table it would not skip, it
     # would fail on an unknown column and take startup down with it.
     _run_migrations(conn)
-    conn.executescript(SCHEMA)
+    try:
+        conn.executescript(SCHEMA)
+    except sqlite3.OperationalError as exc:
+        # Reachable only if the recorded version and the actual tables disagree
+        # - a database stamped as upgraded whose tables were not, which is what
+        # a hand-edited PRAGMA user_version or a restored mismatched pair of
+        # files produces. The migrations above are skipped on the strength of
+        # the stamp, and SCHEMA then meets a table it does not fit. Without
+        # this, that is "no such column: local_date" on every boot.
+        raise RuntimeError(
+            f"Fermata cannot start: its database says it is at schema version "
+            f"{_stored_version(conn)}, but its tables are not the ones that version has "
+            f"({exc}).\n"
+            "\n"
+            "This cannot happen through normal use or through any upgrade. It means the "
+            "recorded version and the actual tables have come apart - by a hand-edited "
+            "PRAGMA user_version, or by restoring a database file over a different one.\n"
+            "\n"
+            "Restoring your config folder from a backup is the reliable way back - see "
+            "the Backups section of docs/deployment.md. Your sheet music is not affected; "
+            "only the database in the config folder is.\n"
+            "\n"
+            "If you have no backup, we would like to hear about it either way: please open "
+            "an issue with the lines above and the version you upgraded from."
+        ) from None
     conn.commit()
     # BEGIN IMMEDIATE takes the write lock before the read below rather than on
     # the first write after it. Two processes starting at once - a second

--- a/server/fermata/db.py
+++ b/server/fermata/db.py
@@ -12,6 +12,118 @@ _local = threading.local()
 # away from being migrated to a real owner id instead of a schema redesign.
 DEFAULT_OWNER = "local"
 
+# The practice session table's columns, written once and used twice: SCHEMA
+# below builds the table from it on a fresh install, and the version 2
+# migration builds the same table under a temporary name to carry existing
+# rows into. Two copies of this definition would be two chances for an
+# upgraded database to end up with a subtly different table from a fresh one -
+# see test_practice_migration.py, which compares the two and fails if they
+# ever disagree.
+#
+# WHY score_id IS NULLABLE, and why that needed a migration rather than an
+# ADD COLUMN. Practice is not only pieces. The exercises this schema has to
+# carry next - fret-to-note, ear training, chord drills - produce practice
+# with no score behind them at all, and so does simply sitting down and
+# playing. The alternative was a second table per kind of practice, after
+# which every history view and every goal calculation would need one more
+# special case forever. So there is ONE session table, and `activity` says
+# what kind of work a row was; `score_id` is present when the work was
+# against something in the library and NULL when it was not.
+#
+# `local_date` is the calendar day the practice happened on IN THE
+# PRACTISER'S OWN TIME, and it is stored rather than derived because it
+# cannot be derived. `started_at` is UTC, so west of Greenwich an evening
+# session falls on the next UTC day - and "how many days did I practise this
+# week" is then wrong by one for the evenings, which is precisely the number
+# a goal is counted against. Rows written before this column existed have
+# NULL here and are attributed to date(started_at), because that is the only
+# day they ever recorded; readers say so rather than presenting a guess as a
+# fact (see practice.LOCAL_DATE_SQL and the local_date_source key on a
+# session response).
+#
+# Whether a tempo ladder reached its target is NOT stored: it is
+# tempo_bpm >= target_tempo_bpm, and a stored answer is one that can end up
+# contradicting the two numbers it was computed from.
+_PRACTICE_SESSIONS_COLUMNS = """(
+    id INTEGER PRIMARY KEY,
+    owner TEXT NOT NULL DEFAULT 'local',
+    score_id INTEGER REFERENCES scores(id) ON DELETE CASCADE,
+    activity TEXT NOT NULL DEFAULT 'piece',
+    mode TEXT,
+    started_at TEXT NOT NULL,
+    local_date TEXT,
+    seconds INTEGER NOT NULL,
+    from_bar INTEGER,
+    to_bar INTEGER,
+    from_page INTEGER,
+    to_page INTEGER,
+    tempo_bpm INTEGER,
+    target_tempo_bpm INTEGER,
+    rating INTEGER,
+    note TEXT
+)"""
+
+# Kept as separate statements rather than one script so SCHEMA can be
+# assembled from them, and so a future migration that needs to build this table
+# under another name has the index set to hand without restating it.
+_PRACTICE_SESSIONS_INDEXES = (
+    "CREATE INDEX IF NOT EXISTS idx_practice_score ON practice_sessions(score_id)",
+    "CREATE INDEX IF NOT EXISTS idx_practice_day ON practice_sessions(owner, local_date)",
+    "CREATE INDEX IF NOT EXISTS idx_practice_started ON practice_sessions(started_at)",
+    "CREATE INDEX IF NOT EXISTS idx_practice_activity ON practice_sessions(owner, activity)",
+)
+
+# A goal is a record of INTENT, and it is deliberately not a record of a
+# verdict. There is no met/missed column and no status: everything about how a
+# period actually went is counted from practice_sessions when asked (see
+# practice.goal_progress), so a goal cannot drift out of agreement with the
+# history it is about, and nothing here accumulates into a scorecard.
+#
+# `reflection` and `realistic` are the person's own words about their own
+# week, written after it ends - the useful question after a missed week is
+# whether the goal was unrealistic or the week was unusual, and only they can
+# answer it. Nothing else writes these two columns.
+#
+# The period is stored as its two inclusive dates rather than as a week
+# number, so a goal keeps meaning exactly what it meant when it was set even
+# if the week-start preference changes underneath it. `period` is 'week' and
+# nothing else today; it is here so a longer period arrives as a value rather
+# than as a second table.
+#
+# One goal per period per owner (the unique index): "a goal for the week" is
+# one intention with one focus. Several concurrent goals would turn the
+# review into a scorecard with rows to lose on.
+#
+# AUTOINCREMENT for the same reason instruments have it: goals are routinely
+# deleted, and a plain INTEGER PRIMARY KEY hands a deleted row's id to the
+# next one, so a reflection typed into an open tab could land on a different
+# goal than the one on screen.
+_PRACTICE_SCHEMA = (
+    "CREATE TABLE IF NOT EXISTS practice_sessions " + _PRACTICE_SESSIONS_COLUMNS + ";\n"
+    + "".join(f"{statement};\n" for statement in _PRACTICE_SESSIONS_INDEXES)
+    + """
+CREATE TABLE IF NOT EXISTS practice_goals (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    owner TEXT NOT NULL DEFAULT 'local',
+    period TEXT NOT NULL DEFAULT 'week',
+    period_start TEXT NOT NULL,
+    period_end TEXT NOT NULL,
+    target_days INTEGER,
+    target_minutes INTEGER,
+    scope TEXT NOT NULL DEFAULT 'all',
+    score_id INTEGER REFERENCES scores(id) ON DELETE CASCADE,
+    activity TEXT,
+    intent TEXT,
+    reflection TEXT,
+    realistic TEXT,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_practice_goals_period
+    ON practice_goals(owner, period_start);
+"""
+)
+
 SCHEMA = """
 CREATE TABLE IF NOT EXISTS scores (
     id INTEGER PRIMARY KEY,
@@ -44,15 +156,6 @@ CREATE TABLE IF NOT EXISTS score_tags (
     tag_id INTEGER NOT NULL REFERENCES tags(id) ON DELETE CASCADE,
     PRIMARY KEY (score_id, tag_id)
 );
-
-CREATE TABLE IF NOT EXISTS practice_sessions (
-    id INTEGER PRIMARY KEY,
-    score_id INTEGER NOT NULL REFERENCES scores(id) ON DELETE CASCADE,
-    started_at TEXT NOT NULL,
-    seconds INTEGER NOT NULL,
-    note TEXT
-);
-CREATE INDEX IF NOT EXISTS idx_practice_score ON practice_sessions(score_id);
 
 -- One extracted row and (at most) one edited row per score, distinguished by
 -- `source`. Kept as separate rows rather than one row with fields that get
@@ -134,7 +237,7 @@ CREATE TABLE IF NOT EXISTS instruments (
     updated_at TEXT NOT NULL DEFAULT (datetime('now'))
 );
 CREATE INDEX IF NOT EXISTS idx_instruments_owner ON instruments(owner);
-"""
+""" + _PRACTICE_SCHEMA
 
 # The schema this code expects. Stamped into PRAGMA user_version once a startup
 # has finished bringing a database up to date.
@@ -146,7 +249,10 @@ CREATE INDEX IF NOT EXISTS idx_instruments_owner ON instruments(owner);
 # deployed database's history from its column set. Stamping now, while every
 # deployed database is unambiguously either pre-instruments or version 1, costs
 # one PRAGMA; stamping later costs that guesswork.
-SCHEMA_VERSION = 1
+#
+# Version 2 is the first change this file's ADD COLUMN mechanism could not
+# express, which is what the stamp was recorded for - see MIGRATIONS.
+SCHEMA_VERSION = 2
 
 # Columns added to a table that had already shipped. CREATE TABLE IF NOT EXISTS
 # does nothing at all to a table that exists, so SCHEMA alone reaches only fresh
@@ -161,8 +267,11 @@ SCHEMA_VERSION = 1
 # rewrite rows a user had since edited. And SQLite requires that an added
 # column's default be NULL when it carries a foreign key, so a future column
 # needing both a foreign key and NOT NULL cannot come through here at all.
-# Anything in that list needs a real runner, and SCHEMA_VERSION is what will let
-# one be written.
+# Anything in that list needs a real runner - that runner is MIGRATIONS below,
+# and this mechanism stays as narrow as it is. A change that CAN be an ADD
+# COLUMN still belongs here, because a migration step runs once and is then
+# trusted forever, whereas this runs on every startup and repairs a database
+# that half-upgraded.
 #
 # Applied by name AND, where the definition carries one, by checking the foreign
 # key is really there: PRAGMA table_info reports only names, so a column that
@@ -186,6 +295,93 @@ COLUMN_ADDITIONS = {
     "scores": {
         "instrument_id": "INTEGER REFERENCES instruments(id) ON DELETE SET NULL",
     },
+}
+
+
+def _migrate_to_2_any_practice(conn) -> None:
+    """Let a practice session exist without a score behind it.
+
+    practice_sessions shipped with `score_id INTEGER NOT NULL`, and SQLite
+    cannot relax a NOT NULL in place, so this is the table-rebuild recipe: a
+    new table under a temporary name, every existing row carried across by id,
+    the old table dropped, the new one renamed into its place. See
+    _PRACTICE_SESSIONS_COLUMNS for why the column has to become nullable at
+    all.
+
+    THE ROWS THIS MOVES ARE THE ONE THING IN FERMATA THAT CANNOT BE
+    REGENERATED. A score row can be rebuilt by rescanning the library and a
+    transcription by re-extracting, but nothing on disk remembers that someone
+    sat down and practised for forty minutes. So every existing row is carried
+    across with its id intact, and the whole rebuild runs inside the caller's
+    transaction: it either lands completely or not at all, and a crash halfway
+    leaves the old table exactly as it was.
+
+    Nothing in the schema references practice_sessions, so dropping it cannot
+    cascade into anything else, and the rename cannot leave another table
+    pointing at a name that has moved.
+
+    Written to be safe to run against a database it has already run against,
+    and against a fresh one: a missing table means SCHEMA is about to create
+    it in its current shape, and an already-nullable score_id means this has
+    run before. Neither is an error - init_db() re-runs a step whose stamp
+    never landed.
+    """
+    info = conn.execute("PRAGMA table_info(practice_sessions)").fetchall()
+    if not info:
+        return
+    score_id = next((row for row in info if row["name"] == "score_id"), None)
+    if score_id is None or not score_id["notnull"]:
+        return
+
+    conn.execute("CREATE TABLE practice_sessions_rebuilt " + _PRACTICE_SESSIONS_COLUMNS)
+    # Named columns on both sides, never SELECT *: the source table's column
+    # order is whatever the release that created it chose, and a positional
+    # copy would happily put a note into a tempo the day they differ.
+    #
+    # `activity` is set to 'piece' rather than left to the column default
+    # because that is what these rows actually are - every session that could
+    # be recorded before this version was against a score. `local_date` is
+    # deliberately NOT backfilled from started_at: nobody recorded which
+    # calendar day these happened on in the practiser's own time, and writing
+    # a guess into the column readers treat as recorded fact is how the
+    # guess stops being visible as one.
+    conn.execute(
+        """INSERT INTO practice_sessions_rebuilt
+               (id, owner, score_id, activity, started_at, seconds, note)
+           SELECT id, ?, score_id, 'piece', started_at, seconds, note
+             FROM practice_sessions""",
+        (DEFAULT_OWNER,),
+    )
+    conn.execute("DROP TABLE practice_sessions")
+    conn.execute("ALTER TABLE practice_sessions_rebuilt RENAME TO practice_sessions")
+    # The old table's indexes went with it. They are NOT recreated here:
+    # init_db runs SCHEMA immediately after this, and SCHEMA's CREATE INDEX IF
+    # NOT EXISTS statements are the one place they are defined. Restating them
+    # here would be a second copy that could quietly stop matching, and the
+    # index set an upgraded install ends up with is asserted against a fresh
+    # one's in test_practice_migration.py either way.
+
+
+# The real migration runner the ADD COLUMN mechanism above deliberately is not:
+# ordered steps, each taking a database from the version below its key to that
+# key, run once and then stamped.
+#
+# A step may do anything SQLite can do - rebuild a table, backfill, drop a
+# column - because unlike COLUMN_ADDITIONS it is NOT re-run on every startup,
+# and so does not have to be idempotent to be safe. It has to be safe to
+# re-run only in the one case init_db() can produce: a process that died after
+# a step's work committed but before its stamp did. Each step above therefore
+# begins by checking whether its work is already there and returning if so,
+# which is cheap and removes the only window in which "run once" is a
+# statement about hope rather than about the code.
+#
+# There is no down direction and there will not be one. A downgrade is already
+# refused outright by _check_schema_version, because a newer release's schema
+# may hold columns this code knows nothing about and writing to it blind is
+# how a downgrade loses data. Restoring a backup is the way back; see the
+# Backups section of docs/deployment.md.
+MIGRATIONS = {
+    2: _migrate_to_2_any_practice,
 }
 
 
@@ -248,13 +444,58 @@ def _check_schema_version(conn) -> None:
         )
 
 
+def _stored_version(conn) -> int:
+    return conn.execute("PRAGMA user_version").fetchone()[0]
+
+
+def _run_migrations(conn) -> None:
+    """Apply every MIGRATIONS step this database has not been stamped for.
+
+    All pending steps share one transaction, and each stamps its own version
+    as it completes - so an interrupted upgrade resumes from the last step
+    that actually landed rather than from the beginning. PRAGMA user_version
+    is part of the database header and is rolled back with the transaction,
+    which is what makes "the work and its stamp cannot disagree" true.
+
+    The version is read once outside the lock so an already-current database
+    never takes the write lock at all; startup is otherwise serialised behind
+    every other instance's startup for nothing.
+    """
+    if not any(version > _stored_version(conn) for version in MIGRATIONS):
+        return
+    conn.execute("BEGIN IMMEDIATE")
+    try:
+        # Re-read inside the lock: another instance starting at the same moment
+        # may have applied these already, and applying a rebuild twice would
+        # not be a no-op if the step's own guard were the only thing stopping
+        # it. Re-checked for a newer writer too, for the same reason init_db
+        # checks twice.
+        _check_schema_version(conn)
+        stored = _stored_version(conn)
+        for version in sorted(MIGRATIONS):
+            if version <= stored:
+                continue
+            MIGRATIONS[version](conn)
+            conn.execute(f"PRAGMA user_version = {version}")
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
+
+
 def init_db() -> None:
     conn = connect()
-    # Before SCHEMA runs, not after. executescript() commits as it goes, so
+    # Before anything writes, not after. executescript() commits as it goes, so
     # checking afterwards means a database written by a newer release has
     # already been altered by this one - and the check exists precisely because
     # writing blind is how a downgrade loses data. SCHEMA is written blind.
     _check_schema_version(conn)
+    # Before SCHEMA, not after, and that order is load-bearing. SCHEMA creates
+    # indexes over practice_sessions columns that only exist once migration 2
+    # has rebuilt that table, and CREATE INDEX IF NOT EXISTS skips only when
+    # the INDEX exists - against the pre-migration table it would not skip, it
+    # would fail on an unknown column and take startup down with it.
+    _run_migrations(conn)
     conn.executescript(SCHEMA)
     conn.commit()
     # BEGIN IMMEDIATE takes the write lock before the read below rather than on

--- a/server/fermata/practice.py
+++ b/server/fermata/practice.py
@@ -1,0 +1,548 @@
+"""Practice: what was actually done, and what someone meant to do.
+
+Two records, kept apart on purpose.
+
+A SESSION is a fact. Somebody sat down at a time, worked for a length, and
+this is what the work was: which piece if any, what kind of practice, which
+bars or pages, at what tempo, and how it felt to them. A session is never
+edited by anything except the person who logged it.
+
+A GOAL is an intention, with a period attached. It says how many days they
+mean to practise and for how long in total, and optionally what on. It carries
+no verdict: nothing anywhere stores whether a goal was met. That is counted
+from the sessions inside its period, every time it is asked for, which is what
+keeps a goal and the history it is about from ever disagreeing - and which is
+the only version of this that stays true when a session is logged late.
+
+HOW THIS TALKS ABOUT A PERIOD THAT DID NOT GO AS PLANNED. The numbers are
+reported and nothing is concluded from them. `days_practised` beside
+`target_days` is three and four; there is no "missed", no percentage, no
+grade, and no comparison against any other period - a best week is the
+mechanism by which a good month becomes the standard a bad month is measured
+against, so no query here ranks one period against another and no field
+invites it. `met` exists because "did this happen" is a fact somebody may
+want, and it is a fact about the goal, not about the person. Everything after
+that is theirs to say, in `reflection`, in answer to a question rather than to
+a verdict: was this goal realistic?
+
+WHY A PRACTICE DAY IS ITS OWN STORED VALUE. Every day-based number here -
+days practised, the per-day breakdown, which week a session falls in - counts
+`local_date`, the calendar day in the practiser's own time, not the UTC day
+inside `started_at`. West of Greenwich those are different days for every
+evening practice, and "how many days did I practise" would be wrong by one for
+exactly the sessions someone is most likely to have. Rows written before the
+column existed have no local date and are attributed to their UTC day, which
+is the only day they ever recorded; a reader is told which of the two it got
+(see `local_date_source`) rather than being handed a guess dressed as a fact.
+
+A back-dated session is a first-class thing: `started_at` is when the session
+was RECORDED and `local_date` is the day the practice HAPPENED, and somebody
+entering yesterday's forgotten hour is not lying about either.
+"""
+
+from datetime import date, timedelta
+
+from .db import DEFAULT_OWNER
+
+# What kind of work a session was. One column on one table rather than a table
+# per kind: the exercises this has to carry next - fret-to-note, ear training,
+# chord drills - are practice in exactly the way a piece is, and a parallel
+# table per kind would mean the history view and every goal calculation
+# growing one more special case with each of them.
+#
+# 'piece' is work on something in the library and is the only value that
+# requires a score. 'free' is unstructured playing, which is real practice and
+# had nowhere to go before. Per-attempt detail from a trainer (which positions
+# were missed, response times) is NOT here: that belongs beside the trainer
+# that produces it, and inventing its shape before one exists would be
+# guessing. What this vocabulary guarantees is that when a trainer arrives, the
+# time it accounts for lands in the same history and the same goals as
+# everything else.
+ACTIVITIES = (
+    "piece",
+    "technique",
+    "sight_reading",
+    "ear_training",
+    "fretboard",
+    "chords",
+    "improvisation",
+    "theory",
+    "free",
+    "other",
+)
+DEFAULT_ACTIVITY = "piece"
+
+# How the work was approached, which is a different question from what it was.
+# Twenty minutes of one awkward bar and twenty minutes of playing the piece
+# end to end are not the same practice, and only the person doing it knows
+# which it was - so this is recorded, never inferred from whether a bar range
+# happens to be present.
+MODES = ("section", "run_through")
+
+GOAL_SCOPES = ("all", "score", "activity")
+
+# 'week' and nothing else today. A goal for the week broken into days is what
+# was asked for; a longer period arrives here as another value rather than as
+# another table.
+GOAL_PERIODS = ("week",)
+PERIOD_DAYS = {"week": 7}
+
+# The answer to "was this goal realistic?", which is the only question asked
+# about a period that did not go to plan. Not a status, and not something
+# anything but the person writes.
+REALISTIC_ANSWERS = ("yes", "no")
+
+WEEK_STARTS = ("monday", "sunday")
+DEFAULT_WEEK_START = "monday"
+
+MAX_SESSION_SECONDS = 86_400
+MIN_RATING = 1
+MAX_RATING = 5
+# Wide enough for anything a person plays and narrow enough to catch a units
+# mistake - a tempo of 3 or 3000 is a bug in whatever sent it.
+MIN_TEMPO_BPM = 20
+MAX_TEMPO_BPM = 400
+MAX_BAR = 100_000
+MAX_PAGE = 10_000
+MAX_NOTE_CHARS = 2_000
+MAX_INTENT_CHARS = 200
+MAX_REFLECTION_CHARS = 2_000
+
+MIN_TARGET_MINUTES = 1
+MAX_TARGET_MINUTES = 7 * 24 * 60
+
+# How far a recorded practice day may sit from the day it is being recorded on.
+# Back-dating is legitimate - forgetting to log an hour is the ordinary case -
+# so the past is generous. The future is not: a date ahead of tomorrow is a
+# broken clock or a broken client, and practice that has not happened yet must
+# not be able to fill in a goal.
+MAX_BACKDATE_DAYS = 400
+MAX_FUTURE_DAYS = 1
+
+# How far back a review looks by default. Long enough to show a pattern
+# including a couple of unusual weeks; short enough that opening it is not a
+# wall of past periods to scroll through. Nothing accumulates beyond what is
+# asked for.
+DEFAULT_REVIEW_WEEKS = 8
+MAX_REVIEW_WEEKS = 52
+
+DEFAULT_HISTORY_DAYS = 90
+MAX_HISTORY_DAYS = 366
+
+DEFAULT_SESSION_LIMIT = 100
+MAX_SESSION_LIMIT = 1_000
+
+# The day a session belongs to, in SQL, for every query that groups or filters
+# by day. Written once because it is not a formula anyone should retype: the
+# COALESCE is what attributes a row from before local_date existed, and a query
+# that forgot it would silently drop that row out of every day count rather
+# than fail.
+LOCAL_DATE_SQL = "COALESCE(p.local_date, date(p.started_at))"
+
+
+def parse_day(value, field: str = "date") -> date:
+    """A YYYY-MM-DD string as a date, or a ValueError naming the field.
+
+    Deliberately strict. date.fromisoformat on Python 3.11+ also accepts
+    'YYYYMMDD' and full timestamps, and a timestamp arriving where a practice
+    day belongs would be stored as text that no other query's BETWEEN would
+    ever match.
+    """
+    text = str(value or "").strip()
+    if len(text) != 10 or text[4] != "-" or text[7] != "-":
+        raise ValueError(f"{field} must be a date written YYYY-MM-DD")
+    try:
+        return date.fromisoformat(text)
+    except ValueError:
+        raise ValueError(f"{field} must be a date written YYYY-MM-DD") from None
+
+
+def week_start(day: date, starts_on: str = DEFAULT_WEEK_START) -> date:
+    """The first day of the week `day` falls in.
+
+    Which day a week starts on is a preference, not a fact, and it is asked for
+    here rather than assumed: a goal counted over the wrong seven days is
+    counted against days its owner did not consider part of the week.
+    """
+    if starts_on not in WEEK_STARTS:
+        raise ValueError(f"week start must be one of {sorted(WEEK_STARTS)}")
+    # weekday() is 0 for Monday. A Sunday-start week begins one day earlier, so
+    # Sunday itself (weekday 6) is offset 0 and Monday is offset 1.
+    offset = day.weekday() if starts_on == "monday" else (day.weekday() + 1) % 7
+    return day - timedelta(days=offset)
+
+
+def period_bounds(start: date, period: str = "week") -> tuple[date, date]:
+    """The inclusive first and last day of a period beginning on `start`."""
+    if period not in GOAL_PERIODS:
+        raise ValueError(f"period must be one of {sorted(GOAL_PERIODS)}")
+    return start, start + timedelta(days=PERIOD_DAYS[period] - 1)
+
+
+def days_between(start: date, end: date) -> list[date]:
+    return [start + timedelta(days=n) for n in range((end - start).days + 1)]
+
+
+def _optional_int(value, field: str, low: int, high: int) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError(f"{field} must be a whole number")
+    if not low <= value <= high:
+        raise ValueError(f"{field} must be between {low} and {high}")
+    return value
+
+
+def _optional_text(value, field: str, limit: int) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    if not text:
+        # An empty box is not a note. Stored as NULL so "nothing was written"
+        # is one value rather than two that every reader has to test for.
+        return None
+    if len(text) > limit:
+        raise ValueError(f"{field} must be at most {limit} characters")
+    return text
+
+
+def _range(low_value, high_value, low_field: str, high_field: str, ceiling: int):
+    low = _optional_int(low_value, low_field, 1, ceiling)
+    high = _optional_int(high_value, high_field, 1, ceiling)
+    if high is not None and low is None:
+        raise ValueError(f"{high_field} needs {low_field} as well")
+    if low is not None and high is not None and high < low:
+        raise ValueError(f"{high_field} cannot be before {low_field}")
+    return low, high
+
+
+def normalise_session(
+    *,
+    score_id,
+    activity,
+    mode,
+    seconds,
+    local_date,
+    recorded_on,
+    from_bar=None,
+    to_bar=None,
+    from_page=None,
+    to_page=None,
+    tempo_bpm=None,
+    target_tempo_bpm=None,
+    rating=None,
+    note=None,
+) -> dict:
+    """Check a session and return the values to store.
+
+    Raises ValueError with a message meant for a person to read. Every write
+    goes through here, whether it arrived on the per-score path or the general
+    one, because a session recorded through one route and one recorded through
+    the other are the same row and have to obey the same rules.
+
+    `recorded_on` is today's date as the SERVER sees it, and exists so the
+    bound on how far a practice day may sit from it is testable without
+    waiting for the calendar.
+    """
+    activity = activity or DEFAULT_ACTIVITY
+    if activity not in ACTIVITIES:
+        raise ValueError(f"activity must be one of {sorted(ACTIVITIES)}")
+
+    if mode is not None and mode not in MODES:
+        raise ValueError(f"mode must be one of {sorted(MODES)}")
+
+    if isinstance(seconds, bool) or not isinstance(seconds, int):
+        raise ValueError("seconds must be a whole number")
+    if not 0 < seconds <= MAX_SESSION_SECONDS:
+        raise ValueError(f"seconds must be between 1 and {MAX_SESSION_SECONDS}")
+
+    if activity == DEFAULT_ACTIVITY and score_id is None:
+        # Every other activity is practice that may well have no piece behind
+        # it. This one is defined by having one, and a 'piece' session with no
+        # piece would sit in the history saying nothing about what was worked.
+        raise ValueError("a session on a piece needs a score_id")
+
+    day = None
+    if local_date is not None:
+        day = parse_day(local_date, "local_date")
+        if day > recorded_on + timedelta(days=MAX_FUTURE_DAYS):
+            raise ValueError("local_date is in the future")
+        if day < recorded_on - timedelta(days=MAX_BACKDATE_DAYS):
+            raise ValueError(f"local_date is more than {MAX_BACKDATE_DAYS} days ago")
+
+    from_bar, to_bar = _range(from_bar, to_bar, "from_bar", "to_bar", MAX_BAR)
+    from_page, to_page = _range(from_page, to_page, "from_page", "to_page", MAX_PAGE)
+
+    return {
+        "score_id": score_id,
+        "activity": activity,
+        "mode": mode,
+        "seconds": seconds,
+        "local_date": day.isoformat() if day else None,
+        "from_bar": from_bar,
+        "to_bar": to_bar,
+        "from_page": from_page,
+        "to_page": to_page,
+        "tempo_bpm": _optional_int(tempo_bpm, "tempo_bpm", MIN_TEMPO_BPM, MAX_TEMPO_BPM),
+        "target_tempo_bpm": _optional_int(
+            target_tempo_bpm, "target_tempo_bpm", MIN_TEMPO_BPM, MAX_TEMPO_BPM
+        ),
+        "rating": _optional_int(rating, "rating", MIN_RATING, MAX_RATING),
+        "note": _optional_text(note, "note", MAX_NOTE_CHARS),
+    }
+
+
+def normalise_goal(
+    *,
+    period,
+    period_start,
+    target_days,
+    target_minutes,
+    scope,
+    score_id,
+    activity,
+    intent,
+) -> dict:
+    """Check a goal and return the values to store.
+
+    A goal has to be concrete enough to be either met or missed, which is the
+    whole point of setting one - so at least one target is required. Both are
+    allowed together, and mean what they say: this many days, and this much
+    time in total across them.
+    """
+    period = period or "week"
+    if period not in GOAL_PERIODS:
+        raise ValueError(f"period must be one of {sorted(GOAL_PERIODS)}")
+    start, end = period_bounds(parse_day(period_start, "period_start"), period)
+
+    length = PERIOD_DAYS[period]
+    days = _optional_int(target_days, "target_days", 1, length)
+    minutes = _optional_int(
+        target_minutes, "target_minutes", MIN_TARGET_MINUTES, MAX_TARGET_MINUTES
+    )
+    if days is None and minutes is None:
+        raise ValueError("a goal needs a target: days of practice, minutes, or both")
+
+    scope = scope or "all"
+    if scope not in GOAL_SCOPES:
+        raise ValueError(f"scope must be one of {sorted(GOAL_SCOPES)}")
+    # Each scope names exactly the thing it is scoped to and nothing else. A
+    # goal carrying a score_id it does not use would read as a goal about that
+    # piece while being counted over everything.
+    if scope == "score":
+        if score_id is None:
+            raise ValueError("a goal for one piece needs a score_id")
+        activity = None
+    elif scope == "activity":
+        if activity not in ACTIVITIES:
+            raise ValueError(f"activity must be one of {sorted(ACTIVITIES)}")
+        score_id = None
+    else:
+        score_id = None
+        activity = None
+
+    return {
+        "period": period,
+        "period_start": start.isoformat(),
+        "period_end": end.isoformat(),
+        "target_days": days,
+        "target_minutes": minutes,
+        "scope": scope,
+        "score_id": score_id,
+        "activity": activity,
+        "intent": _optional_text(intent, "intent", MAX_INTENT_CHARS),
+    }
+
+
+def normalise_reflection(*, reflection, realistic) -> dict:
+    """The person's own account of a period, as stored.
+
+    `realistic` answers a question and is not a status: 'no' says the goal
+    was too big for that week, which is useful for setting the next one, and
+    says nothing whatever about the week or about them.
+    """
+    if realistic is not None and realistic not in REALISTIC_ANSWERS:
+        raise ValueError(f"realistic must be one of {sorted(REALISTIC_ANSWERS)}")
+    return {
+        "reflection": _optional_text(reflection, "reflection", MAX_REFLECTION_CHARS),
+        "realistic": realistic,
+    }
+
+
+def _scope_filter(scope: str, score_id, activity, params: list) -> str:
+    """The extra WHERE this goal's scope adds, appending its parameters."""
+    if scope == "score":
+        params.append(score_id)
+        return " AND p.score_id = ?"
+    if scope == "activity":
+        params.append(activity)
+        return " AND p.activity = ?"
+    return ""
+
+
+def session_dict(row) -> dict:
+    """One session as the API presents it.
+
+    Two things are derived here rather than stored. `local_date` is the day the
+    practice is attributed to, with `local_date_source` saying whether that day
+    was recorded ('recorded') or taken from the UTC timestamp because the row
+    predates the column ('utc_date') - a reader that treats an inferred day as
+    a recorded one is the reason the distinction is on the response at all.
+    And `reached_target` is the tempo comparison, computed so it can never
+    contradict the two numbers it comes from; None means one of them is
+    missing, which is not the same as "did not reach it".
+    """
+    d = dict(row)
+    recorded = d.get("local_date")
+    d["local_date"] = recorded or (d["started_at"] or "")[:10]
+    d["local_date_source"] = "recorded" if recorded else "utc_date"
+    tempo, target = d.get("tempo_bpm"), d.get("target_tempo_bpm")
+    d["reached_target"] = None if tempo is None or target is None else tempo >= target
+    return d
+
+
+def day_totals(conn, owner: str, start: str, end: str, extra: str = "", params=()) -> dict:
+    """Seconds and session count per practice day, for the days that have any."""
+    sql = f"""SELECT {LOCAL_DATE_SQL} AS day,
+                     SUM(p.seconds) AS seconds, COUNT(*) AS sessions
+                FROM practice_sessions p
+               WHERE p.owner = ? AND {LOCAL_DATE_SQL} BETWEEN ? AND ?{extra}
+            GROUP BY day ORDER BY day"""
+    rows = conn.execute(sql, [owner, start, end, *params]).fetchall()
+    return {r["day"]: {"seconds": r["seconds"], "sessions": r["sessions"]} for r in rows}
+
+
+def period_facts(
+    conn,
+    start: str,
+    end: str,
+    *,
+    owner: str = DEFAULT_OWNER,
+    scope: str = "all",
+    score_id=None,
+    activity=None,
+) -> dict:
+    """What actually happened between two days, stated and not judged.
+
+    The per-day list covers every day in the period, including the ones with
+    nothing on them. A day with no practice is a fact about the week and is
+    reported as zero seconds; it is not an absence for a reader to have to
+    infer from a gap in a list, and it is not a failure.
+    """
+    params: list = []
+    extra = _scope_filter(scope, score_id, activity, params)
+    totals = day_totals(conn, owner, start, end, extra, params)
+    days = [
+        {
+            "date": day.isoformat(),
+            "seconds": totals.get(day.isoformat(), {}).get("seconds", 0),
+            "sessions": totals.get(day.isoformat(), {}).get("sessions", 0),
+        }
+        for day in days_between(parse_day(start), parse_day(end))
+    ]
+    seconds = sum(d["seconds"] for d in days)
+    return {
+        "days": days,
+        "seconds": seconds,
+        # Floored, so this can never claim a minute that was not practised.
+        "minutes": seconds // 60,
+        "days_practised": sum(1 for d in days if d["sessions"]),
+        "sessions": sum(d["sessions"] for d in days),
+    }
+
+
+def goal_progress(conn, goal, today: date) -> dict:
+    """Where a goal stands: the counts, the targets, and nothing else.
+
+    `met_days` and `met_minutes` are None when that target was not set, which
+    is not the same as unmet - a goal with no minutes target has nothing to
+    say about minutes, and a False there would read as a shortfall against a
+    target nobody chose.
+
+    `status` is where the period sits relative to today, not how it went. A
+    period still running is reported with `days_left` so the goal can still
+    change the week rather than only judge it - and deliberately without any
+    per-day rate needed "to catch up", which is a verdict wearing arithmetic.
+    """
+    facts = period_facts(
+        conn,
+        goal["period_start"],
+        goal["period_end"],
+        owner=goal["owner"],
+        scope=goal["scope"],
+        score_id=goal["score_id"],
+        activity=goal["activity"],
+    )
+    start = parse_day(goal["period_start"])
+    end = parse_day(goal["period_end"])
+    if today < start:
+        status, days_left = "upcoming", (end - start).days + 1
+    elif today > end:
+        status, days_left = "past", 0
+    else:
+        status, days_left = "running", (end - today).days + 1
+
+    target_days = goal["target_days"]
+    target_minutes = goal["target_minutes"]
+    met_days = None if target_days is None else facts["days_practised"] >= target_days
+    met_minutes = None if target_minutes is None else facts["minutes"] >= target_minutes
+    return {
+        **facts,
+        "status": status,
+        "days_left": days_left,
+        "met_days": met_days,
+        "met_minutes": met_minutes,
+        # True only when every target that was set has been reached. None of
+        # the three values is a grade: "not yet" during a running week and
+        # "not this time" after it are the same False, and the interface says
+        # which by reading `status`.
+        "met": all(m for m in (met_days, met_minutes) if m is not None)
+        and any(m is not None for m in (met_days, met_minutes)),
+    }
+
+
+def goal_dict(conn, row, today: date) -> dict:
+    """A goal with its progress attached, and its piece named if it has one."""
+    d = dict(row)
+    d["score_title"] = None
+    if d["score_id"] is not None:
+        title = conn.execute(
+            "SELECT title FROM scores WHERE id = ?", (d["score_id"],)
+        ).fetchone()
+        d["score_title"] = title["title"] if title else None
+    d["progress"] = goal_progress(conn, row, today)
+    return d
+
+
+def time_spent(
+    conn, start: str, end: str, *, owner: str = DEFAULT_OWNER, limit: int = 20
+) -> dict:
+    """Where the time went between two days: by piece, and by kind of work.
+
+    Ordered by time spent, which is the question being asked, and not
+    presented anywhere as a ranking of pieces or of weeks. Sessions with no
+    score - a trainer, unstructured playing - are counted in `by_activity` and
+    simply absent from `by_score`, which is the honest answer to "which pieces
+    did I work on" rather than a bucket labelled "no piece" that a reader has
+    to know to ignore.
+    """
+    by_score = conn.execute(
+        f"""SELECT p.score_id, s.title,
+                   SUM(p.seconds) AS seconds, COUNT(*) AS sessions,
+                   MAX({LOCAL_DATE_SQL}) AS last_practised
+              FROM practice_sessions p JOIN scores s ON s.id = p.score_id
+             WHERE p.owner = ? AND {LOCAL_DATE_SQL} BETWEEN ? AND ?
+          GROUP BY p.score_id ORDER BY seconds DESC, s.title LIMIT ?""",
+        (owner, start, end, limit),
+    ).fetchall()
+    by_activity = conn.execute(
+        f"""SELECT p.activity, SUM(p.seconds) AS seconds, COUNT(*) AS sessions
+              FROM practice_sessions p
+             WHERE p.owner = ? AND {LOCAL_DATE_SQL} BETWEEN ? AND ?
+          GROUP BY p.activity ORDER BY seconds DESC, p.activity""",
+        (owner, start, end),
+    ).fetchall()
+    return {
+        "by_score": [dict(r) for r in by_score],
+        "by_activity": [dict(r) for r in by_activity],
+    }

--- a/server/fermata/practice.py
+++ b/server/fermata/practice.py
@@ -119,6 +119,18 @@ MAX_TARGET_MINUTES = 7 * 24 * 60
 MAX_BACKDATE_DAYS = 400
 MAX_FUTURE_DAYS = 1
 
+# The window a client's idea of "today" may fall in, relative to the server's
+# date: exactly the window a practice day may name. A date outside it cannot be
+# about any period this instance could hold practice for, so answering it means
+# returning a confident, plausible, empty week - the worst kind of wrong answer,
+# being one nothing in the response marks as suspect.
+#
+# Deliberately as wide as the back-dating window rather than as narrow as a
+# timezone. A browser is never more than a day from UTC, but reasoning about a
+# period that has already ended is a legitimate use of this parameter and the
+# thing that makes every period rule here testable without waiting for the
+# calendar.
+
 # How far back a review looks by default. Long enough to show a pattern
 # including a couple of unusual weeks; short enough that opening it is not a
 # wall of past periods to scroll through. Nothing accumulates beyond what is
@@ -140,6 +152,16 @@ MAX_SESSION_LIMIT = 1_000
 LOCAL_DATE_SQL = "COALESCE(p.local_date, date(p.started_at))"
 
 
+# The range a date is allowed to name. Not a judgement about anybody's
+# practice: it is what keeps the arithmetic downstream inside date's own bounds.
+# Every caller adds or subtracts up to a year - a review reaches 52 weeks back,
+# a history window 366 days - and date.min/date.max are hard walls that raise
+# OverflowError from inside a subtraction, which reaches a client as a 500 for
+# what is only ever a typo. Both ends leave a century of headroom.
+MIN_DAY = date(1900, 1, 1)
+MAX_DAY = date(2200, 1, 1)
+
+
 def parse_day(value, field: str = "date") -> date:
     """A YYYY-MM-DD string as a date, or a ValueError naming the field.
 
@@ -152,9 +174,14 @@ def parse_day(value, field: str = "date") -> date:
     if len(text) != 10 or text[4] != "-" or text[7] != "-":
         raise ValueError(f"{field} must be a date written YYYY-MM-DD")
     try:
-        return date.fromisoformat(text)
+        day = date.fromisoformat(text)
     except ValueError:
         raise ValueError(f"{field} must be a date written YYYY-MM-DD") from None
+    if not MIN_DAY <= day <= MAX_DAY:
+        raise ValueError(
+            f"{field} must be between {MIN_DAY.isoformat()} and {MAX_DAY.isoformat()}"
+        )
+    return day
 
 
 def week_start(day: date, starts_on: str = DEFAULT_WEEK_START) -> date:
@@ -232,6 +259,8 @@ def normalise_session(
     target_tempo_bpm=None,
     rating=None,
     note=None,
+    allow_missing_score=False,
+    check_day_window=True,
 ) -> dict:
     """Check a session and return the values to store.
 
@@ -243,6 +272,19 @@ def normalise_session(
     `recorded_on` is today's date as the SERVER sees it, and exists so the
     bound on how far a practice day may sit from it is testable without
     waiting for the calendar.
+
+    `allow_missing_score` is for a row that is ALREADY stored as work on a
+    piece the library no longer has - see is_orphaned. Such a row is a true
+    record and must stay editable: refusing to let somebody add a note to it
+    because the piece has since been deleted would turn a rule about creating
+    an honest claim into a rule about keeping one.
+
+    `check_day_window` is False when the practice day is not what is being
+    written. How far back a NEW date may be is a rule about what somebody may
+    claim now; applied to a date already stored it becomes a rule that makes a
+    session permanently uneditable once it is old enough - so a note or a
+    rating on last year's practice could not be corrected, for reasons that
+    have nothing to do with either.
     """
     activity = activity or DEFAULT_ACTIVITY
     if activity not in ACTIVITIES:
@@ -256,7 +298,7 @@ def normalise_session(
     if not 0 < seconds <= MAX_SESSION_SECONDS:
         raise ValueError(f"seconds must be between 1 and {MAX_SESSION_SECONDS}")
 
-    if activity == DEFAULT_ACTIVITY and score_id is None:
+    if activity == DEFAULT_ACTIVITY and score_id is None and not allow_missing_score:
         # Every other activity is practice that may well have no piece behind
         # it. This one is defined by having one, and a 'piece' session with no
         # piece would sit in the history saying nothing about what was worked.
@@ -265,10 +307,11 @@ def normalise_session(
     day = None
     if local_date is not None:
         day = parse_day(local_date, "local_date")
-        if day > recorded_on + timedelta(days=MAX_FUTURE_DAYS):
-            raise ValueError("local_date is in the future")
-        if day < recorded_on - timedelta(days=MAX_BACKDATE_DAYS):
-            raise ValueError(f"local_date is more than {MAX_BACKDATE_DAYS} days ago")
+        if check_day_window:
+            if day > recorded_on + timedelta(days=MAX_FUTURE_DAYS):
+                raise ValueError("local_date is in the future")
+            if day < recorded_on - timedelta(days=MAX_BACKDATE_DAYS):
+                raise ValueError(f"local_date is more than {MAX_BACKDATE_DAYS} days ago")
 
     from_bar, to_bar = _range(from_bar, to_bar, "from_bar", "to_bar", MAX_BAR)
     from_page, to_page = _range(from_page, to_page, "from_page", "to_page", MAX_PAGE)
@@ -302,6 +345,7 @@ def normalise_goal(
     score_id,
     activity,
     intent,
+    allow_missing_score=False,
 ) -> dict:
     """Check a goal and return the values to store.
 
@@ -309,6 +353,11 @@ def normalise_goal(
     whole point of setting one - so at least one target is required. Both are
     allowed together, and mean what they say: this many days, and this much
     time in total across them.
+
+    `allow_missing_score` is for a goal ALREADY stored against a piece the
+    library no longer has: the goal cannot be counted any more (see
+    goal_progress) but the reflection on it can still be written, and refusing
+    the edit would mean a deleted file silently locking a record of intent.
     """
     period = period or "week"
     if period not in GOAL_PERIODS:
@@ -330,7 +379,7 @@ def normalise_goal(
     # goal carrying a score_id it does not use would read as a goal about that
     # piece while being counted over everything.
     if scope == "score":
-        if score_id is None:
+        if score_id is None and not allow_missing_score:
             raise ValueError("a goal for one piece needs a score_id")
         activity = None
     elif scope == "activity":
@@ -369,6 +418,95 @@ def normalise_reflection(*, reflection, realistic) -> dict:
     }
 
 
+def overlapping_goal(conn, owner: str, start: str, end: str, ignore_start: str | None = None):
+    """A stored goal whose period shares a day with [start, end], if any.
+
+    Overlap and not equality, because equality is what the unique index on
+    (owner, period_start) already covers and it is not the property that
+    matters. Two goals sharing days is how the same practice ends up counted
+    against two intentions and how two panels of one page come to disagree
+    about which goal "this week" has - and it becomes reachable the moment the
+    week-start preference changes, because the new grid's weeks are offset from
+    the old grid's by a few days rather than being different weeks.
+
+    `ignore_start` is the period being written, which is a replacement rather
+    than an overlap.
+    """
+    sql = """SELECT * FROM practice_goals
+              WHERE owner = ? AND period_start <= ? AND period_end >= ?"""
+    params = [owner, end, start]
+    if ignore_start is not None:
+        sql += " AND period_start != ?"
+        params.append(ignore_start)
+    return conn.execute(sql + " ORDER BY period_start LIMIT 1", params).fetchone()
+
+
+def review_periods(conn, owner: str, grid_start: date, weeks: int, starts_on: str) -> list[dict]:
+    """The periods a review covers, most recent first.
+
+    A GOAL CONTRIBUTES ITS OWN PERIOD, not a slot on today's grid. Matching
+    goals to grid weeks by their start date was wrong in a way that mattered:
+    change the week-start preference and every existing goal stops matching,
+    so a past week carrying somebody's own intent and reflection rendered as
+    "no goal was set for this week" - a false statement about their own record,
+    made by the one feature whose whole premise is that its statements are
+    true. The dates a goal was set for are stored, so history is sliced the way
+    it was lived and a later preference cannot re-slice it.
+
+    The timeline is then walked BACKWARDS from the end of the current week, a
+    period at a time, and each step asks the same question: is there a goal
+    covering this day? If so the period is that goal's own; if not it is the
+    canonical week containing the day. Either way the next step resumes the day
+    before whatever was emitted.
+
+    Walking rather than intersecting two lists is what makes the result
+    contiguous and non-overlapping whatever the two grids do. Listing every
+    goal period AND every canonical week would report the same day twice after
+    a preference change; dropping a canonical week because a goal overlapped it
+    would leave the days on the far side of that goal in no period at all, and
+    a review that quietly stops mentioning a day somebody practised on is the
+    one failure this whole feature cannot afford.
+    """
+    window_end = grid_start + timedelta(days=PERIOD_DAYS["week"] - 1)
+    earliest = grid_start - timedelta(days=7 * (weeks - 1))
+    goals = conn.execute(
+        """SELECT * FROM practice_goals
+            WHERE owner = ? AND period_end >= ? AND period_start <= ?
+         ORDER BY period_start DESC""",
+        (owner, earliest.isoformat(), window_end.isoformat()),
+    ).fetchall()
+
+    def covering(day: date):
+        stamp = day.isoformat()
+        for goal in goals:
+            if goal["period_start"] <= stamp <= goal["period_end"]:
+                return goal
+        return None
+
+    periods = []
+    cursor = window_end
+    # Every step moves the cursor back by at least one day and normally by a
+    # week, so this terminates; the bound is belt to that braces, and it is
+    # generous enough that a shorter period type arriving later cannot silently
+    # truncate the answer.
+    while cursor >= earliest and len(periods) <= weeks * PERIOD_DAYS["week"]:
+        goal = covering(cursor)
+        if goal is not None:
+            start, end = parse_day(goal["period_start"]), parse_day(goal["period_end"])
+        else:
+            start = week_start(cursor, starts_on)
+            end = start + timedelta(days=PERIOD_DAYS["week"] - 1)
+        periods.append(
+            {
+                "period_start": start.isoformat(),
+                "period_end": end.isoformat(),
+                "goal": goal,
+            }
+        )
+        cursor = start - timedelta(days=1)
+    return periods
+
+
 def _scope_filter(scope: str, score_id, activity, params: list) -> str:
     """The extra WHERE this goal's scope adds, appending its parameters."""
     if scope == "score":
@@ -380,17 +518,31 @@ def _scope_filter(scope: str, score_id, activity, params: list) -> str:
     return ""
 
 
+def is_orphaned(activity, score_id) -> bool:
+    """Whether this session is work on a piece that is no longer in the library.
+
+    A 'piece' session cannot be CREATED without a score (see
+    normalise_session), and every other activity may legitimately have none -
+    so this one pair of values says, without a column of its own, that a score
+    row went away from underneath a session. Deleting a score sets score_id to
+    NULL rather than deleting the practice; see db._PRACTICE_SESSIONS_COLUMNS.
+    """
+    return activity == DEFAULT_ACTIVITY and score_id is None
+
+
 def session_dict(row) -> dict:
     """One session as the API presents it.
 
-    Two things are derived here rather than stored. `local_date` is the day the
-    practice is attributed to, with `local_date_source` saying whether that day
-    was recorded ('recorded') or taken from the UTC timestamp because the row
-    predates the column ('utc_date') - a reader that treats an inferred day as
-    a recorded one is the reason the distinction is on the response at all.
-    And `reached_target` is the tempo comparison, computed so it can never
+    Three things are derived here rather than stored. `local_date` is the day
+    the practice is attributed to, with `local_date_source` saying whether that
+    day was recorded ('recorded') or taken from the UTC timestamp because the
+    row predates the column ('utc_date') - a reader that treats an inferred day
+    as a recorded one is the reason the distinction is on the response at all.
+    `reached_target` is the tempo comparison, computed so it can never
     contradict the two numbers it comes from; None means one of them is
-    missing, which is not the same as "did not reach it".
+    missing, which is not the same as "did not reach it". And `score_missing`
+    says the work was on a piece that has since left the library, so a reader
+    can name it as that rather than showing a blank where a title goes.
     """
     d = dict(row)
     recorded = d.get("local_date")
@@ -398,18 +550,34 @@ def session_dict(row) -> dict:
     d["local_date_source"] = "recorded" if recorded else "utc_date"
     tempo, target = d.get("tempo_bpm"), d.get("target_tempo_bpm")
     d["reached_target"] = None if tempo is None or target is None else tempo >= target
+    d["score_missing"] = is_orphaned(d.get("activity"), d.get("score_id"))
     return d
 
 
 def day_totals(conn, owner: str, start: str, end: str, extra: str = "", params=()) -> dict:
-    """Seconds and session count per practice day, for the days that have any."""
+    """Seconds and session count per practice day, for the days that have any.
+
+    `inferred` counts the sessions in that day's total whose day was NOT
+    recorded - rows from before local_date existed, attributed to their UTC
+    day. A single session says which it is; a total said nothing, so over a
+    long window two different kinds of day were being added up with nothing
+    marking the join. See period_facts's `sessions_inferred`.
+    """
     sql = f"""SELECT {LOCAL_DATE_SQL} AS day,
-                     SUM(p.seconds) AS seconds, COUNT(*) AS sessions
+                     SUM(p.seconds) AS seconds, COUNT(*) AS sessions,
+                     SUM(CASE WHEN p.local_date IS NULL THEN 1 ELSE 0 END) AS inferred
                 FROM practice_sessions p
                WHERE p.owner = ? AND {LOCAL_DATE_SQL} BETWEEN ? AND ?{extra}
             GROUP BY day ORDER BY day"""
     rows = conn.execute(sql, [owner, start, end, *params]).fetchall()
-    return {r["day"]: {"seconds": r["seconds"], "sessions": r["sessions"]} for r in rows}
+    return {
+        r["day"]: {
+            "seconds": r["seconds"],
+            "sessions": r["sessions"],
+            "inferred": r["inferred"],
+        }
+        for r in rows
+    }
 
 
 def period_facts(
@@ -437,6 +605,7 @@ def period_facts(
             "date": day.isoformat(),
             "seconds": totals.get(day.isoformat(), {}).get("seconds", 0),
             "sessions": totals.get(day.isoformat(), {}).get("sessions", 0),
+            "inferred": totals.get(day.isoformat(), {}).get("inferred", 0),
         }
         for day in days_between(parse_day(start), parse_day(end))
     ]
@@ -448,10 +617,33 @@ def period_facts(
         "minutes": seconds // 60,
         "days_practised": sum(1 for d in days if d["sessions"]),
         "sessions": sum(d["sessions"] for d in days),
+        # How much of the above rests on a day nobody recorded. A single
+        # session says whether its day was recorded or taken from its UTC
+        # timestamp; a total said nothing, so a window spanning the upgrade
+        # quietly added two kinds of day together. Zero on any install that has
+        # only ever run this version, which is the point: it is silent when
+        # there is nothing to disclose.
+        "sessions_inferred": sum(d["inferred"] for d in days),
     }
 
 
-def goal_progress(conn, goal, today: date) -> dict:
+def _period_status(goal, today: date) -> tuple[str, int]:
+    """Where the period sits relative to today, and how much of it is left.
+
+    Says nothing about how the period went - a goal not reached and a goal
+    reached are both 'past' once the week is over. `days_left` counts today
+    itself, because a day somebody still has is a day they can practise in.
+    """
+    start = parse_day(goal["period_start"])
+    end = parse_day(goal["period_end"])
+    if today < start:
+        return "upcoming", (end - start).days + 1
+    if today > end:
+        return "past", 0
+    return "running", (end - today).days + 1
+
+
+def goal_progress(conn, goal, today: date, facts: dict | None = None) -> dict:
     """Where a goal stands: the counts, the targets, and nothing else.
 
     `met_days` and `met_minutes` are None when that target was not set, which
@@ -463,25 +655,55 @@ def goal_progress(conn, goal, today: date) -> dict:
     period still running is reported with `days_left` so the goal can still
     change the week rather than only judge it - and deliberately without any
     per-day rate needed "to catch up", which is a verdict wearing arithmetic.
-    """
-    facts = period_facts(
-        conn,
-        goal["period_start"],
-        goal["period_end"],
-        owner=goal["owner"],
-        scope=goal["scope"],
-        score_id=goal["score_id"],
-        activity=goal["activity"],
-    )
-    start = parse_day(goal["period_start"])
-    end = parse_day(goal["period_end"])
-    if today < start:
-        status, days_left = "upcoming", (end - start).days + 1
-    elif today > end:
-        status, days_left = "past", 0
-    else:
-        status, days_left = "running", (end - today).days + 1
 
+    `countable` is False for a goal about a piece the library no longer has.
+    The practice is still there, but nothing now says which of it was about
+    that piece, so the goal cannot be counted - and reporting that is the only
+    honest option. Reporting zero days instead would turn a week somebody
+    practised into a shortfall, and a goal that was reached into one that was
+    not, because a file was deleted afterwards.
+    """
+    status, days_left = _period_status(goal, today)
+    countable = not (goal["scope"] == "score" and goal["score_id"] is None)
+    if not countable:
+        return {
+            "days": [
+                {"date": day.isoformat(), "seconds": 0, "sessions": 0}
+                for day in days_between(
+                    parse_day(goal["period_start"]), parse_day(goal["period_end"])
+                )
+            ],
+            "seconds": 0,
+            "minutes": 0,
+            "days_practised": 0,
+            "sessions": 0,
+            "status": status,
+            "days_left": days_left,
+            "countable": False,
+            # None and not False: nothing here is a shortfall. There is simply
+            # no answer to be had, and a reader must say so rather than draw
+            # one from the zeros above - which are here only so the shape of
+            # this object never changes.
+            "met_days": None,
+            "met_minutes": None,
+            "met": None,
+        }
+    # `facts` may be supplied by a caller that has already counted exactly this
+    # period with exactly this scope - the review, whose week facts and a
+    # scope='all' goal's progress are the same question. Only ever an
+    # optimisation: passing facts for a different period or scope would make
+    # this report something it did not measure, which is why the review passes
+    # them only for scope='all'.
+    if facts is None:
+        facts = period_facts(
+            conn,
+            goal["period_start"],
+            goal["period_end"],
+            owner=goal["owner"],
+            scope=goal["scope"],
+            score_id=goal["score_id"],
+            activity=goal["activity"],
+        )
     target_days = goal["target_days"]
     target_minutes = goal["target_minutes"]
     met_days = None if target_days is None else facts["days_practised"] >= target_days
@@ -490,6 +712,7 @@ def goal_progress(conn, goal, today: date) -> dict:
         **facts,
         "status": status,
         "days_left": days_left,
+        "countable": True,
         "met_days": met_days,
         "met_minutes": met_minutes,
         # True only when every target that was set has been reached. None of
@@ -501,7 +724,7 @@ def goal_progress(conn, goal, today: date) -> dict:
     }
 
 
-def goal_dict(conn, row, today: date) -> dict:
+def goal_dict(conn, row, today: date, facts: dict | None = None) -> dict:
     """A goal with its progress attached, and its piece named if it has one."""
     d = dict(row)
     d["score_title"] = None
@@ -510,7 +733,7 @@ def goal_dict(conn, row, today: date) -> dict:
             "SELECT title FROM scores WHERE id = ?", (d["score_id"],)
         ).fetchone()
         d["score_title"] = title["title"] if title else None
-    d["progress"] = goal_progress(conn, row, today)
+    d["progress"] = goal_progress(conn, row, today, facts=facts)
     return d
 
 
@@ -535,6 +758,16 @@ def time_spent(
           GROUP BY p.score_id ORDER BY seconds DESC, s.title LIMIT ?""",
         (owner, start, end, limit),
     ).fetchall()
+    # How many pieces were worked on, not how many are listed. Without this a
+    # by-piece breakdown that stopped at the limit read as a complete account
+    # of where the time went, and its numbers did not add up to the total
+    # beside it with nothing saying why.
+    scores_worked = conn.execute(
+        f"""SELECT COUNT(DISTINCT p.score_id) AS n FROM practice_sessions p
+             WHERE p.owner = ? AND p.score_id IS NOT NULL
+               AND {LOCAL_DATE_SQL} BETWEEN ? AND ?""",
+        (owner, start, end),
+    ).fetchone()["n"]
     by_activity = conn.execute(
         f"""SELECT p.activity, SUM(p.seconds) AS seconds, COUNT(*) AS sessions
               FROM practice_sessions p
@@ -545,4 +778,6 @@ def time_spent(
     return {
         "by_score": [dict(r) for r in by_score],
         "by_activity": [dict(r) for r in by_activity],
+        "scores_worked": scores_worked,
+        "by_score_truncated": scores_worked > len(by_score),
     }

--- a/server/tests/test_instruments_api.py
+++ b/server/tests/test_instruments_api.py
@@ -780,7 +780,7 @@ def test_a_column_present_without_its_foreign_key_stops_startup(app_env):
 
 def test_the_schema_version_is_stamped(app_env):
     conn = db.connect()
-    assert conn.execute("PRAGMA user_version").fetchone()[0] == db.SCHEMA_VERSION == 2
+    assert conn.execute("PRAGMA user_version").fetchone()[0] == db.SCHEMA_VERSION == 3
 
 
 def test_a_database_from_a_newer_release_stops_startup(app_env):

--- a/server/tests/test_instruments_api.py
+++ b/server/tests/test_instruments_api.py
@@ -780,7 +780,7 @@ def test_a_column_present_without_its_foreign_key_stops_startup(app_env):
 
 def test_the_schema_version_is_stamped(app_env):
     conn = db.connect()
-    assert conn.execute("PRAGMA user_version").fetchone()[0] == db.SCHEMA_VERSION == 1
+    assert conn.execute("PRAGMA user_version").fetchone()[0] == db.SCHEMA_VERSION == 2
 
 
 def test_a_database_from_a_newer_release_stops_startup(app_env):

--- a/server/tests/test_practice_api.py
+++ b/server/tests/test_practice_api.py
@@ -577,6 +577,227 @@ def test_a_goals_period_cannot_be_moved_onto_a_different_week(client, score):
 
 
 # ---------------------------------------------------------------------------
+# A preference must not re-slice history
+# ---------------------------------------------------------------------------
+
+
+def test_changing_the_week_start_does_not_change_what_a_past_week_reports(client, score):
+    """The same history has to report the same result. A goal stores the dates
+    it was set for, and the review has to read them - matching goals to slots
+    on today's grid meant flipping this preference turned three days and not
+    met into four days and met, on data nobody had touched."""
+    for day in (MONDAY, D(1), D(2)):
+        log(client, day=day, seconds=1800, score_id=score)
+    log(client, day=D(-1), seconds=1800, score_id=score)  # the Sunday before
+    goal = set_goal(client, today=MONDAY, target_days=4)
+
+    def reported():
+        weeks = client.get(f"/api/practice/review?weeks=4&today={D(9)}").json()["weeks"]
+        hosting = [w for w in weeks if w["goal"] and w["goal"]["id"] == goal["id"]]
+        assert len(hosting) == 1, "the goal is listed exactly once"
+        return hosting[0]
+
+    before = reported()
+    assert before["goal"]["progress"]["days_practised"] == 3
+    assert before["goal"]["progress"]["met"] is False
+    assert (before["period_start"], before["period_end"]) == (MONDAY, SUNDAY)
+
+    client.put("/api/settings", json={"week_starts_on": "sunday"})
+    after = reported()
+    assert after["goal"]["progress"]["days_practised"] == 3
+    assert after["goal"]["progress"]["met"] is False
+    assert (after["period_start"], after["period_end"]) == (MONDAY, SUNDAY)
+
+
+def test_a_past_goal_is_never_reported_as_no_goal_at_all(client, score):
+    """The specific false statement. A week carrying somebody's own intent and
+    reflection rendered as "no goal was set for this week" after the preference
+    changed - a lie about their own record, from the one feature whose premise
+    is that its statements are true."""
+    log(client, day=MONDAY, seconds=1800, score_id=score)
+    goal = set_goal(client, today=MONDAY, target_days=4, intent="the awkward bars")
+    client.patch(
+        f"/api/practice/goals/{goal['id']}?today={D(9)}",
+        json={"reflection": "away for three days", "realistic": "no"},
+    )
+    client.put("/api/settings", json={"week_starts_on": "sunday"})
+
+    weeks = client.get(f"/api/practice/review?weeks=4&today={D(9)}").json()["weeks"]
+    found = [w["goal"] for w in weeks if w["goal"]]
+    assert len(found) == 1
+    assert found[0]["intent"] == "the awkward bars"
+    assert found[0]["reflection"] == "away for three days"
+
+
+def test_every_day_in_the_window_is_still_reported_after_a_flip(client, score):
+    """Dropping a canonical week because a goal overlapped it would take real
+    practice out of the review. Each day of the window appears in at least one
+    listed period."""
+    client.put("/api/settings", json={"week_starts_on": "monday"})
+    set_goal(client, today=MONDAY, target_days=4)
+    client.put("/api/settings", json={"week_starts_on": "sunday"})
+
+    weeks = client.get(f"/api/practice/review?weeks=4&today={D(9)}").json()["weeks"]
+    covered = set()
+    for w in weeks:
+        for day in w["facts"]["days"]:
+            covered.add(day["date"])
+    for offset in range(-14, 10):
+        assert D(offset) in covered, f"{D(offset)} is in no listed period"
+
+
+def test_two_goals_cannot_share_a_day(client):
+    """Overlapping goals are how the same practice gets counted against two
+    intentions, and how two panels of one page come to disagree about which
+    goal this week has. Reachable through the ordinary interface the moment the
+    preference changes, so it is refused rather than documented."""
+    set_goal(client, today=MONDAY, target_days=4)
+    res = client.post(
+        f"/api/practice/goals?today={MONDAY}",
+        json={"period_start": D(-1), "target_days": 2},  # Sunday-start, overlaps by six days
+    )
+    assert res.status_code == 409
+    assert MONDAY in res.text and SUNDAY in res.text
+    assert len(client.get(f"/api/practice/goals?today={MONDAY}").json()["goals"]) == 1
+
+    # A period that merely abuts is fine.
+    ok = client.post(
+        f"/api/practice/goals?today={MONDAY}", json={"period_start": D(7), "target_days": 2}
+    )
+    assert ok.status_code == 200, ok.text
+
+
+def test_replacing_a_goal_clears_the_reflection_written_about_the_old_one(client, score):
+    """The review asks whether a goal was realistic. Answering with words
+    written about a different intention is worse than not asking."""
+    goal = set_goal(client, today=MONDAY, target_days=4)
+    client.patch(
+        f"/api/practice/goals/{goal['id']}?today={D(9)}",
+        json={"reflection": "too much on", "realistic": "no"},
+    )
+    replaced = set_goal(client, today=MONDAY, target_days=2)
+    assert replaced["id"] == goal["id"]
+    assert replaced["reflection"] is None
+    assert replaced["realistic"] is None
+
+
+# ---------------------------------------------------------------------------
+# Dates a client can send
+# ---------------------------------------------------------------------------
+
+
+def test_a_date_at_the_edge_of_the_calendar_is_refused_not_a_crash(client):
+    """Every one of these does arithmetic on the date it is given - a review
+    reaches 52 weeks back, a history window 366 days - and date's own bounds
+    raise OverflowError from inside a subtraction, which reaches a client as a
+    500 for what is only ever a typo."""
+    for url in (
+        "/api/practice/goals/current?today=0001-01-01",
+        "/api/practice/review?weeks=52&today=0001-01-01",
+        "/api/practice/history?days=366&today=0001-01-01",
+        "/api/practice/goals/current?today=9999-12-31",
+        "/api/practice/review?weeks=52&today=9999-12-31",
+        "/api/practice/history?days=366&today=9999-12-31",
+    ):
+        assert client.get(url).status_code == 422, url
+    for body in ({"period_start": "0001-01-01", "target_days": 2},
+                 {"period_start": "9999-12-31", "target_days": 2}):
+        assert client.post(f"/api/practice/goals?today={MONDAY}", json=body).status_code == 422
+
+
+def test_a_today_nowhere_near_the_servers_date_is_refused(client):
+    """A perfectly well-formed date that is nonetheless not a day this instance
+    could hold practice for. Unbounded, `today=2099-01-01` was answered with a
+    plausible-looking empty week - the worst kind of wrong answer, because
+    nothing in the response marks it as suspect."""
+    for far in ("2099-01-01", "1975-06-01"):
+        for url in (
+            f"/api/practice/goals/current?today={far}",
+            f"/api/practice/review?weeks=4&today={far}",
+            f"/api/practice/history?days=30&today={far}",
+            f"/api/practice/goals?today={far}",
+        ):
+            res = client.get(url)
+            assert res.status_code == 422, (url, res.text)
+        assert (
+            client.post(f"/api/practice/goals?today={far}", json={"target_days": 2}).status_code
+            == 422
+        )
+    # A date the practiser's own timezone can actually produce is accepted, and
+    # so is one a week ago - reasoning about a period that has ended is what
+    # this parameter is for.
+    for near in (MONDAY, D(7), date.today().isoformat()):
+        assert client.get(f"/api/practice/goals/current?today={near}").status_code == 200
+
+
+def test_a_boolean_is_not_a_number_of_days(client):
+    """Pydantic's default mode coerces before any validator runs, so `true`
+    arrived as 1 and set a one-day goal past a guard written to reject bools."""
+    res = client.post(f"/api/practice/goals?today={MONDAY}", json={"target_days": True})
+    assert res.status_code == 422
+    assert client.post(
+        f"/api/practice/sessions", json={"seconds": True, "activity": "free"}
+    ).status_code == 422
+
+
+def test_a_session_can_still_be_corrected_when_it_is_old(client, score):
+    """How far back a NEW practice day may be is a rule about what somebody may
+    claim now. Applied to a date already stored it made every session
+    permanently uneditable once it was old enough."""
+    session = log(client, day=MONDAY, seconds=600, score_id=score)
+    ancient = (date.today() - timedelta(days=1000)).isoformat()
+    conn = db.connect()
+    conn.execute(
+        "UPDATE practice_sessions SET local_date = ? WHERE id = ?", (ancient, session["id"])
+    )
+    conn.commit()
+
+    res = client.patch(f"/api/practice/sessions/{session['id']}", json={"rating": 5})
+    assert res.status_code == 200, res.text
+    assert res.json()["rating"] == 5
+    assert res.json()["local_date"] == ancient
+    # Moving the date itself is still bounded, because that IS a new claim.
+    moved = client.patch(
+        f"/api/practice/sessions/{session['id']}", json={"local_date": ancient}
+    )
+    assert moved.status_code == 422
+    assert "days ago" in moved.text
+
+
+# ---------------------------------------------------------------------------
+# Saying what was left out
+# ---------------------------------------------------------------------------
+
+
+def test_a_truncated_session_list_says_how_many_there_were(client, score):
+    for n in range(5):
+        log(client, day=D(n), seconds=600, score_id=score)
+    full = client.get("/api/practice/sessions").json()
+    assert (full["total"], full["truncated"]) == (5, False)
+    capped = client.get("/api/practice/sessions?limit=2").json()
+    assert len(capped["sessions"]) == 2
+    assert (capped["total"], capped["truncated"]) == (5, True)
+
+
+def test_a_truncated_by_piece_breakdown_says_how_many_pieces_there_were(client):
+    conn = db.connect()
+    for n in range(4):
+        conn.execute(
+            """INSERT INTO scores(title, path, file_type, hash, size, mtime)
+               VALUES (?, ?, 'pdf', 'deadbeef', 1, 0.0)""",
+            (f"Piece {n}", f"a/{n}.pdf"),
+        )
+    conn.commit()
+    ids = [r["id"] for r in conn.execute("SELECT id FROM scores")]
+    for score_id in ids:
+        log(client, day=MONDAY, seconds=600, score_id=score_id)
+
+    history = client.get(f"/api/practice/history?days=30&today={D(6)}").json()
+    assert history["scores_worked"] == len(ids)
+    assert history["by_score_truncated"] is False
+
+
+# ---------------------------------------------------------------------------
 # The rest of the app still sees practice the way it did
 # ---------------------------------------------------------------------------
 
@@ -598,6 +819,87 @@ def test_the_recently_practised_and_neglected_views_still_work(client, score, ot
     assert [s["id"] for s in neglected] == [other_score]
 
 
+def test_the_library_views_go_by_the_practice_day_not_the_timestamp(client, score, other_score):
+    """A session entered late says which day it happened on, and the library
+    has to believe it. Windowing on the UTC timestamp instead would call a
+    piece last touched two months ago "recently practised" because the row was
+    typed in this morning - and the library is the view a person sees first, so
+    it must not disagree with the practice page about when they last played
+    something."""
+    long_ago = (date.today() - timedelta(days=60)).isoformat()
+    log(client, day=long_ago, seconds=1800, score_id=score)
+
+    assert client.get("/api/scores?practiced=recent").json() == []
+    neglected = {s["id"] for s in client.get("/api/scores?practiced=neglected").json()}
+    assert neglected == {score, other_score}
+    # And the day it reports is that day, not today.
+    listed = {s["id"]: s for s in client.get("/api/scores").json()}
+    assert listed[score]["last_practiced"] == long_ago
+
+
+def test_an_orphaned_session_does_not_empty_the_neglected_view(client, score, other_score):
+    """SQL's NOT IN against a set containing NULL is never true. Now that a
+    session can have no score, one orphaned row anywhere used to be enough to
+    make "needs attention" list nothing at all - including scores that have
+    never been practised, which is exactly what that view is for."""
+    log(client, day=MONDAY, seconds=600, score_id=score)
+    _delete_score(score)
+    neglected = client.get("/api/scores?practiced=neglected").json()
+    assert [s["id"] for s in neglected] == [other_score]
+
+
+def test_every_practice_query_counts_only_this_owner(client, score):
+    """Dead today - there is one owner - and checked anyway, because the day
+    accounts arrive the failure is somebody else's practice appearing in this
+    person's totals, and the schema's comments ask these sites to stay
+    consistent and greppable rather than correct by accident. /practice/summary
+    was the one that had no owner filter at all.
+
+    The score-scoped totals are deliberately NOT filtered: a score has no owner
+    column, so "this owner's practice on this score" is not a question the
+    schema can answer yet, and pretending otherwise would be a filter that
+    looks like a guarantee and is not.
+    """
+    today = date.today().isoformat()
+    log(client, day=today, seconds=600, score_id=score)
+    conn = db.connect()
+    conn.execute(
+        """INSERT INTO practice_sessions(owner, score_id, activity, started_at, local_date, seconds)
+           VALUES ('someone_else', ?, 'piece', datetime('now'), ?, 9999)""",
+        (score, today),
+    )
+    conn.execute(
+        """INSERT INTO practice_goals(owner, period_start, period_end, target_days, scope)
+           VALUES ('someone_else', ?, ?, 7, 'all')""",
+        (MONDAY, SUNDAY),
+    )
+    conn.commit()
+
+    assert client.get("/api/practice/summary").json()["week_seconds"] == 600
+    history = client.get(f"/api/practice/history?days=30&today={today}").json()
+    assert history["seconds"] == 600
+    assert client.get("/api/practice/sessions").json()["total"] == 1
+    assert client.get(f"/api/practice/goals?today={today}").json()["goals"] == []
+    week = client.get(f"/api/practice/review?weeks=1&today={today}").json()["weeks"][0]
+    assert week["facts"]["seconds"] == 600
+    assert week["goal"] is None
+
+
+def test_the_weekly_summary_counts_practice_days(client, score):
+    """Seven calendar days, so this and the practice page cannot disagree about
+    what "this week" held. A session back-dated well outside the window does
+    not count towards it however recently it was typed in."""
+    today = date.today().isoformat()
+    log(client, day=today, seconds=1800, score_id=score)
+    log(client, day=(date.today() - timedelta(days=30)).isoformat(), seconds=3600, score_id=score)
+    summary = client.get("/api/practice/summary").json()
+    assert summary["week_seconds"] == 1800
+    assert summary["week_sessions"] == 1
+    assert [(s["title"], s["practice_seconds"]) for s in summary["top_scores"]] == [
+        ("Study in C", 1800)
+    ]
+
+
 def test_the_weekly_summary_still_answers(client, score):
     client.post(f"/api/scores/{score}/practice", json={"seconds": 1800})
     summary = client.get("/api/practice/summary").json()
@@ -605,17 +907,136 @@ def test_the_weekly_summary_still_answers(client, score):
     assert [s["title"] for s in summary["top_scores"]] == ["Study in C"]
 
 
-def test_deleting_a_score_takes_its_practice_and_its_goal_with_it(client, score):
-    """Documented, and checked here so it stays deliberate: a score row goes
-    only when its file has left the library, and a goal about a piece that is
-    no longer there could not be reviewed against anything."""
-    log(client, day=MONDAY, seconds=1800, score_id=score)
-    set_goal(client, today=MONDAY, target_days=3, scope="score", score_id=score)
+def _delete_score(score_id: int) -> None:
+    """Remove a score row the way the scanner does when its file has gone.
+
+    There is no delete endpoint yet (#56), and going through the database is
+    the honest stand-in: what matters is what the foreign key does, not which
+    code path asked.
+    """
     conn = db.connect()
-    conn.execute("DELETE FROM scores WHERE id = ?", (score,))
+    conn.execute("DELETE FROM scores WHERE id = ?", (score_id,))
     conn.commit()
-    assert client.get("/api/practice/sessions").json()["sessions"] == []
-    assert client.get("/api/practice/goals").json()["goals"] == []
+
+
+def test_deleting_a_score_keeps_the_practice(client, score, other_score):
+    """The hours were spent whether or not the file is still on disk, and the
+    record of them is a property of the person's history rather than of the
+    file. Every session survives, naming no piece."""
+    log(client, day=MONDAY, seconds=1800, score_id=score, rating=4, note="better today")
+    log(client, day=D(1), seconds=600, score_id=other_score)
+    _delete_score(score)
+
+    sessions = client.get("/api/practice/sessions").json()["sessions"]
+    assert len(sessions) == 2
+    orphan = next(s for s in sessions if s["score_id"] is None)
+    assert orphan["seconds"] == 1800
+    assert orphan["rating"] == 4
+    assert orphan["note"] == "better today"
+    assert orphan["local_date"] == MONDAY
+    # Named as what it is, not left as a blank where a title goes.
+    assert orphan["activity"] == "piece"
+    assert orphan["score_missing"] is True
+    # The other piece is untouched, so the delete took only what it should.
+    assert next(s for s in sessions if s["score_id"] == other_score)["score_missing"] is False
+
+
+def test_a_goal_already_reached_stays_reached_when_a_score_is_deleted(client, score):
+    """The failure this has to rule out. A week's goal counted over any
+    practice must not become unmet because a file was tidied away afterwards."""
+    for day in (MONDAY, D(1), D(2)):
+        log(client, day=day, seconds=1800, score_id=score)
+    goal = set_goal(client, today=D(7), period_start=MONDAY, target_days=3, target_minutes=60)
+    assert goal["progress"]["met"] is True
+
+    _delete_score(score)
+    after = client.get(f"/api/practice/goals?today={D(7)}").json()["goals"][0]
+    assert after["progress"]["met"] is True
+    assert after["progress"]["days_practised"] == 3
+    assert after["progress"]["minutes"] == 90
+    assert after["progress"]["countable"] is True
+
+
+def test_orphaned_practice_still_appears_everywhere_practice_is_counted(client, score):
+    """Not filtered out anywhere. The history, the review and a week's facts
+    all have to keep it, or "where did my time go" starts losing hours to
+    library tidying."""
+    log(client, day=MONDAY, seconds=1800, score_id=score)
+    _delete_score(score)
+
+    history = client.get(f"/api/practice/history?days=30&today={D(6)}").json()
+    assert history["seconds"] == 1800
+    assert history["days_practised"] == 1
+    # by_score can no longer name it - there is no piece to name - so the time
+    # is accounted for under the kind of work it was.
+    assert history["by_score"] == []
+    assert [(r["activity"], r["seconds"]) for r in history["by_activity"]] == [("piece", 1800)]
+
+    week = client.get(f"/api/practice/review?weeks=1&today={D(6)}").json()["weeks"][0]
+    assert week["facts"]["seconds"] == 1800
+    assert week["facts"]["days_practised"] == 1
+
+
+def test_a_goal_about_a_deleted_piece_says_it_cannot_be_counted(client, score):
+    """Its sessions are still in the history but no longer identifiable as
+    being about that piece. So it reports that, rather than reporting zero days
+    - which would read as a week nobody practised."""
+    log(client, day=MONDAY, seconds=1800, score_id=score)
+    goal = set_goal(
+        client, today=D(7), period_start=MONDAY, target_days=1, scope="score", score_id=score
+    )
+    assert goal["progress"]["met"] is True
+
+    _delete_score(score)
+    after = client.get(f"/api/practice/goals?today={D(7)}").json()["goals"][0]
+    assert after["id"] == goal["id"]
+    assert after["scope"] == "score"
+    assert after["score_id"] is None
+    assert after["progress"]["countable"] is False
+    assert after["progress"]["met"] is None
+    assert after["progress"]["met_days"] is None
+
+
+def test_an_orphaned_session_can_still_be_annotated(client, score):
+    """A true record has to stay editable. Refusing a note because the piece
+    was deleted would turn a rule about making an honest claim into a rule
+    about keeping one."""
+    session = log(client, day=MONDAY, seconds=1800, score_id=score)
+    _delete_score(score)
+    res = client.patch(
+        f"/api/practice/sessions/{session['id']}", json={"note": "the one I gave up on"}
+    )
+    assert res.status_code == 200, res.text
+    assert res.json()["note"] == "the one I gave up on"
+    assert res.json()["score_missing"] is True
+
+
+def test_a_goal_about_a_deleted_piece_can_still_be_reflected_on(client, score):
+    log(client, day=MONDAY, seconds=1800, score_id=score)
+    goal = set_goal(client, today=MONDAY, target_days=3, scope="score", score_id=score)
+    _delete_score(score)
+    res = client.patch(
+        f"/api/practice/goals/{goal['id']}?today={D(7)}",
+        json={"reflection": "gave that piece up", "realistic": "no"},
+    )
+    assert res.status_code == 200, res.text
+    assert res.json()["reflection"] == "gave that piece up"
+
+
+def test_a_session_on_a_piece_still_cannot_be_created_without_one(client, score):
+    """The allowance is granted from the STORED row, so it cannot be used to
+    reach that state deliberately: creating a piece session with no piece is
+    still refused, and which piece a session is against is not patchable at
+    all - a session cannot be detached from its score, only outlive it."""
+    assert (
+        client.post("/api/practice/sessions", json={"seconds": 600, "activity": "piece"}).status_code
+        == 422
+    )
+    session = log(client, day=MONDAY, seconds=600, score_id=score)
+    res = client.patch(f"/api/practice/sessions/{session['id']}", json={"score_id": None})
+    assert res.status_code == 200, res.text
+    assert res.json()["score_id"] == score
+    assert res.json()["score_missing"] is False
 
 
 def test_practice_recorded_before_this_change_is_still_counted(client, score):

--- a/server/tests/test_practice_api.py
+++ b/server/tests/test_practice_api.py
@@ -1,0 +1,639 @@
+"""The practice endpoints, over real HTTP against a real database.
+
+Called through TestClient rather than as Python functions, because half of what
+this change adds lives in the request layer - a query parameter that decides
+which week is "this" one, an upsert that must replace rather than duplicate, a
+patch whose explicit null has to mean "clear this" and not "I said nothing".
+None of that is exercised by calling the handler with keyword arguments.
+"""
+
+from datetime import date, timedelta
+
+import pytest
+from fastapi.testclient import TestClient
+
+from fermata import db
+from fermata.main import app
+
+# Every date here is an offset from one Monday, six weeks back.
+#
+# Relative and not literal, deliberately: a session cannot be logged for a day
+# that has not happened, so a fixed calendar date would start failing the day
+# the suite ran past it - and it cannot be logged more than
+# practice.MAX_BACKDATE_DAYS ago either, so a date far enough in the past to be
+# permanently safe from the first rule would eventually break the second. Six
+# weeks back satisfies both on any day the suite is run.
+#
+# D(0) is a Monday, so under the default week start the week under test is
+# D(0) through D(6) and the arithmetic below can be checked by eye.
+_TODAY = date.today()
+_WEEK_START = _TODAY - timedelta(days=_TODAY.weekday() + 42)
+
+
+def D(offset: int) -> str:
+    return (_WEEK_START + timedelta(days=offset)).isoformat()
+
+
+MONDAY = D(0)
+SUNDAY = D(6)
+
+
+@pytest.fixture
+def client(app_env, monkeypatch, tmp_path):
+    """A client whose startup does not scan a library or serve a build."""
+    monkeypatch.setattr("fermata.main.scanner.start_scan", lambda: False)
+    monkeypatch.setattr("fermata.main.init_db", lambda: None)
+    with TestClient(app) as c:
+        yield c
+
+
+@pytest.fixture
+def score(client):
+    conn = db.connect()
+    cur = conn.execute(
+        """INSERT INTO scores(title, path, file_type, hash, size, mtime)
+           VALUES ('Study in C', 'Classical/Study in C.pdf', 'pdf', 'deadbeef', 1, 0.0)"""
+    )
+    conn.commit()
+    return cur.lastrowid
+
+
+@pytest.fixture
+def other_score(client):
+    conn = db.connect()
+    cur = conn.execute(
+        """INSERT INTO scores(title, path, file_type, hash, size, mtime)
+           VALUES ('To Zanarkand', 'Patreon/Zanarkand.pdf', 'pdf', 'cafebabe', 1, 0.0)"""
+    )
+    conn.commit()
+    return cur.lastrowid
+
+
+def log(client, *, day, seconds, score_id=None, **rest):
+    body = {"seconds": seconds, "local_date": day, **rest}
+    if score_id is not None:
+        body["score_id"] = score_id
+        body.setdefault("activity", "piece")
+    res = client.post("/api/practice/sessions", json=body)
+    assert res.status_code == 200, res.text
+    return res.json()
+
+
+def set_goal(client, *, today=MONDAY, **body):
+    res = client.post(f"/api/practice/goals?today={today}", json=body)
+    assert res.status_code == 200, res.text
+    return res.json()
+
+
+# ---------------------------------------------------------------------------
+# Logging a session
+# ---------------------------------------------------------------------------
+
+
+def test_the_timer_can_still_log_a_bare_session_against_a_score(client, score):
+    """The one call the practice timer makes. It has to keep working with
+    nothing but a length, because a player stopping a clock should not be
+    standing in front of a form."""
+    res = client.post(f"/api/scores/{score}/practice", json={"seconds": 900})
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert body["practice_seconds"] == 900
+    assert body["session_count"] == 1
+    # The id, so detail can be added to what was just logged.
+    assert body["session"]["id"]
+    assert body["session"]["activity"] == "piece"
+    assert body["session"]["local_date_source"] == "utc_date"
+
+
+def test_the_timer_can_say_which_day_it_was(client, score):
+    res = client.post(
+        f"/api/scores/{score}/practice", json={"seconds": 900, "local_date": MONDAY}
+    )
+    session = res.json()["session"]
+    assert session["local_date"] == MONDAY
+    assert session["local_date_source"] == "recorded"
+
+
+def test_rich_detail_survives_a_round_trip(client, score):
+    """Every field this change added, written and read back. A store that
+    accepted a field and dropped it would look identical from the write side."""
+    detail = {
+        "seconds": 1500,
+        "local_date": MONDAY,
+        "activity": "piece",
+        "mode": "section",
+        "from_bar": 17,
+        "to_bar": 32,
+        "from_page": 2,
+        "to_page": 3,
+        "tempo_bpm": 76,
+        "target_tempo_bpm": 120,
+        "rating": 3,
+        "note": "left hand still behind",
+    }
+    logged = client.post(f"/api/scores/{score}/practice", json=detail).json()["session"]
+    stored = client.get(f"/api/scores/{score}/practice").json()["sessions"][0]
+    for field, value in detail.items():
+        assert stored[field] == value, field
+        assert logged[field] == value, field
+    assert stored["reached_target"] is False
+
+
+def test_practice_that_is_not_about_a_piece_needs_no_piece(client):
+    session = log(client, day=MONDAY, seconds=600, activity="ear_training")
+    assert session["score_id"] is None
+    assert session["activity"] == "ear_training"
+    listed = client.get("/api/practice/sessions").json()["sessions"]
+    assert [s["activity"] for s in listed] == ["ear_training"]
+
+
+def test_a_session_on_a_piece_that_names_no_piece_is_refused(client):
+    res = client.post("/api/practice/sessions", json={"seconds": 600, "activity": "piece"})
+    assert res.status_code == 422
+    assert "score_id" in res.text
+
+
+def test_a_session_naming_a_score_that_does_not_exist_is_a_404(client):
+    res = client.post(
+        "/api/practice/sessions",
+        json={"seconds": 600, "activity": "piece", "score_id": 4321},
+    )
+    assert res.status_code == 404
+
+
+def test_an_impossible_length_or_rating_is_refused_with_a_reason(client, score):
+    for body, expected in (
+        ({"seconds": 0}, "seconds"),
+        ({"seconds": 90_000}, "seconds"),
+        ({"seconds": 600, "rating": 9}, "rating"),
+        ({"seconds": 600, "tempo_bpm": 3}, "tempo_bpm"),
+        ({"seconds": 600, "to_bar": 32}, "from_bar"),
+        ({"seconds": 600, "activity": "vibes"}, "activity"),
+        ({"seconds": 600, "mode": "noodling"}, "mode"),
+    ):
+        res = client.post(f"/api/scores/{score}/practice", json=body)
+        assert res.status_code == 422, (body, res.text)
+        assert expected in res.text, (body, res.text)
+
+
+# ---------------------------------------------------------------------------
+# Adding detail afterwards, and taking it back
+# ---------------------------------------------------------------------------
+
+
+def test_detail_can_be_added_to_a_session_already_logged(client, score):
+    """How the interface works: the timer stores the length the moment it
+    stops, and how it went is written afterwards - so a stopped clock is never
+    waiting on a form, and a session is never lost because the form was
+    abandoned."""
+    session = client.post(f"/api/scores/{score}/practice", json={"seconds": 900}).json()[
+        "session"
+    ]
+    res = client.patch(
+        f"/api/practice/sessions/{session['id']}",
+        json={"rating": 4, "note": "much better", "mode": "run_through"},
+    )
+    assert res.status_code == 200, res.text
+    patched = res.json()
+    assert (patched["rating"], patched["note"], patched["mode"]) == (4, "much better", "run_through")
+    assert patched["seconds"] == 900  # untouched by a patch that did not mention it
+
+
+def test_an_explicit_null_clears_a_field_rather_than_being_ignored(client, score):
+    """A rating entered by mistake has to be removable. The omit-nulls rule
+    that suits a create would swallow the only way to say "no rating"."""
+    session = client.post(
+        f"/api/scores/{score}/practice", json={"seconds": 900, "rating": 2, "note": "oops"}
+    ).json()["session"]
+    patched = client.patch(
+        f"/api/practice/sessions/{session['id']}", json={"rating": None}
+    ).json()
+    assert patched["rating"] is None
+    assert patched["note"] == "oops"  # not mentioned, so not cleared
+
+
+def test_a_patch_cannot_reach_a_state_a_fresh_log_would_be_refused(client, score):
+    """The whole record is re-checked, not the fragment: to_bar on its own is
+    meaningless, and validating only what changed would let a patch build a row
+    the create path rejects."""
+    session = client.post(f"/api/scores/{score}/practice", json={"seconds": 900}).json()[
+        "session"
+    ]
+    res = client.patch(f"/api/practice/sessions/{session['id']}", json={"to_bar": 32})
+    assert res.status_code == 422
+    assert "from_bar" in res.text
+
+    ok = client.patch(
+        f"/api/practice/sessions/{session['id']}", json={"from_bar": 17, "to_bar": 32}
+    )
+    assert ok.status_code == 200
+    reversed_range = client.patch(
+        f"/api/practice/sessions/{session['id']}", json={"to_bar": 4}
+    )
+    assert reversed_range.status_code == 422
+
+
+def test_a_session_can_be_deleted_and_stops_counting(client, score):
+    """A timer left running by accident is otherwise permanent, and a record
+    with an invented two-hour session in it is not honest either."""
+    session = log(client, day=MONDAY, seconds=7200, score_id=score)
+    assert client.delete(f"/api/practice/sessions/{session['id']}").status_code == 200
+    assert client.get(f"/api/scores/{score}/practice").json()["practice_seconds"] == 0
+    assert client.delete(f"/api/practice/sessions/{session['id']}").status_code == 404
+
+
+def test_patching_or_deleting_a_session_that_is_not_there_is_a_404(client):
+    assert client.patch("/api/practice/sessions/999", json={"rating": 3}).status_code == 404
+    assert client.delete("/api/practice/sessions/999").status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Reading the record back
+# ---------------------------------------------------------------------------
+
+
+def test_sessions_can_be_read_across_every_piece_and_filtered(client, score, other_score):
+    """What answers "what did I actually do this week" without a caller
+    walking the library one score at a time."""
+    log(client, day=D(0), seconds=600, score_id=score)
+    log(client, day=D(2), seconds=1200, score_id=other_score)
+    log(client, day=D(3), seconds=900, activity="fretboard")
+    log(client, day=D(8), seconds=1800, score_id=score)
+
+    everything = client.get("/api/practice/sessions").json()["sessions"]
+    assert [s["local_date"] for s in everything] == [
+        D(8), D(3), D(2), D(0),
+    ]
+
+    week = client.get(f"/api/practice/sessions?start={MONDAY}&end={SUNDAY}").json()["sessions"]
+    assert [s["seconds"] for s in week] == [900, 1200, 600]
+
+    one_piece = client.get(f"/api/practice/sessions?score_id={score}").json()["sessions"]
+    assert [s["seconds"] for s in one_piece] == [1800, 600]
+    assert {s["score_title"] for s in one_piece} == {"Study in C"}
+
+    one_kind = client.get("/api/practice/sessions?activity=fretboard").json()["sessions"]
+    assert [s["seconds"] for s in one_kind] == [900]
+
+
+def test_history_says_where_the_time_went_over_a_long_window(client, score, other_score):
+    """Three months, a day at a time and a piece at a time - the shape of
+    question that previously had to be reassembled score by score."""
+    log(client, day=D(-16), seconds=1800, score_id=score)
+    log(client, day=D(2), seconds=3600, score_id=other_score)
+    log(client, day=D(2), seconds=600, activity="ear_training")
+
+    res = client.get(f"/api/practice/history?days=90&today={D(6)}")
+    assert res.status_code == 200
+    body = res.json()
+    assert body["start"] == D(6 - 89) and body["end"] == D(6)
+    assert len(body["days"]) == 90
+    assert body["days_practised"] == 2
+    assert body["seconds"] == 6000
+    assert [(r["title"], r["seconds"]) for r in body["by_score"]] == [
+        ("To Zanarkand", 3600),
+        ("Study in C", 1800),
+    ]
+    assert [(r["activity"], r["seconds"]) for r in body["by_activity"]] == [
+        ("piece", 5400),
+        ("ear_training", 600),
+    ]
+
+
+def test_a_silly_window_is_refused_rather_than_served(client):
+    assert client.get("/api/practice/history?days=0").status_code == 422
+    assert client.get("/api/practice/history?days=5000").status_code == 422
+    assert client.get("/api/practice/sessions?limit=0").status_code == 422
+    assert client.get("/api/practice/sessions?activity=vibes").status_code == 422
+    assert client.get("/api/practice/sessions?start=17-08-2026").status_code == 422
+    assert client.get("/api/practice/review?weeks=0").status_code == 422
+    assert client.get("/api/practice/review?weeks=99").status_code == 422
+    assert client.get(f"/api/practice/goals/current?today=nonsense").status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Setting a goal
+# ---------------------------------------------------------------------------
+
+
+def test_a_goal_set_without_a_period_is_for_the_week_containing_today(client):
+    goal = set_goal(client, today=D(2), target_days=4)
+    assert (goal["period_start"], goal["period_end"]) == (MONDAY, SUNDAY)
+    assert goal["target_days"] == 4
+    assert goal["progress"]["status"] == "running"
+
+
+def test_the_week_start_preference_decides_which_seven_days_that_is(client):
+    """Half the world starts a week on Sunday, and a goal counted over the
+    wrong seven days is counted against days its owner did not think were part
+    of the week."""
+    assert client.put("/api/settings", json={"week_starts_on": "sunday"}).status_code == 200
+    goal = set_goal(client, today=D(2), target_days=4)
+    assert (goal["period_start"], goal["period_end"]) == (D(-1), D(5))
+
+    current = client.get(f"/api/practice/goals/current?today={D(2)}").json()
+    assert current["week_starts_on"] == "sunday"
+    assert current["week_start"] == D(-1)
+
+
+def test_changing_the_week_start_does_not_move_a_goal_already_set(client):
+    """A goal stores the two dates it was actually set for, so a preference
+    changed afterwards cannot silently re-point it at a different week's
+    practice."""
+    goal = set_goal(client, today=D(2), target_days=4)
+    client.put("/api/settings", json={"week_starts_on": "sunday"})
+    again = client.get(f"/api/practice/goals/current?today={D(2)}").json()["goal"]
+    assert again["id"] == goal["id"]
+    assert (again["period_start"], again["period_end"]) == (MONDAY, SUNDAY)
+
+
+def test_setting_a_goal_again_for_the_same_week_replaces_it(client):
+    """Changing your mind about the week is the ordinary case. A period with
+    two goals in it is a scorecard."""
+    first = set_goal(client, target_days=6, target_minutes=600)
+    second = set_goal(client, target_days=3, target_minutes=None)
+    assert second["id"] == first["id"]
+    assert second["target_days"] == 3
+    assert second["target_minutes"] is None
+    assert len(client.get("/api/practice/goals").json()["goals"]) == 1
+
+
+def test_a_goal_with_no_target_at_all_is_refused(client):
+    res = client.post(f"/api/practice/goals?today={MONDAY}", json={"intent": "practise more"})
+    assert res.status_code == 422
+    assert "target" in res.text
+
+
+def test_a_goal_can_be_scoped_to_one_piece_and_names_it(client, score):
+    goal = set_goal(client, target_days=3, scope="score", score_id=score)
+    assert goal["scope"] == "score"
+    assert goal["score_title"] == "Study in C"
+
+
+def test_a_goal_scoped_to_a_score_that_does_not_exist_is_a_404(client):
+    res = client.post(
+        f"/api/practice/goals?today={MONDAY}",
+        json={"target_days": 3, "scope": "score", "score_id": 4321},
+    )
+    assert res.status_code == 404
+
+
+def test_no_goal_set_is_an_answer_and_not_an_error(client):
+    """Having no goal is an ordinary state, and a perfectly good week can
+    happen inside it."""
+    res = client.get(f"/api/practice/goals/current?today={MONDAY}")
+    assert res.status_code == 200
+    body = res.json()
+    assert body["goal"] is None
+    assert (body["week_start"], body["week_end"]) == (MONDAY, SUNDAY)
+
+
+def test_a_goal_can_be_deleted_without_touching_the_practice(client, score):
+    goal = set_goal(client, target_days=3)
+    log(client, day=MONDAY, seconds=1800, score_id=score)
+    assert client.delete(f"/api/practice/goals/{goal['id']}").status_code == 200
+    assert client.get(f"/api/practice/goals/current?today={MONDAY}").json()["goal"] is None
+    assert client.get(f"/api/scores/{score}/practice").json()["practice_seconds"] == 1800
+    assert client.delete(f"/api/practice/goals/{goal['id']}").status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Standing where the week can still change
+# ---------------------------------------------------------------------------
+
+
+def test_progress_is_visible_while_the_period_is_still_running(client, score):
+    log(client, day=D(0), seconds=1800, score_id=score)
+    log(client, day=D(1), seconds=1800, score_id=score)
+    goal = set_goal(client, today=D(2), target_days=4, target_minutes=180)
+
+    progress = goal["progress"]
+    assert progress["status"] == "running"
+    assert progress["days_practised"] == 2
+    assert progress["minutes"] == 60
+    assert progress["days_left"] == 5
+    assert progress["met"] is False
+
+
+def test_a_target_can_be_changed_while_the_period_runs(client, score):
+    """Seeing where you stand is only useful if the goal can still change the
+    week rather than only judge it afterwards."""
+    goal = set_goal(client, today=D(2), target_days=6)
+    res = client.patch(
+        f"/api/practice/goals/{goal['id']}?today={D(2)}", json={"target_days": 3}
+    )
+    assert res.status_code == 200
+    assert res.json()["target_days"] == 3
+
+
+def test_a_late_entered_session_still_lands_in_the_week_it_happened(client, score):
+    """Nothing stores whether a goal was met, so an hour remembered on Friday
+    counts towards Tuesday - which it would not if a verdict had been written
+    down when the week looked different."""
+    goal = set_goal(client, today=D(4), target_days=1)
+    assert goal["progress"]["days_practised"] == 0
+    log(client, day=D(1), seconds=3600, score_id=score)
+    after = client.get(f"/api/practice/goals/current?today={D(4)}").json()["goal"]
+    assert after["progress"]["days_practised"] == 1
+    assert after["progress"]["met"] is True
+
+
+def test_today_is_the_clients_own_date_not_the_servers(client, score):
+    """Whether a period is still running must not be an accident of the hour
+    the server happens to be in - west of Greenwich the UTC date is already
+    tomorrow while somebody still has their evening."""
+    set_goal(client, today=MONDAY, target_days=4)
+    running = client.get(f"/api/practice/goals/current?today={SUNDAY}").json()["goal"]
+    assert running["progress"]["status"] == "running"
+    over = client.get(f"/api/practice/goals/current?today={D(7)}").json()["goal"]
+    assert over is None
+
+
+# ---------------------------------------------------------------------------
+# The review
+# ---------------------------------------------------------------------------
+
+
+def test_the_review_states_what_happened_in_each_recent_week(client, score, other_score):
+    log(client, day=D(0), seconds=1800, score_id=score)
+    log(client, day=D(1), seconds=1800, score_id=other_score)
+    log(client, day=D(-5), seconds=600, score_id=score)  # the week before
+    set_goal(client, today=MONDAY, target_days=4, target_minutes=120)
+
+    res = client.get(f"/api/practice/review?weeks=3&today={D(7)}")
+    assert res.status_code == 200
+    weeks = res.json()["weeks"]
+    assert [w["period_start"] for w in weeks] == [D(7), D(0), D(-7)]
+
+    this_week = weeks[1]
+    assert this_week["status"] == "past"
+    assert this_week["goal"]["progress"]["days_practised"] == 2
+    assert this_week["goal"]["progress"]["met_days"] is False
+    assert this_week["facts"]["seconds"] == 3600
+    assert [r["title"] for r in this_week["by_score"]] == ["Study in C", "To Zanarkand"]
+
+
+def test_a_week_with_no_goal_still_appears_with_its_facts(client, score):
+    """A week nobody set a goal for is not a gap in the record, and leaving it
+    out would make the review a list of judged weeks."""
+    log(client, day=D(-5), seconds=1800, score_id=score)
+    weeks = client.get(f"/api/practice/review?weeks=3&today={D(7)}").json()["weeks"]
+    previous = next(w for w in weeks if w["period_start"] == D(-7))
+    assert previous["goal"] is None
+    assert previous["facts"]["days_practised"] == 1
+    assert previous["facts"]["seconds"] == 1800
+
+
+def test_a_week_with_nothing_in_it_reports_zeroes_and_not_an_absence(client):
+    weeks = client.get(f"/api/practice/review?weeks=2&today={D(7)}").json()["weeks"]
+    for week in weeks:
+        assert week["facts"]["days_practised"] == 0
+        assert len(week["facts"]["days"]) == 7
+        assert week["facts"]["seconds"] == 0
+
+
+def test_the_review_never_ranks_one_week_against_another(client, score):
+    """Deliberate absence. A best week is the mechanism by which a good month
+    becomes the standard a bad month is punished against, so no field here
+    offers one and no field counts a run of anything."""
+    for day in (D(-7), D(-6), D(-5), D(0)):
+        log(client, day=day, seconds=1800, score_id=score)
+    body = client.get(f"/api/practice/review?weeks=4&today={D(7)}").json()
+    text = repr(body).lower()
+    for word in ("best", "streak", "rank", "worst", "average", "personal"):
+        assert word not in text, f"the review mentions {word!r}"
+
+
+def test_a_reflection_is_stored_and_read_back(client, score):
+    """The person's own account of their own week. The only question asked is
+    whether the goal was realistic - which is useful for setting the next one
+    and says nothing about them."""
+    log(client, day=D(0), seconds=1800, score_id=score)
+    goal = set_goal(client, today=MONDAY, target_days=4)
+    res = client.patch(
+        f"/api/practice/goals/{goal['id']}?today={D(7)}",
+        json={"reflection": "away for three days", "realistic": "no"},
+    )
+    assert res.status_code == 200
+    assert res.json()["reflection"] == "away for three days"
+    assert res.json()["realistic"] == "no"
+
+    reviewed = client.get(f"/api/practice/review?weeks=2&today={D(7)}").json()["weeks"]
+    stored = next(w for w in reviewed if w["period_start"] == MONDAY)["goal"]
+    assert (stored["reflection"], stored["realistic"]) == ("away for three days", "no")
+
+
+def test_a_reflection_is_not_a_status(client):
+    goal = set_goal(client, target_days=4)
+    for bad in ("failed", "met", "maybe", "true"):
+        res = client.patch(f"/api/practice/goals/{goal['id']}", json={"realistic": bad})
+        assert res.status_code == 422, bad
+
+
+def test_a_goal_whose_week_ended_is_left_exactly_where_it_was(client, score):
+    """Nothing closes, archives, grades or deletes a goal when its period ends.
+    The record of what somebody meant to do is what makes the next goal a
+    better one."""
+    log(client, day=D(0), seconds=1800, score_id=score)
+    goal = set_goal(client, today=MONDAY, target_days=4)
+    client.patch(
+        f"/api/practice/goals/{goal['id']}?today=MONDAY".replace("MONDAY", MONDAY),
+        json={"intent": "the awkward middle section"},
+    )
+
+    later = client.get(f"/api/practice/goals?today={D(28)}").json()["goals"]
+    assert len(later) == 1
+    assert later[0]["id"] == goal["id"]
+    assert later[0]["intent"] == "the awkward middle section"
+    assert later[0]["target_days"] == 4
+    assert later[0]["progress"]["status"] == "past"
+    assert later[0]["progress"]["days_practised"] == 1
+    # and a new week's goal sits beside it rather than replacing it
+    set_goal(client, today=D(28), target_days=2)
+    assert len(client.get(f"/api/practice/goals?today={D(28)}").json()["goals"]) == 2
+
+
+def test_nothing_in_a_goal_response_carries_a_verdict_on_the_person(client, score):
+    """The vocabulary is checked, not just the numbers. This is the whole
+    difference between accountable and shamed: what the tool says out loud."""
+    log(client, day=D(0), seconds=600, score_id=score)
+    goal = set_goal(client, today=D(7), target_days=5, target_minutes=300)
+    text = repr(goal).lower()
+    for word in ("fail", "missed", "behind", "should", "only", "streak", "shame"):
+        assert word not in text, f"a goal response mentions {word!r}"
+
+
+def test_a_goals_period_cannot_be_moved_onto_a_different_week(client, score):
+    """period_start is the goal's identity, and moving it would silently
+    re-point the goal at another week's practice. Setting a goal for the other
+    week is what the create endpoint is for."""
+    goal = set_goal(client, today=MONDAY, target_days=4)
+    client.patch(
+        f"/api/practice/goals/{goal['id']}",
+        json={"period_start": D(-7), "period_end": D(-1)},
+    )
+    after = client.get(f"/api/practice/goals/current?today={MONDAY}").json()["goal"]
+    assert (after["period_start"], after["period_end"]) == (MONDAY, SUNDAY)
+
+
+# ---------------------------------------------------------------------------
+# The rest of the app still sees practice the way it did
+# ---------------------------------------------------------------------------
+
+
+def test_the_library_still_reports_a_scores_practice_totals(client, score):
+    log(client, day=MONDAY, seconds=1800, score_id=score)
+    log(client, day=D(1), seconds=600, score_id=score)
+    listed = client.get("/api/scores").json()
+    assert [s["practice_seconds"] for s in listed] == [2400]
+    assert listed[0]["last_practiced"]
+
+
+def test_the_recently_practised_and_neglected_views_still_work(client, score, other_score):
+    today = date.today().isoformat()
+    log(client, day=today, seconds=1800, score_id=score)
+    recent = client.get("/api/scores?practiced=recent").json()
+    assert [s["id"] for s in recent] == [score]
+    neglected = client.get("/api/scores?practiced=neglected").json()
+    assert [s["id"] for s in neglected] == [other_score]
+
+
+def test_the_weekly_summary_still_answers(client, score):
+    client.post(f"/api/scores/{score}/practice", json={"seconds": 1800})
+    summary = client.get("/api/practice/summary").json()
+    assert summary["week_seconds"] == 1800
+    assert [s["title"] for s in summary["top_scores"]] == ["Study in C"]
+
+
+def test_deleting_a_score_takes_its_practice_and_its_goal_with_it(client, score):
+    """Documented, and checked here so it stays deliberate: a score row goes
+    only when its file has left the library, and a goal about a piece that is
+    no longer there could not be reviewed against anything."""
+    log(client, day=MONDAY, seconds=1800, score_id=score)
+    set_goal(client, today=MONDAY, target_days=3, scope="score", score_id=score)
+    conn = db.connect()
+    conn.execute("DELETE FROM scores WHERE id = ?", (score,))
+    conn.commit()
+    assert client.get("/api/practice/sessions").json()["sessions"] == []
+    assert client.get("/api/practice/goals").json()["goals"] == []
+
+
+def test_practice_recorded_before_this_change_is_still_counted(client, score):
+    """A row with no recorded practice day - which is every row an existing
+    install has. It has to appear in a week's facts, attributed to its UTC day,
+    and be marked as inferred rather than presented as recorded."""
+    conn = db.connect()
+    conn.execute(
+        """INSERT INTO practice_sessions(owner, score_id, activity, started_at, seconds, note)
+           VALUES (?, ?, 'piece', ? || ' 20:00:00', 1800, 'from before')""",
+        (db.DEFAULT_OWNER, score, D(2)),
+    )
+    conn.commit()
+
+    session = client.get("/api/practice/sessions").json()["sessions"][0]
+    assert session["local_date"] == D(2)
+    assert session["local_date_source"] == "utc_date"
+
+    week = client.get(f"/api/practice/review?weeks=1&today={D(3)}").json()["weeks"][0]
+    assert week["facts"]["days_practised"] == 1
+    assert week["facts"]["seconds"] == 1800

--- a/server/tests/test_practice_migration.py
+++ b/server/tests/test_practice_migration.py
@@ -13,13 +13,16 @@ imagined: an upgrade test that builds its "old" database out of the CURRENT
 schema tests nothing at all, because the shape it would be migrating from is
 the shape it is migrating to.
 
-Both predecessors are covered. Version 0 is a database from before schema
+Every predecessor is covered. Version 0 is a database from before schema
 versions were stamped at all (no instruments table, no scores.instrument_id);
-version 1 is one from after. Both have to arrive at version 2 with every
-practice row intact.
+version 1 is one from after; version 2 is one that ran the intermediate state
+of the branch that introduced these tables, and so already has the deepened
+session table but still cascades a score deletion into it. All three have to
+arrive at the current version with every practice row intact.
 """
 
 import sqlite3
+from datetime import date
 
 import pytest
 
@@ -85,6 +88,56 @@ CREATE TABLE IF NOT EXISTS instruments (
 ALTER TABLE scores ADD COLUMN instrument_id INTEGER REFERENCES instruments(id) ON DELETE SET NULL;
 """
 
+# Version 2's practice tables, as the intermediate state of this branch created
+# them: score_id already nullable and every deepened column present, but still
+# ON DELETE CASCADE - so deleting one score erased every session against it.
+# Written out rather than derived from db.py for the same reason as above: a
+# fixture built from the current definition is not the shape being migrated
+# from.
+_V2_PRACTICE_SCHEMA = """
+CREATE TABLE IF NOT EXISTS practice_sessions (
+    id INTEGER PRIMARY KEY,
+    owner TEXT NOT NULL DEFAULT 'local',
+    score_id INTEGER REFERENCES scores(id) ON DELETE CASCADE,
+    activity TEXT NOT NULL DEFAULT 'piece',
+    mode TEXT,
+    started_at TEXT NOT NULL,
+    local_date TEXT,
+    seconds INTEGER NOT NULL,
+    from_bar INTEGER,
+    to_bar INTEGER,
+    from_page INTEGER,
+    to_page INTEGER,
+    tempo_bpm INTEGER,
+    target_tempo_bpm INTEGER,
+    rating INTEGER,
+    note TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_practice_score ON practice_sessions(score_id);
+CREATE INDEX IF NOT EXISTS idx_practice_day ON practice_sessions(owner, local_date);
+CREATE INDEX IF NOT EXISTS idx_practice_started ON practice_sessions(started_at);
+CREATE INDEX IF NOT EXISTS idx_practice_activity ON practice_sessions(owner, activity);
+CREATE TABLE IF NOT EXISTS practice_goals (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    owner TEXT NOT NULL DEFAULT 'local',
+    period TEXT NOT NULL DEFAULT 'week',
+    period_start TEXT NOT NULL,
+    period_end TEXT NOT NULL,
+    target_days INTEGER,
+    target_minutes INTEGER,
+    scope TEXT NOT NULL DEFAULT 'all',
+    score_id INTEGER REFERENCES scores(id) ON DELETE CASCADE,
+    activity TEXT,
+    intent TEXT,
+    reflection TEXT,
+    realistic TEXT,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_practice_goals_period
+    ON practice_goals(owner, period_start);
+"""
+
 # Real practice history: several pieces, several days, notes somebody wrote.
 # Ids are not contiguous and not in date order, because a real table's are not
 # either - a copy that renumbered rows or reordered them would pass against a
@@ -105,11 +158,46 @@ _SESSIONS = [
 ]
 
 
+# A version 2 database also has goals in it, and a session carrying the
+# deepened columns - which is what makes the version 3 rebuild's copy worth
+# checking rather than assuming.
+_V2_DETAIL = (
+    20,
+    2,
+    "section",
+    "2026-08-07 19:00:00",
+    "2026-08-07",
+    1500,
+    17,
+    32,
+    2,
+    3,
+    76,
+    120,
+    4,
+    "middle section, hands separately",
+)
+
+_V2_GOALS = [
+    # (id, period_start, period_end, target_days, target_minutes, scope, score_id,
+    #  activity, intent, reflection, realistic)
+    (1, "2026-08-03", "2026-08-09", 4, 120, "all", None, None, "steady week", None, None),
+    (2, "2026-07-27", "2026-08-02", 3, None, "score", 2, None, "the awkward bars",
+     "away for three days", "no"),
+]
+
+
 def _legacy_database(path, version: int) -> None:
     conn = sqlite3.connect(path)
     conn.executescript(_V0_SCHEMA)
     if version >= 1:
         conn.executescript(_V1_ADDITIONS)
+    if version >= 2:
+        # The v0 script created the OLD practice_sessions, so it has to go
+        # before the v2 shape can take its place - this fixture is standing in
+        # for a database that had already been through migration 2.
+        conn.execute("DROP TABLE practice_sessions")
+        conn.executescript(_V2_PRACTICE_SCHEMA)
     for score_id, title, rel in _SCORES:
         conn.execute(
             """INSERT INTO scores(id, title, path, file_type, hash, size, mtime)
@@ -122,6 +210,22 @@ def _legacy_database(path, version: int) -> None:
                VALUES (?, ?, ?, ?, ?)""",
             (session_id, score_id, started_at, seconds, note),
         )
+    if version >= 2:
+        conn.execute(
+            """INSERT INTO practice_sessions
+                   (id, score_id, mode, started_at, local_date, seconds, from_bar, to_bar,
+                    from_page, to_page, tempo_bpm, target_tempo_bpm, rating, note)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            _V2_DETAIL,
+        )
+        for goal in _V2_GOALS:
+            conn.execute(
+                """INSERT INTO practice_goals
+                       (id, period_start, period_end, target_days, target_minutes, scope,
+                        score_id, activity, intent, reflection, realistic)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                goal,
+            )
     conn.execute("INSERT INTO settings(owner, key, value) VALUES ('local', 'staff_theme', 'noir')")
     conn.execute(f"PRAGMA user_version = {version}")
     conn.commit()
@@ -144,31 +248,34 @@ def upgraded(tmp_path, monkeypatch):
     db._local.conn = None
 
 
+PRACTICE_TABLES = ("practice_sessions", "practice_goals")
+
+
 def _fresh_schema(tmp_path, monkeypatch, name="fresh.db"):
-    """A database created from scratch by the current code."""
+    """Every practice table as created from scratch by the current code."""
     path = tmp_path / name
     monkeypatch.setattr(db, "DB_PATH", path)
     db._local.conn = None
     db.init_db()
     conn = db.connect()
-    shape = _table_shape(conn)
+    shape = {table: _table_shape(conn, table) for table in PRACTICE_TABLES}
     db._local.conn = None
     return shape
 
 
-def _table_shape(conn) -> dict:
+def _table_shape(conn, table="practice_sessions") -> dict:
     columns = [
         (r["name"], r["type"].upper(), r["notnull"], r["dflt_value"], r["pk"])
-        for r in conn.execute("PRAGMA table_info(practice_sessions)")
+        for r in conn.execute(f"PRAGMA table_info({table})")
     ]
     indexes = {}
-    for row in conn.execute("PRAGMA index_list(practice_sessions)"):
+    for row in conn.execute(f"PRAGMA index_list({table})"):
         indexes[row["name"]] = [
             r["name"] for r in conn.execute(f"PRAGMA index_info({row['name']})")
         ]
     keys = [
         (r["table"], r["from"], r["to"], r["on_delete"])
-        for r in conn.execute("PRAGMA foreign_key_list(practice_sessions)")
+        for r in conn.execute(f"PRAGMA foreign_key_list({table})")
     ]
     return {"columns": columns, "indexes": indexes, "foreign_keys": keys}
 
@@ -178,7 +285,7 @@ def _table_shape(conn) -> dict:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize("version", [0, 1])
+@pytest.mark.parametrize("version", [0, 1, 2])
 def test_every_practice_session_survives_the_upgrade(upgraded, version):
     """Row for row, id for id, value for value.
 
@@ -190,16 +297,19 @@ def test_every_practice_session_survives_the_upgrade(upgraded, version):
     upgraded(version)
     conn = db.connect()
     rows = conn.execute(
-        "SELECT id, score_id, started_at, seconds, note FROM practice_sessions ORDER BY id"
+        """SELECT id, score_id, started_at, seconds, note FROM practice_sessions
+            WHERE id IN (SELECT id FROM practice_sessions ORDER BY id LIMIT ?)
+         ORDER BY id""",
+        (len(_SESSIONS),),
     ).fetchall()
     assert [tuple(r) for r in rows] == sorted(_SESSIONS)
 
 
-@pytest.mark.parametrize("version", [0, 1])
+@pytest.mark.parametrize("version", [0, 1, 2])
 def test_the_upgrade_stamps_the_new_version(upgraded, version):
     upgraded(version)
     conn = db.connect()
-    assert conn.execute("PRAGMA user_version").fetchone()[0] == db.SCHEMA_VERSION == 2
+    assert conn.execute("PRAGMA user_version").fetchone()[0] == db.SCHEMA_VERSION == 3
 
 
 def test_carried_rows_are_marked_as_the_piece_practice_they_were(upgraded):
@@ -265,15 +375,16 @@ def test_an_upgraded_table_is_identical_to_a_freshly_created_one(tmp_path, monke
     other test here would pass on both."""
     fresh = _fresh_schema(tmp_path, monkeypatch)
 
-    legacy = tmp_path / "legacy.db"
-    _legacy_database(legacy, 1)
-    monkeypatch.setattr(db, "DB_PATH", legacy)
-    db._local.conn = None
-    db.init_db()
-    migrated = _table_shape(db.connect())
-    db._local.conn = None
-
-    assert migrated == fresh
+    for version in (0, 1, 2):
+        legacy = tmp_path / f"legacy_shape_v{version}.db"
+        _legacy_database(legacy, version)
+        monkeypatch.setattr(db, "DB_PATH", legacy)
+        db._local.conn = None
+        db.init_db()
+        conn = db.connect()
+        migrated = {table: _table_shape(conn, table) for table in PRACTICE_TABLES}
+        db._local.conn = None
+        assert migrated == fresh, f"upgraded from version {version}"
 
 
 def test_the_rebuilt_column_still_carries_its_foreign_key(upgraded):
@@ -289,17 +400,135 @@ def test_the_rebuilt_column_still_carries_its_foreign_key(upgraded):
     conn.rollback()
 
 
-def test_deleting_a_score_still_takes_its_sessions_with_it(upgraded):
-    """ON DELETE CASCADE, unchanged. The scanner relies on it: it re-links a
-    renamed file to its existing score row by content hash precisely so that
-    a rename never reaches this cascade, and a row that genuinely goes means
-    the file is gone from the library."""
-    upgraded()
+@pytest.mark.parametrize("version", [0, 1, 2])
+def test_deleting_a_score_keeps_the_practice_and_only_forgets_the_piece(upgraded, version):
+    """The point of version 3, and the thing the cascade used to destroy.
+
+    Three sessions here were against score 1. After the score row goes they
+    are all still present, with every other column untouched, naming no piece.
+    The hours were spent whether or not the file is still on disk.
+    """
+    upgraded(version)
+    conn = db.connect()
+    before = conn.execute(
+        """SELECT id, started_at, seconds, note FROM practice_sessions
+            WHERE score_id = 1 ORDER BY id"""
+    ).fetchall()
+    assert len(before) == 3
+
+    conn.execute("DELETE FROM scores WHERE id = 1")
+    conn.commit()
+
+    after = conn.execute(
+        """SELECT id, started_at, seconds, note FROM practice_sessions
+            WHERE score_id IS NULL ORDER BY id"""
+    ).fetchall()
+    assert [tuple(r) for r in after] == [tuple(r) for r in before]
+    # Nothing was lost from the table at all, not merely "the right number
+    # remains" - a count is survived by a delete that took the wrong rows.
+    total = conn.execute("SELECT COUNT(*) FROM practice_sessions").fetchone()[0]
+    assert total == len(_SESSIONS) + (1 if version >= 2 else 0)
+
+
+@pytest.mark.parametrize("version", [0, 1, 2])
+def test_an_orphaned_session_is_identifiable_as_piece_practice(upgraded, version):
+    """A session that outlives its score keeps activity='piece' with no
+    score_id, and that pair is what tells it apart from practice that never
+    had a piece: a 'piece' session cannot be created without one."""
+    upgraded(version)
     conn = db.connect()
     conn.execute("DELETE FROM scores WHERE id = 1")
     conn.commit()
-    remaining = {r["id"] for r in conn.execute("SELECT id FROM practice_sessions")}
-    assert remaining == {9, 11}
+    row = conn.execute("SELECT * FROM practice_sessions WHERE id = 3").fetchone()
+    presented = practice.session_dict(row)
+    assert presented["score_id"] is None
+    assert presented["activity"] == "piece"
+    assert presented["score_missing"] is True
+
+
+@pytest.mark.parametrize("version", [0, 1, 2])
+def test_a_goal_already_reached_is_not_unmade_by_deleting_a_score(upgraded, version):
+    """The specific failure this has to rule out. A goal counted over any
+    practice must not go from met to unmet because a file was tidied away
+    afterwards - the days were practised either way, and a record that changes
+    its verdict retrospectively is worse than no record."""
+    upgraded(version)
+    conn = db.connect()
+    goal = conn.execute(
+        """INSERT INTO practice_goals(owner, period_start, period_end, target_days, scope)
+           VALUES (?, '2026-08-01', '2026-08-07', 4, 'all') RETURNING *""",
+        (db.DEFAULT_OWNER,),
+    ).fetchone()
+    conn.commit()
+    today = date(2026, 8, 10)
+    before = practice.goal_progress(conn, goal, today)
+    assert before["met"] is True
+    assert before["days_practised"] >= 4
+
+    conn.execute("DELETE FROM scores WHERE id = 1")
+    conn.commit()
+    after = practice.goal_progress(conn, goal, today)
+    assert after["met"] is True
+    assert after["countable"] is True
+    # Not merely still met - the counts themselves are untouched, because the
+    # practice is untouched. A goal that stayed met on fewer days would mean
+    # this only held for goals with slack in them.
+    assert after["days_practised"] == before["days_practised"]
+    assert after["seconds"] == before["seconds"]
+
+
+def test_a_goal_about_a_deleted_piece_becomes_uncountable_not_unmet(upgraded):
+    """A goal scoped to one piece cannot be counted once the piece is gone: the
+    sessions are still in the history but no longer identifiable as being about
+    it. So it reports that it cannot be counted rather than reporting a
+    shortfall - and it is not deleted, because the intention was still formed.
+    """
+    upgraded(2)
+    conn = db.connect()
+    goal = conn.execute("SELECT * FROM practice_goals WHERE id = 2").fetchone()
+    assert goal["scope"] == "score" and goal["score_id"] == 2
+
+    conn.execute("DELETE FROM scores WHERE id = 2")
+    conn.commit()
+
+    survivor = conn.execute("SELECT * FROM practice_goals WHERE id = 2").fetchone()
+    assert survivor is not None, "the goal was deleted with the score"
+    assert survivor["score_id"] is None
+    assert survivor["intent"] == "the awkward bars"
+    assert survivor["reflection"] == "away for three days"
+
+    progress = practice.goal_progress(conn, survivor, date(2026, 8, 10))
+    assert progress["countable"] is False
+    assert progress["met"] is None
+    assert progress["met_days"] is None
+
+
+def test_every_goal_survives_the_upgrade(upgraded):
+    """Version 3 rebuilds practice_goals too, so its rows have to be carried
+    the same way the sessions are - including the reflection somebody wrote."""
+    upgraded(2)
+    conn = db.connect()
+    rows = conn.execute(
+        """SELECT id, period_start, period_end, target_days, target_minutes, scope,
+                  score_id, activity, intent, reflection, realistic
+             FROM practice_goals ORDER BY id"""
+    ).fetchall()
+    assert [tuple(r) for r in rows] == _V2_GOALS
+
+
+def test_the_deepened_columns_survive_the_upgrade_from_version_2(upgraded):
+    """Version 2 is the first predecessor whose rows have anything in the
+    columns this feature added, so it is the only one that can prove the
+    version 3 rebuild carries them."""
+    upgraded(2)
+    conn = db.connect()
+    row = conn.execute(
+        """SELECT id, score_id, mode, started_at, local_date, seconds, from_bar, to_bar,
+                  from_page, to_page, tempo_bpm, target_tempo_bpm, rating, note
+             FROM practice_sessions WHERE id = ?""",
+        (_V2_DETAIL[0],),
+    ).fetchone()
+    assert tuple(row) == _V2_DETAIL
 
 
 def test_a_session_with_no_score_is_now_storable(upgraded):
@@ -317,6 +546,137 @@ def test_a_session_with_no_score_is_now_storable(upgraded):
         "SELECT score_id, activity FROM practice_sessions WHERE activity = 'ear_training'"
     ).fetchone()
     assert row["score_id"] is None
+
+
+# ---------------------------------------------------------------------------
+# A database somebody has opened by hand
+# ---------------------------------------------------------------------------
+
+# A session pointing at a score that is not in the table. Fermata cannot
+# produce this - the reference has always been enforced - but the sqlite3
+# command line produces it trivially, because ITS default is foreign_keys OFF.
+# Before this schema such a row was inert. Now that a rebuild has to copy it,
+# it decides whether the application starts.
+_DANGLING = (30, 404, "2026-08-04 18:00:00", 1200, "the one on the missing score")
+
+
+def _with_a_dangling_reference(path, version: int) -> None:
+    _legacy_database(path, version)
+    conn = sqlite3.connect(path)  # foreign_keys defaults OFF, like the CLI
+    conn.execute(
+        """INSERT INTO practice_sessions(id, score_id, started_at, seconds, note)
+           VALUES (?, ?, ?, ?, ?)""",
+        _DANGLING,
+    )
+    conn.commit()
+    conn.close()
+
+
+@pytest.mark.parametrize("version", [1, 2])
+def test_a_dangling_reference_does_not_stop_the_application_starting(
+    tmp_path, monkeypatch, caplog, version
+):
+    """The rebuild copies every row, and with foreign keys ON one row whose
+    score is missing is REJECTED on the copy - so the upgrade fails, and fails
+    again on every subsequent boot, with the only exits being hand SQL or
+    deleting the very rows the migration exists to protect. SQLite's own
+    table-rebuild recipe opens by saying to turn them off for this reason.
+    """
+    path = tmp_path / f"hand_edited_v{version}.db"
+    _with_a_dangling_reference(path, version)
+    monkeypatch.setattr(db, "DB_PATH", path)
+    db._local.conn = None
+
+    with caplog.at_level("WARNING"):
+        db.init_db()  # must not raise
+
+    conn = db.connect()
+    row = conn.execute(
+        "SELECT score_id, seconds, note FROM practice_sessions WHERE id = ?", (_DANGLING[0],)
+    ).fetchone()
+    assert row is not None, "the row the migration exists to protect was dropped"
+    # Put right rather than carried across still broken: NULL is exactly what
+    # the reference's own ON DELETE SET NULL would have done had the deletion
+    # gone through the database.
+    assert row["score_id"] is None
+    assert (row["seconds"], row["note"]) == (_DANGLING[3], _DANGLING[4])
+    # And the database is left consistent, not merely startable.
+    assert conn.execute("PRAGMA foreign_key_check").fetchall() == []
+    # Said out loud. It is somebody's history, and a row that stops naming a
+    # piece is a visible difference.
+    assert any("no longer in the database" in r.message for r in caplog.records), caplog.text
+    db._local.conn = None
+
+
+def test_the_rest_of_a_hand_edited_database_is_still_carried(tmp_path, monkeypatch):
+    upgraded_path = tmp_path / "hand_edited_rest.db"
+    _with_a_dangling_reference(upgraded_path, 1)
+    monkeypatch.setattr(db, "DB_PATH", upgraded_path)
+    db._local.conn = None
+    db.init_db()
+    conn = db.connect()
+    rows = conn.execute(
+        """SELECT id, score_id, started_at, seconds, note FROM practice_sessions
+            WHERE id != ? ORDER BY id""",
+        (_DANGLING[0],),
+    ).fetchall()
+    assert [tuple(r) for r in rows] == sorted(_SESSIONS)
+    db._local.conn = None
+
+
+def test_foreign_keys_are_on_again_after_an_upgrade(upgraded):
+    """They are turned off for the rebuild. Left off, every write afterwards
+    would accept a reference to nothing - the guarantee the rest of the code
+    assumes, quietly withdrawn by a successful upgrade."""
+    upgraded()
+    conn = db.connect()
+    assert conn.execute("PRAGMA foreign_keys").fetchone()[0] == 1
+    with pytest.raises(sqlite3.IntegrityError):
+        conn.execute(
+            """INSERT INTO practice_sessions(score_id, activity, started_at, seconds)
+               VALUES (777, 'piece', datetime('now'), 60)"""
+        )
+    conn.rollback()
+
+
+def test_the_rebuild_helper_carries_columns_by_name_not_by_position(app_env):
+    """Called directly, on a shape no released version ever had.
+
+    This helper exists for the steps that come after these two as much as for
+    them, and a positional copy - INSERT INTO new SELECT * FROM old - is
+    correct only while the two column orders happen to agree. The day they do
+    not, it silently puts a note into a tempo. Every shape a released version
+    produced happens to agree, so the only honest way to test the rule is to
+    hand the helper a table that does not.
+    """
+    conn = db.connect()
+    conn.execute("CREATE TABLE oldish (id INTEGER PRIMARY KEY, note TEXT, seconds INTEGER)")
+    conn.execute("INSERT INTO oldish(id, note, seconds) VALUES (5, 'kept', 900)")
+    conn.commit()
+
+    db._rebuild_carrying_rows(
+        conn,
+        "oldish",
+        "(id INTEGER PRIMARY KEY, seconds INTEGER, added TEXT DEFAULT 'new', note TEXT)",
+    )
+
+    row = conn.execute("SELECT id, seconds, added, note FROM oldish").fetchone()
+    assert tuple(row) == (5, 900, "new", "kept")
+
+
+def test_the_rebuild_helper_drops_a_column_the_new_shape_does_not_have(app_env):
+    """The only way a rebuild can remove a column, and the reason the carried
+    list is the INTERSECTION rather than the new table's columns."""
+    conn = db.connect()
+    conn.execute("CREATE TABLE oldish (id INTEGER PRIMARY KEY, keep TEXT, retired TEXT)")
+    conn.execute("INSERT INTO oldish(id, keep, retired) VALUES (1, 'yes', 'no')")
+    conn.commit()
+
+    db._rebuild_carrying_rows(conn, "oldish", "(id INTEGER PRIMARY KEY, keep TEXT)")
+
+    columns = {r["name"] for r in conn.execute("PRAGMA table_info(oldish)")}
+    assert columns == {"id", "keep"}
+    assert conn.execute("SELECT keep FROM oldish").fetchone()["keep"] == "yes"
 
 
 # ---------------------------------------------------------------------------
@@ -338,17 +698,21 @@ def test_starting_up_again_changes_nothing(upgraded):
     assert [tuple(r) for r in rows] == sorted(_SESSIONS)
 
 
-def test_an_upgrade_interrupted_before_its_stamp_landed_resumes_safely(upgraded):
+@pytest.mark.parametrize("rewind_to", [1, 2])
+def test_an_upgrade_interrupted_before_its_stamp_landed_resumes_safely(upgraded, rewind_to):
     """The one case a migration step has to survive being re-run: the process
-    died after the work committed and before the stamp did. The step's own
+    died after the work committed and before the stamp did. Each step's own
     guard has to see its work already there and do nothing.
 
     A session with the NEW columns filled in is what makes this bite. A second
-    rebuild would copy across only the columns the old table had - id, score,
-    timestamp, length, note - and silently drop the practice day, the rating
-    and the tempo out of every row it touched. With only carried-over rows in
-    the table there is nothing in those columns to lose, and a missing guard
-    looks exactly like a working one.
+    rebuild through step 2 would copy across only the columns the OLD table
+    had - id, score, timestamp, length, note - and silently drop the practice
+    day, the rating and the tempo out of every row it touched. With only
+    carried-over rows in the table there is nothing in those columns to lose,
+    and a missing guard looks exactly like a working one.
+
+    Rewound to both stamps: to 1, where every step is offered again, and to 2,
+    where only the last one is.
     """
     upgraded()
     conn = db.connect()
@@ -360,7 +724,7 @@ def test_an_upgrade_interrupted_before_its_stamp_landed_resumes_safely(upgraded)
                    17, 32, 76, 120, 4, 'logged after the upgrade')""",
         (db.DEFAULT_OWNER,),
     )
-    conn.execute("PRAGMA user_version = 1")
+    conn.execute(f"PRAGMA user_version = {rewind_to}")
     conn.commit()
 
     db.init_db()
@@ -374,7 +738,7 @@ def test_an_upgrade_interrupted_before_its_stamp_landed_resumes_safely(upgraded)
              FROM practice_sessions WHERE note = 'logged after the upgrade'"""
     ).fetchone()
     assert tuple(detailed) == ("section", "2026-08-20", 17, 32, 76, 120, 4)
-    assert conn.execute("PRAGMA user_version").fetchone()[0] == 2
+    assert conn.execute("PRAGMA user_version").fetchone()[0] == db.SCHEMA_VERSION
 
 
 def test_a_failing_step_leaves_the_old_table_untouched(tmp_path, monkeypatch):
@@ -424,6 +788,6 @@ def test_a_fresh_install_needs_no_migration_and_still_lands_on_the_new_table(
         r["name"]: r["notnull"] for r in conn.execute("PRAGMA table_info(practice_sessions)")
     }
     assert notnull["score_id"] == 0
-    assert conn.execute("PRAGMA user_version").fetchone()[0] == 2
+    assert conn.execute("PRAGMA user_version").fetchone()[0] == 3
     assert conn.execute("SELECT COUNT(*) FROM practice_sessions").fetchone()[0] == 0
     db._local.conn = None

--- a/server/tests/test_practice_migration.py
+++ b/server/tests/test_practice_migration.py
@@ -1,0 +1,429 @@
+"""Upgrading a database that predates the deepened practice model.
+
+WHY THIS FILE IS LONGER THAN THE MIGRATION IT TESTS. practice_sessions rows are
+the only thing in Fermata that cannot be regenerated. Rescanning rebuilds every
+score row and re-extraction rebuilds every transcription, but nothing on disk
+remembers that somebody sat down and practised for forty minutes on a Tuesday.
+The migration rebuilds that table - creates a new one, copies the rows across,
+drops the old - so "the copy is complete and correct" is not a detail of this
+change, it is the change.
+
+So the schema below is the real one, as it shipped, written out rather than
+imagined: an upgrade test that builds its "old" database out of the CURRENT
+schema tests nothing at all, because the shape it would be migrating from is
+the shape it is migrating to.
+
+Both predecessors are covered. Version 0 is a database from before schema
+versions were stamped at all (no instruments table, no scores.instrument_id);
+version 1 is one from after. Both have to arrive at version 2 with every
+practice row intact.
+"""
+
+import sqlite3
+
+import pytest
+
+from fermata import api, db, practice
+
+# ---------------------------------------------------------------------------
+# The schema as it shipped, before this change. Only what the migration and
+# the assertions below actually touch - scores, because practice_sessions
+# references it, and practice_sessions itself, whose score_id was NOT NULL.
+# ---------------------------------------------------------------------------
+
+_V0_SCHEMA = """
+CREATE TABLE IF NOT EXISTS scores (
+    id INTEGER PRIMARY KEY,
+    title TEXT NOT NULL,
+    composer TEXT,
+    collection TEXT,
+    series TEXT,
+    source TEXT,
+    path TEXT NOT NULL UNIQUE,
+    file_type TEXT NOT NULL,
+    content_kind TEXT NOT NULL DEFAULT 'unknown',
+    pages INTEGER,
+    favorite INTEGER NOT NULL DEFAULT 0,
+    hash TEXT NOT NULL,
+    size INTEGER NOT NULL,
+    mtime REAL NOT NULL,
+    last_page INTEGER NOT NULL DEFAULT 1,
+    added_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE TABLE IF NOT EXISTS practice_sessions (
+    id INTEGER PRIMARY KEY,
+    score_id INTEGER NOT NULL REFERENCES scores(id) ON DELETE CASCADE,
+    started_at TEXT NOT NULL,
+    seconds INTEGER NOT NULL,
+    note TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_practice_score ON practice_sessions(score_id);
+CREATE TABLE IF NOT EXISTS settings (
+    owner TEXT NOT NULL DEFAULT 'local',
+    key TEXT NOT NULL,
+    value TEXT NOT NULL,
+    PRIMARY KEY (owner, key)
+);
+"""
+
+# Version 1 added instruments and scores.instrument_id.
+_V1_ADDITIONS = """
+CREATE TABLE IF NOT EXISTS instruments (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    owner TEXT NOT NULL DEFAULT 'local',
+    kind TEXT NOT NULL DEFAULT 'string',
+    name TEXT NOT NULL,
+    fretted INTEGER NOT NULL DEFAULT 1,
+    string_count INTEGER NOT NULL,
+    string_pitches TEXT NOT NULL,
+    fret_count INTEGER,
+    capo INTEGER,
+    reference_pitch REAL NOT NULL DEFAULT 440.0,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+ALTER TABLE scores ADD COLUMN instrument_id INTEGER REFERENCES instruments(id) ON DELETE SET NULL;
+"""
+
+# Real practice history: several pieces, several days, notes somebody wrote.
+# Ids are not contiguous and not in date order, because a real table's are not
+# either - a copy that renumbered rows or reordered them would pass against a
+# tidy fixture and lose the link between a session and whatever else ever
+# refers to it.
+_SCORES = [
+    (1, "To Zanarkand", "Patreon/To Zanarkand.pdf"),
+    (2, "Study in C", "Classical/Tarrega/Study in C.pdf"),
+    (7, "Clair de Lune", "Favorites/ClairDeLune.pdf"),
+]
+
+_SESSIONS = [
+    (3, 1, "2026-08-01 19:30:00", 1800, "bars 1-16 still muddy"),
+    (4, 1, "2026-08-02 20:05:00", 2400, None),
+    (9, 2, "2026-08-02 08:15:00", 600, "warm-up only"),
+    (11, 7, "2026-08-05 21:40:00", 3600, "whole thing, twice"),
+    (12, 1, "2026-08-06 18:00:00", 900, "left hand alone"),
+]
+
+
+def _legacy_database(path, version: int) -> None:
+    conn = sqlite3.connect(path)
+    conn.executescript(_V0_SCHEMA)
+    if version >= 1:
+        conn.executescript(_V1_ADDITIONS)
+    for score_id, title, rel in _SCORES:
+        conn.execute(
+            """INSERT INTO scores(id, title, path, file_type, hash, size, mtime)
+               VALUES (?, ?, ?, 'pdf', 'deadbeef', 1, 0.0)""",
+            (score_id, title, rel),
+        )
+    for session_id, score_id, started_at, seconds, note in _SESSIONS:
+        conn.execute(
+            """INSERT INTO practice_sessions(id, score_id, started_at, seconds, note)
+               VALUES (?, ?, ?, ?, ?)""",
+            (session_id, score_id, started_at, seconds, note),
+        )
+    conn.execute("INSERT INTO settings(owner, key, value) VALUES ('local', 'staff_theme', 'noir')")
+    conn.execute(f"PRAGMA user_version = {version}")
+    conn.commit()
+    conn.close()
+
+
+@pytest.fixture
+def upgraded(tmp_path, monkeypatch):
+    """A legacy database of a given version, brought up to date by init_db."""
+
+    def _upgrade(version: int = 1):
+        path = tmp_path / f"legacy_v{version}.db"
+        _legacy_database(path, version)
+        monkeypatch.setattr(db, "DB_PATH", path)
+        db._local.conn = None
+        db.init_db()
+        return path
+
+    yield _upgrade
+    db._local.conn = None
+
+
+def _fresh_schema(tmp_path, monkeypatch, name="fresh.db"):
+    """A database created from scratch by the current code."""
+    path = tmp_path / name
+    monkeypatch.setattr(db, "DB_PATH", path)
+    db._local.conn = None
+    db.init_db()
+    conn = db.connect()
+    shape = _table_shape(conn)
+    db._local.conn = None
+    return shape
+
+
+def _table_shape(conn) -> dict:
+    columns = [
+        (r["name"], r["type"].upper(), r["notnull"], r["dflt_value"], r["pk"])
+        for r in conn.execute("PRAGMA table_info(practice_sessions)")
+    ]
+    indexes = {}
+    for row in conn.execute("PRAGMA index_list(practice_sessions)"):
+        indexes[row["name"]] = [
+            r["name"] for r in conn.execute(f"PRAGMA index_info({row['name']})")
+        ]
+    keys = [
+        (r["table"], r["from"], r["to"], r["on_delete"])
+        for r in conn.execute("PRAGMA foreign_key_list(practice_sessions)")
+    ]
+    return {"columns": columns, "indexes": indexes, "foreign_keys": keys}
+
+
+# ---------------------------------------------------------------------------
+# The history survives
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("version", [0, 1])
+def test_every_practice_session_survives_the_upgrade(upgraded, version):
+    """Row for row, id for id, value for value.
+
+    Compared as a whole set rather than by counting: a count survives a copy
+    that carried five rows across and put the notes in the wrong ones, which is
+    exactly what a positional INSERT ... SELECT * does the day the column
+    orders differ.
+    """
+    upgraded(version)
+    conn = db.connect()
+    rows = conn.execute(
+        "SELECT id, score_id, started_at, seconds, note FROM practice_sessions ORDER BY id"
+    ).fetchall()
+    assert [tuple(r) for r in rows] == sorted(_SESSIONS)
+
+
+@pytest.mark.parametrize("version", [0, 1])
+def test_the_upgrade_stamps_the_new_version(upgraded, version):
+    upgraded(version)
+    conn = db.connect()
+    assert conn.execute("PRAGMA user_version").fetchone()[0] == db.SCHEMA_VERSION == 2
+
+
+def test_carried_rows_are_marked_as_the_piece_practice_they_were(upgraded):
+    """Every session that could be recorded before this change was against a
+    score, so 'piece' is a statement of fact about these rows rather than a
+    convenient default."""
+    upgraded()
+    conn = db.connect()
+    rows = conn.execute("SELECT activity, owner FROM practice_sessions").fetchall()
+    assert {(r["activity"], r["owner"]) for r in rows} == {("piece", db.DEFAULT_OWNER)}
+
+
+def test_a_carried_row_has_no_recorded_practice_day_and_says_so(upgraded):
+    """Nobody recorded which calendar day these happened on in the practiser's
+    own time. The column stays NULL rather than being backfilled from the UTC
+    timestamp, and a reader is told the day it got was inferred."""
+    upgraded()
+    conn = db.connect()
+    stored = conn.execute(
+        "SELECT local_date FROM practice_sessions WHERE id = 3"
+    ).fetchone()["local_date"]
+    assert stored is None
+
+    presented = practice.session_dict(
+        conn.execute("SELECT * FROM practice_sessions WHERE id = 3").fetchone()
+    )
+    assert presented["local_date"] == "2026-08-01"
+    assert presented["local_date_source"] == "utc_date"
+
+
+def test_carried_history_still_counts_towards_a_goal(upgraded):
+    """The point of keeping these rows is that they are somebody's record of
+    their own work - so they have to be visible to what reads practice, not
+    merely present in the table."""
+    upgraded()
+    conn = db.connect()
+    facts = practice.period_facts(conn, "2026-08-01", "2026-08-07")
+    assert facts["days_practised"] == 4  # 1st, 2nd, 5th, 6th
+    assert facts["seconds"] == sum(s[3] for s in _SESSIONS)
+    assert facts["sessions"] == len(_SESSIONS)
+
+
+def test_nothing_else_in_the_database_is_disturbed(upgraded):
+    """The migration touches one table. A rebuild that dropped the wrong thing,
+    or a stray cascade, would show up here first."""
+    upgraded()
+    conn = db.connect()
+    titles = [r["title"] for r in conn.execute("SELECT title FROM scores ORDER BY id")]
+    assert titles == [s[1] for s in _SCORES]
+    assert api.get_settings()["staff_theme"] == "noir"
+
+
+# ---------------------------------------------------------------------------
+# The rebuilt table is the table the current code would have created
+# ---------------------------------------------------------------------------
+
+
+def test_an_upgraded_table_is_identical_to_a_freshly_created_one(tmp_path, monkeypatch):
+    """The migration builds practice_sessions from the same column definition
+    SCHEMA does, and this is what keeps that true. If the two ever diverge -
+    a column added to one and not the other, an index left off - an upgraded
+    install would run on a subtly different table from a fresh one, and every
+    other test here would pass on both."""
+    fresh = _fresh_schema(tmp_path, monkeypatch)
+
+    legacy = tmp_path / "legacy.db"
+    _legacy_database(legacy, 1)
+    monkeypatch.setattr(db, "DB_PATH", legacy)
+    db._local.conn = None
+    db.init_db()
+    migrated = _table_shape(db.connect())
+    db._local.conn = None
+
+    assert migrated == fresh
+
+
+def test_the_rebuilt_column_still_carries_its_foreign_key(upgraded):
+    """A rebuild is where a REFERENCES clause gets quietly dropped, and a
+    score_id pointing at nothing would then be accepted for ever."""
+    upgraded()
+    conn = db.connect()
+    with pytest.raises(sqlite3.IntegrityError):
+        conn.execute(
+            """INSERT INTO practice_sessions(score_id, activity, started_at, seconds)
+               VALUES (99999, 'piece', datetime('now'), 60)"""
+        )
+    conn.rollback()
+
+
+def test_deleting_a_score_still_takes_its_sessions_with_it(upgraded):
+    """ON DELETE CASCADE, unchanged. The scanner relies on it: it re-links a
+    renamed file to its existing score row by content hash precisely so that
+    a rename never reaches this cascade, and a row that genuinely goes means
+    the file is gone from the library."""
+    upgraded()
+    conn = db.connect()
+    conn.execute("DELETE FROM scores WHERE id = 1")
+    conn.commit()
+    remaining = {r["id"] for r in conn.execute("SELECT id FROM practice_sessions")}
+    assert remaining == {9, 11}
+
+
+def test_a_session_with_no_score_is_now_storable(upgraded):
+    """The whole reason this needed a migration rather than an ADD COLUMN.
+    Practice that is not against a piece - a trainer, unstructured playing -
+    had nowhere to go while score_id was NOT NULL."""
+    upgraded()
+    conn = db.connect()
+    conn.execute(
+        """INSERT INTO practice_sessions(score_id, activity, started_at, seconds)
+           VALUES (NULL, 'ear_training', datetime('now'), 600)"""
+    )
+    conn.commit()
+    row = conn.execute(
+        "SELECT score_id, activity FROM practice_sessions WHERE activity = 'ear_training'"
+    ).fetchone()
+    assert row["score_id"] is None
+
+
+# ---------------------------------------------------------------------------
+# Running it again, and resuming it
+# ---------------------------------------------------------------------------
+
+
+def test_starting_up_again_changes_nothing(upgraded):
+    """init_db runs on every start. A migration that is not stamped, or whose
+    guard does not hold, would rebuild the table a second time - and the second
+    rebuild is the one that copies from an already-copied table."""
+    upgraded()
+    db.init_db()
+    db.init_db()
+    conn = db.connect()
+    rows = conn.execute(
+        "SELECT id, score_id, started_at, seconds, note FROM practice_sessions ORDER BY id"
+    ).fetchall()
+    assert [tuple(r) for r in rows] == sorted(_SESSIONS)
+
+
+def test_an_upgrade_interrupted_before_its_stamp_landed_resumes_safely(upgraded):
+    """The one case a migration step has to survive being re-run: the process
+    died after the work committed and before the stamp did. The step's own
+    guard has to see its work already there and do nothing.
+
+    A session with the NEW columns filled in is what makes this bite. A second
+    rebuild would copy across only the columns the old table had - id, score,
+    timestamp, length, note - and silently drop the practice day, the rating
+    and the tempo out of every row it touched. With only carried-over rows in
+    the table there is nothing in those columns to lose, and a missing guard
+    looks exactly like a working one.
+    """
+    upgraded()
+    conn = db.connect()
+    conn.execute(
+        """INSERT INTO practice_sessions
+               (owner, score_id, activity, mode, started_at, local_date, seconds,
+                from_bar, to_bar, tempo_bpm, target_tempo_bpm, rating, note)
+           VALUES (?, 1, 'piece', 'section', '2026-08-20 19:00:00', '2026-08-20', 1500,
+                   17, 32, 76, 120, 4, 'logged after the upgrade')""",
+        (db.DEFAULT_OWNER,),
+    )
+    conn.execute("PRAGMA user_version = 1")
+    conn.commit()
+
+    db.init_db()
+
+    rows = conn.execute(
+        "SELECT id, score_id, started_at, seconds, note FROM practice_sessions ORDER BY id"
+    ).fetchall()
+    assert [tuple(r) for r in rows][: len(_SESSIONS)] == sorted(_SESSIONS)
+    detailed = conn.execute(
+        """SELECT mode, local_date, from_bar, to_bar, tempo_bpm, target_tempo_bpm, rating
+             FROM practice_sessions WHERE note = 'logged after the upgrade'"""
+    ).fetchone()
+    assert tuple(detailed) == ("section", "2026-08-20", 17, 32, 76, 120, 4)
+    assert conn.execute("PRAGMA user_version").fetchone()[0] == 2
+
+
+def test_a_failing_step_leaves_the_old_table_untouched(tmp_path, monkeypatch):
+    """The rebuild runs inside one transaction, so an upgrade that dies partway
+    has to leave the history exactly as it was rather than half-copied. Nothing
+    in the real step fails, so the failure is injected."""
+    legacy = tmp_path / "doomed.db"
+    _legacy_database(legacy, 1)
+    monkeypatch.setattr(db, "DB_PATH", legacy)
+    db._local.conn = None
+
+    def explode(conn):
+        db._migrate_to_2_any_practice(conn)
+        raise RuntimeError("simulated crash partway through the upgrade")
+
+    monkeypatch.setitem(db.MIGRATIONS, 2, explode)
+    with pytest.raises(RuntimeError):
+        db.init_db()
+
+    conn = db.connect()
+    rows = conn.execute(
+        "SELECT id, score_id, started_at, seconds, note FROM practice_sessions ORDER BY id"
+    ).fetchall()
+    assert [tuple(r) for r in rows] == sorted(_SESSIONS)
+    # Still on the old version, and still the old table - so the next startup
+    # tries the whole step again rather than trusting a half-applied one.
+    assert conn.execute("PRAGMA user_version").fetchone()[0] == 1
+    notnull = {
+        r["name"]: r["notnull"] for r in conn.execute("PRAGMA table_info(practice_sessions)")
+    }
+    assert notnull["score_id"] == 1
+    db._local.conn = None
+
+
+def test_a_fresh_install_needs_no_migration_and_still_lands_on_the_new_table(
+    tmp_path, monkeypatch
+):
+    """The step has to be a no-op against a database that never had the old
+    table - SCHEMA creates it in its current shape, and a step that ran anyway
+    would be operating on a table it did not build."""
+    path = tmp_path / "brand_new.db"
+    monkeypatch.setattr(db, "DB_PATH", path)
+    db._local.conn = None
+    db.init_db()
+    conn = db.connect()
+    notnull = {
+        r["name"]: r["notnull"] for r in conn.execute("PRAGMA table_info(practice_sessions)")
+    }
+    assert notnull["score_id"] == 0
+    assert conn.execute("PRAGMA user_version").fetchone()[0] == 2
+    assert conn.execute("SELECT COUNT(*) FROM practice_sessions").fetchone()[0] == 0
+    db._local.conn = None

--- a/server/tests/test_practice_model.py
+++ b/server/tests/test_practice_model.py
@@ -65,6 +65,40 @@ def test_a_practice_day_must_be_a_plain_calendar_date():
             practice.parse_day(bad)
 
 
+def test_a_date_outside_the_plausible_range_is_refused():
+    """Not a judgement about anybody's practice - it is what keeps the
+    arithmetic downstream inside date's own bounds. Every caller adds or
+    subtracts up to a year, and date.min/date.max raise OverflowError from
+    inside a subtraction, which reaches a client as a 500 for a typo."""
+    for bad in ["0001-01-01", "1899-12-31", "9999-12-31", "2200-01-02"]:
+        with pytest.raises(ValueError, match="between"):
+            practice.parse_day(bad)
+    for good in ["1900-01-01", "2026-08-17", "2200-01-01"]:
+        assert practice.parse_day(good).isoformat() == good
+
+
+def test_the_day_index_is_the_one_every_day_query_can_actually_use(conn):
+    """The index is on the EXPRESSION these queries filter by, not on the
+    column, because a plain index on local_date cannot serve a wrapped one -
+    SQLite would scan the owner's whole practice history to answer a question
+    about seven days of it. Asserted through the query planner rather than by
+    reading the DDL, because the expression has to match character for
+    character and nothing else would notice when it stops."""
+    plan = " ".join(
+        str(row[3])
+        for row in conn.execute(
+            f"""EXPLAIN QUERY PLAN
+                SELECT {practice.LOCAL_DATE_SQL} AS day, SUM(p.seconds)
+                  FROM practice_sessions p
+                 WHERE p.owner = ? AND {practice.LOCAL_DATE_SQL} BETWEEN ? AND ?
+              GROUP BY day""",
+            ("local", "2026-08-17", "2026-08-23"),
+        )
+    )
+    assert "idx_practice_day" in plan, plan
+    assert "SCAN" not in plan, plan
+
+
 def test_a_monday_start_week_runs_monday_to_sunday():
     # 2026-08-17 is a Monday.
     for day in ("2026-08-17", "2026-08-19", "2026-08-23"):
@@ -297,6 +331,9 @@ def test_each_scope_names_only_the_thing_it_is_scoped_to():
 def test_a_scoped_goal_needs_the_thing_it_is_scoped_to():
     with pytest.raises(ValueError, match="score_id"):
         _goal(scope="score", score_id=None)
+    # Unless it is already stored that way, because its piece has since been
+    # deleted - such a goal can no longer be counted but must stay writable.
+    assert _goal(scope="score", score_id=None, allow_missing_score=True)["score_id"] is None
     with pytest.raises(ValueError, match="activity"):
         _goal(scope="activity", activity=None)
     with pytest.raises(ValueError, match="activity"):
@@ -487,6 +524,100 @@ def test_a_running_period_says_how_much_of_it_is_left_and_nothing_about_pace(con
 
     before = practice.goal_progress(conn, goal, date(2026, 8, 10))
     assert (before["status"], before["days_left"]) == ("upcoming", 7)
+
+
+def test_a_goal_about_a_piece_that_is_gone_is_uncountable_rather_than_unmet(conn):
+    """A goal scoped to a score that no longer exists reports that it cannot be
+    counted. Zeros with met=False would say the person did not practise, when
+    what actually happened is that the link between their practice and that
+    piece went with the file."""
+    piece = _score(conn)
+    for day in ("2026-08-17", "2026-08-18", "2026-08-19"):
+        _log(conn, day=day, seconds=1800, score_id=piece)
+    goal = _stored_goal(conn, scope="score", score_id=piece, target_days=3)
+    assert practice.goal_progress(conn, goal, date(2026, 8, 24))["met"] is True
+
+    conn.execute("DELETE FROM scores WHERE id = ?", (piece,))
+    conn.commit()
+    orphaned = conn.execute("SELECT * FROM practice_goals WHERE id = ?", (goal["id"],)).fetchone()
+    progress = practice.goal_progress(conn, orphaned, date(2026, 8, 24))
+    assert progress["countable"] is False
+    assert progress["met"] is None
+    assert progress["met_days"] is None
+    assert progress["met_minutes"] is None
+    # The shape is unchanged, so no reader has to test for missing keys - and
+    # the period is still described, because when it was is still known.
+    assert progress["status"] == "past"
+    assert len(progress["days"]) == 7
+
+
+def test_an_uncountable_goal_still_says_where_its_period_sits(conn):
+    piece = _score(conn)
+    goal = _stored_goal(conn, scope="score", score_id=piece, target_days=3)
+    conn.execute("DELETE FROM scores WHERE id = ?", (piece,))
+    conn.commit()
+    orphaned = conn.execute("SELECT * FROM practice_goals WHERE id = ?", (goal["id"],)).fetchone()
+    running = practice.goal_progress(conn, orphaned, date(2026, 8, 19))
+    assert (running["status"], running["days_left"]) == ("running", 5)
+
+
+def test_a_countable_goal_says_so(conn):
+    """The flag has to be present and True on an ordinary goal, or a reader
+    that branches on it would treat every goal as uncountable."""
+    goal = _stored_goal(conn, target_days=3)
+    assert practice.goal_progress(conn, goal, date(2026, 8, 19))["countable"] is True
+
+
+def test_a_session_that_outlives_its_score_is_still_piece_practice(conn):
+    """Deleting a score sets the reference to NULL rather than deleting the
+    practice. The row keeps everything else it recorded, and the pair
+    (activity='piece', score_id IS NULL) is what identifies it - a 'piece'
+    session cannot be created without a score, so nothing else produces it."""
+    piece = _score(conn)
+    conn.execute(
+        """INSERT INTO practice_sessions
+               (owner, score_id, activity, started_at, local_date, seconds, rating, note)
+           VALUES (?, ?, 'piece', '2026-08-18 02:00:00', '2026-08-17', 1800, 4, 'nearly there')""",
+        (db.DEFAULT_OWNER, piece),
+    )
+    conn.commit()
+    conn.execute("DELETE FROM scores WHERE id = ?", (piece,))
+    conn.commit()
+
+    row = conn.execute("SELECT * FROM practice_sessions").fetchone()
+    presented = practice.session_dict(row)
+    assert presented["score_id"] is None
+    assert presented["score_missing"] is True
+    assert (presented["seconds"], presented["rating"], presented["note"]) == (
+        1800,
+        4,
+        "nearly there",
+    )
+    assert presented["local_date"] == "2026-08-17"
+
+    # And it is still counted: the hours were spent.
+    facts = practice.period_facts(conn, "2026-08-17", "2026-08-23")
+    assert (facts["days_practised"], facts["seconds"]) == (1, 1800)
+
+
+def test_practice_that_never_had_a_piece_is_not_reported_as_a_missing_one(conn):
+    """The other half of the same signal. Ear training has no score and never
+    did, and calling that a piece no longer in the library would be a lie about
+    what the person did."""
+    _log(conn, day="2026-08-17", seconds=600, score_id=None, activity="ear_training")
+    row = conn.execute("SELECT * FROM practice_sessions").fetchone()
+    assert practice.session_dict(row)["score_missing"] is False
+    assert practice.is_orphaned("ear_training", None) is False
+    assert practice.is_orphaned("piece", None) is True
+    assert practice.is_orphaned("piece", 4) is False
+
+
+def test_an_orphaned_session_can_be_revalidated_but_one_cannot_be_created(conn):
+    """The allowance exists for a row that is already stored in that state, so
+    a note can be added to it. It must not make the state creatable."""
+    with pytest.raises(ValueError, match="score_id"):
+        _session(score_id=None)
+    assert _session(score_id=None, allow_missing_score=True)["score_id"] is None
 
 
 def test_a_scoped_goal_is_counted_against_only_its_own_scope(conn):

--- a/server/tests/test_practice_model.py
+++ b/server/tests/test_practice_model.py
@@ -1,0 +1,537 @@
+"""The practice model's own rules, called directly.
+
+The API tests exercise these through HTTP-shaped calls; these exercise the
+arithmetic and the vocabulary where they live, because the interesting failures
+are all in the arithmetic. A day count that quietly used the UTC date, a
+partially-met goal that reported itself met, a week that always started on
+Monday - none of those break an endpoint. They just answer wrong.
+"""
+
+from datetime import date, timedelta
+
+import pytest
+
+from fermata import db, practice
+
+
+@pytest.fixture
+def conn(app_env):
+    return db.connect()
+
+
+def _score(conn, title="Test Score", path="a/b.pdf") -> int:
+    cur = conn.execute(
+        """INSERT INTO scores(title, path, file_type, hash, size, mtime)
+           VALUES (?, ?, 'pdf', 'deadbeef', 1, 0.0)""",
+        (title, path),
+    )
+    conn.commit()
+    return cur.lastrowid
+
+
+def _log(conn, *, day, seconds, score_id=None, activity="piece", started_at=None):
+    """A session as it really sits in the table.
+
+    started_at defaults to the small hours of the day AFTER `day`, which is
+    what an evening's practice west of Greenwich actually stores - and it is
+    deliberate: a fixture whose UTC timestamp and recorded practice day agree
+    cannot tell a query that reads the right one from a query that reads the
+    wrong one. Every day-based assertion in this file is therefore also a
+    check that the recorded practice day is what got counted.
+    """
+    if started_at is None:
+        started_at = f"{date.fromisoformat(day) + timedelta(days=1)} 02:30:00"
+    conn.execute(
+        """INSERT INTO practice_sessions(owner, score_id, activity, started_at, local_date, seconds)
+           VALUES (?, ?, ?, ?, ?, ?)""",
+        (db.DEFAULT_OWNER, score_id, activity, started_at, day, seconds),
+    )
+    conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# Dates and weeks
+# ---------------------------------------------------------------------------
+
+
+def test_a_practice_day_must_be_a_plain_calendar_date():
+    """Strict on purpose: date.fromisoformat also accepts '20260817' and full
+    timestamps, and a timestamp stored where a day belongs is text no BETWEEN
+    over practice days would ever match again."""
+    assert practice.parse_day("2026-08-17") == date(2026, 8, 17)
+    for bad in ["20260817", "2026-08-17T10:00:00", "2026-8-7", "", None, "not a date",
+                "2026-13-01", "2026-02-30"]:
+        with pytest.raises(ValueError):
+            practice.parse_day(bad)
+
+
+def test_a_monday_start_week_runs_monday_to_sunday():
+    # 2026-08-17 is a Monday.
+    for day in ("2026-08-17", "2026-08-19", "2026-08-23"):
+        assert practice.week_start(date.fromisoformat(day), "monday") == date(2026, 8, 17)
+    assert practice.week_start(date(2026, 8, 16), "monday") == date(2026, 8, 10)
+
+
+def test_a_sunday_start_week_runs_sunday_to_saturday():
+    # The same Monday belongs to a week that began the day before.
+    assert practice.week_start(date(2026, 8, 17), "sunday") == date(2026, 8, 16)
+    assert practice.week_start(date(2026, 8, 16), "sunday") == date(2026, 8, 16)
+    assert practice.week_start(date(2026, 8, 22), "sunday") == date(2026, 8, 16)
+    assert practice.week_start(date(2026, 8, 23), "sunday") == date(2026, 8, 23)
+
+
+def test_every_weekday_is_covered_by_exactly_one_week_under_either_setting():
+    """Not a restatement of the offsets above: this walks a whole year and
+    checks each day lands in a seven-day window that contains it, which is what
+    an off-by-one in the modulo actually breaks."""
+    for starts_on in practice.WEEK_STARTS:
+        for ordinal in range(date(2026, 1, 1).toordinal(), date(2026, 12, 31).toordinal()):
+            day = date.fromordinal(ordinal)
+            start, end = practice.period_bounds(practice.week_start(day, starts_on))
+            assert start <= day <= end
+            assert (end - start).days == 6
+            expected_first = 0 if starts_on == "monday" else 6
+            assert start.weekday() == expected_first
+
+
+def test_an_unknown_week_start_is_refused_rather_than_defaulted():
+    with pytest.raises(ValueError):
+        practice.week_start(date(2026, 8, 17), "tuesday")
+
+
+# ---------------------------------------------------------------------------
+# A session's rules
+# ---------------------------------------------------------------------------
+
+TODAY = date(2026, 8, 20)
+
+
+def _session(**over):
+    fields = {
+        "score_id": 1,
+        "activity": "piece",
+        "mode": None,
+        "seconds": 600,
+        "local_date": "2026-08-20",
+        "recorded_on": TODAY,
+    }
+    fields.update(over)
+    return practice.normalise_session(**fields)
+
+
+def test_a_session_on_a_piece_needs_a_piece():
+    with pytest.raises(ValueError, match="score_id"):
+        _session(score_id=None)
+
+
+def test_every_other_kind_of_practice_needs_no_piece():
+    """The reason the column had to become nullable. Ear training and simply
+    sitting down to play are practice, and neither has a score behind it."""
+    for activity in practice.ACTIVITIES:
+        if activity == "piece":
+            continue
+        assert _session(score_id=None, activity=activity)["score_id"] is None
+
+
+def test_an_unknown_activity_or_mode_is_refused():
+    with pytest.raises(ValueError):
+        _session(activity="vibes")
+    with pytest.raises(ValueError):
+        _session(mode="noodling")
+    assert _session(mode="section")["mode"] == "section"
+    assert _session(mode="run_through")["mode"] == "run_through"
+
+
+def test_practice_cannot_be_recorded_for_a_day_that_has_not_happened():
+    """A goal counts the days inside its period. Practice dated into the future
+    would fill one in before it happened."""
+    with pytest.raises(ValueError, match="future"):
+        _session(local_date="2026-08-25")
+    # Tomorrow is allowed: a client an hour ahead of the server's UTC date is
+    # not a broken clock, it is a timezone.
+    assert _session(local_date="2026-08-21")["local_date"] == "2026-08-21"
+
+
+def test_a_forgotten_session_can_be_entered_late_but_not_arbitrarily_late():
+    assert _session(local_date="2026-08-14")["local_date"] == "2026-08-14"
+    with pytest.raises(ValueError, match="days ago"):
+        _session(local_date="2020-01-01")
+
+
+def test_no_practice_day_given_means_none_is_stored():
+    """Not the server's own date: a client that does not know its timezone
+    should not have one invented for it, and the reader is told the day it gets
+    came from the timestamp."""
+    assert _session(local_date=None)["local_date"] is None
+
+
+def test_a_length_has_to_be_a_plausible_length():
+    for bad in [0, -1, 86_401, True, 1.5, "600"]:
+        with pytest.raises(ValueError):
+            _session(seconds=bad)
+    assert _session(seconds=86_400)["seconds"] == 86_400
+
+
+def test_a_range_needs_its_start_and_cannot_run_backwards():
+    assert _session(from_bar=17, to_bar=32)["to_bar"] == 32
+    assert _session(from_bar=17)["to_bar"] is None
+    with pytest.raises(ValueError, match="from_bar"):
+        _session(to_bar=32)
+    with pytest.raises(ValueError, match="before"):
+        _session(from_bar=32, to_bar=17)
+    with pytest.raises(ValueError, match="from_page"):
+        _session(to_page=3)
+
+
+def test_a_tempo_outside_anything_playable_is_a_units_mistake():
+    for bad in [0, 3, 19, 401, 3000]:
+        with pytest.raises(ValueError):
+            _session(tempo_bpm=bad)
+    assert _session(tempo_bpm=76, target_tempo_bpm=120)["target_tempo_bpm"] == 120
+
+
+def test_a_rating_is_one_to_five_and_optional():
+    assert _session(rating=None)["rating"] is None
+    for value in range(1, 6):
+        assert _session(rating=value)["rating"] == value
+    for bad in [0, 6, -1]:
+        with pytest.raises(ValueError):
+            _session(rating=bad)
+
+
+def test_an_empty_note_is_no_note_rather_than_an_empty_one():
+    assert _session(note="   ")["note"] is None
+    assert _session(note="  bars 1-16  ")["note"] == "bars 1-16"
+    with pytest.raises(ValueError):
+        _session(note="x" * (practice.MAX_NOTE_CHARS + 1))
+
+
+# ---------------------------------------------------------------------------
+# Whether a tempo ladder reached its target - derived, never stored
+# ---------------------------------------------------------------------------
+
+
+def test_reaching_the_target_is_the_comparison_and_not_a_stored_opinion(conn):
+    score_id = _score(conn)
+    cases = [
+        (120, 120, True),
+        (121, 120, True),
+        (100, 120, False),
+        (None, 120, None),
+        (100, None, None),
+        (None, None, None),
+    ]
+    for tempo, target, expected in cases:
+        conn.execute(
+            """INSERT INTO practice_sessions
+                   (owner, score_id, activity, started_at, local_date, seconds,
+                    tempo_bpm, target_tempo_bpm)
+               VALUES (?, ?, 'piece', datetime('now'), '2026-08-20', 600, ?, ?)""",
+            (db.DEFAULT_OWNER, score_id, tempo, target),
+        )
+        conn.commit()
+        row = conn.execute(
+            "SELECT * FROM practice_sessions ORDER BY id DESC LIMIT 1"
+        ).fetchone()
+        assert practice.session_dict(row)["reached_target"] is expected, (tempo, target)
+    # There is no column for it, which is what stops the answer and the two
+    # numbers it comes from from ever disagreeing.
+    columns = {r["name"] for r in conn.execute("PRAGMA table_info(practice_sessions)")}
+    assert "reached_target" not in columns
+
+
+# ---------------------------------------------------------------------------
+# A goal's rules
+# ---------------------------------------------------------------------------
+
+
+def _goal(**over):
+    fields = {
+        "period": "week",
+        "period_start": "2026-08-17",
+        "target_days": 4,
+        "target_minutes": None,
+        "scope": "all",
+        "score_id": None,
+        "activity": None,
+        "intent": None,
+    }
+    fields.update(over)
+    return practice.normalise_goal(**fields)
+
+
+def test_a_goal_has_to_be_concrete_enough_to_be_met_or_missed():
+    with pytest.raises(ValueError, match="needs a target"):
+        _goal(target_days=None, target_minutes=None)
+    assert _goal(target_days=None, target_minutes=150)["target_minutes"] == 150
+    both = _goal(target_days=3, target_minutes=150)
+    assert (both["target_days"], both["target_minutes"]) == (3, 150)
+
+
+def test_a_weekly_goal_cannot_ask_for_more_days_than_the_week_has():
+    assert _goal(target_days=7)["target_days"] == 7
+    with pytest.raises(ValueError):
+        _goal(target_days=8)
+    with pytest.raises(ValueError):
+        _goal(target_days=0)
+
+
+def test_the_period_end_is_derived_from_its_start(conn):
+    goal = _goal(period_start="2026-08-17")
+    assert (goal["period_start"], goal["period_end"]) == ("2026-08-17", "2026-08-23")
+
+
+def test_each_scope_names_only_the_thing_it_is_scoped_to():
+    """A goal carrying a score_id it does not use would read as a goal about
+    that piece while being counted over everything practised."""
+    everything = _goal(scope="all", score_id=4, activity="technique")
+    assert everything["score_id"] is None and everything["activity"] is None
+
+    one_piece = _goal(scope="score", score_id=4, activity="technique")
+    assert one_piece["score_id"] == 4 and one_piece["activity"] is None
+
+    one_kind = _goal(scope="activity", activity="technique", score_id=4)
+    assert one_kind["activity"] == "technique" and one_kind["score_id"] is None
+
+
+def test_a_scoped_goal_needs_the_thing_it_is_scoped_to():
+    with pytest.raises(ValueError, match="score_id"):
+        _goal(scope="score", score_id=None)
+    with pytest.raises(ValueError, match="activity"):
+        _goal(scope="activity", activity=None)
+    with pytest.raises(ValueError, match="activity"):
+        _goal(scope="activity", activity="vibes")
+
+
+def test_an_unknown_scope_or_period_is_refused():
+    with pytest.raises(ValueError):
+        _goal(scope="instrument")
+    with pytest.raises(ValueError):
+        _goal(period="fortnight")
+
+
+def test_the_reflection_answers_a_question_and_is_not_a_status():
+    assert practice.normalise_reflection(reflection="  busy week  ", realistic="no") == {
+        "reflection": "busy week",
+        "realistic": "no",
+    }
+    assert practice.normalise_reflection(reflection="", realistic=None) == {
+        "reflection": None,
+        "realistic": None,
+    }
+    for bad in ["maybe", "failed", "met", "true"]:
+        with pytest.raises(ValueError):
+            practice.normalise_reflection(reflection=None, realistic=bad)
+
+
+# ---------------------------------------------------------------------------
+# What actually happened, counted
+# ---------------------------------------------------------------------------
+
+
+def test_a_practice_day_is_the_practisers_day_and_not_the_utc_one(conn):
+    """The whole reason local_date exists. Both sessions here have a UTC
+    timestamp on the 21st and were practised on the evening of the 20th; a
+    count off the timestamp puts them in the wrong day and, at a week boundary,
+    the wrong week."""
+    score_id = _score(conn)
+    _log(conn, day="2026-08-20", seconds=1800, score_id=score_id,
+         started_at="2026-08-21 02:30:00")
+    _log(conn, day="2026-08-20", seconds=600, score_id=score_id,
+         started_at="2026-08-21 03:10:00")
+
+    facts = practice.period_facts(conn, "2026-08-17", "2026-08-23")
+    assert facts["days_practised"] == 1
+    assert facts["seconds"] == 2400
+    on_the_20th = next(d for d in facts["days"] if d["date"] == "2026-08-20")
+    assert (on_the_20th["seconds"], on_the_20th["sessions"]) == (2400, 2)
+    assert next(d for d in facts["days"] if d["date"] == "2026-08-21")["sessions"] == 0
+
+
+def test_a_day_with_nothing_on_it_is_reported_as_zero_not_left_out(conn):
+    """A gap in a list is something a reader has to infer. Seven days, always,
+    so a week can be drawn without inventing the days nobody practised - and
+    they are zeroes, not failures."""
+    score_id = _score(conn)
+    _log(conn, day="2026-08-19", seconds=900, score_id=score_id)
+    facts = practice.period_facts(conn, "2026-08-17", "2026-08-23")
+    assert [d["date"] for d in facts["days"]] == [
+        "2026-08-17", "2026-08-18", "2026-08-19", "2026-08-20",
+        "2026-08-21", "2026-08-22", "2026-08-23",
+    ]
+    assert [d["seconds"] for d in facts["days"]] == [0, 0, 900, 0, 0, 0, 0]
+
+
+def test_minutes_never_claim_a_minute_that_was_not_practised(conn):
+    score_id = _score(conn)
+    _log(conn, day="2026-08-19", seconds=119, score_id=score_id)
+    assert practice.period_facts(conn, "2026-08-17", "2026-08-23")["minutes"] == 1
+
+
+def test_two_sessions_in_one_day_are_one_day_of_practice(conn):
+    """Days, not sessions, and this is why: counting sessions rewards breaking
+    an hour into six, which is not what a goal for four days a week means."""
+    score_id = _score(conn)
+    _log(conn, day="2026-08-19", seconds=600, score_id=score_id)
+    _log(conn, day="2026-08-19", seconds=600, score_id=score_id)
+    facts = practice.period_facts(conn, "2026-08-17", "2026-08-23")
+    assert (facts["days_practised"], facts["sessions"]) == (1, 2)
+
+
+def test_practice_outside_the_period_is_not_counted_in_it(conn):
+    score_id = _score(conn)
+    _log(conn, day="2026-08-16", seconds=3600, score_id=score_id)  # day before
+    _log(conn, day="2026-08-24", seconds=3600, score_id=score_id)  # day after
+    _log(conn, day="2026-08-17", seconds=600, score_id=score_id)  # first day, inclusive
+    _log(conn, day="2026-08-23", seconds=600, score_id=score_id)  # last day, inclusive
+    facts = practice.period_facts(conn, "2026-08-17", "2026-08-23")
+    assert (facts["days_practised"], facts["seconds"]) == (2, 1200)
+
+
+def test_a_scoped_period_counts_only_what_it_is_scoped_to(conn):
+    piece = _score(conn, "Study in C", "a/study.pdf")
+    other = _score(conn, "Something Else", "a/other.pdf")
+    _log(conn, day="2026-08-17", seconds=600, score_id=piece)
+    _log(conn, day="2026-08-18", seconds=600, score_id=other)
+    _log(conn, day="2026-08-19", seconds=600, score_id=None, activity="ear_training")
+
+    everything = practice.period_facts(conn, "2026-08-17", "2026-08-23")
+    assert (everything["days_practised"], everything["seconds"]) == (3, 1800)
+
+    one_piece = practice.period_facts(
+        conn, "2026-08-17", "2026-08-23", scope="score", score_id=piece
+    )
+    assert (one_piece["days_practised"], one_piece["seconds"]) == (1, 600)
+
+    one_kind = practice.period_facts(
+        conn, "2026-08-17", "2026-08-23", scope="activity", activity="ear_training"
+    )
+    assert (one_kind["days_practised"], one_kind["seconds"]) == (1, 600)
+
+
+# ---------------------------------------------------------------------------
+# Where a goal stands
+# ---------------------------------------------------------------------------
+
+
+def _stored_goal(conn, **over):
+    values = _goal(**over)
+    columns = ", ".join(values)
+    placeholders = ", ".join("?" * len(values))
+    conn.execute(
+        f"INSERT INTO practice_goals(owner, {columns}) VALUES (?, {placeholders})",
+        [db.DEFAULT_OWNER, *values.values()],
+    )
+    conn.commit()
+    return conn.execute("SELECT * FROM practice_goals ORDER BY id DESC LIMIT 1").fetchone()
+
+
+def test_a_partly_met_goal_reports_both_numbers_and_no_verdict(conn):
+    """Three of four planned days. The counts are stated, `met` is False, and
+    there is nothing here that grades the shortfall - no percentage, no
+    'missed', and nothing comparing this week to another."""
+    score_id = _score(conn)
+    for day in ("2026-08-17", "2026-08-18", "2026-08-20"):
+        _log(conn, day=day, seconds=1800, score_id=score_id)
+    goal = _stored_goal(conn, target_days=4, target_minutes=120)
+
+    progress = practice.goal_progress(conn, goal, date(2026, 8, 24))
+    assert progress["days_practised"] == 3
+    assert progress["minutes"] == 90
+    assert progress["met_days"] is False
+    assert progress["met_minutes"] is False
+    assert progress["met"] is False
+    assert progress["status"] == "past"
+    assert not any("best" in key or "streak" in key for key in progress)
+
+
+def test_a_target_that_was_not_set_reports_none_rather_than_unmet(conn):
+    """False would read as a shortfall against a target nobody chose."""
+    score_id = _score(conn)
+    _log(conn, day="2026-08-17", seconds=600, score_id=score_id)
+    goal = _stored_goal(conn, target_days=1, target_minutes=None)
+    progress = practice.goal_progress(conn, goal, date(2026, 8, 24))
+    assert progress["met_days"] is True
+    assert progress["met_minutes"] is None
+    assert progress["met"] is True
+
+
+def test_a_goal_is_met_only_when_every_target_it_set_is_reached(conn):
+    score_id = _score(conn)
+    for day in ("2026-08-17", "2026-08-18"):
+        _log(conn, day=day, seconds=1800, score_id=score_id)
+    goal = _stored_goal(conn, target_days=2, target_minutes=120)
+    progress = practice.goal_progress(conn, goal, date(2026, 8, 24))
+    assert (progress["met_days"], progress["met_minutes"]) == (True, False)
+    assert progress["met"] is False
+
+
+def test_a_running_period_says_how_much_of_it_is_left_and_nothing_about_pace(conn):
+    """So the goal can still change the week. Deliberately no per-day rate
+    'needed to catch up' - that is a verdict wearing arithmetic."""
+    score_id = _score(conn)
+    _log(conn, day="2026-08-17", seconds=1800, score_id=score_id)
+    goal = _stored_goal(conn, target_days=4)
+
+    running = practice.goal_progress(conn, goal, date(2026, 8, 19))
+    assert running["status"] == "running"
+    assert running["days_left"] == 5  # the 19th through the 23rd, inclusive
+    assert running["met"] is False
+    assert not any("pace" in key or "needed" in key for key in running)
+
+    last_day = practice.goal_progress(conn, goal, date(2026, 8, 23))
+    assert (last_day["status"], last_day["days_left"]) == ("running", 1)
+
+    after = practice.goal_progress(conn, goal, date(2026, 8, 24))
+    assert (after["status"], after["days_left"]) == ("past", 0)
+
+    before = practice.goal_progress(conn, goal, date(2026, 8, 10))
+    assert (before["status"], before["days_left"]) == ("upcoming", 7)
+
+
+def test_a_scoped_goal_is_counted_against_only_its_own_scope(conn):
+    piece = _score(conn, "Study in C", "a/study.pdf")
+    other = _score(conn, "Something Else", "a/other.pdf")
+    for day in ("2026-08-17", "2026-08-18", "2026-08-19"):
+        _log(conn, day=day, seconds=1800, score_id=other)
+    _log(conn, day="2026-08-17", seconds=1800, score_id=piece)
+
+    goal = _stored_goal(conn, scope="score", score_id=piece, target_days=3)
+    progress = practice.goal_progress(conn, goal, date(2026, 8, 24))
+    assert progress["days_practised"] == 1
+    assert progress["met_days"] is False
+
+
+# ---------------------------------------------------------------------------
+# Where the time went
+# ---------------------------------------------------------------------------
+
+
+def test_time_spent_names_the_pieces_and_the_kinds_of_work(conn):
+    study = _score(conn, "Study in C", "a/study.pdf")
+    zanarkand = _score(conn, "To Zanarkand", "a/zan.pdf")
+    _log(conn, day="2026-08-17", seconds=600, score_id=study)
+    _log(conn, day="2026-08-18", seconds=1800, score_id=zanarkand)
+    _log(conn, day="2026-08-18", seconds=900, score_id=None, activity="ear_training")
+    _log(conn, day="2026-08-19", seconds=300, score_id=None, activity="free")
+
+    spent = practice.time_spent(conn, "2026-08-17", "2026-08-23")
+    assert [(r["title"], r["seconds"]) for r in spent["by_score"]] == [
+        ("To Zanarkand", 1800),
+        ("Study in C", 600),
+    ]
+    assert [(r["activity"], r["seconds"]) for r in spent["by_activity"]] == [
+        ("piece", 2400),
+        ("ear_training", 900),
+        ("free", 300),
+    ]
+
+
+def test_practice_with_no_piece_is_absent_from_by_score_rather_than_bucketed(conn):
+    """"Which pieces did I work on" has an honest answer that does not include
+    a row labelled "no piece" for a reader to know to ignore. The time is not
+    lost: it is in by_activity."""
+    _log(conn, day="2026-08-17", seconds=900, score_id=None, activity="fretboard")
+    spent = practice.time_spent(conn, "2026-08-17", "2026-08-23")
+    assert spent["by_score"] == []
+    assert [(r["activity"], r["seconds"]) for r in spent["by_activity"]] == [("fretboard", 900)]

--- a/server/tests/test_settings_api.py
+++ b/server/tests/test_settings_api.py
@@ -7,14 +7,32 @@ from fastapi import HTTPException
 from fermata import api, db
 
 
+# Compared against SETTINGS_DEFAULTS rather than a literal dict of every
+# setting: what these tests are about is the store's behaviour - defaulting,
+# upserting, rejecting - and spelling out the whole set in each of them means
+# adding a preference breaks eight assertions that were never about it. The
+# defaults themselves are pinned once, below.
+def defaults(**overrides) -> dict:
+    return {**api.SETTINGS_DEFAULTS, **overrides}
+
+
+def test_the_defaults_are_what_a_fresh_install_behaves_as():
+    """Pinned deliberately, because these are what an install with nothing
+    stored acts on, and every other test here compares against them."""
+    assert api.SETTINGS_DEFAULTS == {"staff_theme": "parchment", "week_starts_on": "monday"}
+    for key, value in api.SETTINGS_DEFAULTS.items():
+        choices = api.SETTINGS_CHOICES.get(key)
+        assert choices is None or value in choices, f"{key}'s default is not one of its choices"
+
+
 def test_defaults_when_nothing_is_stored(app_env):
-    assert api.get_settings() == {"staff_theme": "parchment"}
+    assert api.get_settings() == defaults()
 
 
 def test_write_then_read_back(app_env):
     written = api.put_settings({"staff_theme": "noir"})
-    assert written == {"staff_theme": "noir"}
-    assert api.get_settings() == {"staff_theme": "noir"}
+    assert written == defaults(staff_theme="noir")
+    assert api.get_settings() == defaults(staff_theme="noir")
 
 
 def test_write_is_an_upsert_not_a_duplicate_row(app_env):
@@ -38,7 +56,7 @@ def test_unknown_key_alongside_a_known_one_rejects_the_whole_write(app_env):
     fails the whole call rather than silently dropping just that key."""
     with pytest.raises(HTTPException):
         api.put_settings({"staff_theme": "noir", "bogus": "x"})
-    assert api.get_settings() == {"staff_theme": "parchment"}
+    assert api.get_settings() == defaults()
 
 
 def test_invalid_value_for_a_known_key_is_rejected(app_env):
@@ -56,15 +74,10 @@ def test_owner_defaults_to_the_single_instance_owner(app_env):
     assert row["owner"] == db.DEFAULT_OWNER == "local"
 
 
-def test_writing_several_settings_in_one_call(app_env, monkeypatch):
-    # Only one real setting exists today; a second is faked in to prove the
-    # endpoint's "one or several" contract rather than only ever exercising
-    # a single-key dict.
-    monkeypatch.setitem(api.SETTINGS_DEFAULTS, "practice_reminder", "off")
-    monkeypatch.setitem(api.SETTINGS_CHOICES, "practice_reminder", {"on", "off"})
-    result = api.put_settings({"staff_theme": "noir", "practice_reminder": "on"})
+def test_writing_several_settings_in_one_call(app_env):
+    result = api.put_settings({"staff_theme": "noir", "week_starts_on": "sunday"})
     assert result["staff_theme"] == "noir"
-    assert result["practice_reminder"] == "on"
+    assert result["week_starts_on"] == "sunday"
     assert api.get_settings() == result
 
 
@@ -86,7 +99,7 @@ def test_a_stored_value_no_longer_in_choices_falls_back_to_the_default(app_env):
         (db.DEFAULT_OWNER,),
     )
     conn.commit()
-    assert api.get_settings() == {"staff_theme": "parchment"}
+    assert api.get_settings() == defaults()
 
 
 def test_a_stored_unknown_key_is_omitted_not_surfaced(app_env):
@@ -96,7 +109,7 @@ def test_a_stored_unknown_key_is_omitted_not_surfaced(app_env):
         (db.DEFAULT_OWNER,),
     )
     conn.commit()
-    assert api.get_settings() == {"staff_theme": "parchment"}
+    assert api.get_settings() == defaults()
 
 
 def test_staff_theme_choices_match_the_frontends_score_themes():
@@ -113,3 +126,16 @@ def test_staff_theme_choices_match_the_frontends_score_themes():
     assert match, "could not find SCORE_THEMES in score-render.js"
     frontend_themes = set(re.findall(r'"([^"]+)"', match.group(1)))
     assert frontend_themes == api.SETTINGS_CHOICES["staff_theme"]
+
+
+def test_week_start_choices_match_the_frontends():
+    """Same problem, same cheap check. The week a goal is set for is decided
+    from this setting, so a value the picker offers and the server rejects
+    would leave somebody unable to set a goal at all - and the two lists have
+    nothing connecting them at runtime."""
+    js_path = Path(__file__).resolve().parents[2] / "web" / "src" / "lib" / "settings.svelte.js"
+    source = js_path.read_text(encoding="utf-8")
+    match = re.search(r"WEEK_STARTS\s*=\s*\[([^\]]*)\]", source)
+    assert match, "could not find WEEK_STARTS in settings.svelte.js"
+    frontend = set(re.findall(r'"([^"]+)"', match.group(1)))
+    assert frontend == api.SETTINGS_CHOICES["week_starts_on"]

--- a/web/playwright.config.js
+++ b/web/playwright.config.js
@@ -18,7 +18,21 @@ if (!fs.existsSync(path.join(here, "dist", "index.html"))) {
 
 // A throwaway library and config per run, so the suite never sees a previous
 // run's rows and never touches a real install's database.
-const scratch = fs.mkdtempSync(path.join(os.tmpdir(), "fermata-browser-"));
+// Created once per RUN, not once per process. This file is evaluated again in
+// every worker, so an unconditional mkdtemp gave the worker a different scratch
+// directory from the one the server was started with - which is invisible until
+// a spec needs the real path, and then quietly does nothing. The runner
+// evaluates this before it spawns any worker, so the variable is inherited.
+const scratch =
+  process.env.FERMATA_TEST_SCRATCH ??
+  fs.mkdtempSync(path.join(os.tmpdir(), "fermata-browser-"));
+process.env.FERMATA_TEST_SCRATCH = scratch;
+// Published to the specs, so a test that needs a real score can put a file in
+// the library and take it out again afterwards. Without a path, the only way to
+// cover anything score-shaped was to weaken the guard that stops this suite
+// running against a real install - and that guard is the reason it is safe to
+// delete practice history in here at all.
+process.env.FERMATA_TEST_LIBRARY_DIR = path.join(scratch, "library");
 // Not 8080, and not a port anything else here uses. The suite starts its own
 // server and never adopts one (see reuseExistingServer below), so a collision
 // should fail loudly rather than quietly point these tests at whatever is

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -2,12 +2,14 @@
   import Library from "./lib/Library.svelte";
   import Viewer from "./lib/Viewer.svelte";
   import Settings from "./lib/Settings.svelte";
+  import Practice from "./lib/Practice.svelte";
 
   function parse(hash) {
     const m = hash.match(/^#\/score\/(\d+)/);
     if (m) return { page: "score", id: Number(m[1]) };
     if (hash.startsWith("#/demo")) return { page: "demo" };
     if (hash.startsWith("#/settings")) return { page: "settings" };
+    if (hash.startsWith("#/practice")) return { page: "practice" };
     return { page: "library" };
   }
 
@@ -26,6 +28,8 @@
   <Viewer demo={true} />
 {:else if route.page === "settings"}
   <Settings />
+{:else if route.page === "practice"}
+  <Practice />
 {:else}
   <Library />
 {/if}

--- a/web/src/lib/Library.svelte
+++ b/web/src/lib/Library.svelte
@@ -171,6 +171,7 @@
       <button onclick={triggerScan} disabled={scan?.scanning}>
         {scan?.scanning ? `Scanning ${scan.processed}/${scan.total}…` : "Scan library"}
       </button>
+      <a class="demo-link practice-link" href="#/practice">◴ Practice &amp; goals</a>
       <a class="demo-link" href="#/demo">Notation/tab demo →</a>
       <a class="demo-link" href="#/settings">⚙ Settings</a>
     </div>

--- a/web/src/lib/Library.svelte
+++ b/web/src/lib/Library.svelte
@@ -95,14 +95,21 @@
 
   function practicedAgo(lastPracticed) {
     if (!lastPracticed) return "";
-    const iso = lastPracticed.replace(" ", "T") + "Z";
-    const then = new Date(iso);
+    // A practice DAY (YYYY-MM-DD), which is the day in the practiser's own
+    // time - not the UTC timestamp this used to be handed. That mattered
+    // because the answer here is a count of calendar days: reading it off a
+    // UTC instant put an evening's practice on the next day for anyone west of
+    // Greenwich, so "practised today" became "practised 1d ago" at nine at
+    // night. The slice also tolerates a timestamp, so an older server (or a
+    // row read through some other path) still reads sensibly rather than
+    // showing nothing.
+    const [year, month, day] = String(lastPracticed).slice(0, 10).split("-").map(Number);
+    if (!year || !month || !day) return "";
+    const then = new Date(year, month - 1, day);
     if (!Number.isFinite(then.getTime())) return "";
-    // Compare calendar dates (in local time), not raw elapsed milliseconds,
-    // so e.g. 23:00 yesterday reads as 1 day ago rather than "today".
     const startOfDay = (d) => new Date(d.getFullYear(), d.getMonth(), d.getDate());
     const days = Math.round((startOfDay(new Date()) - startOfDay(then)) / 86400000);
-    if (days <= 0) return "practiced <24h ago";
+    if (days <= 0) return "practiced today";
     if (days === 1) return "practiced 1d ago";
     return `practiced ${days}d ago`;
   }

--- a/web/src/lib/Practice.svelte
+++ b/web/src/lib/Practice.svelte
@@ -28,10 +28,13 @@
     goalStatements,
     localDay,
     periodLabel,
+    formatDays,
     periodStatement,
     rangeLabel,
+    sessionSubject,
     tempoLabel,
     timeLeftStatement,
+    uncountableStatement,
   } from "./practice.js";
 
   const REVIEW_WEEKS = 8;
@@ -97,11 +100,15 @@
       // it - the server decides which seven days "this week" is, from the
       // week-start preference, and asking for a week the client worked out
       // itself is how the two quietly disagree.
+      const shown = nextCurrent.goal ?? nextCurrent;
       sessions = (
-        await api.sessions({ start: nextCurrent.week_start, end: nextCurrent.week_end })
+        await api.sessions({
+          start: shown.period_start ?? nextCurrent.week_start,
+          end: shown.period_end ?? nextCurrent.week_end,
+        })
       ).sessions;
     } catch (e) {
-      error = e?.message ?? "Could not load your practice record.";
+      error = e?.message ?? "Could not load your practice history.";
     } finally {
       loading = false;
     }
@@ -113,10 +120,25 @@
 
   let goal = $derived(current?.goal ?? null);
   let statements = $derived(goalStatements(goal));
+  // The period on screen is the GOAL's when there is one, and the canonical
+  // week from the preference only when there is not. A goal stores the dates it
+  // was set for, so after the week-start preference changes the two differ -
+  // and showing the canonical week while displaying that goal's counts had the
+  // header, the day strip and the Adjust button each talking about a different
+  // seven days.
+  let periodStart = $derived(goal?.period_start ?? current?.week_start);
+  let periodEnd = $derived(goal?.period_end ?? current?.week_end);
   // The review's first entry is always the week containing today, which is
   // where a week with no goal gets its facts from.
   let thisWeek = $derived(review?.weeks?.[0] ?? null);
   let pastWeeks = $derived((review?.weeks ?? []).slice(1));
+  // Nothing has been practised and nothing has been planned. Without this the
+  // first thing a new install shows is fourteen statements of absence - seven
+  // empty days and seven weeks that had no goal - which is a poor greeting for
+  // somebody who has simply not started yet.
+  let nothingYet = $derived(
+    !!review && !goal && !history?.sessions && !(review.weeks ?? []).some((w) => w.goal),
+  );
   // A scoped goal's own days when there is one, so the strip shows the
   // practice the goal is actually counted against; the week's whole practice
   // otherwise.
@@ -152,9 +174,9 @@
       // and no way to end up with two goals for one week.
       await api.setGoal(
         {
-          period_start: current?.week_start,
-          target_days: form.use_days ? Number(form.target_days) : null,
-          target_minutes: form.use_minutes ? Number(form.target_minutes) : null,
+          period_start: periodStart,
+          target_days: form.use_days ? Math.round(Number(form.target_days)) : null,
+          target_minutes: form.use_minutes ? Math.round(Number(form.target_minutes)) : null,
           scope: form.scope,
           score_id: form.scope === "score" ? Number(form.score_id) || null : null,
           activity: form.scope === "activity" ? form.activity : null,
@@ -166,6 +188,19 @@
       await refresh();
     } catch (e) {
       error = e?.message ?? "Could not save that goal.";
+    } finally {
+      saving = false;
+    }
+  }
+
+  async function removePastGoal(week) {
+    saving = true;
+    error = "";
+    try {
+      await api.deleteGoal(week.goal.id);
+      await refresh();
+    } catch (e) {
+      error = e?.message ?? "Could not remove that goal.";
     } finally {
       saving = false;
     }
@@ -250,12 +285,21 @@
 
     {#if loading}
       <p class="quiet">Loading…</p>
+    {:else if !current || !review || !history}
+      <!-- The load failed, and the message above says why. Everything below
+           reads from these three answers, and rendering it without them put
+           "NaN undefined" on screen where the week should be - a page that
+           looks broken rather than one that says what happened. -->
+      <p class="quiet">
+        Your practice history could not be loaded, so nothing below is shown rather than
+        shown wrongly. Reload to try again.
+      </p>
     {:else}
       <!-- ------------------------------------------------ this week -->
-      <section class="week" data-week={current?.week_start}>
+      <section class="week" data-week={periodStart}>
         <div class="section-head">
           <h2>This week</h2>
-          <span class="quiet">{periodLabel(current?.week_start, current?.week_end)}</span>
+          <span class="quiet">{periodLabel(periodStart, periodEnd)}</span>
         </div>
 
         {#if goal && !editing}
@@ -264,21 +308,25 @@
             {#if goal.intent}<span class="intent-text">— {goal.intent}</span>{/if}
           </p>
 
-          <ul class="statements">
-            {#each statements as statement (statement.key)}
-              <li class="statement" class:reached={statement.met} data-statement={statement.key}>
-                <span class="tick" aria-hidden="true">{statement.met ? "✓" : ""}</span>
-                <span class="statement-text">{statement.text}</span>
-              </li>
-            {/each}
-          </ul>
+          {#if uncountableStatement(goal)}
+            <p class="statement-text uncountable">{uncountableStatement(goal)}</p>
+          {:else}
+            <ul class="statements">
+              {#each statements as statement (statement.key)}
+                <li class="statement" class:reached={statement.met} data-statement={statement.key}>
+                  <span class="tick" aria-hidden="true">{statement.met ? "✓" : ""}</span>
+                  <span class="statement-text">{statement.text}</span>
+                </li>
+              {/each}
+            </ul>
+          {/if}
 
           {#if timeLeftStatement(goal.progress)}
             <p class="quiet days-left">{timeLeftStatement(goal.progress)}</p>
           {/if}
         {:else if !editing}
           <p class="statement-text no-goal">
-            No goal set for this week. {periodStatement(thisWeek?.facts)}.
+            No goal set for this week. {periodStatement(thisWeek?.facts, true)}.
           </p>
         {/if}
 
@@ -408,6 +456,19 @@
         </div>
       </section>
 
+      {#if nothingYet}
+        <!-- Nothing practised and nothing planned. Everything below this point
+             would be a statement of absence, and a page that opens with
+             fourteen of them is not a good greeting for somebody who has
+             simply not started yet. -->
+        <section class="nothing-yet">
+          <p class="statement-text">
+            Nothing logged yet. Open a score and start the practice timer, or log a stretch
+            of technique above — this page fills in as you go, and the weeks below it will
+            show what you did against what you meant to do.
+          </p>
+        </section>
+      {:else}
       <!-- ----------------------------------------------------- the review -->
       <section class="review">
         <div class="section-head">
@@ -420,18 +481,22 @@
             <li class="past-week" data-week={week.period_start}>
               <div class="week-head">
                 <span class="week-label">{periodLabel(week.period_start, week.period_end)}</span>
-                <span class="week-facts">{periodStatement(week.facts)}</span>
+                <span class="week-facts">{periodStatement(week.facts, false)}</span>
               </div>
 
               {#if week.goal}
-                <ul class="statements compact">
-                  {#each goalStatements(week.goal) as statement (statement.key)}
-                    <li class="statement" class:reached={statement.met}>
-                      <span class="tick" aria-hidden="true">{statement.met ? "✓" : ""}</span>
-                      <span class="statement-text">{statement.text}</span>
-                    </li>
-                  {/each}
-                </ul>
+                {#if uncountableStatement(week.goal)}
+                  <p class="statement-text uncountable">{uncountableStatement(week.goal)}</p>
+                {:else}
+                  <ul class="statements compact">
+                    {#each goalStatements(week.goal) as statement (statement.key)}
+                      <li class="statement" class:reached={statement.met}>
+                        <span class="tick" aria-hidden="true">{statement.met ? "✓" : ""}</span>
+                        <span class="statement-text">{statement.text}</span>
+                      </li>
+                    {/each}
+                  </ul>
+                {/if}
 
                 <div class="reflection">
                   <p class="question">Was this goal realistic?</p>
@@ -455,12 +520,22 @@
                     value={draft(week).reflection}
                     oninput={(e) => setDraft(week, { reflection: e.target.value })}
                   ></textarea>
-                  <button class="save-reflection" onclick={() => saveReflection(week)} disabled={saving}>
-                    Save
-                  </button>
+                  <div class="row">
+                    <button class="save-reflection" onclick={() => saveReflection(week)} disabled={saving}>
+                      Save
+                    </button>
+                    <button
+                      class="ghost remove-past-goal"
+                      onclick={() => removePastGoal(week)}
+                      disabled={saving}
+                      title="Forget this goal. The practice stays."
+                    >
+                      Remove goal
+                    </button>
+                  </div>
                 </div>
               {:else}
-                <p class="quiet no-goal">No goal was set for this week.</p>
+                <p class="quiet no-goal">No goal was set for these days.</p>
               {/if}
             </li>
           {/each}
@@ -475,7 +550,7 @@
         </div>
 
         <p class="statement-text totals">
-          {history?.days_practised ?? 0} days of practice, {formatDuration(history?.seconds)} in
+          {formatDays(history?.days_practised)} of practice, {formatDuration(history?.seconds)} in
           total.
         </p>
 
@@ -523,15 +598,15 @@
             {#each sessions as session (session.id)}
               <li class="session" data-session={session.id}>
                 <span class="session-day">{session.local_date}</span>
-                <span class="session-what">
+                <span class="session-what" class:orphaned={session.score_missing}>
                   {#if session.score_title}
                     <a href={"#/score/" + session.score_id}>{session.score_title}</a>
                   {:else}
-                    {activityLabel(session.activity)}
+                    {sessionSubject(session)}
                   {/if}
                 </span>
                 <span class="session-length">{formatDuration(session.seconds)}</span>
-                <span class="quiet session-detail">
+                <span class="quiet session-extra">
                   {[rangeLabel(session), tempoLabel(session), session.note]
                     .filter(Boolean)
                     .join(" · ")}
@@ -540,9 +615,10 @@
             {/each}
           </ul>
         {:else}
-          <p class="quiet">Nothing logged this week yet.</p>
+          <p class="quiet">Nothing logged in this period yet.</p>
         {/if}
       </section>
+      {/if}
     {/if}
   </main>
 </div>
@@ -665,6 +741,12 @@
     color: var(--brass-bright);
   }
 
+  /* Deliberately the colour it already inherits, which makes this rule a
+     no-op - and it is meant to be. It exists so that "what does a reached
+     target look like" has an answer in one place, and so that the answer is
+     recorded as "the same as an unreached one" rather than looking like an
+     oversight somebody should helpfully fill in with a green. The tick is the
+     whole difference, and it is additive. */
   .statement.reached .statement-text {
     color: var(--ink);
   }
@@ -884,6 +966,12 @@
     margin: 0 0 14px;
   }
 
+  .nothing-yet .statement-text {
+    color: var(--ink-dim);
+    max-width: 56ch;
+    line-height: 1.6;
+  }
+
   .session-list {
     list-style: none;
     padding: 0;
@@ -910,7 +998,23 @@
     font-variant-numeric: tabular-nums;
   }
 
-  .session-detail {
+  /* NOT .session-detail: that is the post-session panel in the viewer, and two
+     components sharing a class name meant a test looking for the panel matched
+     these rows instead - a locator that passed for the wrong reason. */
+  .session-extra {
     grid-column: 2 / -1;
+  }
+
+  /* Dimmer than a title because there is no piece to click through to, and
+     deliberately not otherwise different: this is practice that happened, not
+     a row with something wrong with it. */
+  .session-what.orphaned,
+  .uncountable {
+    color: var(--ink-dim);
+  }
+
+  .uncountable {
+    margin: 0 0 12px;
+    max-width: 52ch;
   }
 </style>

--- a/web/src/lib/Practice.svelte
+++ b/web/src/lib/Practice.svelte
@@ -1,0 +1,916 @@
+<script>
+  // Practice: the week you meant to have, and the weeks you have had.
+  //
+  // The whole design constraint of this page is in one sentence from the
+  // issue it comes from: "Three of four planned days" is the same information
+  // as "you missed a day", and only one of them makes a person want to open
+  // the app again tomorrow. So:
+  //
+  //   - Nothing on this page is styled as an error. A goal not reached uses
+  //     exactly the same colours, weight and order as one that was; the only
+  //     difference is a small mark beside the ones that were reached. There is
+  //     no --danger anywhere in this file, and a test checks for it.
+  //   - Nothing compares one week to another. No best week, no run of weeks,
+  //     no average. The per-day bars are scaled inside their own week for the
+  //     same reason.
+  //   - A finished week asks a question rather than reaching a verdict: was
+  //     this goal realistic? Only the person practising knows whether the week
+  //     was unusual, and that answer is the useful half of a review.
+  //   - Every zero is stated plainly. A day with no practice is a fact about
+  //     the week and is drawn as an empty bar, not as a gap and not in red.
+  import { api } from "./api.js";
+  import {
+    ACTIVITY_LABELS,
+    activityLabel,
+    dayBars,
+    formatDuration,
+    goalScopeLabel,
+    goalStatements,
+    localDay,
+    periodLabel,
+    periodStatement,
+    rangeLabel,
+    tempoLabel,
+    timeLeftStatement,
+  } from "./practice.js";
+
+  const REVIEW_WEEKS = 8;
+  const HISTORY_DAYS = 90;
+
+  // The browser's own date, not the server's. Read once per load: a page left
+  // open across midnight showing yesterday is a smaller problem than a page
+  // that recomputes the week under a half-finished form.
+  const today = localDay();
+
+  let current = $state(null);
+  let review = $state(null);
+  let history = $state(null);
+  let scores = $state([]);
+  let sessions = $state([]);
+  let loading = $state(true);
+  let error = $state("");
+
+  // The goal form, open either to set a first goal or to adjust one.
+  let editing = $state(false);
+  let form = $state(blankForm());
+  let saving = $state(false);
+
+  // Reflections in progress, keyed by goal id, so several past weeks can be
+  // written about without one box clobbering another.
+  let reflections = $state({});
+
+  // The "log other practice" form - how a session that is not against a piece
+  // gets recorded until the exercises that produce them exist.
+  let otherActivity = $state("technique");
+  let otherMinutes = $state(15);
+  let otherNote = $state("");
+  let logging = $state(false);
+
+  function blankForm() {
+    return {
+      id: null,
+      target_days: 4,
+      use_days: true,
+      target_minutes: 150,
+      use_minutes: true,
+      scope: "all",
+      score_id: null,
+      activity: "technique",
+      intent: "",
+    };
+  }
+
+  async function refresh() {
+    error = "";
+    try {
+      const [nextCurrent, nextReview, nextHistory, nextScores] = await Promise.all([
+        api.currentGoal(today),
+        api.practiceReview(REVIEW_WEEKS, today),
+        api.practiceHistory(HISTORY_DAYS, today),
+        api.scores(),
+      ]);
+      current = nextCurrent;
+      review = nextReview;
+      history = nextHistory;
+      scores = nextScores;
+      // Sent after the first call, because the week to ask for comes back from
+      // it - the server decides which seven days "this week" is, from the
+      // week-start preference, and asking for a week the client worked out
+      // itself is how the two quietly disagree.
+      sessions = (
+        await api.sessions({ start: nextCurrent.week_start, end: nextCurrent.week_end })
+      ).sessions;
+    } catch (e) {
+      error = e?.message ?? "Could not load your practice record.";
+    } finally {
+      loading = false;
+    }
+  }
+
+  $effect(() => {
+    refresh();
+  });
+
+  let goal = $derived(current?.goal ?? null);
+  let statements = $derived(goalStatements(goal));
+  // The review's first entry is always the week containing today, which is
+  // where a week with no goal gets its facts from.
+  let thisWeek = $derived(review?.weeks?.[0] ?? null);
+  let pastWeeks = $derived((review?.weeks ?? []).slice(1));
+  // A scoped goal's own days when there is one, so the strip shows the
+  // practice the goal is actually counted against; the week's whole practice
+  // otherwise.
+  let weekBars = $derived(dayBars(goal ? goal.progress.days : (thisWeek?.facts?.days ?? [])));
+
+  function startEditing() {
+    form = goal
+      ? {
+          id: goal.id,
+          target_days: goal.target_days ?? 4,
+          use_days: goal.target_days != null,
+          target_minutes: goal.target_minutes ?? 150,
+          use_minutes: goal.target_minutes != null,
+          scope: goal.scope,
+          score_id: goal.score_id,
+          activity: goal.activity ?? "technique",
+          intent: goal.intent ?? "",
+        }
+      : blankForm();
+    editing = true;
+  }
+
+  async function saveGoal() {
+    if (!form.use_days && !form.use_minutes) {
+      error = "Choose a number of days, an amount of time, or both.";
+      return;
+    }
+    saving = true;
+    error = "";
+    try {
+      // POST rather than PATCH even when adjusting: setting a goal for a week
+      // that already has one replaces its targets, so there is one code path
+      // and no way to end up with two goals for one week.
+      await api.setGoal(
+        {
+          period_start: current?.week_start,
+          target_days: form.use_days ? Number(form.target_days) : null,
+          target_minutes: form.use_minutes ? Number(form.target_minutes) : null,
+          scope: form.scope,
+          score_id: form.scope === "score" ? Number(form.score_id) || null : null,
+          activity: form.scope === "activity" ? form.activity : null,
+          intent: form.intent.trim() || null,
+        },
+        today,
+      );
+      editing = false;
+      await refresh();
+    } catch (e) {
+      error = e?.message ?? "Could not save that goal.";
+    } finally {
+      saving = false;
+    }
+  }
+
+  async function removeGoal() {
+    if (!goal) return;
+    saving = true;
+    try {
+      await api.deleteGoal(goal.id);
+      editing = false;
+      await refresh();
+    } catch (e) {
+      error = e?.message ?? "Could not remove that goal.";
+    } finally {
+      saving = false;
+    }
+  }
+
+  function draft(week) {
+    const g = week.goal;
+    return (
+      reflections[g.id] ?? {
+        realistic: g.realistic ?? "",
+        reflection: g.reflection ?? "",
+      }
+    );
+  }
+
+  function setDraft(week, patch) {
+    reflections = { ...reflections, [week.goal.id]: { ...draft(week), ...patch } };
+  }
+
+  async function saveReflection(week) {
+    const d = draft(week);
+    saving = true;
+    error = "";
+    try {
+      await api.patchGoal(
+        week.goal.id,
+        { realistic: d.realistic || null, reflection: d.reflection.trim() || null },
+        today,
+      );
+      await refresh();
+    } catch (e) {
+      error = e?.message ?? "Could not save that.";
+    } finally {
+      saving = false;
+    }
+  }
+
+  async function logOther() {
+    logging = true;
+    error = "";
+    try {
+      await api.logSession({
+        activity: otherActivity,
+        seconds: Math.round(Number(otherMinutes) * 60),
+        local_date: today,
+        note: otherNote.trim() || null,
+      });
+      otherNote = "";
+      await refresh();
+    } catch (e) {
+      error = e?.message ?? "Could not log that.";
+    } finally {
+      logging = false;
+    }
+  }
+</script>
+
+<div class="practice">
+  <header>
+    <a class="back" href="#/">← Library</a>
+    <h1>Practice</h1>
+  </header>
+
+  <main>
+    {#if error}
+      <p class="notice" role="status">{error}</p>
+    {/if}
+
+    {#if loading}
+      <p class="quiet">Loading…</p>
+    {:else}
+      <!-- ------------------------------------------------ this week -->
+      <section class="week" data-week={current?.week_start}>
+        <div class="section-head">
+          <h2>This week</h2>
+          <span class="quiet">{periodLabel(current?.week_start, current?.week_end)}</span>
+        </div>
+
+        {#if goal && !editing}
+          <p class="intent">
+            <span class="scope">{goalScopeLabel(goal)}</span>
+            {#if goal.intent}<span class="intent-text">— {goal.intent}</span>{/if}
+          </p>
+
+          <ul class="statements">
+            {#each statements as statement (statement.key)}
+              <li class="statement" class:reached={statement.met} data-statement={statement.key}>
+                <span class="tick" aria-hidden="true">{statement.met ? "✓" : ""}</span>
+                <span class="statement-text">{statement.text}</span>
+              </li>
+            {/each}
+          </ul>
+
+          {#if timeLeftStatement(goal.progress)}
+            <p class="quiet days-left">{timeLeftStatement(goal.progress)}</p>
+          {/if}
+        {:else if !editing}
+          <p class="statement-text no-goal">
+            No goal set for this week. {periodStatement(thisWeek?.facts)}.
+          </p>
+        {/if}
+
+        <div class="strip" aria-label="practice each day this week">
+          {#each weekBars as bar (bar.date)}
+            <div class="day" data-day={bar.date} data-seconds={bar.seconds}>
+              <div class="bar-track">
+                <div class="bar" style={`height:${Math.round(bar.fill * 100)}%`}></div>
+              </div>
+              <span class="day-label">{bar.label}</span>
+              <span class="day-value">{bar.seconds ? formatDuration(bar.seconds) : "—"}</span>
+            </div>
+          {/each}
+        </div>
+
+        {#if editing}
+          <div class="goal-form">
+            <h3>{form.id ? "Adjust this week's goal" : "Set a goal for this week"}</h3>
+
+            <label class="row">
+              <input type="checkbox" bind:checked={form.use_days} />
+              <span>Days of practice</span>
+              <select bind:value={form.target_days} disabled={!form.use_days} class="days-target">
+                {#each [1, 2, 3, 4, 5, 6, 7] as n}
+                  <option value={n}>{n}</option>
+                {/each}
+              </select>
+            </label>
+
+            <label class="row">
+              <input type="checkbox" bind:checked={form.use_minutes} />
+              <span>Minutes in total</span>
+              <input
+                class="minutes-target"
+                type="number"
+                min="1"
+                max="10080"
+                bind:value={form.target_minutes}
+                disabled={!form.use_minutes}
+              />
+            </label>
+
+            <label class="row">
+              <span>On</span>
+              <select bind:value={form.scope} class="scope-select">
+                <option value="all">any practice</option>
+                <option value="score">one piece</option>
+                <option value="activity">a kind of work</option>
+              </select>
+              {#if form.scope === "score"}
+                <select bind:value={form.score_id} class="score-select">
+                  <option value={null}>choose a piece…</option>
+                  {#each scores as s (s.id)}
+                    <option value={s.id}>{s.title}</option>
+                  {/each}
+                </select>
+              {:else if form.scope === "activity"}
+                <select bind:value={form.activity} class="activity-select">
+                  {#each Object.entries(ACTIVITY_LABELS) as [value, label]}
+                    <option {value}>{label}</option>
+                  {/each}
+                </select>
+              {/if}
+            </label>
+
+            <label class="row wide">
+              <span>What you mean to work on</span>
+              <input
+                class="intent-input"
+                type="text"
+                maxlength="200"
+                placeholder="the awkward middle section"
+                bind:value={form.intent}
+              />
+            </label>
+
+            <div class="actions">
+              <button class="primary save-goal" onclick={saveGoal} disabled={saving}>
+                {saving ? "Saving…" : "Save goal"}
+              </button>
+              <button onclick={() => (editing = false)} disabled={saving}>Cancel</button>
+              {#if form.id}
+                <button class="ghost remove-goal" onclick={removeGoal} disabled={saving}>
+                  Remove
+                </button>
+              {/if}
+            </div>
+          </div>
+        {:else}
+          <div class="actions">
+            <button class="primary edit-goal" onclick={startEditing}>
+              {goal ? "Adjust this goal" : "Set a goal for this week"}
+            </button>
+          </div>
+        {/if}
+      </section>
+
+      <!-- --------------------------------------------- log other practice -->
+      <section class="log-other">
+        <div class="section-head">
+          <h2>Log practice that is not a piece</h2>
+        </div>
+        <p class="hint">
+          Technique, ear training, or simply playing. Practice at a score is timed in the
+          viewer; this is for everything else.
+        </p>
+        <div class="row">
+          <select bind:value={otherActivity} class="other-activity">
+            {#each Object.entries(ACTIVITY_LABELS) as [value, label]}
+              {#if value !== "piece"}
+                <option {value}>{label}</option>
+              {/if}
+            {/each}
+          </select>
+          <input class="other-minutes" type="number" min="1" max="1440" bind:value={otherMinutes} />
+          <span class="quiet">minutes</span>
+          <input
+            class="other-note"
+            type="text"
+            maxlength="2000"
+            placeholder="note (optional)"
+            bind:value={otherNote}
+          />
+          <button class="log-other-button" onclick={logOther} disabled={logging}>
+            {logging ? "Saving…" : "Log it"}
+          </button>
+        </div>
+      </section>
+
+      <!-- ----------------------------------------------------- the review -->
+      <section class="review">
+        <div class="section-head">
+          <h2>Recent weeks</h2>
+          <span class="quiet">what happened, and room to say why</span>
+        </div>
+
+        <ul class="weeks">
+          {#each pastWeeks as week (week.period_start)}
+            <li class="past-week" data-week={week.period_start}>
+              <div class="week-head">
+                <span class="week-label">{periodLabel(week.period_start, week.period_end)}</span>
+                <span class="week-facts">{periodStatement(week.facts)}</span>
+              </div>
+
+              {#if week.goal}
+                <ul class="statements compact">
+                  {#each goalStatements(week.goal) as statement (statement.key)}
+                    <li class="statement" class:reached={statement.met}>
+                      <span class="tick" aria-hidden="true">{statement.met ? "✓" : ""}</span>
+                      <span class="statement-text">{statement.text}</span>
+                    </li>
+                  {/each}
+                </ul>
+
+                <div class="reflection">
+                  <p class="question">Was this goal realistic?</p>
+                  <div class="row">
+                    {#each ["yes", "no"] as answer}
+                      <button
+                        class="answer"
+                        class:on={draft(week).realistic === answer}
+                        data-answer={answer}
+                        onclick={() => setDraft(week, { realistic: answer })}
+                      >
+                        {answer === "yes" ? "Yes" : "Not for this week"}
+                      </button>
+                    {/each}
+                  </div>
+                  <textarea
+                    class="reflection-text"
+                    rows="2"
+                    maxlength="2000"
+                    placeholder="anything worth remembering about this week"
+                    value={draft(week).reflection}
+                    oninput={(e) => setDraft(week, { reflection: e.target.value })}
+                  ></textarea>
+                  <button class="save-reflection" onclick={() => saveReflection(week)} disabled={saving}>
+                    Save
+                  </button>
+                </div>
+              {:else}
+                <p class="quiet no-goal">No goal was set for this week.</p>
+              {/if}
+            </li>
+          {/each}
+        </ul>
+      </section>
+
+      <!-- --------------------------------------------- where the time went -->
+      <section class="where">
+        <div class="section-head">
+          <h2>Where the time went</h2>
+          <span class="quiet">the last {HISTORY_DAYS} days</span>
+        </div>
+
+        <p class="statement-text totals">
+          {history?.days_practised ?? 0} days of practice, {formatDuration(history?.seconds)} in
+          total.
+        </p>
+
+        <div class="columns">
+          <div>
+            <h3>By piece</h3>
+            {#if history?.by_score?.length}
+              <ul class="spent by-score">
+                {#each history.by_score as row (row.score_id)}
+                  <li>
+                    <a href={"#/score/" + row.score_id}>{row.title}</a>
+                    <span class="quiet">{formatDuration(row.seconds)}</span>
+                  </li>
+                {/each}
+              </ul>
+            {:else}
+              <p class="quiet">No practice against a piece in this window.</p>
+            {/if}
+          </div>
+          <div>
+            <h3>By kind of work</h3>
+            {#if history?.by_activity?.length}
+              <ul class="spent by-activity">
+                {#each history.by_activity as row (row.activity)}
+                  <li>
+                    <span>{activityLabel(row.activity)}</span>
+                    <span class="quiet">{formatDuration(row.seconds)}</span>
+                  </li>
+                {/each}
+              </ul>
+            {:else}
+              <p class="quiet">Nothing recorded in this window.</p>
+            {/if}
+          </div>
+        </div>
+      </section>
+
+      <!-- ------------------------------------------------- this week's work -->
+      <section class="sessions">
+        <div class="section-head">
+          <h2>This week, session by session</h2>
+        </div>
+        {#if sessions.length}
+          <ul class="session-list">
+            {#each sessions as session (session.id)}
+              <li class="session" data-session={session.id}>
+                <span class="session-day">{session.local_date}</span>
+                <span class="session-what">
+                  {#if session.score_title}
+                    <a href={"#/score/" + session.score_id}>{session.score_title}</a>
+                  {:else}
+                    {activityLabel(session.activity)}
+                  {/if}
+                </span>
+                <span class="session-length">{formatDuration(session.seconds)}</span>
+                <span class="quiet session-detail">
+                  {[rangeLabel(session), tempoLabel(session), session.note]
+                    .filter(Boolean)
+                    .join(" · ")}
+                </span>
+              </li>
+            {/each}
+          </ul>
+        {:else}
+          <p class="quiet">Nothing logged this week yet.</p>
+        {/if}
+      </section>
+    {/if}
+  </main>
+</div>
+
+<style>
+  .practice {
+    height: 100vh;
+    display: flex;
+    flex-direction: column;
+  }
+
+  header {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    padding: 10px 16px;
+    border-bottom: 1px solid var(--line);
+    background: var(--bg-raised);
+  }
+
+  .back {
+    color: var(--ink-dim);
+    white-space: nowrap;
+  }
+
+  .back:hover {
+    color: var(--brass-bright);
+  }
+
+  header h1 {
+    font-size: 18px;
+  }
+
+  main {
+    flex: 1;
+    overflow-y: auto;
+    padding: 28px;
+    display: flex;
+    flex-direction: column;
+    gap: 34px;
+    max-width: 760px;
+  }
+
+  .section-head {
+    display: flex;
+    align-items: baseline;
+    gap: 12px;
+    margin-bottom: 12px;
+  }
+
+  h2 {
+    font-size: 16px;
+  }
+
+  h3 {
+    font-size: 13px;
+    color: var(--ink-dim);
+    margin-bottom: 6px;
+  }
+
+  .quiet {
+    color: var(--ink-dim);
+    font-size: 13px;
+  }
+
+  .hint {
+    color: var(--ink-dim);
+    font-size: 13px;
+    margin: 0 0 12px;
+  }
+
+  /* Deliberately NOT var(--danger). Nothing on this page is an error - a
+     message here is something that did not save, or an amount that needs
+     choosing, and it reads as information rather than as a fault. */
+  .notice {
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-left: 3px solid var(--brass);
+    border-radius: 6px;
+    padding: 10px 14px;
+    margin: 0;
+    font-size: 14px;
+  }
+
+  .intent {
+    margin: 0 0 10px;
+    font-size: 14px;
+  }
+
+  .scope {
+    color: var(--brass-bright);
+  }
+
+  .intent-text {
+    color: var(--ink-dim);
+  }
+
+  .statements {
+    list-style: none;
+    padding: 0;
+    margin: 0 0 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+  }
+
+  /* One style for every statement, reached or not. A target that was not
+     reached is not an error condition and is not coloured like one; the tick
+     column is the only difference, and it is additive - something appears when
+     a target IS met, rather than something being marked when it is not. */
+  .statement {
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+    font-size: 15px;
+  }
+
+  .statement .tick {
+    width: 1em;
+    color: var(--brass-bright);
+  }
+
+  .statement.reached .statement-text {
+    color: var(--ink);
+  }
+
+  .statement-text {
+    font-variant-numeric: tabular-nums;
+  }
+
+  .statements.compact .statement {
+    font-size: 14px;
+  }
+
+  .days-left {
+    margin: 0 0 12px;
+  }
+
+  .no-goal {
+    color: var(--ink-dim);
+  }
+
+  .strip {
+    display: grid;
+    grid-template-columns: repeat(7, 1fr);
+    gap: 8px;
+    margin: 14px 0 18px;
+  }
+
+  .day {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 4px;
+  }
+
+  .bar-track {
+    width: 100%;
+    height: 64px;
+    display: flex;
+    align-items: flex-end;
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: 5px;
+    overflow: hidden;
+  }
+
+  .bar {
+    width: 100%;
+    background: var(--brass);
+    border-radius: 4px 4px 0 0;
+  }
+
+  .day-label {
+    font-size: 11px;
+    color: var(--ink-dim);
+  }
+
+  .day-value {
+    font-size: 11px;
+    color: var(--ink-dim);
+    font-variant-numeric: tabular-nums;
+  }
+
+  .goal-form {
+    background: var(--bg-raised);
+    border: 1px solid var(--line);
+    border-radius: var(--radius);
+    padding: 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  .goal-form h3 {
+    color: var(--ink);
+    font-family: var(--font-display);
+    font-size: 15px;
+  }
+
+  .row {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    flex-wrap: wrap;
+    font-size: 14px;
+  }
+
+  .row.wide {
+    align-items: stretch;
+    flex-direction: column;
+    gap: 5px;
+  }
+
+  .intent-input,
+  .other-note {
+    flex: 1;
+    min-width: 180px;
+  }
+
+  .minutes-target,
+  .other-minutes {
+    width: 90px;
+  }
+
+  .actions {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+    flex-wrap: wrap;
+  }
+
+  .primary {
+    background: var(--brass);
+    border-color: var(--brass);
+    color: #241d0f;
+  }
+
+  .ghost {
+    background: none;
+    border-color: transparent;
+    color: var(--ink-dim);
+  }
+
+  .ghost:hover {
+    border-color: var(--line);
+    color: var(--ink);
+  }
+
+  .weeks {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+  }
+
+  .past-week {
+    background: var(--bg-raised);
+    border: 1px solid var(--line);
+    border-radius: var(--radius);
+    padding: 14px 16px;
+  }
+
+  .week-head {
+    display: flex;
+    justify-content: space-between;
+    gap: 12px;
+    margin-bottom: 8px;
+  }
+
+  .week-label {
+    font-family: var(--font-display);
+    font-size: 15px;
+  }
+
+  .week-facts {
+    color: var(--ink-dim);
+    font-size: 13px;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .reflection {
+    margin-top: 10px;
+    padding-top: 10px;
+    border-top: 1px solid var(--line);
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    align-items: flex-start;
+  }
+
+  .question {
+    margin: 0;
+    font-size: 14px;
+    color: var(--ink);
+  }
+
+  .answer.on {
+    border-color: var(--brass);
+    color: var(--brass-bright);
+  }
+
+  .reflection-text {
+    width: 100%;
+    resize: vertical;
+    font: inherit;
+    background: var(--surface);
+    color: var(--ink);
+    border: 1px solid var(--line);
+    border-radius: 6px;
+    padding: 8px 10px;
+  }
+
+  .columns {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 24px;
+  }
+
+  .spent {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    font-size: 14px;
+  }
+
+  .spent li {
+    display: flex;
+    justify-content: space-between;
+    gap: 12px;
+  }
+
+  .totals {
+    margin: 0 0 14px;
+  }
+
+  .session-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    font-size: 14px;
+  }
+
+  .session {
+    display: grid;
+    grid-template-columns: 92px 1fr 70px;
+    gap: 10px;
+    align-items: baseline;
+    padding-bottom: 6px;
+    border-bottom: 1px solid var(--line);
+  }
+
+  .session-day,
+  .session-length {
+    color: var(--ink-dim);
+    font-size: 13px;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .session-detail {
+    grid-column: 2 / -1;
+  }
+</style>

--- a/web/src/lib/Settings.svelte
+++ b/web/src/lib/Settings.svelte
@@ -6,6 +6,8 @@
     STAFF_THEMES,
     STAFF_THEME_LABELS,
     STAFF_THEME_TOKEN_PREFIX,
+    WEEK_STARTS,
+    WEEK_START_LABELS,
   } from "./settings.svelte.js";
 
   const settings = getSettings();
@@ -17,6 +19,21 @@
   // silently doing nothing.
   let pending = $state(null);
   let error = $state("");
+
+  let weekPending = $state(false);
+
+  async function chooseWeekStart(day) {
+    if (day === settings.week_starts_on || weekPending) return;
+    weekPending = true;
+    error = "";
+    try {
+      await setSetting("week_starts_on", day);
+    } catch (e) {
+      error = e?.message ?? "Could not save that.";
+    } finally {
+      weekPending = false;
+    }
+  }
 
   async function chooseTheme(theme) {
     if (theme === settings.staff_theme || pending) return;
@@ -72,6 +89,30 @@
       {#if error}
         <p class="error">{error}</p>
       {/if}
+    </section>
+
+    <section class="week-start">
+      <h2>A week starts on</h2>
+      <p class="hint">
+        Which seven days a practice goal is counted over. Changing this decides the week a
+        <em>new</em> goal is for; a goal already set keeps the dates it was set for.
+      </p>
+      <div class="row">
+        {#each WEEK_STARTS as day}
+          <button
+            class="week-option"
+            class:on={settings.week_starts_on === day}
+            data-week-start={day}
+            disabled={weekPending}
+            onclick={() => chooseWeekStart(day)}
+          >
+            {WEEK_START_LABELS[day]}
+          </button>
+        {/each}
+      </div>
+      <p class="hint goals-link">
+        <a href="#/practice">Practice &amp; goals →</a>
+      </p>
     </section>
 
     <Instruments />
@@ -159,6 +200,21 @@
 
   .theme-card.saving {
     opacity: 0.6;
+  }
+
+  .row {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+  }
+
+  .week-option.on {
+    border-color: var(--brass);
+    color: var(--brass-bright);
+  }
+
+  .goals-link {
+    margin: 14px 0 0;
   }
 
   .theme-card:disabled {

--- a/web/src/lib/Viewer.svelte
+++ b/web/src/lib/Viewer.svelte
@@ -151,9 +151,20 @@
   let detail = $state(null);
   let savingDetail = $state(false);
   let detailError = $state("");
+  // A session the server would not take. Shown until dismissed, because the
+  // alternative is a stopwatch that ran and a record that does not mention it.
+  let practiceError = $state("");
 
   function blankDetail() {
-    return { rating: null, mode: "", from_bar: "", to_bar: "", tempo_bpm: "", note: "" };
+    return {
+      rating: null,
+      mode: "",
+      from_bar: "",
+      to_bar: "",
+      tempo_bpm: "",
+      target_tempo_bpm: "",
+      note: "",
+    };
   }
 
   const RATING_LABELS = {
@@ -164,20 +175,37 @@
     5: "as I want it",
   };
 
-  /** Today in the BROWSER's timezone, which is the day the practice actually
-   * happened on. The server stores UTC timestamps, and west of Greenwich the
-   * UTC date of an evening session is already tomorrow - so a goal counting
-   * days would put it in the wrong one, and at a week boundary in the wrong
-   * week. Sent explicitly rather than inferred there. */
-  function practiceDay() {
-    const now = new Date();
+  /** The day a session is filed under: the BROWSER's calendar day at the
+   * moment the timer STARTED.
+   *
+   * The start and not the stop. A session from 23:40 to 00:20 is practice done
+   * on the earlier day - that is when they sat down - and taking the day from
+   * the clock at flush time filed the whole thing on the following one, which
+   * at a week boundary counted it towards the next week's goal rather than the
+   * one it was practised for. This is the single field the entire feature
+   * counts, so which day it picks is chosen rather than incidental.
+   *
+   * Local and not UTC for the same reason: the server stores UTC timestamps,
+   * and west of Greenwich the UTC date of an evening session is already
+   * tomorrow. */
+  function practiceDay(startedAt) {
+    const when = new Date(startedAt ?? Date.now());
     const pad = (n) => String(n).padStart(2, "0");
-    return `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}`;
+    return `${when.getFullYear()}-${pad(when.getMonth() + 1)}-${pad(when.getDate())}`;
   }
 
   function numberOrNull(value) {
+    // An empty field means UNSET, and never zero. Svelte's bind:value on a
+    // number input hands back null when the box is cleared, and Number(null)
+    // is 0 - so clearing a tempo sent 0, which the server refuses, and the
+    // whole save failed with a message about a field the person had just
+    // emptied. Same shape of bug as the reference-pitch one in the instruments
+    // editor, and the same rule fixes it.
+    if (value === "" || value == null) return null;
     const n = Number(value);
-    return value === "" || Number.isNaN(n) ? null : n;
+    // Rounded, because the server takes whole numbers and nothing that merely
+    // converts to one - a number input hands back "76.5" if it is typed.
+    return Number.isNaN(n) ? null : Math.round(n);
   }
 
   async function saveDetail() {
@@ -191,6 +219,7 @@
         from_bar: numberOrNull(detail.from_bar),
         to_bar: numberOrNull(detail.to_bar),
         tempo_bpm: numberOrNull(detail.tempo_bpm),
+        target_tempo_bpm: numberOrNull(detail.target_tempo_bpm),
         note: detail.note.trim() || null,
       });
       lastSession = null;
@@ -232,44 +261,98 @@
   // away off-screen - the gig HUDs in both viewers surface this
   let practiceLabel = $derived(practiceStart != null ? formatElapsed(practiceElapsed) : null);
 
-  function flushPractice() {
+  /** Store a stopped session.
+   *
+   * `leaving` is true when the page itself is going away. A normal fetch is
+   * routinely CANCELLED by the browser once a page starts unloading, which
+   * would silently drop the session - and this is the write path for the data
+   * every goal is counted from, so losing one is losing part of somebody's
+   * record. sendBeacon exists for exactly this: the browser takes ownership of
+   * the request and completes it after the page is gone. Nothing can be read
+   * back from it, so the detail panel is not offered in that case; the session
+   * is stored either way, which is the part that matters.
+   */
+  function storePractice(scoreId, body, leaving) {
+    const url = `/api/scores/${scoreId}/practice`;
+    if (leaving && navigator.sendBeacon) {
+      navigator.sendBeacon(url, new Blob([JSON.stringify(body)], { type: "application/json" }));
+      return;
+    }
+    api
+      .logPractice(scoreId, body)
+      .then((result) => {
+        // Only offer the detail panel for the score still on screen. A flush
+        // triggered by navigating to another score has nowhere to show one,
+        // and the session is already stored either way.
+        if (result?.session && score?.id === scoreId) {
+          lastSession = result.session;
+          detail = blankDetail();
+        }
+      })
+      .catch((e) => {
+        // Said out loud rather than swallowed. A timer that appears to stop and
+        // stores nothing is the worst failure this feature has, because nothing
+        // else in the app would ever show the gap.
+        practiceError =
+          `That session (${formatDuration(body.seconds)}) could not be saved: ` +
+          `${e?.message ?? "the server did not answer"}.`;
+      });
+  }
+
+  /** Stop the timer and store what it measured.
+   *
+   * `leaving` says the page itself is going away, which changes HOW the write
+   * is sent - see storePractice. Every caller therefore has to pass it
+   * deliberately: wired straight to an onclick, the DOM event arrives here as
+   * the first argument and every ordinary stop took the page-unload path,
+   * which cannot read the response back and so never offered the detail panel.
+   */
+  function flushPractice(leaving = false) {
     if (practiceStart == null) return;
-    const seconds = Math.floor((Date.now() - practiceStart) / 1000);
+    const startedAt = practiceStart;
+    const seconds = Math.floor((Date.now() - startedAt) / 1000);
     const scoreId = practiceScoreId;
     clearInterval(practiceInterval);
     practiceStart = null;
     practiceElapsed = 0;
     practiceScoreId = null;
     if (seconds >= PRACTICE_MIN_SECONDS && scoreId != null) {
-      api
-        .logPractice(scoreId, {
-          seconds,
-          activity: "piece",
-          local_date: practiceDay(),
-        })
-        .then((result) => {
-          // Only offer the detail panel for the score still on screen. A flush
-          // triggered by navigating away has nowhere to show one, and the
-          // session is already safely stored either way.
-          if (result?.session && score?.id === scoreId) {
-            lastSession = result.session;
-            detail = blankDetail();
-          }
-        })
-        .catch(() => {});
+      practiceError = "";
+      storePractice(
+        scoreId,
+        { seconds, activity: "piece", local_date: practiceDay(startedAt) },
+        leaving,
+      );
     }
   }
 
   // Flushes on switching to a different score too: the route swaps `id` on
   // this same component instance rather than remounting it.
+  //
+  // The detail panel is dismissed at the same time, and that is a correctness
+  // fix rather than tidying: it survived the navigation, so a rating or a note
+  // typed into it afterwards was PATCHed onto the previous score's session -
+  // writing an opinion against practice that did not happen. The session it
+  // belonged to is already stored; only the offer to say more about it ends.
   $effect(() => {
     void id;
-    return () => flushPractice();
+    return () => {
+      flushPractice();
+      dismissDetail();
+    };
   });
 
   $effect(() => {
-    window.addEventListener("beforeunload", flushPractice);
-    return () => window.removeEventListener("beforeunload", flushPractice);
+    const onLeave = () => flushPractice(true);
+    window.addEventListener("beforeunload", onLeave);
+    // pagehide as well as beforeunload: a mobile browser backgrounding a tab
+    // fires only this one, and a timer left running on a phone is an ordinary
+    // way for a session to end.
+    window.addEventListener("pagehide", onLeave);
+    return () => {
+      window.removeEventListener("beforeunload", onLeave);
+      window.removeEventListener("pagehide", onLeave);
+    };
   });
 
   async function setKind(ev) {
@@ -334,7 +417,7 @@
           <button
             class="ghost timer"
             class:on={practiceStart != null}
-            onclick={practiceStart != null ? flushPractice : startPractice}
+            onclick={() => (practiceStart != null ? flushPractice() : startPractice())}
             title={practiceStart != null ? "Stop practice timer" : "Start practice timer"}
           >
             {practiceStart != null ? `■ ${formatElapsed(practiceElapsed)}` : "▶ Practice"}
@@ -346,6 +429,13 @@
         </div>
       {/if}
     </header>
+  {/if}
+
+  {#if practiceError && !gigMode}
+    <p class="practice-error" role="status">
+      {practiceError}
+      <button class="ghost" onclick={() => (practiceError = "")}>Dismiss</button>
+    </p>
   {/if}
 
   {#if lastSession && detail && !gigMode}
@@ -389,6 +479,15 @@
         <input class="detail-bar" type="number" min="1" placeholder="to" bind:value={detail.to_bar} />
         <span class="detail-label">tempo</span>
         <input class="detail-tempo" type="number" min="20" max="400" placeholder="bpm" bind:value={detail.tempo_bpm} />
+        <span class="detail-label">aiming at</span>
+        <input
+          class="detail-target-tempo"
+          type="number"
+          min="20"
+          max="400"
+          placeholder="bpm"
+          bind:value={detail.target_tempo_bpm}
+        />
       </div>
 
       <div class="detail-row">
@@ -416,9 +515,9 @@
     <TabViewer demo={true} {gigMode} onToggleGig={toggleGigMode} />
   {:else if score}
     {#if score.file_type === "pdf"}
-      <ScoreCompare {score} {gigMode} onToggleGig={toggleGigMode} {practiceLabel} onStopPractice={flushPractice} />
+      <ScoreCompare {score} {gigMode} onToggleGig={toggleGigMode} {practiceLabel} onStopPractice={() => flushPractice()} />
     {:else}
-      <TabViewer {score} {gigMode} onToggleGig={toggleGigMode} {practiceLabel} onStopPractice={flushPractice} />
+      <TabViewer {score} {gigMode} onToggleGig={toggleGigMode} {practiceLabel} onStopPractice={() => flushPractice()} />
     {/if}
   {/if}
 </div>
@@ -554,8 +653,23 @@
   }
 
   .detail-bar,
-  .detail-tempo {
+  .detail-tempo,
+  .detail-target-tempo {
     width: 76px;
+  }
+
+  /* This one IS a failure - a session that did not save - so unlike anything on
+     the practice page it is allowed to look like one. */
+  .practice-error {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin: 0;
+    padding: 8px 16px;
+    font-size: 14px;
+    color: var(--danger);
+    border-bottom: 1px solid var(--line);
+    background: var(--bg-raised);
   }
 
   .detail-note {

--- a/web/src/lib/Viewer.svelte
+++ b/web/src/lib/Viewer.svelte
@@ -1,5 +1,6 @@
 <script>
   import { api } from "./api.js";
+  import { formatDuration } from "./practice.js";
   import PdfViewer from "./PdfViewer.svelte";
   import TabViewer from "./TabViewer.svelte";
   import ScoreCompare from "./ScoreCompare.svelte";
@@ -141,6 +142,75 @@
   let practiceInterval;
   let practiceScoreId = null;
 
+  // The session just logged, if it is still worth adding detail to. The length
+  // is stored the moment the timer stops - see flushPractice - and this panel
+  // patches that stored row afterwards. That order matters: a form standing
+  // between a player and a stopped clock is a form that loses sessions, and a
+  // session abandoned at the form would be a session that never happened.
+  let lastSession = $state(null);
+  let detail = $state(null);
+  let savingDetail = $state(false);
+  let detailError = $state("");
+
+  function blankDetail() {
+    return { rating: null, mode: "", from_bar: "", to_bar: "", tempo_bpm: "", note: "" };
+  }
+
+  const RATING_LABELS = {
+    1: "rough",
+    2: "getting there",
+    3: "steady",
+    4: "solid",
+    5: "as I want it",
+  };
+
+  /** Today in the BROWSER's timezone, which is the day the practice actually
+   * happened on. The server stores UTC timestamps, and west of Greenwich the
+   * UTC date of an evening session is already tomorrow - so a goal counting
+   * days would put it in the wrong one, and at a week boundary in the wrong
+   * week. Sent explicitly rather than inferred there. */
+  function practiceDay() {
+    const now = new Date();
+    const pad = (n) => String(n).padStart(2, "0");
+    return `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}`;
+  }
+
+  function numberOrNull(value) {
+    const n = Number(value);
+    return value === "" || Number.isNaN(n) ? null : n;
+  }
+
+  async function saveDetail() {
+    if (!lastSession) return;
+    savingDetail = true;
+    detailError = "";
+    try {
+      await api.patchSession(lastSession.id, {
+        rating: detail.rating,
+        mode: detail.mode || null,
+        from_bar: numberOrNull(detail.from_bar),
+        to_bar: numberOrNull(detail.to_bar),
+        tempo_bpm: numberOrNull(detail.tempo_bpm),
+        note: detail.note.trim() || null,
+      });
+      lastSession = null;
+      detail = null;
+    } catch (e) {
+      detailError = e?.message ?? "Could not save that.";
+    } finally {
+      savingDetail = false;
+    }
+  }
+
+  function dismissDetail() {
+    // The session itself stays. Closing this only declines to say more about
+    // it, which is the ordinary case and must never read as losing the
+    // practice.
+    lastSession = null;
+    detail = null;
+    detailError = "";
+  }
+
   function formatElapsed(sec) {
     const m = Math.floor(sec / 60);
     const s = sec % 60;
@@ -171,7 +241,22 @@
     practiceElapsed = 0;
     practiceScoreId = null;
     if (seconds >= PRACTICE_MIN_SECONDS && scoreId != null) {
-      api.logPractice(scoreId, { seconds }).catch(() => {});
+      api
+        .logPractice(scoreId, {
+          seconds,
+          activity: "piece",
+          local_date: practiceDay(),
+        })
+        .then((result) => {
+          // Only offer the detail panel for the score still on screen. A flush
+          // triggered by navigating away has nowhere to show one, and the
+          // session is already safely stored either way.
+          if (result?.session && score?.id === scoreId) {
+            lastSession = result.session;
+            detail = blankDetail();
+          }
+        })
+        .catch(() => {});
     }
   }
 
@@ -261,6 +346,68 @@
         </div>
       {/if}
     </header>
+  {/if}
+
+  {#if lastSession && detail && !gigMode}
+    <!-- What that session was, in the player's own words. Every field is
+         optional and closing the panel keeps the session exactly as logged -
+         this asks for detail, it does not require it. -->
+    <section class="session-detail" data-session={lastSession.id}>
+      <div class="detail-head">
+        <span class="detail-title">
+          Logged {formatDuration(lastSession.seconds)} on {lastSession.local_date}
+        </span>
+        <button class="ghost close-detail" onclick={dismissDetail} title="Close">✕</button>
+      </div>
+
+      <div class="detail-row">
+        <span class="detail-label">How it went</span>
+        {#each [1, 2, 3, 4, 5] as value}
+          <button
+            class="rating"
+            class:on={detail.rating === value}
+            data-rating={value}
+            title={RATING_LABELS[value]}
+            onclick={() => (detail.rating = detail.rating === value ? null : value)}
+          >
+            {value}
+          </button>
+        {/each}
+        <span class="detail-hint">
+          {detail.rating ? RATING_LABELS[detail.rating] : "optional"}
+        </span>
+      </div>
+
+      <div class="detail-row">
+        <select bind:value={detail.mode} class="detail-mode" title="What kind of work">
+          <option value="">unstated</option>
+          <option value="section">section work</option>
+          <option value="run_through">run-through</option>
+        </select>
+        <span class="detail-label">bars</span>
+        <input class="detail-bar" type="number" min="1" placeholder="from" bind:value={detail.from_bar} />
+        <input class="detail-bar" type="number" min="1" placeholder="to" bind:value={detail.to_bar} />
+        <span class="detail-label">tempo</span>
+        <input class="detail-tempo" type="number" min="20" max="400" placeholder="bpm" bind:value={detail.tempo_bpm} />
+      </div>
+
+      <div class="detail-row">
+        <input
+          class="detail-note"
+          type="text"
+          maxlength="2000"
+          placeholder="what to pick up next time"
+          bind:value={detail.note}
+        />
+        <button class="save-detail" onclick={saveDetail} disabled={savingDetail}>
+          {savingDetail ? "Saving…" : "Save"}
+        </button>
+      </div>
+
+      {#if detailError}
+        <p class="detail-hint">{detailError}</p>
+      {/if}
+    </section>
   {/if}
 
   {#if error}
@@ -356,6 +503,64 @@
 
   .tags-input {
     width: 220px;
+  }
+
+  /* Not styled as an alert of any kind: nothing here went wrong, a session was
+     recorded. It sits under the header rather than over the score so it never
+     covers the music. */
+  .session-detail {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    padding: 10px 16px 12px;
+    border-bottom: 1px solid var(--line);
+    background: var(--bg-raised);
+  }
+
+  .detail-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+  }
+
+  .detail-title {
+    font-size: 14px;
+    color: var(--brass-bright);
+    font-variant-numeric: tabular-nums;
+  }
+
+  .detail-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
+  }
+
+  .detail-label,
+  .detail-hint {
+    font-size: 13px;
+    color: var(--ink-dim);
+  }
+
+  .rating {
+    width: 32px;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .rating.on {
+    border-color: var(--brass);
+    color: var(--brass-bright);
+  }
+
+  .detail-bar,
+  .detail-tempo {
+    width: 76px;
+  }
+
+  .detail-note {
+    flex: 1;
+    min-width: 200px;
   }
 
   .error {

--- a/web/src/lib/api.js
+++ b/web/src/lib/api.js
@@ -69,6 +69,55 @@ export const api = {
       body: JSON.stringify(body),
     }).then(j),
   practiceSummary: () => fetch("/api/practice/summary").then(j),
+  // Detail added to a session already logged. The timer stores the length the
+  // moment it stops and this fills in how it went, so a stopped clock is never
+  // waiting on a form and a session is never lost to an abandoned one. An
+  // explicit null clears a field - which is how a rating entered by mistake
+  // comes off again.
+  patchSession: (id, body) =>
+    fetch(`/api/practice/sessions/${id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }).then(j),
+  deleteSession: (id) => fetch(`/api/practice/sessions/${id}`, { method: "DELETE" }).then(j),
+  // Practice that is not against a piece at all - an exercise, or simply
+  // playing. `score_id` is optional for every activity except "piece".
+  logSession: (body) =>
+    fetch("/api/practice/sessions", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }).then(j),
+  sessions: (params = {}) => {
+    const q = new URLSearchParams(
+      Object.fromEntries(Object.entries(params).filter(([, v]) => v != null && v !== "")),
+    );
+    return fetch(`/api/practice/sessions?${q}`).then(j);
+  },
+  practiceHistory: (days, today) =>
+    fetch(`/api/practice/history?days=${days}&today=${today}`).then(j),
+  // `today` is the BROWSER's date on every one of these. The server's own date
+  // is UTC, and whether a week is still running must not be an accident of the
+  // hour - west of Greenwich the UTC date is already tomorrow while somebody
+  // still has their evening to practise in.
+  currentGoal: (today) => fetch(`/api/practice/goals/current?today=${today}`).then(j),
+  goals: (today) => fetch(`/api/practice/goals?today=${today}`).then(j),
+  setGoal: (body, today) =>
+    fetch(`/api/practice/goals?today=${today}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }).then(j),
+  patchGoal: (id, body, today) =>
+    fetch(`/api/practice/goals/${id}?today=${today}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }).then(j),
+  deleteGoal: (id) => fetch(`/api/practice/goals/${id}`, { method: "DELETE" }).then(j),
+  practiceReview: (weeks, today) =>
+    fetch(`/api/practice/review?weeks=${weeks}&today=${today}`).then(j),
   scan: () => fetch("/api/scan", { method: "POST" }).then(j),
   scanStatus: () => fetch("/api/scan/status").then(j),
   upload: (file, folder = "Uploads") => {

--- a/web/src/lib/practice.js
+++ b/web/src/lib/practice.js
@@ -1,0 +1,284 @@
+// How practice is put into words, and the calendar arithmetic that decides
+// which day a session belongs to.
+//
+// No runes and no imports, so the whole of it can be called directly from a
+// test without a browser or a component - which matters more here than
+// anywhere else in this project, because the words themselves are the feature.
+// "Three of four planned days" and "you missed a day" carry the same
+// information and only one of them makes a person want to open the app again
+// tomorrow, and the difference lives entirely in these functions.
+//
+// THE RULES THESE FOLLOW, so that a later edit knows what it is breaking:
+//
+//   State the fact and stop.       Counts and totals, in the order they were
+//                                 planned. No adverbs, no "only", no "just".
+//   Never grade.                  No percentages, no marks, no "well done".
+//   Never compare periods.        No best, no worst, no average, no run of
+//                                 anything. A good month must not become the
+//                                 standard a bad month is measured against.
+//   A shortfall is not an error.   Nothing here returns a severity, a level,
+//                                 or anything a caller could colour red.
+//   Ask, do not conclude.         The only question put to a person about a
+//                                 period is whether the goal was realistic.
+
+/** Words that must never reach a person about their own practice. Exported so
+ * the tests can check the phrasing this module produces rather than trusting
+ * that whoever edits it remembers the rules above.
+ *
+ * Matched as WHOLE words by forbiddenWord below, which is not pedantry: "No
+ * practice recorded this week" is exactly the plain statement this feature is
+ * built on, and a substring check rejects it for containing "record". */
+export const FORBIDDEN_WORDS = [
+  "fail",
+  "failed",
+  "missed",
+  "miss",
+  "behind",
+  "streak",
+  "best",
+  "worst",
+  "record",
+  "average",
+  "should",
+  "only",
+  "just",
+  "shame",
+  "lazy",
+  "poor",
+  "bad",
+];
+
+const FORBIDDEN_PATTERN = new RegExp(`\\b(${FORBIDDEN_WORDS.join("|")})\\b`, "i");
+
+/** The first forbidden word in some text, or null. The rule lives here rather
+ * than in the tests so there is one list and one way of applying it. */
+export function forbiddenWord(text) {
+  const found = FORBIDDEN_PATTERN.exec(String(text ?? ""));
+  return found ? found[1].toLowerCase() : null;
+}
+
+export const WEEK_STARTS = ["monday", "sunday"];
+
+const DAY_MS = 86_400_000;
+
+const DAY_NAMES = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+
+const MONTH_NAMES = [
+  "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+  "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+];
+
+/** How each activity is written for a person to read. */
+export const ACTIVITY_LABELS = {
+  piece: "A piece",
+  technique: "Technique",
+  sight_reading: "Sight reading",
+  ear_training: "Ear training",
+  fretboard: "Fretboard",
+  chords: "Chords",
+  improvisation: "Improvisation",
+  theory: "Theory",
+  free: "Playing freely",
+  other: "Something else",
+};
+
+export const MODE_LABELS = {
+  section: "Section work",
+  run_through: "Run-through",
+};
+
+export function activityLabel(activity) {
+  return ACTIVITY_LABELS[activity] ?? "Practice";
+}
+
+/** Today's date in the BROWSER's timezone, as YYYY-MM-DD.
+ *
+ * Not toISOString().slice(0, 10), which is the UTC date: west of Greenwich
+ * that is already tomorrow for every evening practice, so a session logged at
+ * nine at night would be filed on the wrong day and, at a week boundary, in
+ * the wrong week. This is the value the server stores as the practice day and
+ * counts every goal against.
+ */
+export function localDay(date = new Date()) {
+  const pad = (n) => String(n).padStart(2, "0");
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`;
+}
+
+/** A YYYY-MM-DD string as a Date at local midday.
+ *
+ * Midday, not midnight: new Date("2026-08-17") is parsed as UTC and can land
+ * on the previous local day, and midnight local is a daylight-saving edge in
+ * some zones. Nothing here needs a time, only a calendar day that survives
+ * being read back.
+ */
+export function dayDate(day) {
+  const [y, m, d] = String(day).split("-").map(Number);
+  return new Date(y, m - 1, d, 12);
+}
+
+export function addDays(day, n) {
+  const date = dayDate(day);
+  date.setDate(date.getDate() + n);
+  return localDay(date);
+}
+
+/** The first day of the week `day` falls in - the same rule the server
+ * applies, so the week a client offers to set a goal for and the week the
+ * server counts are the same seven days. */
+export function weekStart(day, startsOn = "monday") {
+  const weekday = dayDate(day).getDay(); // 0 is Sunday
+  const offset = startsOn === "sunday" ? weekday : (weekday + 6) % 7;
+  return addDays(day, -offset);
+}
+
+export function shortDayName(day) {
+  return DAY_NAMES[dayDate(day).getDay()];
+}
+
+/** "17 Aug" - a day, for a label. */
+export function shortDate(day) {
+  const date = dayDate(day);
+  return `${date.getDate()} ${MONTH_NAMES[date.getMonth()]}`;
+}
+
+/** "17-23 Aug", or "28 Sep - 4 Oct" across a month boundary. */
+export function periodLabel(start, end) {
+  const from = dayDate(start);
+  const to = dayDate(end);
+  if (from.getMonth() === to.getMonth()) {
+    return `${from.getDate()}-${to.getDate()} ${MONTH_NAMES[to.getMonth()]}`;
+  }
+  return `${shortDate(start)} - ${shortDate(end)}`;
+}
+
+/** A length of practice, as a person says it: "45m", "1h 30m", "2h".
+ *
+ * Zero is "none", not "0m": a week with no practice in it is a fact about the
+ * week and reads better as a word than as a number with a unit.
+ */
+export function formatDuration(seconds) {
+  const total = Math.max(0, Math.floor(Number(seconds) || 0));
+  if (total < 60) return total ? "under a minute" : "none";
+  const minutes = Math.floor(total / 60);
+  const hours = Math.floor(minutes / 60);
+  const rest = minutes % 60;
+  if (!hours) return `${minutes}m`;
+  return rest ? `${hours}h ${rest}m` : `${hours}h`;
+}
+
+/** The same, from minutes - which is the unit a goal's target is set in. */
+export function formatMinutes(minutes) {
+  return formatDuration(Math.max(0, Math.floor(Number(minutes) || 0)) * 60);
+}
+
+/** What a goal's targets came to, one statement per target that was set.
+ *
+ * Each is `{ key, text, met }`. `met` is there so a caller can mark what was
+ * reached - and only what was reached; there is deliberately no value meaning
+ * "this one went badly", because a caller given one will eventually colour it.
+ *
+ * A target that was not set produces no statement at all, rather than a
+ * statement about a target of zero.
+ */
+export function goalStatements(goal) {
+  if (!goal) return [];
+  const progress = goal.progress ?? {};
+  const out = [];
+  if (goal.target_days != null) {
+    out.push({
+      key: "days",
+      text: `${progress.days_practised ?? 0} of ${goal.target_days} planned days`,
+      met: progress.met_days === true,
+    });
+  }
+  if (goal.target_minutes != null) {
+    out.push({
+      key: "minutes",
+      text: `${formatMinutes(progress.minutes ?? 0)} of ${formatMinutes(goal.target_minutes)} planned`,
+      met: progress.met_minutes === true,
+    });
+  }
+  return out;
+}
+
+/** What a goal is scoped to, in words: "any practice", "Study in C",
+ * "ear training". */
+export function goalScopeLabel(goal) {
+  if (!goal) return "";
+  if (goal.scope === "score") return goal.score_title ?? "one piece";
+  if (goal.scope === "activity") return activityLabel(goal.activity).toLowerCase();
+  return "any practice";
+}
+
+/** How much of a running period is left, or nothing at all once it has ended.
+ *
+ * Days remaining and not a rate: "you need forty minutes a day to catch up" is
+ * a verdict wearing arithmetic, and it is the one thing a person looking at a
+ * half-finished week does not need told.
+ */
+export function timeLeftStatement(progress) {
+  if (!progress || progress.status !== "running") return "";
+  const left = progress.days_left ?? 0;
+  if (left <= 0) return "";
+  if (left === 1) return "1 day left in this week";
+  return `${left} days left in this week`;
+}
+
+/** What a period came to, whether or not a goal was set for it. */
+export function periodStatement(facts) {
+  if (!facts || !facts.days_practised) return "No practice recorded this week";
+  const days = facts.days_practised;
+  return `${days} ${days === 1 ? "day" : "days"}, ${formatDuration(facts.seconds)}`;
+}
+
+/** The bars of a week's per-day strip, scaled against the busiest day IN THAT
+ * WEEK.
+ *
+ * Scaled within the week and never against another week or an all-time high:
+ * a bar that shrinks because last month was busier is a comparison, and a
+ * comparison is the thing this feature must not make. A week with no practice
+ * has no tallest day, so every bar is empty rather than every bar being full.
+ */
+export function dayBars(days = []) {
+  const most = days.reduce((max, d) => Math.max(max, d.seconds ?? 0), 0);
+  return days.map((d) => ({
+    date: d.date,
+    label: shortDayName(d.date),
+    seconds: d.seconds ?? 0,
+    sessions: d.sessions ?? 0,
+    // A day with any practice at all gets a visible floor, so "a little" never
+    // renders as "nothing".
+    fill: most > 0 && d.seconds > 0 ? Math.max(0.12, d.seconds / most) : 0,
+  }));
+}
+
+/** A session's worked range, as a person wrote it: "bars 17-32", "page 2". */
+export function rangeLabel(session) {
+  if (!session) return "";
+  const parts = [];
+  const span = (from, to, one, many) => {
+    if (from == null) return null;
+    return to == null || to === from ? `${one} ${from}` : `${many} ${from}-${to}`;
+  };
+  const bars = span(session.from_bar, session.to_bar, "bar", "bars");
+  const pages = span(session.from_page, session.to_page, "page", "pages");
+  if (bars) parts.push(bars);
+  if (pages) parts.push(pages);
+  return parts.join(", ");
+}
+
+/** A session's tempo, and whether a ladder run reached what it was aiming at.
+ *
+ * "reached 120" only when it did; when it did not, the two numbers are stated
+ * and nothing is said about the gap. `reached_target` is null when either
+ * number is missing, which is not the same as not having reached it.
+ */
+export function tempoLabel(session) {
+  if (!session || session.tempo_bpm == null) return "";
+  const at = `${session.tempo_bpm} bpm`;
+  if (session.target_tempo_bpm == null) return at;
+  if (session.reached_target === true) {
+    return `${at}, reached the ${session.target_tempo_bpm} target`;
+  }
+  return `${at}, aiming at ${session.target_tempo_bpm}`;
+}

--- a/web/src/lib/practice.js
+++ b/web/src/lib/practice.js
@@ -91,6 +91,24 @@ export function activityLabel(activity) {
   return ACTIVITY_LABELS[activity] ?? "Practice";
 }
 
+/** What a piece that has left the library is called where its title would go.
+ *
+ * Deleting a score no longer deletes the practice against it, so a session can
+ * outlive the piece it was about. It is still practice that happened and it
+ * still has its day, its length and whatever was written about it - so it says
+ * what it is, plainly, rather than showing a blank or reading as a broken row.
+ */
+export const MISSING_PIECE_LABEL = "A piece no longer in your library";
+
+/** What a session is about, in words: the piece's title, or the fact that the
+ * piece has gone, or the kind of work it was. */
+export function sessionSubject(session) {
+  if (!session) return "";
+  if (session.score_title) return session.score_title;
+  if (session.score_missing) return MISSING_PIECE_LABEL;
+  return activityLabel(session.activity);
+}
+
 /** Today's date in the BROWSER's timezone, as YYYY-MM-DD.
  *
  * Not toISOString().slice(0, 10), which is the UTC date: west of Greenwich
@@ -171,6 +189,25 @@ export function formatMinutes(minutes) {
   return formatDuration(Math.max(0, Math.floor(Number(minutes) || 0)) * 60);
 }
 
+/** A count where zero is a word rather than a nought.
+ *
+ * The same rule formatDuration already applies to a length of none, applied to
+ * the other target: "0 of 5 planned days" beside "none of 5h planned" is the
+ * rule kept in one place and dropped in the other, and a bare nought beside a
+ * target reads like a mark out of five.
+ */
+export function countOrNone(count) {
+  const n = Math.max(0, Math.floor(Number(count) || 0));
+  return n ? String(n) : "none";
+}
+
+/** A number of days, as a person says it: "no days", "1 day", "4 days". */
+export function formatDays(days) {
+  const count = Math.max(0, Math.floor(Number(days) || 0));
+  if (!count) return "no days";
+  return `${count} ${count === 1 ? "day" : "days"}`;
+}
+
 /** What a goal's targets came to, one statement per target that was set.
  *
  * Each is `{ key, text, met }`. `met` is there so a caller can mark what was
@@ -183,11 +220,17 @@ export function formatMinutes(minutes) {
 export function goalStatements(goal) {
   if (!goal) return [];
   const progress = goal.progress ?? {};
+  // A goal about a piece that has left the library cannot be counted at all -
+  // the practice is still in the history but nothing says which of it was
+  // about that piece. Reporting "0 of 3 planned days" would say the person did
+  // not practise, which is both untrue and the exact thing this feature must
+  // never say. uncountableStatement is what a caller shows instead.
+  if (progress.countable === false) return [];
   const out = [];
   if (goal.target_days != null) {
     out.push({
       key: "days",
-      text: `${progress.days_practised ?? 0} of ${goal.target_days} planned days`,
+      text: `${countOrNone(progress.days_practised)} of ${goal.target_days} planned days`,
       met: progress.met_days === true,
     });
   }
@@ -205,9 +248,24 @@ export function goalStatements(goal) {
  * "ear training". */
 export function goalScopeLabel(goal) {
   if (!goal) return "";
-  if (goal.scope === "score") return goal.score_title ?? "one piece";
+  if (goal.scope === "score") {
+    if (goal.score_title) return goal.score_title;
+    return goal.score_id == null ? MISSING_PIECE_LABEL.toLowerCase() : "one piece";
+  }
   if (goal.scope === "activity") return activityLabel(goal.activity).toLowerCase();
   return "any practice";
+}
+
+/** Why a goal has no counts, when it has none. Empty for an ordinary goal.
+ *
+ * States the situation and stops. It does not apologise, does not suggest the
+ * goal was wasted, and does not offer to delete anything - the intention was
+ * genuinely formed and the practice genuinely happened; only the link between
+ * them went with the file.
+ */
+export function uncountableStatement(goal) {
+  if (!goal || goal.progress?.countable !== false) return "";
+  return "This goal was about a piece that is no longer in your library, so there is nothing left to count it against. The practice itself is still in your history.";
 }
 
 /** How much of a running period is left, or nothing at all once it has ended.
@@ -224,11 +282,20 @@ export function timeLeftStatement(progress) {
   return `${left} days left in this week`;
 }
 
-/** What a period came to, whether or not a goal was set for it. */
-export function periodStatement(facts) {
-  if (!facts || !facts.days_practised) return "No practice recorded this week";
-  const days = facts.days_practised;
-  return `${days} ${days === 1 ? "day" : "days"}, ${formatDuration(facts.seconds)}`;
+/** What a period came to, whether or not a goal was set for it.
+ *
+ * `current` says whether this is the week in progress, and it is a parameter
+ * rather than a constant because it was a constant: every past week in the
+ * review said "this week", so a quiet spell in July rendered as three
+ * consecutive rows reading "No practice recorded this week" beside dates
+ * nowhere near it. The dates are already on the row; the sentence does not
+ * need to name the week, only to avoid naming the wrong one.
+ */
+export function periodStatement(facts, current = true) {
+  if (!facts || !facts.days_practised) {
+    return current ? "No practice recorded this week" : "No practice recorded";
+  }
+  return `${formatDays(facts.days_practised)}, ${formatDuration(facts.seconds)}`;
 }
 
 /** The bars of a week's per-day strip, scaled against the busiest day IN THAT

--- a/web/src/lib/settings.svelte.js
+++ b/web/src/lib/settings.svelte.js
@@ -26,7 +26,17 @@ export const STAFF_THEME_TOKEN_PREFIX = {
   print: "--score-print",
 };
 
-const DEFAULTS = { staff_theme: STAFF_THEMES[0] };
+// Which day a week starts on decides the seven days a practice goal is
+// counted over, so it is a real preference rather than a cosmetic one. Kept
+// in step with SETTINGS_CHOICES["week_starts_on"] in server/fermata/api.py.
+export const WEEK_STARTS = ["monday", "sunday"];
+
+export const WEEK_START_LABELS = {
+  monday: "Monday",
+  sunday: "Sunday",
+};
+
+const DEFAULTS = { staff_theme: STAFF_THEMES[0], week_starts_on: WEEK_STARTS[0] };
 
 const settings = $state({ ...DEFAULTS });
 

--- a/web/tests/browser/practice.spec.js
+++ b/web/tests/browser/practice.spec.js
@@ -84,6 +84,30 @@ test("with no goal set, the week says so and shows seven empty days", async ({ p
   await expect(notices(page)).toHaveCount(0);
 });
 
+test("a fresh install is greeted rather than shown fourteen absences", async ({ page }) => {
+  // Nothing practised and nothing planned. Every section below the week would
+  // be a statement of absence - seven "No practice recorded" rows and seven
+  // "No goal was set" ones - which is a poor first impression for somebody who
+  // has simply not started yet.
+  await expect(page.locator(".nothing-yet")).toBeVisible();
+  await expect(page.locator(".nothing-yet")).toContainText("Nothing logged yet");
+  await expect(pastWeeks(page)).toHaveCount(0);
+  await expect(page.locator("section.review")).toHaveCount(0);
+  // The week itself, and the way to set a goal, are still there.
+  await expect(days(page)).toHaveCount(7);
+  await expect(page.locator(".edit-goal")).toBeVisible();
+});
+
+test("once there is practice, the review appears", async ({ page, request }) => {
+  // The other half of the test above: the greeting has to give way, or it is
+  // just a way of hiding the feature.
+  await logPractice(request, { day: weekStart(today, "monday"), minutes: 20 });
+  await page.reload();
+  await expect(page.locator(".nothing-yet")).toHaveCount(0);
+  await expect(page.locator("section.review")).toBeVisible();
+  await expect(pastWeeks(page)).toHaveCount(7);
+});
+
 test("a goal is set from this page and its progress is stated as counts", async ({
   page,
   request,
@@ -236,10 +260,30 @@ test("a week nobody set a goal for still appears with what happened in it", asyn
 
   const card = page.locator(`.past-week[data-week="${lastWeek}"]`);
   await expect(card).toContainText("1 day, 25m");
-  await expect(card.locator(".no-goal")).toContainText("No goal was set for this week");
+  await expect(card.locator(".no-goal")).toContainText("No goal was set for these days");
+  // Not "this week" - every past row used to say that, so a quiet spell in
+  // July rendered as three consecutive rows naming a week nowhere near them.
+  await expect(card).not.toContainText("this week");
   // Every week in the window is listed, goal or no goal, so the review is not
   // a list of judged weeks.
   await expect(pastWeeks(page)).toHaveCount(7);
+});
+
+test("a past week with nothing in it does not call itself this week", async ({
+  page,
+  request,
+}) => {
+  // Rendered, not asserted on a string in isolation - which is how this got
+  // through: every past row said "this week", so a gap after a good run showed
+  // three consecutive rows naming a week nowhere near their own dates.
+  await logPractice(request, { day: today, minutes: 20 });
+  await page.reload();
+
+  const empty = pastWeeks(page).first();
+  await expect(empty).toContainText("No practice recorded");
+  await expect(empty).not.toContainText("this week");
+  // And the current week's panel still says it, where it is true.
+  await expect(week(page)).toContainText("this week");
 });
 
 test("the week this page offers is the week the server counts", async ({ page, request }) => {

--- a/web/tests/browser/practice.spec.js
+++ b/web/tests/browser/practice.spec.js
@@ -1,0 +1,345 @@
+// The practice page, against the real backend and the real build.
+//
+// What these are for that a unit test cannot do: the phrasing helpers are
+// tested directly in tests/unit/practice.spec.js, but "a goal that was not
+// reached is not styled as an error" is a claim about computed CSS on a real
+// page, and "the week the interface offers is the week the server counts" is a
+// claim about two independent pieces of calendar arithmetic agreeing. Neither
+// survives being asserted against a mock.
+//
+// The assertions here are therefore about seams: the text that reaches the
+// screen, the colours it reaches it in, the values that survive a reload, and
+// the fact that a session logged from this page lands in the record the server
+// keeps.
+import { expect, test } from "@playwright/test";
+
+import { addDays, forbiddenWord, localDay, weekStart } from "../../src/lib/practice.js";
+
+const week = (page) => page.locator("section.week");
+const statements = (page) => page.locator("section.week .statement");
+const days = (page) => page.locator("section.week .strip .day");
+const sessionRows = (page) => page.locator(".session-list .session");
+const pastWeeks = (page) => page.locator(".past-week");
+// Shared so that every "nothing went wrong" assertion uses the SAME selector
+// one test proves can match something. A toHaveCount(0) built from an inline
+// literal is permanently true the moment the class is renamed.
+const notices = (page) => page.locator(".notice");
+
+const today = localDay();
+
+// A timezone whose calendar day is GUARANTEED not to be the UTC one, chosen
+// from the clock when this file is loaded. Kiritimati is UTC+14, so it is a day
+// ahead once UTC passes ten in the morning; Midway is UTC-11, so it is a day
+// behind until UTC reaches eleven. One of the two always differs, whatever hour
+// CI happens to run at - and a fixture that only sometimes differs is a fixture
+// that only sometimes tests anything.
+const SKEWED_ZONE = new Date().getUTCHours() < 11 ? "Pacific/Midway" : "Pacific/Kiritimati";
+
+async function reset(request) {
+  // The suite shares one database, and a goal is unique per week - so a test
+  // that left one behind would decide what the next test sees.
+  const goals = (await (await request.get(`/api/practice/goals?today=${today}`)).json()).goals;
+  for (const goal of goals) await request.delete(`/api/practice/goals/${goal.id}`);
+  const sessions = (
+    await (await request.get("/api/practice/sessions?limit=1000")).json()
+  ).sessions;
+  for (const session of sessions) await request.delete(`/api/practice/sessions/${session.id}`);
+  await request.put("/api/settings", { data: { week_starts_on: "monday" } });
+}
+
+async function logPractice(request, { day, minutes, activity = "technique", note = null }) {
+  const res = await request.post("/api/practice/sessions", {
+    data: { activity, seconds: minutes * 60, local_date: day, note },
+  });
+  expect(res.ok(), await res.text()).toBe(true);
+}
+
+test.beforeEach(async ({ page, request }) => {
+  // Refuses to touch anything that is not the throwaway instance this suite
+  // starts. The cleanup above DELETES practice sessions, and practice history
+  // is the one thing in this application that cannot be regenerated from the
+  // files on disk - so running these against a real install would destroy the
+  // very data the feature exists to keep.
+  const scores = await (await request.get("/api/scores")).json();
+  expect(
+    scores,
+    "refusing to run: this backend has scores in its library, so it is not the " +
+      "throwaway instance the suite creates - and these tests delete practice history",
+  ).toEqual([]);
+
+  await reset(request);
+  await page.goto("/#/practice");
+  await expect(week(page)).toBeVisible();
+});
+
+test("with no goal set, the week says so and shows seven empty days", async ({ page }) => {
+  const thisWeek = week(page).locator(".no-goal");
+  await expect(thisWeek).toContainText("No goal set for this week");
+  await expect(thisWeek).toContainText("No practice recorded this week");
+  await expect(days(page)).toHaveCount(7);
+  const fills = await days(page)
+    .locator(".bar")
+    .evaluateAll((bars) => bars.map((b) => b.style.height));
+  expect(fills).toEqual(Array(7).fill("0%"));
+  await expect(notices(page)).toHaveCount(0);
+});
+
+test("a goal is set from this page and its progress is stated as counts", async ({
+  page,
+  request,
+}) => {
+  const monday = weekStart(today, "monday");
+  await logPractice(request, { day: monday, minutes: 30 });
+  await logPractice(request, { day: addDays(monday, 1), minutes: 30 });
+  await page.reload();
+
+  await page.locator(".edit-goal").click();
+  await page.locator(".days-target").selectOption("3");
+  await page.locator(".minutes-target").fill("120");
+  await page.locator(".intent-input").fill("the awkward middle section");
+  await page.locator(".save-goal").click();
+
+  await expect(statements(page)).toHaveCount(2);
+  await expect(page.locator('[data-statement="days"]')).toContainText("2 of 3 planned days");
+  await expect(page.locator('[data-statement="minutes"]')).toContainText("1h of 2h planned");
+  await expect(page.locator(".intent-text")).toContainText("the awkward middle section");
+  await expect(notices(page)).toHaveCount(0);
+
+  // And it is the server's answer, not the form's - a reload reads it back.
+  await page.reload();
+  await expect(page.locator('[data-statement="days"]')).toContainText("2 of 3 planned days");
+});
+
+test("a target not reached is drawn exactly like one that is", async ({ page, request }) => {
+  // The whole difference between accountable and shamed, as computed CSS. A
+  // goal not met is not an error condition and must not be coloured like one.
+  const monday = weekStart(today, "monday");
+  await logPractice(request, { day: monday, minutes: 200 });
+  await page.reload();
+
+  await page.locator(".edit-goal").click();
+  await page.locator(".days-target").selectOption("5");
+  await page.locator(".minutes-target").fill("60");
+  await page.locator(".save-goal").click();
+
+  const unmet = page.locator('[data-statement="days"]');
+  const met = page.locator('[data-statement="minutes"]');
+  await expect(unmet).toContainText("1 of 5 planned days");
+  await expect(met).toContainText("3h 20m of 1h planned");
+
+  const style = (locator) =>
+    locator.evaluate((el) => {
+      const computed = getComputedStyle(el);
+      const text = getComputedStyle(el.querySelector(".statement-text"));
+      return {
+        color: computed.color,
+        textColor: text.color,
+        weight: text.fontWeight,
+        background: computed.backgroundColor,
+        border: computed.borderColor,
+      };
+    });
+  const unmetStyle = await style(unmet);
+  const metStyle = await style(met);
+  expect(unmetStyle).toEqual(metStyle);
+
+  // Independent of the comparison above, which would also pass if BOTH were
+  // red: the danger colour this app uses for real errors must not appear.
+  const danger = await page.evaluate(() =>
+    getComputedStyle(document.documentElement).getPropertyValue("--danger").trim(),
+  );
+  expect(danger).not.toBe("");
+  const dangerRgb = await page.evaluate((hex) => {
+    const probe = document.createElement("span");
+    probe.style.color = hex;
+    document.body.appendChild(probe);
+    const value = getComputedStyle(probe).color;
+    probe.remove();
+    return value;
+  }, danger);
+  expect(unmetStyle.textColor).not.toBe(dangerRgb);
+
+  // The only difference is additive: a tick appears beside what was reached.
+  await expect(met.locator(".tick")).toHaveText("✓");
+  await expect(unmet.locator(".tick")).toHaveText("");
+});
+
+test("a running week says how many days are left and nothing about catching up", async ({
+  page,
+}) => {
+  await page.locator(".edit-goal").click();
+  await page.locator(".save-goal").click();
+  await expect(page.locator(".days-left")).toContainText(/\d+ days? left in this week/);
+  const text = await page.locator("section.week").innerText();
+  expect(text.toLowerCase()).not.toContain("catch up");
+  expect(text.toLowerCase()).not.toContain("per day");
+});
+
+test("practice that is not a piece is logged here and lands in the record", async ({ page }) => {
+  await page.locator(".other-activity").selectOption("ear_training");
+  await page.locator(".other-minutes").fill("20");
+  await page.locator(".other-note").fill("intervals, ascending only");
+  await page.locator(".log-other-button").click();
+
+  await expect(sessionRows(page)).toHaveCount(1);
+  await expect(sessionRows(page).first()).toContainText("Ear training");
+  await expect(sessionRows(page).first()).toContainText("20m");
+  await expect(sessionRows(page).first()).toContainText("intervals, ascending only");
+  await expect(sessionRows(page).first()).toContainText(today);
+  await expect(page.locator(".by-activity")).toContainText("Ear training");
+  await expect(notices(page)).toHaveCount(0);
+
+  // The day it was practised, as the browser's own date - a bar appears on
+  // today and nowhere else.
+  const withPractice = await days(page).evaluateAll((cells) =>
+    cells.filter((c) => Number(c.dataset.seconds) > 0).map((c) => c.dataset.day),
+  );
+  expect(withPractice).toEqual([today]);
+});
+
+test("a finished week asks whether the goal was realistic, and remembers the answer", async ({
+  page,
+  request,
+}) => {
+  const lastWeek = addDays(weekStart(today, "monday"), -7);
+  await logPractice(request, { day: lastWeek, minutes: 45 });
+  const created = await request.post(`/api/practice/goals?today=${today}`, {
+    data: { period_start: lastWeek, target_days: 4 },
+  });
+  expect(created.ok(), await created.text()).toBe(true);
+  await page.reload();
+
+  const card = page.locator(`.past-week[data-week="${lastWeek}"]`);
+  await expect(card).toBeVisible();
+  await expect(card).toContainText("1 of 4 planned days");
+  // A question, not a verdict.
+  await expect(card.locator(".question")).toHaveText("Was this goal realistic?");
+
+  await card.locator('[data-answer="no"]').click();
+  await card.locator(".reflection-text").fill("away for three days");
+  await card.locator(".save-reflection").click();
+
+  await expect(notices(page)).toHaveCount(0);
+  await page.reload();
+  const again = page.locator(`.past-week[data-week="${lastWeek}"]`);
+  await expect(again.locator(".reflection-text")).toHaveValue("away for three days");
+  await expect(again.locator('[data-answer="no"]')).toHaveClass(/on/);
+});
+
+test("a week nobody set a goal for still appears with what happened in it", async ({
+  page,
+  request,
+}) => {
+  const lastWeek = addDays(weekStart(today, "monday"), -7);
+  await logPractice(request, { day: addDays(lastWeek, 2), minutes: 25 });
+  await page.reload();
+
+  const card = page.locator(`.past-week[data-week="${lastWeek}"]`);
+  await expect(card).toContainText("1 day, 25m");
+  await expect(card.locator(".no-goal")).toContainText("No goal was set for this week");
+  // Every week in the window is listed, goal or no goal, so the review is not
+  // a list of judged weeks.
+  await expect(pastWeeks(page)).toHaveCount(7);
+});
+
+test("the week this page offers is the week the server counts", async ({ page, request }) => {
+  await request.put("/api/settings", { data: { week_starts_on: "sunday" } });
+  await page.reload();
+
+  const offered = await week(page).getAttribute("data-week");
+  expect(offered).toBe(weekStart(today, "sunday"));
+
+  await page.locator(".edit-goal").click();
+  await page.locator(".save-goal").click();
+  const goals = (await (await request.get(`/api/practice/goals?today=${today}`)).json()).goals;
+  expect(goals).toHaveLength(1);
+  expect(goals[0].period_start).toBe(weekStart(today, "sunday"));
+});
+
+test("a goal can be adjusted mid-week, and removing it keeps the practice", async ({
+  page,
+  request,
+}) => {
+  await logPractice(request, { day: today, minutes: 20 });
+  await page.reload();
+
+  await page.locator(".edit-goal").click();
+  await page.locator(".days-target").selectOption("5");
+  await page.locator(".save-goal").click();
+  await expect(page.locator('[data-statement="days"]')).toContainText("1 of 5 planned days");
+
+  // Seeing where you stand is only useful if the goal can still change the
+  // week rather than only judge it afterwards.
+  await page.locator(".edit-goal").click();
+  await page.locator(".days-target").selectOption("1");
+  await page.locator(".save-goal").click();
+  await expect(page.locator('[data-statement="days"]')).toContainText("1 of 1 planned days");
+  await expect(page.locator('[data-statement="days"] .tick')).toHaveText("✓");
+  // Adjusting replaced the goal rather than adding a second one for the week.
+  const goals = (await (await request.get(`/api/practice/goals?today=${today}`)).json()).goals;
+  expect(goals).toHaveLength(1);
+
+  await page.locator(".edit-goal").click();
+  await page.locator(".remove-goal").click();
+  await expect(page.locator("section.week .no-goal")).toContainText("No goal set for this week");
+  await expect(sessionRows(page)).toHaveCount(1);
+});
+
+test.describe("in a timezone whose calendar day is not the UTC one", () => {
+  test.use({ timezoneId: SKEWED_ZONE });
+
+  test("a session is filed under the practiser's own day, not the server's", async ({
+    page,
+    request,
+  }) => {
+    // The reason local_date exists at all. The server stores UTC timestamps,
+    // so leaving the day to be derived there files an evening's practice on
+    // the wrong date - and at a week boundary in the wrong week, against a
+    // goal counting days.
+    const browserDay = await page.evaluate(() => {
+      const now = new Date();
+      const pad = (n) => String(n).padStart(2, "0");
+      return `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}`;
+    });
+    const utcDay = new Date().toISOString().slice(0, 10);
+    expect(
+      browserDay,
+      `this test is only meaningful when the browser's day differs from UTC's (zone ${SKEWED_ZONE})`,
+    ).not.toBe(utcDay);
+
+    await page.locator(".other-activity").selectOption("technique");
+    await page.locator(".other-minutes").fill("18");
+    await page.locator(".log-other-button").click();
+    await expect(sessionRows(page)).toHaveCount(1);
+
+    const stored = (
+      await (await request.get("/api/practice/sessions?limit=10")).json()
+    ).sessions;
+    expect(stored).toHaveLength(1);
+    expect(stored[0].local_date).toBe(browserDay);
+    expect(stored[0].local_date_source).toBe("recorded");
+    // And the page agrees with what was stored, rather than each having its
+    // own idea of which day it was.
+    await expect(sessionRows(page).first()).toContainText(browserDay);
+  });
+});
+
+test("nothing on this page says anything that grades the person", async ({ page, request }) => {
+  // The page in its least flattering state: a goal nowhere near reached, a
+  // week with almost nothing in it, and a past week with no goal at all.
+  const monday = weekStart(today, "monday");
+  await logPractice(request, { day: monday, minutes: 2 });
+  const created = await request.post(`/api/practice/goals?today=${today}`, {
+    data: { period_start: monday, target_days: 7, target_minutes: 600 },
+  });
+  expect(created.ok(), await created.text()).toBe(true);
+  const lastWeek = addDays(monday, -7);
+  await request.post(`/api/practice/goals?today=${today}`, {
+    data: { period_start: lastWeek, target_days: 6 },
+  });
+  await page.reload();
+  await expect(statements(page)).toHaveCount(2);
+
+  const text = await page.locator("main").innerText();
+  expect(forbiddenWord(text), text).toBeNull();
+});

--- a/web/tests/browser/viewer-practice.spec.js
+++ b/web/tests/browser/viewer-practice.spec.js
@@ -1,0 +1,274 @@
+// The practice timer and the panel that asks what the session was, against a
+// real score in a real library.
+//
+// WHY THIS IS ITS OWN FILE. Every other spec here runs against an EMPTY
+// library, and instruments.spec.js and practice.spec.js both refuse to run
+// otherwise - which is the guard that makes it safe for them to delete
+// instruments and practice history. Reaching this panel needs a score, so this
+// spec puts a file in the throwaway library and takes it out again afterwards.
+// It is named to sort LAST, so that even a cleanup that fails cannot leave a
+// score behind for another spec to trip over.
+//
+// What it covers that a unit test cannot: that stopping the timer stores a
+// session at all (the write goes through fetch from a real page), that the
+// panel patches the session that was just logged rather than some other one,
+// and that clearing a field means unset rather than zero - all of which live in
+// the seam between the component, the endpoint and the database.
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { expect, test } from "@playwright/test";
+
+import { localDay } from "../../src/lib/practice.js";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const FIXTURE = path.join(here, "..", "..", "test-fixtures", "notation-only.musicxml");
+// A MusicXML file rather than a PDF: the scanner reads it without needing a
+// thumbnailer, and the viewer chrome under test - the timer button and the
+// panel - is the same for either.
+const SCORE_NAME = "practice-timer-fixture.musicxml";
+// A second score, so the route can swap `id` on the SAME Viewer instance -
+// which is the navigation the detail panel had to survive being carried
+// across, and the only one where it could be saved onto the wrong session.
+const OTHER_NAME = "practice-timer-fixture-two.musicxml";
+
+const libraryDir = () => {
+  const dir = process.env.FERMATA_TEST_LIBRARY_DIR;
+  if (!dir) throw new Error("FERMATA_TEST_LIBRARY_DIR is not set - see playwright.config.js");
+  return dir;
+};
+
+const panel = (page) => page.locator(".session-detail");
+const timer = (page) => page.locator("button.timer");
+
+async function waitForScore(request, name) {
+  // The scan runs in a background thread, so the row appears a moment after the
+  // upload returns.
+  for (let attempt = 0; attempt < 60; attempt += 1) {
+    const scores = await (await request.get("/api/scores")).json();
+    const found = scores.find((s) => s.path.endsWith(name));
+    if (found) return found;
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+  throw new Error(`the uploaded score ${name} never appeared in the library`);
+}
+
+async function upload(request, name) {
+  const res = await request.post("/api/upload?folder=Uploads", {
+    multipart: {
+      file: { name, mimeType: "application/xml", buffer: fs.readFileSync(FIXTURE) },
+    },
+  });
+  expect(res.ok(), await res.text()).toBe(true);
+  return waitForScore(request, name);
+}
+
+async function removeScore(request) {
+  for (const name of [SCORE_NAME, OTHER_NAME]) {
+    const target = path.join(libraryDir(), "Uploads", name);
+    if (fs.existsSync(target)) fs.rmSync(target);
+  }
+  await request.post("/api/scan");
+  for (let attempt = 0; attempt < 60; attempt += 1) {
+    const scores = await (await request.get("/api/scores")).json();
+    if (!scores.length) return;
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+  throw new Error("the library did not empty again - later specs would see this score");
+}
+
+let score;
+
+test.beforeEach(async ({ request }) => {
+  // The same refusal every other spec makes, and for the same reason: this one
+  // deletes practice history too.
+  const existing = await (await request.get("/api/scores")).json();
+  expect(
+    existing,
+    "refusing to run: this backend already has scores in its library, so it is not the " +
+      "throwaway instance the suite creates",
+  ).toEqual([]);
+
+  // Earlier specs clear practice history on the way IN rather than out, so the
+  // last one leaves its rows behind. Cleared here too, because the assertions
+  // below count sessions in the whole record.
+  const stale = (await (await request.get("/api/practice/sessions?limit=1000")).json()).sessions;
+  for (const session of stale) await request.delete(`/api/practice/sessions/${session.id}`);
+
+  score = await upload(request, SCORE_NAME);
+});
+
+test.afterEach(async ({ request }) => {
+  const sessions = (await (await request.get("/api/practice/sessions?limit=1000")).json())
+    .sessions;
+  for (const session of sessions) await request.delete(`/api/practice/sessions/${session.id}`);
+  await removeScore(request);
+});
+
+/** Run the timer for long enough to be stored. The component refuses anything
+ * under ten seconds, on purpose - opening a score for a moment is not
+ * practice - so this is a real wait rather than a mock. */
+async function practiseFor(page, seconds = 12) {
+  await timer(page).click();
+  await expect(timer(page)).toHaveClass(/on/);
+  await page.waitForTimeout(seconds * 1000);
+  await timer(page).click();
+}
+
+test("stopping the timer stores a session, and the panel adds detail to that session", async ({
+  page,
+  request,
+}) => {
+  await page.goto(`/#/score/${score.id}`);
+  await expect(timer(page)).toBeVisible();
+
+  await practiseFor(page);
+  await expect(panel(page)).toBeVisible();
+  // The length and the day it was filed under, stated back.
+  await expect(panel(page)).toContainText(localDay());
+
+  const logged = (await (await request.get("/api/practice/sessions")).json()).sessions;
+  expect(logged).toHaveLength(1);
+  expect(logged[0].seconds).toBeGreaterThanOrEqual(10);
+  expect(logged[0].score_id).toBe(score.id);
+  expect(logged[0].local_date).toBe(localDay());
+  expect(logged[0].local_date_source).toBe("recorded");
+  // Nothing has been said about it yet.
+  expect(logged[0].rating).toBeNull();
+
+  await page.locator('[data-rating="4"]').click();
+  await page.locator(".detail-mode").selectOption("section");
+  await page.locator(".detail-bar").first().fill("17");
+  await page.locator(".detail-bar").nth(1).fill("32");
+  await page.locator(".detail-tempo").fill("76");
+  await page.locator(".detail-target-tempo").fill("120");
+  await page.locator(".detail-note").fill("left hand still behind");
+  await page.locator(".save-detail").click();
+  await expect(panel(page)).toHaveCount(0);
+
+  const stored = (await (await request.get("/api/practice/sessions")).json()).sessions;
+  expect(stored).toHaveLength(1);
+  expect(stored[0].id).toBe(logged[0].id);
+  expect(stored[0].rating).toBe(4);
+  expect(stored[0].mode).toBe("section");
+  expect(stored[0].from_bar).toBe(17);
+  expect(stored[0].to_bar).toBe(32);
+  expect(stored[0].tempo_bpm).toBe(76);
+  expect(stored[0].target_tempo_bpm).toBe(120);
+  expect(stored[0].note).toBe("left hand still behind");
+  // Derived from the two tempos rather than stored, and false because 76 is
+  // short of 120 - the one place the interface could tell somebody they are
+  // further on than they are.
+  expect(stored[0].reached_target).toBe(false);
+});
+
+test("a field left empty is unset rather than zero", async ({ page, request }) => {
+  // Number(null) is 0, so an emptied number input used to send 0 - which the
+  // server refuses, failing the whole save with a message about a field the
+  // person had just cleared.
+  await page.goto(`/#/score/${score.id}`);
+  await practiseFor(page);
+  await expect(panel(page)).toBeVisible();
+
+  await page.locator(".detail-tempo").fill("76");
+  await page.locator(".detail-tempo").fill("");
+  await page.locator(".detail-note").fill("no tempo worth naming");
+  await page.locator(".save-detail").click();
+
+  await expect(panel(page)).toHaveCount(0);
+  await expect(page.locator(".detail-hint")).toHaveCount(0);
+  const stored = (await (await request.get("/api/practice/sessions")).json()).sessions;
+  expect(stored[0].tempo_bpm).toBeNull();
+  expect(stored[0].note).toBe("no tempo worth naming");
+});
+
+test("closing the panel keeps the session it was about", async ({ page, request }) => {
+  await page.goto(`/#/score/${score.id}`);
+  await practiseFor(page);
+  await expect(panel(page)).toBeVisible();
+  await page.locator(".close-detail").click();
+  await expect(panel(page)).toHaveCount(0);
+
+  const stored = (await (await request.get("/api/practice/sessions")).json()).sessions;
+  expect(stored).toHaveLength(1);
+  expect(stored[0].rating).toBeNull();
+});
+
+test("moving to another score closes the panel rather than aiming it there", async ({
+  page,
+  request,
+}) => {
+  // A data-integrity bug, not a cosmetic one. The route swaps `id` on the same
+  // Viewer instance rather than remounting it, so the panel stayed on screen
+  // across the change - and a rating typed into it then went to the PREVIOUS
+  // score's session, recording an opinion about practice that did not happen.
+  //
+  // Navigated by changing the hash from inside the page, not with goto(): a
+  // full document load would unmount the component and destroy the panel
+  // whatever the component did, which is a test that passes for the wrong
+  // reason.
+  const other = await upload(request, OTHER_NAME);
+
+  await page.goto(`/#/score/${score.id}`);
+  await practiseFor(page);
+  await expect(panel(page)).toBeVisible();
+  const logged = (await (await request.get("/api/practice/sessions")).json()).sessions;
+  expect(logged).toHaveLength(1);
+
+  await page.evaluate((id) => {
+    window.location.hash = `#/score/${id}`;
+  }, other.id);
+  await expect(page.locator("header .title")).toContainText("Notation-only example");
+  await expect(panel(page)).toHaveCount(0);
+
+  const after = (await (await request.get("/api/practice/sessions")).json()).sessions;
+  expect(after).toHaveLength(1);
+  expect(after[0].id).toBe(logged[0].id);
+  expect(after[0].rating).toBeNull();
+});
+
+test("a session that runs past midnight is filed on the day it started", async ({
+  page,
+  request,
+}) => {
+  // The single field this whole feature counts, and the day it picks has to be
+  // chosen rather than incidental. Taking the day from the clock at flush time
+  // filed a 23:40-to-00:20 session entirely on the following day - and at a
+  // week boundary, against the next week's goal rather than the one it was
+  // practised for.
+  //
+  // A fake clock, because the alternative is waiting until midnight. Installed
+  // at a fixed local time so both the start day and the stop day are known.
+  const beforeMidnight = new Date(2026, 7, 17, 23, 59, 50);
+  await page.clock.install({ time: beforeMidnight });
+  await page.goto(`/#/score/${score.id}`);
+  await expect(timer(page)).toBeVisible();
+
+  await timer(page).click();
+  await expect(timer(page)).toHaveClass(/on/);
+  // Past midnight, and past the ten-second floor.
+  await page.clock.fastForward("00:30");
+  await timer(page).click();
+  await expect(panel(page)).toBeVisible();
+
+  const stored = (await (await request.get("/api/practice/sessions")).json()).sessions;
+  expect(stored).toHaveLength(1);
+  expect(stored[0].local_date).toBe("2026-08-17");
+  expect(stored[0].local_date_source).toBe("recorded");
+});
+
+test("the session reaches the library's own view of the score", async ({ page, request }) => {
+  await page.goto(`/#/score/${score.id}`);
+  await practiseFor(page);
+  await expect(panel(page)).toBeVisible();
+
+  const listed = await (await request.get("/api/scores")).json();
+  expect(listed[0].practice_seconds).toBeGreaterThanOrEqual(10);
+  // The practice DAY, not a timestamp - this is what the library's "practised
+  // today" is computed from.
+  expect(listed[0].last_practiced).toBe(localDay());
+
+  await page.goto("/#/");
+  await expect(page.locator(".card .practiced")).toHaveText("practiced today");
+});

--- a/web/tests/minimum-tests.js
+++ b/web/tests/minimum-tests.js
@@ -18,7 +18,7 @@
 // This is also read directly by scripts/run-browser-tests.mjs, which is the
 // OTHER half of this guard - see that file's own comment for why counting
 // here is not, by itself, enough. Keep the two numbers in sync.
-export const MINIMUM_TESTS = 97;
+export const MINIMUM_TESTS = 133;
 
 export default class MinimumTests {
   constructor() {

--- a/web/tests/minimum-tests.js
+++ b/web/tests/minimum-tests.js
@@ -18,7 +18,7 @@
 // This is also read directly by scripts/run-browser-tests.mjs, which is the
 // OTHER half of this guard - see that file's own comment for why counting
 // here is not, by itself, enough. Keep the two numbers in sync.
-export const MINIMUM_TESTS = 133;
+export const MINIMUM_TESTS = 146;
 
 export default class MinimumTests {
   constructor() {

--- a/web/tests/unit/practice.spec.js
+++ b/web/tests/unit/practice.spec.js
@@ -9,16 +9,24 @@
 //
 // No browser is needed for any of it - practice.js has no runes and no imports
 // precisely so this can import it.
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
 import { expect, test } from "@playwright/test";
 
 import {
   ACTIVITY_LABELS,
   FORBIDDEN_WORDS,
+  MISSING_PIECE_LABEL,
   WEEK_STARTS,
   forbiddenWord,
+  sessionSubject,
+  uncountableStatement,
   activityLabel,
   addDays,
   dayBars,
+  formatDays,
   formatDuration,
   formatMinutes,
   goalScopeLabel,
@@ -162,6 +170,55 @@ test("the forbidden vocabulary is matched as whole words", () => {
   }
 });
 
+// The user-facing text in the components, which the vocabulary check did not
+// reach. practice.js owns the phrases it generates, but the pages carry
+// literals of their own - and one of them ("your practice record") failed this
+// on the whole word "record", in a file whose header says the words are the
+// feature.
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const COMPONENTS = ["Practice.svelte", "Viewer.svelte", "Library.svelte"];
+
+// The attributes a person actually reads. Every other attribute value is
+// dropped before the check, because they are machine vocabulary and collide
+// with it: loading="lazy" is a standard HTML value, and weakening the word list
+// to accommodate it would be exactly the wrong way round.
+const READ_BY_A_PERSON = /^(placeholder|title|aria-label|alt)=/;
+
+/** A component's text with everything that is not shown to a person removed:
+ * comments in all three syntaxes, the style block, and attribute values nobody
+ * reads. */
+function visibleText(source) {
+  return source
+    .replace(/<style[\s\S]*?<\/style>/g, " ")
+    .replace(/<!--[\s\S]*?-->/g, " ")
+    .replace(/\/\*[\s\S]*?\*\//g, " ")
+    .replace(/^\s*\/\/.*$/gm, " ")
+    .replace(/[\w-]+="[^"]*"/g, (attr) => (READ_BY_A_PERSON.test(attr) ? attr : " "));
+}
+
+test("the practice interface's own words pass the same vocabulary check", () => {
+  for (const name of COMPONENTS) {
+    const source = fs.readFileSync(path.join(HERE, "..", "..", "src", "lib", name), "utf8");
+    const found = forbiddenWord(visibleText(source));
+    expect(found, `${name} contains the word ${found}`).toBeNull();
+  }
+});
+
+test("the vocabulary check would notice if one of those files slipped", () => {
+  // The check above is worth nothing unless it can fail on the files it reads,
+  // and a comment-stripper is exactly the sort of thing that quietly stops
+  // matching anything.
+  expect(forbiddenWord(visibleText('<p>you missed a day</p>'))).toBe("missed");
+  expect(forbiddenWord(visibleText('<script>const s = "your best week";</script>'))).toBe("best");
+  // ...and that it is the stripping, not luck, that lets the real files pass.
+  expect(forbiddenWord(visibleText("<!-- a comment mentioning your best week -->"))).toBeNull();
+  expect(forbiddenWord(visibleText("<style>.missed { color: red }</style>"))).toBeNull();
+  expect(forbiddenWord(visibleText('<img loading="lazy" alt="" />'))).toBeNull();
+  // An attribute a person DOES read is still checked.
+  expect(forbiddenWord(visibleText('<input placeholder="you missed a day" />'))).toBe("missed");
+  expect(forbiddenWord(visibleText('<button title="your best week">x</button>'))).toBe("best");
+});
+
 // ------------------------------------------------------------- the statements
 
 test("a partly met goal states both numbers and reaches no verdict", () => {
@@ -187,6 +244,31 @@ test("both targets produce one statement each, in the order they were set", () =
   );
   expect(statements.map((s) => s.key)).toEqual(["days", "minutes"]);
   expect(statements[1].text).toBe("1h 30m of 2h 30m planned");
+});
+
+test("a week with no practice in it says none, not nought", () => {
+  // The rule formatDuration already applies to a length, applied to the other
+  // target. "0 of 5 planned days" beside "none of 5h planned" is the rule kept
+  // in one place and dropped in the other, and a bare nought beside a target
+  // reads like a mark out of five.
+  const statements = goalStatements(
+    goal({
+      target_days: 5,
+      target_minutes: 300,
+      progress: {
+        ...goal().progress,
+        days_practised: 0,
+        minutes: 0,
+        met_days: false,
+        met_minutes: false,
+      },
+    }),
+  );
+  expect(statements[0].text).toBe("none of 5 planned days");
+  expect(statements[1].text).toBe("none of 5h planned");
+  expect(formatDays(0)).toBe("no days");
+  expect(formatDays(1)).toBe("1 day");
+  expect(formatDays(4)).toBe("4 days");
 });
 
 test("a target that was not set produces no statement at all", () => {
@@ -234,6 +316,20 @@ test("a week states its days and its total, or says plainly there was none", () 
   expect(periodStatement(null)).toBe("No practice recorded this week");
 });
 
+test("a past week does not call itself this week", () => {
+  // It did, for every row in the review - so a quiet spell in July rendered as
+  // three consecutive rows reading "No practice recorded this week" beside
+  // dates nowhere near the current one. The row already carries its dates; the
+  // sentence does not need to name the week, only to avoid naming the wrong
+  // one.
+  expect(periodStatement({ days_practised: 0, seconds: 0 }, false)).toBe("No practice recorded");
+  expect(periodStatement(null, false)).toBe("No practice recorded");
+  expect(periodStatement({ days_practised: 2, seconds: 600 }, false)).toBe("2 days, 10m");
+  for (const facts of [null, { days_practised: 0, seconds: 0 }, { days_practised: 3, seconds: 1 }]) {
+    expect(periodStatement(facts, false)).not.toContain("this week");
+  }
+});
+
 test("nothing said about a week compares it to another week", () => {
   const said = [
     periodStatement({ days_practised: 0, seconds: 0 }),
@@ -249,8 +345,15 @@ test("a goal says what it is about", () => {
   expect(goalScopeLabel(goal({ scope: "activity", activity: "ear_training" }))).toBe(
     "ear training",
   );
-  // A piece whose row has gone still has a goal to describe.
-  expect(goalScopeLabel(goal({ scope: "score", score_title: null }))).toBe("one piece");
+  // A title that did not come back, but the piece is still there.
+  expect(goalScopeLabel(goal({ scope: "score", score_id: 4, score_title: null }))).toBe(
+    "one piece",
+  );
+  // A piece that has left the library says so, rather than showing a blank
+  // where a title goes.
+  expect(goalScopeLabel(goal({ scope: "score", score_id: null, score_title: null }))).toBe(
+    MISSING_PIECE_LABEL.toLowerCase(),
+  );
 });
 
 // ------------------------------------------------------------------- the bars

--- a/web/tests/unit/practice.spec.js
+++ b/web/tests/unit/practice.spec.js
@@ -1,0 +1,346 @@
+// How practice is put into words, and the calendar arithmetic behind it.
+//
+// These are the assertions that matter most in the whole practice feature, and
+// not because the arithmetic is hard. The wording IS the feature: an interface
+// that reports the same numbers as "you missed a day" instead of "3 of 4
+// planned days" has failed at the one thing it was asked to do, and no amount
+// of correct counting fixes it. So the strings are pinned character for
+// character, and the vocabulary is checked against a list.
+//
+// No browser is needed for any of it - practice.js has no runes and no imports
+// precisely so this can import it.
+import { expect, test } from "@playwright/test";
+
+import {
+  ACTIVITY_LABELS,
+  FORBIDDEN_WORDS,
+  WEEK_STARTS,
+  forbiddenWord,
+  activityLabel,
+  addDays,
+  dayBars,
+  formatDuration,
+  formatMinutes,
+  goalScopeLabel,
+  goalStatements,
+  localDay,
+  periodLabel,
+  periodStatement,
+  rangeLabel,
+  shortDayName,
+  tempoLabel,
+  timeLeftStatement,
+  weekStart,
+} from "../../src/lib/practice.js";
+
+const goal = (over = {}) => ({
+  target_days: 4,
+  target_minutes: null,
+  scope: "all",
+  score_title: null,
+  activity: null,
+  progress: {
+    status: "past",
+    days_practised: 3,
+    minutes: 90,
+    seconds: 5400,
+    days_left: 0,
+    met_days: false,
+    met_minutes: null,
+    met: false,
+  },
+  ...over,
+});
+
+// --------------------------------------------------------------- the calendar
+
+test("the practice day is the browser's own day, not the UTC one", () => {
+  // 23:30 local on 17 August is, in any timezone east of about UTC+1, already
+  // the 18th in UTC - and toISOString().slice(0,10) would say so. The day the
+  // practice happened on is the local one.
+  const late = new Date(2026, 7, 17, 23, 30);
+  expect(localDay(late)).toBe("2026-08-17");
+  const early = new Date(2026, 7, 17, 0, 15);
+  expect(localDay(early)).toBe("2026-08-17");
+  // Months and days are zero-padded, because the server compares these as
+  // text: "2026-8-7" sorts and ranges wrongly against "2026-08-17".
+  expect(localDay(new Date(2026, 0, 5))).toBe("2026-01-05");
+});
+
+test("a monday-start week runs monday to sunday", () => {
+  for (const day of ["2026-08-17", "2026-08-19", "2026-08-23"]) {
+    expect(weekStart(day, "monday"), day).toBe("2026-08-17");
+  }
+  expect(weekStart("2026-08-16", "monday")).toBe("2026-08-10");
+});
+
+test("a sunday-start week runs sunday to saturday", () => {
+  expect(weekStart("2026-08-17", "sunday")).toBe("2026-08-16");
+  expect(weekStart("2026-08-16", "sunday")).toBe("2026-08-16");
+  expect(weekStart("2026-08-22", "sunday")).toBe("2026-08-16");
+  expect(weekStart("2026-08-23", "sunday")).toBe("2026-08-23");
+});
+
+test("every day of a year falls in exactly one week, under either setting", () => {
+  // Not a restatement of the two tests above: this walks a whole year, across
+  // month ends and a daylight-saving change in most timezones, and checks the
+  // window actually contains the day - which is what an off-by-one in the
+  // modulo breaks and a handful of spot checks can miss.
+  for (const startsOn of WEEK_STARTS) {
+    for (let d = new Date(2026, 0, 1); d.getFullYear() === 2026; d.setDate(d.getDate() + 1)) {
+      const day = localDay(d);
+      const start = weekStart(day, startsOn);
+      const end = addDays(start, 6);
+      expect(start <= day && day <= end, `${day} in ${start}..${end}`).toBe(true);
+      expect(shortDayName(start), `${startsOn} week starts on`).toBe(
+        startsOn === "monday" ? "Mon" : "Sun",
+      );
+    }
+  }
+});
+
+test("adding days crosses a month, a year and a daylight-saving boundary", () => {
+  expect(addDays("2026-08-31", 1)).toBe("2026-09-01");
+  expect(addDays("2026-12-31", 1)).toBe("2027-01-01");
+  expect(addDays("2026-01-01", -1)).toBe("2025-12-31");
+  // Spring forward in most of Europe and North America. Parsing a day at
+  // midnight instead of midday is what makes this land on the wrong date.
+  expect(addDays("2026-03-28", 1)).toBe("2026-03-29");
+  expect(addDays("2026-03-29", 1)).toBe("2026-03-30");
+  expect(addDays("2026-11-01", 1)).toBe("2026-11-02");
+});
+
+test("a period reads as a range, and says the month once when it can", () => {
+  expect(periodLabel("2026-08-17", "2026-08-23")).toBe("17-23 Aug");
+  expect(periodLabel("2026-09-28", "2026-10-04")).toBe("28 Sep - 4 Oct");
+});
+
+// ---------------------------------------------------------------- the lengths
+
+test("a length of practice reads the way a person says it", () => {
+  expect(formatDuration(0)).toBe("none");
+  expect(formatDuration(30)).toBe("under a minute");
+  expect(formatDuration(60)).toBe("1m");
+  expect(formatDuration(2700)).toBe("45m");
+  expect(formatDuration(3600)).toBe("1h");
+  expect(formatDuration(5400)).toBe("1h 30m");
+  expect(formatDuration(7500)).toBe("2h 5m");
+  expect(formatMinutes(150)).toBe("2h 30m");
+  expect(formatMinutes(0)).toBe("none");
+});
+
+test("a length is never rounded up into time that was not practised", () => {
+  expect(formatDuration(119)).toBe("1m");
+  expect(formatDuration(3599)).toBe("59m");
+});
+
+test("nonsense in gives none out rather than NaN", () => {
+  for (const bad of [null, undefined, "", NaN, -50, {}]) {
+    expect(formatDuration(bad), String(bad)).toBe("none");
+  }
+});
+
+// ------------------------------------------------------------- the vocabulary
+
+test("the forbidden vocabulary is matched as whole words", () => {
+  expect(forbiddenWord("you missed a day")).toBe("missed");
+  expect(forbiddenWord("your best week so far")).toBe("best");
+  expect(forbiddenWord("you should practise more")).toBe("should");
+  // The plain statements this feature is built on have to survive the check,
+  // or the check is the thing that gets deleted.
+  expect(forbiddenWord("No practice recorded this week")).toBeNull();
+  expect(forbiddenWord("3 of 4 planned days")).toBeNull();
+  expect(forbiddenWord("1h 30m of 2h 30m planned")).toBeNull();
+  expect(forbiddenWord("5 days left in this week")).toBeNull();
+  for (const word of FORBIDDEN_WORDS) {
+    expect(forbiddenWord(`a sentence with ${word} in it`), word).toBe(word);
+  }
+  // The list itself, pinned - the vocabulary is the rule, so quietly emptying
+  // it would switch every check above off while leaving them green.
+  for (const required of ["missed", "failed", "streak", "best", "should", "only"]) {
+    expect(FORBIDDEN_WORDS, required).toContain(required);
+  }
+});
+
+// ------------------------------------------------------------- the statements
+
+test("a partly met goal states both numbers and reaches no verdict", () => {
+  const [days] = goalStatements(goal());
+  expect(days.text).toBe("3 of 4 planned days");
+  expect(days.met).toBe(false);
+});
+
+test("a met goal is marked as reached and worded identically otherwise", () => {
+  const [days] = goalStatements(
+    goal({ progress: { ...goal().progress, days_practised: 4, met_days: true } }),
+  );
+  expect(days.text).toBe("4 of 4 planned days");
+  expect(days.met).toBe(true);
+});
+
+test("both targets produce one statement each, in the order they were set", () => {
+  const statements = goalStatements(
+    goal({
+      target_minutes: 150,
+      progress: { ...goal().progress, minutes: 90, met_minutes: false },
+    }),
+  );
+  expect(statements.map((s) => s.key)).toEqual(["days", "minutes"]);
+  expect(statements[1].text).toBe("1h 30m of 2h 30m planned");
+});
+
+test("a target that was not set produces no statement at all", () => {
+  // Not "0 of 0 minutes", which would read as a target nobody chose and could
+  // be marked unmet.
+  expect(goalStatements(goal({ target_days: null, target_minutes: null }))).toEqual([]);
+  const minutesOnly = goalStatements(
+    goal({ target_days: null, target_minutes: 60, progress: { ...goal().progress, minutes: 60, met_minutes: true } }),
+  );
+  expect(minutesOnly.map((s) => s.key)).toEqual(["minutes"]);
+});
+
+test("nothing said about a goal uses a word that grades the person", () => {
+  const cases = [
+    goal(),
+    goal({ progress: { ...goal().progress, days_practised: 0 } }),
+    goal({ target_minutes: 600, progress: { ...goal().progress, minutes: 5 } }),
+    goal({ target_days: 7, progress: { ...goal().progress, days_practised: 7, met_days: true } }),
+  ];
+  for (const g of cases) {
+    const words = goalStatements(g)
+      .map((s) => s.text)
+      .join(" ");
+    expect(forbiddenWord(words), words).toBeNull();
+  }
+});
+
+test("a running week says how much of it is left and nothing about pace", () => {
+  const running = { status: "running", days_left: 5 };
+  expect(timeLeftStatement(running)).toBe("5 days left in this week");
+  expect(timeLeftStatement({ status: "running", days_left: 1 })).toBe("1 day left in this week");
+  // Nothing at all once it has ended - a finished week has no time left to
+  // report, and saying "0 days left" about it is a shape of nagging.
+  expect(timeLeftStatement({ status: "past", days_left: 0 })).toBe("");
+  expect(timeLeftStatement({ status: "running", days_left: 0 })).toBe("");
+  expect(timeLeftStatement(null)).toBe("");
+});
+
+test("a week states its days and its total, or says plainly there was none", () => {
+  expect(periodStatement({ days_practised: 4, seconds: 12000 })).toBe("4 days, 3h 20m");
+  expect(periodStatement({ days_practised: 1, seconds: 600 })).toBe("1 day, 10m");
+  expect(periodStatement({ days_practised: 0, seconds: 0 })).toBe(
+    "No practice recorded this week",
+  );
+  expect(periodStatement(null)).toBe("No practice recorded this week");
+});
+
+test("nothing said about a week compares it to another week", () => {
+  const said = [
+    periodStatement({ days_practised: 0, seconds: 0 }),
+    periodStatement({ days_practised: 7, seconds: 40000 }),
+    timeLeftStatement({ status: "running", days_left: 3 }),
+  ].join(" ");
+  expect(forbiddenWord(said), said).toBeNull();
+});
+
+test("a goal says what it is about", () => {
+  expect(goalScopeLabel(goal())).toBe("any practice");
+  expect(goalScopeLabel(goal({ scope: "score", score_title: "Study in C" }))).toBe("Study in C");
+  expect(goalScopeLabel(goal({ scope: "activity", activity: "ear_training" }))).toBe(
+    "ear training",
+  );
+  // A piece whose row has gone still has a goal to describe.
+  expect(goalScopeLabel(goal({ scope: "score", score_title: null }))).toBe("one piece");
+});
+
+// ------------------------------------------------------------------- the bars
+
+test("a week's bars are scaled inside that week and never against another", () => {
+  const bars = dayBars([
+    { date: "2026-08-17", seconds: 1800, sessions: 1 },
+    { date: "2026-08-18", seconds: 3600, sessions: 2 },
+    { date: "2026-08-19", seconds: 0, sessions: 0 },
+  ]);
+  expect(bars.map((b) => b.label)).toEqual(["Mon", "Tue", "Wed"]);
+  expect(bars[1].fill).toBe(1);
+  expect(bars[0].fill).toBe(0.5);
+  expect(bars[2].fill).toBe(0);
+
+  // The same shape of week at ten times the scale draws identically. If these
+  // were scaled against anything outside the week - a personal best, a
+  // rolling maximum - a quiet week would render as flat next to a busy one,
+  // which is a comparison drawn in pixels.
+  const tenfold = dayBars([
+    { date: "2026-08-17", seconds: 18000, sessions: 1 },
+    { date: "2026-08-18", seconds: 36000, sessions: 2 },
+    { date: "2026-08-19", seconds: 0, sessions: 0 },
+  ]);
+  expect(tenfold.map((b) => b.fill)).toEqual(bars.map((b) => b.fill));
+});
+
+test("a day with a little practice still shows something", () => {
+  const bars = dayBars([
+    { date: "2026-08-17", seconds: 36000, sessions: 4 },
+    { date: "2026-08-18", seconds: 60, sessions: 1 },
+  ]);
+  expect(bars[1].seconds).toBe(60);
+  expect(bars[1].fill).toBeGreaterThan(0);
+});
+
+test("a week with no practice draws seven empty bars, not seven full ones", () => {
+  const week = Array.from({ length: 7 }, (_, i) => ({
+    date: addDays("2026-08-17", i),
+    seconds: 0,
+    sessions: 0,
+  }));
+  const bars = dayBars(week);
+  expect(bars).toHaveLength(7);
+  expect(bars.every((b) => b.fill === 0)).toBe(true);
+});
+
+// --------------------------------------------------------- a session's detail
+
+test("a worked range reads as bars and pages, singular when it is one", () => {
+  expect(rangeLabel({ from_bar: 17, to_bar: 32 })).toBe("bars 17-32");
+  expect(rangeLabel({ from_bar: 17, to_bar: 17 })).toBe("bar 17");
+  expect(rangeLabel({ from_bar: 17, to_bar: null })).toBe("bar 17");
+  expect(rangeLabel({ from_page: 2, to_page: 3 })).toBe("pages 2-3");
+  expect(rangeLabel({ from_bar: 1, to_bar: 8, from_page: 1, to_page: 1 })).toBe(
+    "bars 1-8, page 1",
+  );
+  expect(rangeLabel({})).toBe("");
+  expect(rangeLabel(null)).toBe("");
+});
+
+test("a tempo says it reached the target only when it did", () => {
+  expect(tempoLabel({ tempo_bpm: 120, target_tempo_bpm: 120, reached_target: true })).toBe(
+    "120 bpm, reached the 120 target",
+  );
+  // Short of the target: both numbers, and nothing about the gap.
+  expect(tempoLabel({ tempo_bpm: 88, target_tempo_bpm: 120, reached_target: false })).toBe(
+    "88 bpm, aiming at 120",
+  );
+  expect(tempoLabel({ tempo_bpm: 88, target_tempo_bpm: null })).toBe("88 bpm");
+  // Two numbers with no verdict attached to them - an older or newer server,
+  // or a session assembled by something that did not compute the comparison.
+  // Claiming the target was reached because nothing said it was not is the one
+  // answer this must never give: it is the only field here that could tell a
+  // player they are further on than they are.
+  expect(tempoLabel({ tempo_bpm: 88, target_tempo_bpm: 120 })).toBe("88 bpm, aiming at 120");
+  expect(tempoLabel({ tempo_bpm: 88, target_tempo_bpm: 120, reached_target: null })).toBe(
+    "88 bpm, aiming at 120",
+  );
+  expect(tempoLabel({ tempo_bpm: null, target_tempo_bpm: 120 })).toBe("");
+  expect(tempoLabel(null)).toBe("");
+});
+
+test("every activity has a label, and an unknown one still reads as practice", () => {
+  for (const key of Object.keys(ACTIVITY_LABELS)) {
+    expect(activityLabel(key), key).toBe(ACTIVITY_LABELS[key]);
+    expect(ACTIVITY_LABELS[key].length).toBeGreaterThan(0);
+  }
+  // A kind of practice this build has never heard of - a newer server, an
+  // exercise added later - must not render as "undefined" beside a real one.
+  expect(activityLabel("time_travel")).toBe("Practice");
+  expect(activityLabel(undefined)).toBe("Practice");
+});


### PR DESCRIPTION
Closes #32. Closes #3.

## What this changes

Practice was a duration and an optional note per score. This deepens the record
and builds the weekly goal and review on top of it, in one change because the
goals sit directly on the model and splitting them would have meant designing it
twice.

**A session says what the work was.** Bars or pages worked, the tempo practised
at and the tempo aimed for, section work or a run-through, a 1-5 sense of how it
went beside the existing note. And it can say all that with no piece behind it:
`activity` distinguishes work on a piece from technique, sight reading, ear
training, fretboard, chords, improvisation, theory, and simply playing. One
table, not one per kind — the exercises coming next are practice in exactly the
way a piece is, and a parallel table per kind would mean the history view and
every goal calculation growing another special case with each of them.

**A goal names days and minutes over one week**, optionally scoped to one piece
or one kind of work, with room for what you mean to work on. While the week runs
it shows where you stand; afterwards it states what happened and asks whether
the goal was realistic.

**Nothing stores whether a goal was met.** Progress is counted from the sessions
inside the period every time it is asked for, so a goal and the history it is
about cannot drift apart — and an hour remembered and logged on Friday still
counts towards Tuesday.

The model and the query surface over it are documented in
[docs/practice-data.md](docs/practice-data.md): the raw sessions for a period,
per-day and per-piece and per-activity totals over months, and each recent
week's plan beside what actually happened.

### Accountable, not shamed — as a constraint, not a coat of paint

- The interface states counts and stops: "3 of 4 planned days", "1h 30m of 2h
  30m planned". No percentage, no grade, no "missed".
- A target not reached is drawn **identically** to one that was. The only
  difference is additive: a tick appears beside what was reached. A browser test
  compares the computed colour, weight, background and border of a met and an
  unmet statement and requires them equal, and separately checks neither is the
  colour this app uses for real errors.
- Nothing compares one week to another. No best week, no run of anything, no
  average. The per-day bars are scaled inside their own week for the same
  reason — a bar that shrinks because last month was busier is a comparison
  drawn in pixels.
- A running week reports the days left in it and nothing about what is needed
  per day to catch up, which is a verdict wearing arithmetic.
- A finished week asks "Was this goal realistic?" rather than concluding
  anything. A goal whose week has ended is not closed, archived, graded or
  deleted.
- `web/src/lib/practice.js` owns every phrase and carries the word list its
  tests check it against.

### Judgement calls, and why

- **Days and minutes, not sessions or pieces.** Two sessions in one day is not
  two days of practice, and counting sessions rewards fragmenting an hour into
  six. A piece count would push breadth over depth; "on what" is handled by
  scoping instead.
- **Global, per-piece or per-kind-of-work — not per instrument.** Sessions have
  no instrument link at all today (`scores.instrument_id` is still unread, per
  its own comment in `db.py`), so a per-instrument goal could not be counted
  honestly.
- **One goal per week.** Setting another for the same week replaces it —
  changing your mind about the week is the ordinary case, and a period with two
  goals in it is a scorecard with rows to lose on.
- **The review looks back eight weeks**, and lists every week whether or not a
  goal was set for it. Long enough to show a pattern including a couple of
  unusual weeks; short enough that opening it is not a wall of past periods. A
  week with no goal is not a gap in the record, and leaving it out would make
  this a list of judged weeks.
- **The practice day is stored, not derived.** `started_at` is UTC, so west of
  Greenwich an evening's practice falls on the next UTC day — and "how many days
  did I practise this week" would be wrong by one for exactly the sessions
  somebody is most likely to have. The client sends its own calendar day, and
  passes its own `today` to anything that has to decide whether a week is still
  running.
- **A back-dated session is first-class.** `started_at` is when a session was
  recorded, `local_date` is when the practice happened. Entering yesterday's
  forgotten hour is not lying about either.
- **`reached_target` is derived, not stored** — it is `tempo_bpm >=
  target_tempo_bpm`, and a stored answer is one that can contradict the two
  numbers it came from.

### The schema change, and why it needed a real runner

`practice_sessions.score_id` shipped `NOT NULL`, and practice that is not about
a piece cannot be recorded while it stays that way. SQLite cannot relax a NOT
NULL in place, so `COLUMN_ADDITIONS` genuinely could not express this — which is
what `SCHEMA_VERSION` was stamped for, in its own words. `db.py` now has
`MIGRATIONS`: ordered steps, each taking a database from the version below its
key to that key, all pending steps in one transaction, each stamping its own
version as it lands. Step 2 rebuilds the table and carries every row across with
its id intact. `COLUMN_ADDITIONS` is unchanged and stays as narrow as it was.

Migrations run *before* `SCHEMA`, and that order is load-bearing: `SCHEMA`
creates indexes over columns that only exist once the rebuild has happened, and
`CREATE INDEX IF NOT EXISTS` skips only when the *index* exists — against the old
table it would fail on an unknown column and take startup down.

## How it was verified

**Server (first round):** 402 passed, 2 skipped (both `FERMATA_MUSICXML_XSD`, unrelated), run
with `FERMATA_TEST_LIBRARY` set. 97 of those are new (a further one moved from
skipped to passing, once alphaTab was installed).

**Browser and unit (first round):** 133 passed, up from 97.

**The upgrade path, from databases that predate this change.**
`server/tests/test_practice_migration.py` writes out the schema *as it shipped* —
version 0 (pre-instruments) and version 1 — fills it with real practice history
across several pieces and days with non-contiguous ids, then runs `init_db` and
checks the rows as a whole set rather than by counting. Also covered: the
rebuilt table compared field-for-field and index-for-index against a freshly
created one so the two definitions cannot drift; the foreign key and its cascade
still in force; an upgrade interrupted after its work committed and before its
stamp landed, with a detailed session in the table so a second rebuild would
visibly lose columns; an upgrade that fails partway, which must leave the old
table exactly as it was; and a fresh install, where the step must do nothing at
all.

**Every test here was checked by breaking the thing it covers.** 42 mutations,
all caught.

*Migration* — dropping `note` from the copy; renumbering rows instead of
carrying ids; backfilling `local_date` from the timestamp; building the table
from a diverged definition; removing the already-migrated guard; leaving
`score_id NOT NULL`; dropping the cascade; dropping the foreign key; running
migrations after `SCHEMA`; committing a failed step instead of rolling it back.

*Model* — counting days off the UTC timestamp instead of the practice day;
reporting a short goal as met; rounding minutes up; omitting empty days from a
week; ignoring a goal's scope; accepting practice dated into the future;
accepting a piece session with no piece; defaulting `reached_target` to false;
always starting the week on Monday; accepting a goal with no target; reporting a
running period as past.

*API* — validating only a patch's own fields instead of the merged record;
turning the goal upsert into an insert; ignoring the client's `today`; dropping
goalless weeks from the review; not storing the reflection; ignoring the session
list's filters.

*Interface* — `localDay` using the UTC date; the week always starting Monday;
durations rounding up; a statement editorialising ("you missed 2 days"), which
the vocabulary check catches; reporting a target nobody set; scaling the day bars
against a fixed ceiling instead of the week; drawing an empty day as non-empty;
claiming a tempo target was reached when nothing said it was; colouring an unmet
target with `--danger`; showing the tick on everything; hiding weeks without a
goal; never sending the reflection; adding pace advice; the page showing its own
idea of the week instead of the server's; not sending the practice day when
logging.

The timezone test picks its zone from the clock at collection time —
`Pacific/Midway` before 11:00 UTC, `Pacific/Kiritimati` after — so the browser's
calendar day is *guaranteed* to differ from the UTC one whatever hour CI runs at.
A fixture that only sometimes differs only sometimes tests anything.

## Anything left uncertain

- **The post-session detail panel in the viewer is not covered by a browser
  test.** Its endpoint is (`PATCH /api/practice/sessions/{id}`, including that an
  explicit null clears a field and that a patch cannot reach a state a fresh log
  would be refused), and so are the helpers it renders with — but the panel
  itself is only exercised by hand. The browser suite guards on the library being
  empty before it will delete anything, and reaching that panel needs a score,
  which would mean uploading a file into the shared scratch library and breaking
  that guard for the other specs. Worth doing properly with a fixture that can
  add and remove a score.
- **Deleting a score still deletes its practice** (`ON DELETE CASCADE`,
  unchanged, and now documented). It is narrower than it sounds — the scanner
  re-links a renamed or moved file to its existing row by content hash, so a
  rename never reaches the cascade — but it does mean tidying a file out of the
  library discards the record of having practised it. Making it `SET NULL` is now
  expressible, and would leave sessions claiming to be piece work with no piece;
  I left the behaviour as it was rather than change it as a side effect of this.
- **`?practiced=recent|neglected` and `/practice/summary` still use rolling
  windows over `started_at`**, not the practice day, so a back-dated session can
  read as recent. "In the last 14 days" is a question about elapsed time rather
  than calendar days, so this is defensible, but the two notions of time now
  coexist and the distinction is documented rather than resolved.
- **Not attempted from #32, deliberately.** Per-attempt trainer results belong
  beside the trainer that produces them (#25-#30) — inventing that shape with no
  consumer would be guessing, and what the `activity` vocabulary guarantees is
  that when a trainer lands, its time joins the same history and the same goals.
  Key, tempo and difficulty per score is #8: metadata about the piece rather than
  about the practice.
- **A minute is floored, never rounded up.** 119 seconds reads as 1m, so a total
  can be up to a minute lower than the seconds behind it. That is the direction
  to be wrong in — this must never claim time that was not practised.
- **A week's boundary is a preference** (`week_starts_on`, Monday or Sunday) and
  only ever decides the default for a *new* goal; a goal stores the two dates it
  was set for, so changing the setting cannot re-point one at another week's
  practice. Nothing stops a goal being created for a period that overlaps another
  via the API, which the interface never does.

---

## Update: the review round

Three blockers and the batch that came with them are fixed in `e5b1aa9`. Test
counts are now **451 server** (up from 402) and **146 browser/unit** (up from
133, floor raised deliberately). **34 further mutations, all caught** — six
survived a first attempt and produced better tests rather than weaker ones.

### Blocker 1 — deleting a score no longer deletes the practice

Both practice tables are now `ON DELETE SET NULL`, via migration 3. A session
that outlives its score keeps `activity = 'piece'` with no `score_id`, which is
exactly what identifies it — every other activity may legitimately have no
score, and a `piece` session cannot be *created* without one. It reads as
"A piece no longer in your library" rather than as a blank or a broken row, and
nothing filters it out of a total, a day count, a week's facts or a goal. A goal
counted over any practice therefore cannot be unmade by a file being deleted
afterwards.

A goal *scoped to* that piece reports `progress.countable = false` with `met` as
`null`. Its sessions are still in the history but no longer identifiable as
being about that piece, so reporting zero days would turn a week somebody
practised into a shortfall. The goal is kept, not deleted — the intention was
genuinely formed, and the reflection on it can still be written.

**The orphaned-row startup failure is fixed too.** The rebuild now runs with
foreign keys off, as SQLite's own table-rebuild recipe says to; a dangling
`score_id` is repaired to `NULL` — precisely what the reference's own `ON DELETE
SET NULL` would have done — and announced in the log, with `PRAGMA
foreign_key_check` reporting anything that remains. Two neighbours got real
messages instead of tracebacks: a read-only database file, and a stamped version
that disagrees with the tables it names.

### Blocker 2 — a preference can no longer re-slice history

The review now walks the timeline a period at a time: at each step it takes the
goal covering that day and *its own* stored dates, or the canonical week when
there is none, then resumes the day before. That keeps the result contiguous and
non-overlapping whatever the two grids do, lists every goal exactly once, and
leaves no day unreported — I rejected "drop the canonical week a goal overlaps"
because it silently removed days of real practice from the far side of the goal.

No two goals may share a day: overlap is refused with a 409 naming the clashing
period, and a past week's goal can be removed from the review so a refusal is
always resolvable. The page reads the covering goal's own period for its header,
its day strip, its session list and its Adjust button, so those four can no
longer be talking about different weeks.

**One deliberate deviation:** I did not snap `period_start` to a week boundary.
Once the stored dates are authoritative, snapping either refuses or silently
moves a goal set under a different preference — reintroducing the coupling this
removes. Overlap prevention is the guard that actually holds; the interface only
ever sends a canonical week start or an existing goal's own start.

### Blocker 3 — the Neglected view

`NOT EXISTS`, as recommended. I had independently hit this while writing the
change and patched it with `IS NOT NULL`; the reviewer's form says what the
filter means, so I took it. I grepped every `NOT IN` in `server/fermata` — the
only other one is inside the new repair statement, against `scores.id`, which is
a non-null primary key.

### Everything else in the two batches

| Fix | |
| --- | --- |
| Session straddling midnight | Filed on the day it **started**, not the day it stopped |
| Old sessions uneditable | The back-dating bound applies only when the date itself is written |
| Four dates → 500 | `parse_day` bounded; `today` bounded to the window a practice day may name, so `today=2099-01-01` is a 422 rather than a plausible empty week |
| Reflection carried onto a replacement | Cleared with the goal it was written about |
| `{"target_days": true}` | Strict integers; a bool is not a number of days |
| `target_tempo_bpm` unreachable | Now in the post-session panel, and covered |
| Cleared number field sent `0` | An empty field means unset, never zero |
| Panel survived a score change | Dismissed on the route change — it was writing a rating onto the previous score's session |
| Failed initial load rendered "NaN undefined" | Its own state |
| `/practice/summary` unowned | Owner-filtered, with a test that a foreign-owner row is ignored by *every* practice query |
| Truncation | `total`/`truncated` on the session list, `scores_worked`/`by_score_truncated` on the breakdown |
| Day index unusable | Index on the expression the queries actually filter by; the test asserts the **query plan**, not the DDL |
| Review query count | A `scope: "all"` goal reuses the week facts already counted — 5 statements per week down to 3 |
| Migration ordering | Documented against `COLUMN_ADDITIONS` as well as `SCHEMA`, with the version-0 `instrument_id` trap named |
| Provenance | `sessions_inferred` beside every total, so a window spanning the upgrade says how much of it rests on a day nobody recorded |
| `.reached` no-op | Commented as deliberate, so nobody "fixes" it into a colour difference |

### Tone

- Every past week called itself "this week" — a July gap rendered as three rows
  naming the current one. `periodStatement` now takes the period.
- `0 of 5 planned days` beside `none of 5h planned` was the same rule kept in
  one place and dropped in the other. Zero is a word for both now.
- A fresh install opened on fourteen statements of absence. It gets a greeting.
- The vocabulary check now covers the components that carry the phrases, not
  only the module that generates them — comments, styles and machine-only
  attributes stripped, `placeholder`/`title`/`aria-label`/`alt` kept. It caught
  one of their own literals on the first run.

### The viewer panel now has a browser test

`web/tests/browser/viewer-practice.spec.js` uploads a score into the throwaway
library and removes it afterwards, so the guard that refuses to run against a
backend holding scores is untouched. It is named to sort **last**, so even a
failed cleanup cannot leave a score for another spec. Writing it found a bug
nothing else would have: `onclick={flushPractice}` passed the DOM event as the
`leaving` flag, so every ordinary stop took the page-unload path and the panel
never appeared.

Two smaller things it also surfaced: the config's scratch directory was being
re-created per worker process, so a spec could never see the path the server was
started with; and `.session-detail` existed in two components, so a locator
looking for the panel matched the other one's rows.

### Mutations this round

*Migration and the cascade* — sessions cascading again; goals cascading again;
step 3 never running; step 3 skipping the goals table; a positional row copy;
the rebuild running with foreign keys on; a dangling reference left alone; an
orphaned goal reporting zero rather than uncountable; an orphaned session not
identified as one; an orphaned session refused an annotation.

*The week grid* — matching goals by grid slot; overlap allowed; a reflection
carried onto its replacement.

*Dates and numbers* — unbounded `today`; unbounded `parse_day`; loose integers;
the stale-date bound blocking every edit.

*Existing views* — `NOT IN` instead of `NOT EXISTS`; the library windowing on the
timestamp; the summary ignoring the owner; the session list hiding truncation;
the day index made unusable.

*The interface* — the practice day taken from the stop rather than the start; a
cleared field sending zero; the panel surviving navigation; the flush wired
straight to the click; no empty state; every past week saying "this week"; a zero
day written as a digit; a component literal slipping the vocabulary check.

The four that survived their first attempt are worth naming, because the fix was
the test: a positional copy is indistinguishable from a named one against every
shape a released version ever produced (so the helper is now exercised directly
on a shape none of them had); a midnight-straddling session cannot be observed
without moving the clock (Playwright's fake clock now does); the panel's
navigation bug only manifests score-to-score on the same component instance (the
spec uploads a second score); and a past week saying "this week" only shows on a
week with *no* practice in it.

### Still uncertain

- **`test_a_dangling_reference_does_not_stop_the_application_starting` asserts a
  log record.** If the logger's name or level changes, that assertion goes quiet
  rather than red. The row-level assertions beside it are the real check.
- **After a `week_starts_on` change, one or two days can appear in two adjacent
  review rows** for the single week where the grid moved. I chose that over the
  alternative, which was leaving days out. Documented.
- **The overlap refusal is reachable in one corner**: flip the preference, then
  set a goal for a week that a still-listed older goal extends into. The message
  names the clashing period and the review has a Remove button, so it is always
  resolvable, but it is a 409 a person can meet.
- **The two narrower cascade triggers** the review found in the scanner (a file
  edited *and* moved between scans; duplicate content with one copy renamed) are
  untouched here, per your note that #95 covers that ground.
- **`sessions_inferred` is not surfaced in the interface yet.** It is on every
  aggregate; nothing draws it, because on any install that has only run this
  version it is always zero and a permanent "0 inferred" is noise.
