### PR TITLE
Say what the compiler gate does not catch, and fix the flake it exposed

### DIFF
--- a/web/src/lib/Metronome.svelte
+++ b/web/src/lib/Metronome.svelte
@@ -186,6 +186,22 @@
   // drive one. Created eagerly rather than on first use: it holds no audio
   // resources until the click is actually switched on (see prime() and
   // ensureAudioCtx in metronome-engine.js), so there is nothing to defer.
+  //
+  // `ownsClick` is read ONCE, here, and must therefore be true or false on the
+  // very first render. That is the whole reason it exists as its own flag
+  // instead of being inferred from whether `control` happens to be present: a
+  // caller that builds its transport in an effect passes null on mount and the
+  // real object a tick later, so inferring it built a second engine nobody
+  // asked for. Do not derive `ownsClick` from anything that arrives late, and
+  // do not replace it with a `control` check.
+  //
+  // Worth knowing why that earlier second engine was harmless, since it is not
+  // a reason to relax this: toggling drives `target`, so the stray engine's own
+  // `enabled` never left false, `prime()` returned early, and no audio context
+  // was ever opened. A call site mounting with the click ALREADY on, alongside a
+  // late transport, would have had two engines and two clicks. The build's
+  // compiler gate catches the shape that produced it, but only that shape -
+  // see the note in vite.config.js for what it does not catch.
   let ownTempo = $state(null);
   let ownLimit = $state(null);
   const ownEngine = untrack(() => ownsClick)

--- a/web/tests/browser/practice.spec.js
+++ b/web/tests/browser/practice.spec.js
@@ -295,6 +295,21 @@ test("the week this page offers is the week the server counts", async ({ page, r
 
   await page.locator(".edit-goal").click();
   await page.locator(".save-goal").click();
+  // Wait for the save to have LANDED before reading it back. click() resolves
+  // when the click is dispatched, not when the request it triggers finishes,
+  // and the read below goes out of band - through the request context rather
+  // than the page - so it is not ordered against it. Without this the read
+  // overtakes the POST and sees no goals; it failed in CI exactly that way.
+  //
+  // The edit form closing is a real barrier rather than a convenient one:
+  // saveGoal() sets editing = false only AFTER awaiting the request, so this
+  // cannot be true until the server has answered.
+  //
+  // This is the second time this pattern has bitten (see #82, which asked for
+  // it to be grepped for). Every other out-of-band read in this suite waits on
+  // the interface first - for a count attribute, a rendered row, a tick - and
+  // those assertions are barriers as much as checks. Do not remove one.
+  await expect(page.locator(".edit-goal")).toBeVisible();
   const goals = (await (await request.get(`/api/practice/goals?today=${today}`)).json()).goals;
   expect(goals).toHaveLength(1);
   expect(goals[0].period_start).toBe(weekStart(today, "sunday"));

--- a/web/vite.config.js
+++ b/web/vite.config.js
@@ -17,6 +17,22 @@ import { defineConfig } from "vite";
 // which is exactly what happened. To silence a warning on purpose, say so at
 // the site - `untrack(...)`, or a `<!-- svelte-ignore ... -->` comment with a
 // reason next to it - rather than adding a code to a list here.
+//
+// Know what this does NOT buy, because it is narrower than the defect that
+// prompted it. It catches a particular SHAPE - a reactive value read at the top
+// level of a component - not the mistake of capturing a value that arrives
+// late. The same defect written any of these ways compiles silently:
+//
+//   - the read moved inside a function body;
+//   - the read wrapped in `untrack(...)`, which is how a deliberate one is
+//     declared, so the declaration and the bug are indistinguishable here;
+//   - a value captured into a plain `const` from somewhere the compiler does
+//     not track at all.
+//
+// So a green build means no warning, not "nothing captured too early". The
+// question to ask at a call site is still whether every value it reads once is
+// actually available on the first render - and for a prop the caller builds in
+// an effect, it is not.
 function failOnSvelteWarnings(warning, defaultHandler) {
   // Not a defect in our source and not actionable from here: a dependency's own
   // compiled Svelte, if one ever appears in the graph.


### PR DESCRIPTION
Two things, and the second arrived by accident: the first commit is comments only, and its CI run failed on an unrelated flaky test — which turned out to be a pattern already documented and asked to be swept for.

## The compiler gate is narrower than the defect that bought it

The build now fails on Svelte compiler warnings, and it earned that: four had shipped silently and one was load-bearing. But the comment explaining it reads as though the gate covers the *defect*, and it covers a *shape*.

It catches a reactive value read at the top level of a component. It does not catch the mistake that produced the warning — capturing a value that arrives late. The same defect compiles silently if the read moves inside a function body, or is wrapped in `untrack`, which is also how a *deliberate* initial read is declared, so from the gate's point of view the declaration and the bug are indistinguishable.

A green build therefore means no warning, not "nothing was captured too early".

Also recorded at the guard itself: why the second engine that prompted all this was harmless — toggling drives the shared target, so the stray engine's own enabled flag never left false and no audio context opened. A caller mounting with the click already on, alongside a transport that arrives a tick later, would have had two engines and two clicks. That is a reason to keep the once-read flag honest on the first render, not a reason to relax it.

## The flake, which is the same pattern as #82

The week-boundary practice test clicked Save and then read the goals **out of band** — through the request context rather than the page — so the read was never ordered against the click. It overtook the request in CI and saw no goals.

The barrier used is a real one rather than a convenient one: `saveGoal` sets `editing = false` only *after* awaiting, so the edit form closing cannot happen until the server has answered.

**#82 asked for this pattern to be grepped for, and it was not.** Doing that now finds exactly one instance — this one. Every other out-of-band read in the suite already waits on the interface first, for a count attribute, a rendered row or a tick, and those assertions are barriers as much as checks. There is now a comment saying so at the site.

## Verification

The previously-failing test passes three consecutive times; the full suite is 185 passed, 0 skipped. The build still emits zero compiler warnings, so the gate is not sitting on a violation.

Incidentally confirmed while doing this: narrowing the suite with a filter really does trip the minimum-count guard, which is what it is for.