### PR TITLE
Stop counting invented silence as a bar that adds up

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,29 @@ jobs:
       - name: Install alphaTab
         working-directory: web
         run: npm ci --omit=dev
+      # The emitted MusicXML is validated against the REAL MusicXML 4.0 schema,
+      # which is what catches a child in the wrong place - the profile's
+      # xs:sequence elements have exactly one legal order and anything else
+      # fails validation outright. The schema cannot live in the repository, so
+      # the two tests that use it read its path from FERMATA_MUSICXML_XSD and
+      # skip without it, and for a long time that meant they only ever ran on a
+      # maintainer's machine. Fetched here instead, from the tagged release, so
+      # they run on every change: the schema's own xs:import elements name
+      # remote URLs for xml.xsd and xlink.xsd, which is why the two are
+      # downloaded alongside it and the schemaLocation attributes repointed - a
+      # validator would otherwise fail with an unrelated complaint about
+      # xml:lang. The step fails loudly rather than silently degrading to a skip.
+      - name: Fetch the MusicXML schema
+        run: |
+          mkdir -p "$RUNNER_TEMP/musicxml-schema"
+          cd "$RUNNER_TEMP/musicxml-schema"
+          base=https://raw.githubusercontent.com/w3c/musicxml/v4.0/schema
+          for f in musicxml.xsd xml.xsd xlink.xsd; do
+            curl -fsSL --retry 3 --retry-all-errors -o "$f" "$base/$f"
+          done
+          sed -i 's|http://www.musicxml.org/xsd/xml.xsd|xml.xsd|;
+                  s|http://www.musicxml.org/xsd/xlink.xsd|xlink.xsd|' musicxml.xsd
+          echo "FERMATA_MUSICXML_XSD=$RUNNER_TEMP/musicxml-schema/musicxml.xsd" >> "$GITHUB_ENV"
       # Extraction is exercised against the engraved fixtures committed under
       # server/tests/fixtures/engraved. The tests that need the maintainer's
       # own sheet music read it from FERMATA_TEST_LIBRARY and skip when it is

--- a/README.md
+++ b/README.md
@@ -44,13 +44,16 @@ them.
   than only here — see [the tab profile](docs/musicxml-tab-profile.md) for
   exactly what is written. Fret numbers, strings and chords come out reliably; how much of the
   rhythm survives depends on the engraving, and whatever stayed uncertain is
-  listed with the staff rather than hidden. Bars whose voices the engraved
-  stems do not separate still do not add up — that is now a stated conformance
-  rule of the profile, so any MusicXML tool finds those bars too, and the count
-  is reported either way. Scanned PDFs have nothing to read and are not
-  transcribed. Harmonics are currently dropped rather than read — a gap worth
-  knowing about separately, because a note that is missing does not announce
-  itself the way a note read wrongly does.
+  listed with the staff rather than hidden. A bar that does not add up — because
+  its voices were flattened into one, or a note was read short, or one was
+  dropped — is reported as such, and that is a stated conformance rule of the
+  profile, so any MusicXML tool finds the same bars from the file alone. Where
+  one voice of a bar has to be filled out with silence for the bar to play in
+  time, that silence is marked in the MusicXML, counted as missing rather than
+  as read, and the bars it happened in are named. Scanned PDFs have nothing to
+  read and are not transcribed. Harmonics are currently dropped rather than
+  read — a gap worth knowing about separately, because a missing note announces
+  itself only in the arithmetic of its bar, not in the note itself.
 - **Instruments** — define what you actually play: any number of strings, any
   tuning including reentrant ones, a capo, and a reference pitch other than
   A440. Each string shows the note and frequency it sounds and can be played,

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -240,7 +240,11 @@ or less than the time signature says it should hold. Fermata does not silently
 pad or trim a bar to make the arithmetic work — it reports exactly how many
 bars in a transcription don't add up, alongside the transcription itself, so
 you can see which passages to check by ear rather than trusting an unstated
-guess.
+guess. Where one voice of a bar does have to be filled out with silence — a
+voice that enters halfway through the bar has to start halfway through the bar,
+or its notes play early — the transcription names the bars that happened in,
+counts that silence as missing rather than as read, and marks it in the
+MusicXML so another program can tell it from a rest that was printed.
 
 **Harmonics are not carried into a transcription.** Natural and artificial
 harmonics on a fretted instrument are dropped entirely when Fermata converts

--- a/docs/musicxml-tab-profile.md
+++ b/docs/musicxml-tab-profile.md
@@ -439,18 +439,46 @@ the entire reason for choosing a standard format.
 **What this rule covers, and what it does not.** It covers silence inserted to
 complete a voice the producer *did* read notes from. A measure a producer read
 nothing at all from is a different statement — it holds no voice to complete —
-and is written as an ordinary measure of rests. Fermata does that (so the
-measure keeps its number, and side-by-side comparison against the source stays
-aligned) and treats it as conforming, which is a weaker claim than this rule
-makes and is stated here rather than left to be discovered.
+and is written as an ordinary measure of rests.
 
-**For a reader.** Two things follow, and both matter:
+Writing *that* as `<forward>` would be worse, not better: a voice consisting of
+nothing but `<forward>` contributes no notes and no rests, so a consumer
+enumerating voices from `<note>` elements never sees the voice at all, and the
+measure reads as vacuously conforming. An honest measure of rests is the better
+encoding, and Fermata emits one — the measure keeps its number, so side-by-side
+comparison against the source stays aligned.
+
+The consequence has to be stated, because a consumer cannot recover it: **a
+measure of rests may be either genuinely engraved silence or a measure whose
+contents were missed, and nothing in the file distinguishes them.** In the
+library this profile was developed against, 338 measures are a bar of rests and
+exactly one of them was printed that way. Fermata therefore reports these
+measures outside the Rule 8 figures — counted, named by number, and folded into
+its own confidence — because the file cannot carry the distinction. A consumer
+that needs it has to get it from the producer.
+
+**For a reader.** Four things follow, and they all matter:
 
 - Do not treat `<forward>` as a rest when checking Rule 8. It is what makes a
   short measure detectable.
 - A file with no `<forward>` in it makes no claim either way. This profile
   requires a producer that infers silence to mark it; it cannot make a producer
   that pads silently declare itself.
+- A `<forward>` that is the last thing in its voice may be dropped rather than
+  rendered: nothing sounds after it, so no note moves either way. alphaTab ends
+  the voice there; MuseScore rewrites it as an invisible rest. A `<forward>`
+  anywhere else must advance the position, or every note after it sounds early.
+- **The marking does not survive a save by another program.** Measured over the
+  same library with MuseScore 4: every one of 3,464 `<forward>` elements loses
+  its `<footnote>` and its `<voice>`, a trailing one is rewritten as an
+  invisible rest and a leading one as a `<backup>` with no `<forward>` at all.
+  Net effect on a Rule 8 check of the re-saved files: defective measures fall
+  from 6,013 to 5,707 and identifiable inferred silence from 5,831.6 to 4,466.2
+  quarter notes, so **306 measures this profile reports defective read as
+  conforming to anything downstream of that save**. The agreement between a
+  producer's figures and an independent check holds for the file *as the
+  producer wrote it*. Verify against that file, not against a round trip
+  through an editor — see [Checking a file](#checking-a-file).
 
 **In the other direction.** Fermata also emits the same music as alphaTex for
 its transcription editor. That format has no editorial mechanism for this and
@@ -756,6 +784,19 @@ come back on the wrong strings while everything else looks correct. Fermata
 uses [alphaTab](https://alphatab.net/) for this, via
 `server/tools/tab_extract/verify_musicxml.mjs`, which reports each file's bar,
 voice and note counts along with the first note's MIDI value, string and fret.
+Its `--onsets` flag adds every beat's playback position, which is how [Rule
+14](#inferred-silence-rule-14)'s central assumption is checked: a note after a
+`<forward>` has to sound where a note after a rest of the same duration would.
+A loader that ignored the element would produce a file that still loads, still
+validates, and plays every late-entering voice on the downbeat.
+
+**Load the file, do not save it.** This check means opening the file, not
+opening and re-saving it. A save by another program is that program's encoding
+of the music, not this one's, and at least one major editor rewrites Rule 14's
+`<forward>` elements into something that no longer carries the marking — with
+the figures moving accordingly. The bound is in [Rule
+14](#inferred-silence-rule-14). Whatever a producer states about its own file
+is a statement about the bytes it wrote.
 
 **What Fermata reports about its own transcriptions.** A transcription's
 warnings and confidence live on the transcription record and in the API
@@ -773,16 +814,28 @@ with two voices can have one over its meter and the other under it, so
 `bars_measured`; `bars_defective` is the figure to compare against another
 tool's count, and the one the reported confidence is derived from.
 
-`bars_padded` is how many of those measures hold inferred silence, with the
-measure numbers themselves named in the warning that reports it, and
-`inferred_rest_quarters` is how much silence there is in quarter notes. These
-are the counterpart of the `<forward>` elements in the file: a consumer that
-counts measures containing one should get `bars_padded`, and a consumer that
-sums their durations should get `inferred_rest_quarters`. A padded measure is
-normally also a short one — that is the point of not counting the padding — but
-the two counts are not the same number, since a measure can be padded by less
-than one voice's shortfall and can be over its meter in another voice at the
-same time.
+`bars_padded` is how many of those measures hold inferred silence,
+`padded_bars` is which ones by number, and `inferred_rest_quarters` is how much
+silence there is in quarter notes. These are the counterpart of the `<forward>`
+elements in the file: a consumer that counts measures containing one gets
+`bars_padded`, one that lists them gets `padded_bars`, and one that sums their
+durations gets `inferred_rest_quarters`.
+
+Every padded measure is also a short one, without exception: the padding only
+fires for a voice that is under its meter, and the Rule 8 sum measures exactly
+that pre-padding total. `bars_padded` can still be smaller than `bars_short` —
+a measure with a single voice is never padded, and is emitted short — and could
+in principle be larger only for a measure carrying no `<time>` at all, which is
+not a thing a conforming file has.
+
+`bars_unread` and `unread_bars` are the measures nothing was read from, reported
+separately for the reason given in [Rule 14](#inferred-silence-rule-14): the
+measure of rests they hold does add up, so counting them as Rule 8 defects would
+make these figures disagree with the file, and *not* counting them anywhere let
+a score read as nothing at all report every measure conforming. They are folded
+into the reported confidence instead. That confidence also states any known
+defect below the threshold at which it changes label, so an unqualified
+high-confidence string means no measure was in question rather than not many.
 
 ## Out of scope
 

--- a/docs/musicxml-tab-profile.md
+++ b/docs/musicxml-tab-profile.md
@@ -26,6 +26,7 @@ several things this profile has to decide.
   - [Tab staff description](#tab-staff-description-rules-4-5)
   - [Voices](#voices-rules-6-8)
   - [Fret, string and pitch](#fret-string-and-pitch-rules-9-13)
+  - [Inferred silence](#inferred-silence-rule-14)
 - [Example 1: one monophonic bar](#example-1-one-monophonic-bar)
 - [Example 2: two voices in one bar](#example-2-two-voices-in-one-bar)
 - [Checking a file](#checking-a-file)
@@ -262,7 +263,16 @@ Two notes on what conformance means in practice:
 - A producer must not pad or trim a measure to satisfy Rule 8. Silently
   inserting a rest to make the sum work hides the defect the rule exists to
   expose. Fermata emits measures exactly as read and reports how many fail the
-  rule — see [Checking a file](#checking-a-file).
+  rule — see [Checking a file](#checking-a-file). Where a producer genuinely
+  has to hold a position it did not read — a voice that enters late still has
+  to enter late — [Rule 14](#inferred-silence-rule-14) says how, and that
+  mechanism is deliberately not a rest and so does not enter this sum.
+- "Every voice that appears in it" is the whole of the measure's voices, and a
+  voice can appear without carrying a note: a `<forward>` names a `<voice>`
+  too. A checker that enumerates voices only from `<note>` elements will miss
+  such a voice entirely, and score a measure whose every voice was inferred as
+  conforming. Enumerate voices from `<note>` **and** `<forward>`, then sum only
+  notes and rests.
 - A reader should treat a Rule 8 violation as a diagnostic, not a parse error.
   The file is still valid MusicXML and still largely playable; the affected
   measures simply drift.
@@ -382,6 +392,71 @@ Both cost only how accidentals are written. The sounding pitch, the fret and
 the string are unaffected by the key, so a wrong or missing key signature never
 makes a note wrong — only oddly spelled. That asymmetry is why this profile
 picks a documented default instead of recording per-note uncertainty.
+
+### Inferred silence (Rule 14)
+
+**Rule 14.** Silence a producer deduced rather than read is written as
+`<forward>`, never as a `<rest>`. Each such element carries a `<duration>`, a
+`<footnote>` saying so, and the `<voice>` it belongs to:
+
+```xml
+<forward>
+  <duration>960</duration>
+  <footnote>silence deduced from the time signature, not read from a rest printed in the source</footnote>
+  <voice>1</voice>
+</forward>
+```
+
+The schema's sequence for `forward` is `duration`, `footnote?`, `level?`,
+`voice?`, `staff?` — the footnote comes **before** the voice.
+
+**Why a producer needs this at all.** Reading polyphonic tablature off an
+engraved page loses notes: an unmapped notehead, an unreadable fret number, a
+rest glyph too far from any onset to place. A voice that has lost a note is
+shorter than its meter, and a voice that is shorter than its meter cannot
+simply be written short, because *where* its remaining notes fall depends on
+the silence around them. A voice that enters on beat three and is written with
+nothing before it enters on beat one instead, and every note in it sounds two
+beats early against the other voices. The silence has to be there for the bar
+to play.
+
+**Why it must not be a rest.** A rest is a claim about the source: somebody
+engraved it. Writing invented silence as a rest makes the measure add up, so
+[Rule 8](#voices-rules-6-8) passes, the transcription reports itself conformant,
+and the notes that went missing leave no trace anywhere. Measured on one real
+library, a score that had lost ninety notes and gained seventy-seven quarter
+notes of invented rest reported every bar as adding up, at high confidence.
+Every dropped note downstream of that was invisible for the same reason.
+
+`<forward>` resolves both halves. It advances the writing position exactly as a
+rest of the same duration would, so notes still sound where they should and the
+measure still lays out — renderers treat it as the silence it is. But it is not
+a note and not a rest, so it does not enter Rule 8's sum, and the measure fails
+Rule 8 by exactly the amount that was never read. **The producer's own count of
+defective measures and an independent tool's count therefore agree**, which is
+the entire reason for choosing a standard format.
+
+**What this rule covers, and what it does not.** It covers silence inserted to
+complete a voice the producer *did* read notes from. A measure a producer read
+nothing at all from is a different statement — it holds no voice to complete —
+and is written as an ordinary measure of rests. Fermata does that (so the
+measure keeps its number, and side-by-side comparison against the source stays
+aligned) and treats it as conforming, which is a weaker claim than this rule
+makes and is stated here rather than left to be discovered.
+
+**For a reader.** Two things follow, and both matter:
+
+- Do not treat `<forward>` as a rest when checking Rule 8. It is what makes a
+  short measure detectable.
+- A file with no `<forward>` in it makes no claim either way. This profile
+  requires a producer that infers silence to mark it; it cannot make a producer
+  that pads silently declare itself.
+
+**In the other direction.** Fermata also emits the same music as alphaTex for
+its transcription editor. That format has no editorial mechanism for this and
+carries the inferred silence as an ordinary rest; MusicXML is the canonical
+output, and the numbers under [Checking a file](#checking-a-file) name the
+affected measures for a reader of either.
 
 ## Example 1: one monophonic bar
 
@@ -670,7 +745,10 @@ numbering or a Rule 8 violation, because both produce perfectly valid XML.
 **Measure arithmetic.** Rule 8 is checkable by any MusicXML implementation.
 [music21](https://www.music21.org/) reports it directly: parse the file, and for
 each measure compare each voice's summed `duration.quarterLength` against the
-measure's `barDuration.quarterLength`.
+measure's `barDuration.quarterLength`. Count notes and rests only: a
+`<forward>` is [inferred silence](#inferred-silence-rule-14) and holding it
+against the meter would report the measure as adding up when the producer knows
+it does not.
 
 **Round-trip through a renderer.** Loading the file in an application that
 reads tablature is what catches a mirrored string numbering, since the notes
@@ -681,18 +759,30 @@ voice and note counts along with the first note's MIDI value, string and fret.
 
 **What Fermata reports about its own transcriptions.** A transcription's
 warnings and confidence live on the transcription record and in the API
-response, not in the MusicXML — the emitted file is an ordinary score with
-nothing unusual in it. The warnings say how many measures fail Rule 8, in each
-direction, and how many notes were unwritable under Rule 11. The same Rule 8
-counts are also returned as numbers — `bars_overfull`, `bars_short`,
-`bars_defective` and `bars_measured` — so a consumer can compare them against
-what its own MusicXML tooling makes of the file.
+response, not in the MusicXML — the emitted file is an ordinary score, and the
+one thing in it that speaks about provenance is [Rule
+14](#inferred-silence-rule-14)'s `<forward>`. The warnings say how many measures
+fail Rule 8, in each direction, and how many notes were unwritable under Rule
+11. The same Rule 8 counts are also returned as numbers — `bars_overfull`,
+`bars_short`, `bars_defective` and `bars_measured` — so a consumer can compare
+them against what its own MusicXML tooling makes of the file.
 
 `bars_defective` counts a measure once whichever way it is wrong. A measure
 with two voices can have one over its meter and the other under it, so
 `bars_overfull + bars_short` double-counts such a measure and can exceed
 `bars_measured`; `bars_defective` is the figure to compare against another
 tool's count, and the one the reported confidence is derived from.
+
+`bars_padded` is how many of those measures hold inferred silence, with the
+measure numbers themselves named in the warning that reports it, and
+`inferred_rest_quarters` is how much silence there is in quarter notes. These
+are the counterpart of the `<forward>` elements in the file: a consumer that
+counts measures containing one should get `bars_padded`, and a consumer that
+sums their durations should get `inferred_rest_quarters`. A padded measure is
+normally also a short one — that is the point of not counting the padding — but
+the two counts are not the same number, since a measure can be padded by less
+than one voice's shortfall and can be over its meter in another voice at the
+same time.
 
 ## Out of scope
 

--- a/server/fermata/api.py
+++ b/server/fermata/api.py
@@ -1309,7 +1309,14 @@ def _transcription_row(conn, score_id: int):
 # which is a far stronger statement than either row can support. Anything
 # wanting real figures for edited content has to measure that content; it
 # cannot inherit them from the extraction it replaced.
-_BAR_KEYS = ("bars_overfull", "bars_short", "bars_defective", "bars_measured")
+#
+# `bars_padded` belongs with them for the same reason: a bar holding silence
+# that was deduced from the meter rather than read from the page is only partly
+# a reading, and which bars those were is not recoverable from the figures
+# above - the bar numbers themselves stay in the warning prose, which is stored
+# beside these.
+_BAR_KEYS = ("bars_overfull", "bars_short", "bars_defective", "bars_measured",
+             "bars_padded")
 
 
 def _transcription_dict(row) -> dict:
@@ -1428,6 +1435,7 @@ def transcribe(score_id: RowId, body: TranscribeIn | None = Body(default=None)):
             "bars_short": result.bars_short,
             "bars_defective": result.bars_defective,
             "bars_measured": result.bars_measured,
+            "bars_padded": result.bars_padded,
         }
     )
     with tx() as tx_conn:

--- a/server/fermata/api.py
+++ b/server/fermata/api.py
@@ -1310,13 +1310,44 @@ def _transcription_row(conn, score_id: int):
 # wanting real figures for edited content has to measure that content; it
 # cannot inherit them from the extraction it replaced.
 #
-# `bars_padded` belongs with them for the same reason: a bar holding silence
-# that was deduced from the meter rather than read from the page is only partly
-# a reading, and which bars those were is not recoverable from the figures
-# above - the bar numbers themselves stay in the warning prose, which is stored
-# beside these.
+# `bars_padded` and `bars_unread` belong with them for the same reason: a bar
+# holding silence that was deduced from the meter rather than read from the
+# page, or holding nothing that was read at all, is not the reading the other
+# figures make it look like, and neither is recoverable from them.
 _BAR_KEYS = ("bars_overfull", "bars_short", "bars_defective", "bars_measured",
-             "bars_padded")
+             "bars_padded", "bars_unread")
+
+# WHICH bars those were, as data and not only inside the warning prose. The
+# prose names them, but it caps the list, and the profile document states that a
+# consumer summing the `<forward>` durations in the file should get
+# `inferred_rest_quarters` - a claim the application has to actually make good
+# on. `padded_bars` / `unread_bars` are lists of bar numbers;
+# `inferred_rest_quarters` is a quarter-note count and can be fractional.
+_BAR_LIST_KEYS = ("padded_bars", "unread_bars")
+_BAR_AMOUNT_KEYS = ("inferred_rest_quarters",)
+
+
+def _stored_count(value):
+    """A stored bar count, or None if the blob holds something else there. bool
+    is a subclass of int and would otherwise pass as a count."""
+    return value if isinstance(value, int) and not isinstance(value, bool) else None
+
+
+def _stored_bar_list(value):
+    """A stored list of bar numbers, or None. Validated element by element: a
+    list with a string in it is not a list of bar numbers, and passing it
+    through would hand a caller something to do arithmetic on that cannot be."""
+    if not isinstance(value, list):
+        return None
+    return value if all(_stored_count(n) is not None for n in value) else None
+
+
+def _stored_amount(value):
+    """A stored quarter-note count, or None. Accepts int as well as float - 12
+    quarters is a whole number and JSON writes it as one."""
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    return float(value)
 
 
 def _transcription_dict(row) -> dict:
@@ -1334,9 +1365,11 @@ def _transcription_dict(row) -> dict:
     warnings = stored.get("warnings")
     d["warnings"] = warnings if isinstance(warnings, list) else []
     for key in _BAR_KEYS:
-        value = stored.get(key)
-        # bool is a subclass of int and would otherwise pass as a count.
-        d[key] = value if isinstance(value, int) and not isinstance(value, bool) else None
+        d[key] = _stored_count(stored.get(key))
+    for key in _BAR_LIST_KEYS:
+        d[key] = _stored_bar_list(stored.get(key))
+    for key in _BAR_AMOUNT_KEYS:
+        d[key] = _stored_amount(stored.get(key))
     return d
 
 
@@ -1436,6 +1469,10 @@ def transcribe(score_id: RowId, body: TranscribeIn | None = Body(default=None)):
             "bars_defective": result.bars_defective,
             "bars_measured": result.bars_measured,
             "bars_padded": result.bars_padded,
+            "bars_unread": result.bars_unread,
+            "padded_bars": result.padded_bars,
+            "unread_bars": result.unread_bars,
+            "inferred_rest_quarters": result.inferred_rest_quarters,
         }
     )
     with tx() as tx_conn:

--- a/server/fermata/musicxml.py
+++ b/server/fermata/musicxml.py
@@ -113,6 +113,49 @@ MIN_OCTAVE = 0
 MAX_OCTAVE = 9
 
 
+class InferredRest(list):
+    """The `notes` slot of a rest beat that was DEDUCED, not read.
+
+    Any rest beat carries an empty notes list. This marks the subset of them
+    that were never printed in the source and exist only because a voice the
+    producer DID read notes from came up short of its meter - see tabextract's
+    _pad_voice_to_budget. Telling the two apart is the whole point: silence
+    invented to balance a bar must not read as silence somebody engraved.
+
+    It subclasses `list` and is always empty, so every existing consumer of the
+    beats model that only asks "does this beat have notes" is unaffected, and
+    an inferred rest still compares equal to a plain one. Anything that needs
+    the distinction asks is_inferred_rest().
+    """
+
+    __slots__ = ()
+
+
+def inferred_rest() -> InferredRest:
+    """A fresh notes list marked as inferred silence.
+
+    Fresh rather than one shared module-level instance: it is a list, and a
+    single shared mutable empty list is one stray append away from putting the
+    same note into every inferred rest in the document.
+    """
+    return InferredRest()
+
+
+def is_inferred_rest(notes) -> bool:
+    """Whether this beat's notes slot marks silence deduced from the meter."""
+    return isinstance(notes, InferredRest)
+
+
+# What a `<forward>` written for inferred silence says about itself, in words,
+# beside the machine-readable fact of being a forward and not a rest. A
+# constant because it is part of the published profile (Rule 14), so a consumer
+# may match on it - see _append_forward.
+INFERRED_REST_FOOTNOTE = (
+    "silence deduced from the time signature, not read from a rest printed in "
+    "the source"
+)
+
+
 def _fifths_position(n: int) -> tuple[str, int]:
     """The (step, alter) at position n on the line of fifths."""
     return _FIFTHS_LETTERS[(n + 1) % 7], (n + 1) // 7
@@ -276,8 +319,15 @@ def voice_durations(beats) -> list[int]:
     """Each voice's total length in divisions, in voice order. This is the
     left-hand side of Rule 8, computed from the beats model rather than from
     emitted XML, so a caller can report on a transcription without parsing its
-    own output back in."""
-    return [sum(beat_divisions(code, dots) for code, dots, _notes in voice)
+    own output back in.
+
+    Inferred silence (see InferredRest) is NOT counted, because it is not
+    written as a note or a rest: build() emits `<forward>` for it, which Rule 8
+    does not count either. That is what keeps this equal to the per-voice sums
+    a consumer adds up out of the emitted file.
+    """
+    return [sum(beat_divisions(code, dots) for code, dots, notes in voice
+                if not is_inferred_rest(notes))
             for voice in voices_of(beats)]
 
 
@@ -321,6 +371,26 @@ def _append_note(measure, duration, type_name, dots, voice, string=None,
         technical = _sub(notations, "technical")
         _sub(technical, "string", string)
         _sub(technical, "fret", fret)
+
+
+def _append_forward(measure, duration, voice):
+    """Advance one voice's writing position without writing a note or a rest.
+
+    This is how inferred silence is emitted (Rule 14). `<forward>` moves the
+    position exactly as a rest of the same duration would, so the notes after
+    it still sound where they should and the measure still lays out - but it is
+    not a rest, so it does not claim the source printed one, and Rule 8's sum
+    over that voice's notes and rests genuinely falls short. A measure padded
+    to look complete would report as conformant to every tool that reads it,
+    which is precisely the defect that must stay visible.
+
+    The schema's sequence for forward is duration, footnote?, level?, voice?,
+    staff? - so the footnote comes before the voice, not after.
+    """
+    forward = _sub(measure, "forward")
+    _sub(forward, "duration", duration)
+    _sub(forward, "footnote", INFERRED_REST_FOOTNOTE)
+    _sub(forward, "voice", voice)
 
 
 def _append_attributes(measure, ts, fifths, tuning, capo, opening):
@@ -419,6 +489,13 @@ def build(title, tempo, tuning, ts, measures, fifths=0, capo=None,
     reports, and the whole point of emitting a standard format is that
     somebody else's tool can find those.
 
+    A beat whose notes are an InferredRest is silence the extractor deduced
+    from the meter rather than read from the page. It is written as
+    `<forward>`, not as a rest (Rule 14): the position advances so the rest of
+    the voice still sounds in the right place, while the measure's notes and
+    rests genuinely fall short of its meter, so a Rule 8 check by any consumer
+    reports the same defect this producer reports.
+
     The one thing it does refuse to write is a pitch MusicXML has no way to
     express - see is_representable, and unrepresentable_notes for the count a
     caller should report.
@@ -475,6 +552,13 @@ def build(title, tempo, tuning, ts, measures, fifths=0, capo=None,
                     # <duration> is positive-divisions, so there is no way to
                     # write a zero-length beat. Nothing sounds for no time
                     # either, so dropping it loses nothing.
+                    continue
+                if is_inferred_rest(notes):
+                    # Silence this producer deduced rather than read. Written
+                    # as `<forward>`, which holds the position without
+                    # asserting a rest - see _append_forward and Rule 14.
+                    _append_forward(measure, duration, voice_number)
+                    written += duration
                     continue
                 type_name = TYPE_NAMES.get(duration_code)
                 dot_count = min(max(dots, 0), len(_DOT_FACTORS) - 1)

--- a/server/fermata/musicxml.py
+++ b/server/fermata/musicxml.py
@@ -126,6 +126,15 @@ class InferredRest(list):
     beats model that only asks "does this beat have notes" is unaffected, and
     an inferred rest still compares equal to a plain one. Anything that needs
     the distinction asks is_inferred_rest().
+
+    WHAT DESTROYS THE MARK, because it rides on the type rather than on a
+    value: it survives copy, deepcopy and pickle, and is lost by slicing
+    (`notes[:]`), by `list(notes)`, by concatenation, and by any round trip
+    through JSON - all of which hand back a plain list. None of those is reached
+    today; the beats model goes straight from the extractor to the two
+    emitters. But anything that caches the model as JSON and reads it back would
+    turn every inferred rest in the document into an engraved one, silently, and
+    nothing here would fail. Such a cache has to carry the mark itself.
     """
 
     __slots__ = ()
@@ -313,6 +322,37 @@ def voices_of(beats):
     if not beats:
         return []
     return list(beats) if isinstance(beats[0], list) else [beats]
+
+
+def writes_a_note(duration_code, dots, notes) -> bool:
+    """Whether build() writes this beat as a `<note>` at all.
+
+    Two kinds of beat produce none. Inferred silence becomes a `<forward>`
+    (Rule 14), and a beat that resolves to no duration cannot be written,
+    because `<duration>` is positive-divisions. Both are decided here rather
+    than by each caller, so a count reported beside the file and the file itself
+    cannot come from two different rules - see written_beats and build().
+    """
+    if is_inferred_rest(notes):
+        return False
+    return beat_divisions(duration_code, dots) >= _MIN_DURATION
+
+
+def written_beats(measures) -> int:
+    """How many beats the emitted document actually holds.
+
+    This is what `<note>` elements a consumer counts (chord members share their
+    beat's onset and carry `<chord>`, so a chord is one beat, not one per note -
+    Rule 7). Reported rather than the number of beats extraction produced,
+    because those are no longer the same number: silence deduced from the meter
+    is emitted as `<forward>` and is not a beat of the score.
+    """
+    count = 0
+    for measure_in in measures:
+        beats_in, _ts = _split_measure(measure_in, None)
+        for voice in voices_of(beats_in):
+            count += sum(1 for beat in voice if writes_a_note(*beat))
+    return count
 
 
 def voice_durations(beats) -> list[int]:
@@ -553,10 +593,14 @@ def build(title, tempo, tuning, ts, measures, fifths=0, capo=None,
                     # write a zero-length beat. Nothing sounds for no time
                     # either, so dropping it loses nothing.
                     continue
-                if is_inferred_rest(notes):
-                    # Silence this producer deduced rather than read. Written
-                    # as `<forward>`, which holds the position without
-                    # asserting a rest - see _append_forward and Rule 14.
+                if not writes_a_note(duration_code, dots, notes):
+                    # Everything writes_a_note rejects EXCEPT the zero-duration
+                    # case, which the guard above has already skipped: silence
+                    # this producer deduced rather than read. Written as
+                    # `<forward>`, which holds the position without asserting a
+                    # rest - see _append_forward and Rule 14. The predicate is
+                    # shared with written_beats, so the beat count reported
+                    # beside the file and the file itself cannot disagree.
                     _append_forward(measure, duration, voice_number)
                     written += duration
                     continue

--- a/server/fermata/tabextract.py
+++ b/server/fermata/tabextract.py
@@ -62,6 +62,15 @@ alphaTex's `\\voice` separator. Assembling every note into one sequence
 instead made a bar hold the SUM of its voices - typically about double its
 meter - while every individual duration in it was decoded correctly.
 
+INFERRED SILENCE: those filling rests are silence nothing on the page said was
+there, and they are marked as such (musicxml.InferredRest). They exist because
+a voice that entered late needs its leading silence or every note in it sounds
+early, so removing them would move notes rather than tell the truth - but they
+are not evidence of anything, so they do not count towards a bar adding up
+(_bar_conformance), and the MusicXML writes them as `<forward>` rather than as
+a rest (profile Rule 14). Counting them was how a score missing ninety notes
+came to report every bar conformant at high confidence.
+
 Stem direction alone is not enough and is not used alone: in ordinary
 single-voice writing stems also flip with pitch around the middle line, so
 splitting on direction wherever it changes would shred a monophonic melody
@@ -75,7 +84,8 @@ be checkable only by a script written here is a conformance rule of that
 profile - every sounding voice's durations sum to the measure's duration - so
 any MusicXML tool can now find a bar that does not add up. _bar_conformance
 counts them from the same beats model the emitters read, in both directions,
-and nothing is padded or trimmed to make the sums come out.
+counting only what was actually read off the page, and nothing is padded or
+trimmed to make the sums come out.
 
 KNOWN LIMITATIONS, deliberately not modeled: tuplets, ties, and any bar
 whose voices the stems do not separate. Bars that still do not add up are
@@ -137,6 +147,15 @@ class ExtractionResult:
     bars_short: int = 0
     bars_defective: int = 0
     bars_measured: int = 0
+    # Bars holding silence that was deduced from the time signature instead of
+    # read from a rest printed on the page, the bar numbers (1-based, as the
+    # emitted measures are numbered), and how many quarter notes of it there
+    # are. Reported as data and not only in the warning prose, because "which
+    # bars are partly invented" is the question a reader comparing the
+    # transcription against the PDF actually has. See _pad_voice_to_budget.
+    bars_padded: int = 0
+    padded_bars: list[int] = field(default_factory=list)
+    inferred_rest_quarters: float = 0.0
     # Total tab / standard staff systems found across the whole document
     # (summed across pages) - same definition analyze() uses, not a
     # per-page maximum.
@@ -171,6 +190,9 @@ class ExtractionResult:
             "bars_short": self.bars_short,
             "bars_defective": self.bars_defective,
             "bars_measured": self.bars_measured,
+            "bars_padded": self.bars_padded,
+            "padded_bars": list(self.padded_bars),
+            "inferred_rest_quarters": self.inferred_rest_quarters,
             "tab_staff_count": self.tab_staff_count,
             "standard_staff_count": self.standard_staff_count,
             "pages_processed": self.pages_processed,
@@ -1142,13 +1164,19 @@ def _match_onset_columns(onset_groups, cols_sorted, col_xcs, used, x_tol, split_
     return per_group, max(0, needed - len(digits))
 
 
-def _rest_beats_for(quarters, limit=12):
-    """Decompose a span of silence into plain rest beats, longest first."""
+def _rest_beats_for(quarters, limit=12, inferred=False):
+    """Decompose a span of silence into plain rest beats, longest first.
+
+    `inferred=True` marks every beat produced as silence this extractor
+    deduced from the meter rather than read from a rest glyph on the page (see
+    musicxml.InferredRest). Every caller here that fills from the meter passes
+    it: nothing on the page said these rests were there.
+    """
     out = []
     remaining = quarters
     for q, code in _PLAIN_DURATIONS:
         while remaining >= q - 1e-6 and len(out) < limit:
-            out.append((code, 0, []))
+            out.append((code, 0, mxl.inferred_rest() if inferred else []))
             remaining -= q
     return out
 
@@ -1156,23 +1184,35 @@ def _rest_beats_for(quarters, limit=12):
 def _pad_voice_to_budget(tagged, budget, bar_first_x, onset_tol):
     """Fill a voice's silence so it accounts for the whole bar on its own.
 
-    A voice that sounds for only part of a bar is engraved with rests for the
-    remainder, and those rests are what make the arithmetic work: without
-    them every voice but the busiest reads as a short bar and the others
-    drift out of time against it. Where the decoded rest glyphs already
-    account for the silence this adds nothing.
+    KEPT, deliberately, and marked. A voice that sounds for only part of a bar
+    is engraved with rests for the remainder, and the silence has to be there
+    for the bar to play: without it a voice that entered late starts on the
+    downbeat instead, so every note in it sounds early and the voices drift
+    against each other. Dropping the padding would not turn a wrong bar into an
+    honestly short one - it would turn a bar whose notes are in the wrong
+    PLACES into a bar whose notes are in the wrong places AND short. So the
+    silence stays, and the lie it used to tell is removed instead: every beat
+    inserted here is marked as inferred, which keeps it out of the Rule 8 sums
+    (_bar_conformance, musicxml.voice_durations) and out of the emitted
+    MusicXML's rests (it becomes `<forward>` - Rule 14). The bar therefore
+    still reports SHORT by exactly what was missing, still reaches the
+    confidence downgrade, and still lays out.
 
-    Returns the quarters of rest that had to be inferred, so the caller can
-    say how much of the emitted silence was read from the score and how much
-    was deduced from the meter.
+    Where the decoded rest glyphs already account for the silence this adds
+    nothing.
+
+    Nothing is returned. How much silence was inferred, and in which bars, is
+    read back off the marked beats themselves (_bar_conformance) rather than
+    reported through a side channel here - one source of truth, and the one the
+    emitters read.
     """
     total = sum(_beat_quarters(code, dots) for _x, code, dots, _n in tagged)
     deficit = budget - total
     if deficit <= 1e-6:
-        return 0.0
-    fills = _rest_beats_for(deficit)
+        return
+    fills = _rest_beats_for(deficit, inferred=True)
     if not fills:
-        return 0.0
+        return
     # A voice whose first note sits well right of the bar's first onset
     # entered late, so its silence belongs at the front.
     late = not tagged or (tagged[0][0] - bar_first_x) > onset_tol
@@ -1182,7 +1222,6 @@ def _pad_voice_to_budget(tagged, budget, bar_first_x, onset_tol):
         tagged[:0] = inserted
     else:
         tagged.extend(inserted)
-    return sum(_beat_quarters(c, d) for _x, c, d, _n in inserted)
 
 
 def _build_measure_beats_glyph(m_cols, m_lo, m_hi, note_events, note_xs, x_tol,
@@ -1219,14 +1258,16 @@ def _build_measure_beats_glyph(m_cols, m_lo, m_hi, note_events, note_xs, x_tol,
     staff. `budget` is the measure's quarter-note allowance, needed to know
     how much of each voice is silence; without it no rests are inferred.
 
-    Returns (voices, unmatched_columns, unmatched_glyph_notes,
-    inferred_rest_quarters): voices is a list of one or more beat lists, each
-    a list of (duration_code, dots, notes) triples in x order ready for
-    _fmt_beat; unmatched_columns is how many tab columns had no glyph note
-    within x_tol; unmatched_glyph_notes is how many decoded noteheads had no
-    fret number to match (expected to be rare - every played tab note should
-    have one); inferred_rest_quarters is how much silence was deduced from
-    the meter rather than read from a rest glyph.
+    Returns (voices, unmatched_columns, unmatched_glyph_notes): voices is a
+    list of one or more beat lists, each a list of (duration_code, dots, notes)
+    triples in x order ready for _fmt_beat; unmatched_columns is how many tab
+    columns had no glyph note within x_tol; unmatched_glyph_notes is how many
+    decoded noteheads had no fret number to match (expected to be rare - every
+    played tab note should have one).
+
+    Silence that had to be deduced from the meter is not reported here: the
+    beats carry it themselves, as an InferredRest notes slot, which is what the
+    conformance count and both emitters read.
     """
     lo_i = bisect.bisect_left(note_xs, m_lo)
     hi_i = bisect.bisect_left(note_xs, m_hi)
@@ -1287,14 +1328,13 @@ def _build_measure_beats_glyph(m_cols, m_lo, m_hi, note_events, note_xs, x_tol,
     noted = [t for t in tagged if any(notes for _x, _c, _d, notes in t)]
     live = noted if noted else [t for t in tagged if t]
 
-    inferred = 0.0
     if len(live) > 1 and budget:
         first_x = min(t[0][0] for t in live)
         for t in live:
-            inferred += _pad_voice_to_budget(t, budget, first_x, onset_tol)
+            _pad_voice_to_budget(t, budget, first_x, onset_tol)
 
     return ([[(code, dots, notes) for _x, code, dots, notes in t] for t in live],
-            unmatched_columns, unmatched_glyph_notes, inferred)
+            unmatched_columns, unmatched_glyph_notes)
 
 
 def _voice_mean_y(groups):
@@ -1574,6 +1614,12 @@ _TIE_WARNING = (
 
 _DOT_FACTORS = (1.0, 1.5, 1.75)
 
+# How many padded bar numbers the warning names before summarising the rest.
+# Enough to check a handful against the PDF without turning one warning into a
+# wall of a hundred numbers; the count beside them is always complete, and the
+# MusicXML carries every one of them.
+_PADDED_BARS_LISTED = 12
+
 
 def _beat_quarters(code, dots) -> float:
     if not code:
@@ -1591,10 +1637,18 @@ def _voices_of(beats):
     return list(beats) if isinstance(beats[0], list) else [beats]
 
 
-def _voice_quarters(beats) -> list[float]:
-    """Each voice's total length in quarter notes, in voice order - the
-    quantity both _bar_quarters and _bar_conformance are about."""
-    return [sum(_beat_quarters(code, dots) for code, dots, _n in v)
+def _voice_quarters(beats, count_inferred=True) -> list[float]:
+    """Each voice's total length in quarter notes, in voice order.
+
+    `count_inferred=False` leaves out rests this extractor deduced from the
+    meter rather than read from the page (musicxml.is_inferred_rest), which
+    gives what the bar was actually READ as. That is the quantity
+    _bar_conformance measures: with the padding counted, a voice filled out
+    from its meter is exactly as long as its meter by construction, so no
+    padded bar could ever be reported short.
+    """
+    return [sum(_beat_quarters(code, dots) for code, dots, notes in v
+                if count_inferred or not mxl.is_inferred_rest(notes))
             for v in _voices_of(beats)]
 
 
@@ -1602,7 +1656,12 @@ def _bar_quarters(beats) -> float:
     """The longest voice in this bar, in quarter notes. Voices sound
     CONCURRENTLY, so a bar is as long as its longest voice - not the sum of
     them, which is exactly the mistake that made a bar of two-voice writing
-    read as double its meter."""
+    read as double its meter.
+
+    This is how long the bar PLAYS, so inferred silence counts: it occupies
+    time. Not what to check conformance with - see _bar_conformance, which
+    measures what was read instead.
+    """
     return max(_voice_quarters(beats), default=0.0)
 
 
@@ -1620,6 +1679,18 @@ class _BarConformance(NamedTuple):
     short: int
     defective: int
     counted: int
+    # Of `counted`, how many bars hold silence that was deduced from the meter
+    # rather than read from the page, and which bars those are (1-based, in the
+    # same numbering the emitted measures use). A padded bar is normally also a
+    # SHORT one - that is the point - but not always: padding a voice that lost
+    # a note to exactly the meter can coincide with another voice that decoded
+    # correctly, and a bar padded by less than the tolerance is not short.
+    padded: int = 0
+    padded_bars: tuple[int, ...] = ()
+    # And how much of it there is, in quarter notes, across the whole score.
+    # Read off the marked beats rather than accumulated as the padding happens,
+    # so the figure reported and the silence emitted cannot disagree.
+    inferred_quarters: float = 0.0
 
 
 def _bar_conformance(measures) -> _BarConformance:
@@ -1639,17 +1710,36 @@ def _bar_conformance(measures) -> _BarConformance:
     is the same thing as "some voice differs from the meter". Nothing here
     corrects anything: a bar that does not add up is emitted as it was read,
     counted, and reported.
+
+    MEASURED ON WHAT WAS READ, not on what is emitted. Rests the extractor
+    deduced from the meter to fill a voice out (_pad_voice_to_budget) are left
+    out of the sums, because counting them makes this incapable of ever
+    reporting a padded bar short: the padding fills a voice to exactly its
+    meter by construction, so `min(voices) < budget` could not fire and a bar
+    that lost sixty notes reported as perfectly conformant. Leaving them out is
+    the same measurement as running this before the padding, and it is also
+    what a consumer computes from the emitted MusicXML, where inferred silence
+    is a `<forward>` rather than a rest and so is not part of Rule 8's sum
+    either.
     """
     overfull = 0
     short = 0
     defective = 0
     counted = 0
-    for beats, ts in measures:
+    padded_bars = []
+    inferred_quarters = 0.0
+    for index, (beats, ts) in enumerate(measures, start=1):
         if not ts:
             continue
         counted += 1
         budget = _measure_quarter_length(ts)
-        voices = _voice_quarters(beats)
+        voices = _voice_quarters(beats, count_inferred=False)
+        bar_inferred = sum(_beat_quarters(code, dots)
+                           for v in _voices_of(beats) for code, dots, notes in v
+                           if mxl.is_inferred_rest(notes))
+        if bar_inferred:
+            padded_bars.append(index)
+            inferred_quarters += bar_inferred
         if not voices:
             continue
         over = max(voices) > budget + 1e-6
@@ -1657,7 +1747,9 @@ def _bar_conformance(measures) -> _BarConformance:
         overfull += over
         short += under
         defective += over or under
-    return _BarConformance(overfull, short, defective, counted)
+    return _BarConformance(overfull, short, defective, counted,
+                           len(padded_bars), tuple(padded_bars),
+                           inferred_quarters)
 
 
 def _overfull_bars(measures) -> tuple[int, int]:
@@ -1679,6 +1771,8 @@ def _rhythm_report(counts, details, conformance=None):
     conformance = conformance or _BarConformance(0, 0, 0, 0)
     overfull, short = conformance.overfull, conformance.short
     defective, bars = conformance.defective, conformance.counted
+    padded, padded_bars = conformance.padded, conformance.padded_bars
+    inferred_quarters = conformance.inferred_quarters
     glyphs = counts.get(PROV_GLYPHS, 0)
     degraded = counts.get(PROV_GLYPHS_DEGRADED, 0)
     spacing = counts.get(PROV_SPACING, 0)
@@ -1741,6 +1835,23 @@ def _rhythm_report(counts, details, conformance=None):
             "with a gap at the end. The emitted score says so rather than padding it out, so any "
             "MusicXML tool will report those bars too"
         )
+    # Which bars were padded, not just how much silence was added across the
+    # score. A total says a score is partly invented; the bar numbers say WHERE,
+    # which is what lets somebody check those bars against the PDF.
+    if padded:
+        listed = ", ".join(str(n) for n in padded_bars[:_PADDED_BARS_LISTED])
+        rest = len(padded_bars) - _PADDED_BARS_LISTED
+        if rest > 0:
+            listed += f" and {rest} more"
+        warnings.append(
+            f"{padded} of {bars} bar(s) contain silence that was deduced from the time signature "
+            f"rather than read from a rest printed in the score - about {inferred_quarters:.4g} "
+            f"quarter note(s) of it, in bar(s) {listed}. A voice with a note missing from it is "
+            "filled out the same way a genuinely resting voice is, so that the voices of the bar "
+            "still play in time with each other; the inferred silence is NOT counted towards those "
+            "bars adding up, and is written into the MusicXML as <forward> rather than as a rest so "
+            "no consumer mistakes it for one the engraver printed"
+        )
     # The downgrade is driven by bars that fail Rule 8 in EITHER direction. A
     # score whose bars are mostly SHORT because notes were dropped is just as
     # unplayable as one whose bars overflow, and reporting "high - decoded
@@ -1779,6 +1890,14 @@ def _fmt_beat(duration_code, dots, notes):
     # trailing dot on the duration code (":8." / ":8.." fail to parse) - it
     # is a beat effect appended to the note/chord body instead
     # (":8 3.4{d}", or with a chord ":2 (3.4 5.3){d}").
+    #
+    # An INFERRED rest comes out as a plain `r` here, unmarked. alphaTex has no
+    # editorial mechanism to mark one with - it is a compact format for
+    # describing music, not for annotating provenance - and inventing a
+    # non-standard token would break the importer that has to read this back.
+    # MusicXML is the canonical output and does mark it (Rule 14); this format
+    # exists for the transcription editor to work in, and the padded bars are
+    # named in the warnings for a reader of either.
     if not notes:
         body = "r"
     else:
@@ -2162,12 +2281,11 @@ def _extract(doc, pdf_path, time_signature: tuple[int, int] | None) -> Extractio
     prov_details = collections.defaultdict(list)
     unmatched_columns_glyph = 0
     unmatched_glyph_notes_total = 0
-    # How many bars were transcribed as concurrent voices, and how much of
-    # the silence in them was deduced from the meter rather than read from a
-    # rest glyph - both reported, so "the voices add up" can be told apart
-    # from "the voices were padded until they added up".
+    # How many bars were transcribed as concurrent voices. How much of the
+    # silence in them was deduced from the meter is counted off the emitted
+    # beats instead (see _bar_conformance), so "the voices add up" can be told
+    # apart from "the voices were padded until they added up".
     multivoice_bars = 0
-    inferred_rest_quarters = 0.0
     font_warnings_seen = []
     for page_idx, page, tab_staves, std_staves in pages_with_tab:
         tokens = _extract_digit_tokens(page)
@@ -2237,7 +2355,7 @@ def _extract(doc, pdf_path, time_signature: tuple[int, int] | None) -> Extractio
             for i, m_cols in enumerate(measures_for_staff):
                 m_lo, m_hi = bounds[i], bounds[i + 1]
                 if source.uses_glyphs:
-                    voices, unmatched_cols, unmatched_notes, inferred = (
+                    voices, unmatched_cols, unmatched_notes = (
                         _build_measure_beats_glyph(
                             m_cols, m_lo, m_hi, source.note_events, source.note_xs,
                             x_tol, std_staff.spacing, measure_quarter_len,
@@ -2245,13 +2363,24 @@ def _extract(doc, pdf_path, time_signature: tuple[int, int] | None) -> Extractio
                     )
                     unmatched_columns_glyph += unmatched_cols
                     unmatched_glyph_notes_total += unmatched_notes
-                    inferred_rest_quarters += inferred
                     if len(voices) > 1:
                         multivoice_bars += 1
                     if not voices:
                         # Nothing decoded and no tab columns either - still
                         # emit an explicit rest bar rather than dropping the
                         # measure (see the non-glyph branch below for why).
+                        # NOT marked inferred, even though the meter is where
+                        # it came from. A bar of nothing but rests is already
+                        # conspicuous - it is the one shape a reader cannot
+                        # mistake for a reading - whereas an inferred rest that
+                        # emits `<forward>` in a voice with no notes at all
+                        # leaves the measure with nothing for a Rule 8 check to
+                        # sum, so its defect would be visible to this extractor
+                        # and to nobody else. Measured on the library, 337 bars
+                        # across 172 scores take this branch. Keeping the
+                        # marker to silence that COMPLETES a voice that was
+                        # read is what keeps every reported figure equal to
+                        # what a consumer computes from the file.
                         voices = [_rest_beats_for(measure_quarter_len)]
                     all_measures.append((voices, staff_ts))
                     continue
@@ -2263,7 +2392,8 @@ def _extract(doc, pdf_path, time_signature: tuple[int, int] | None) -> Extractio
                     # breaks side-by-side comparison against the original.
                     # Rests that ADD UP to the meter, not one snapped to the
                     # nearest plain value: a 3/4 bar's 3.0 quarters snap to a
-                    # whole rest, which is a third longer than the bar.
+                    # whole rest, which is a third longer than the bar. Left
+                    # unmarked for the same reason as the glyph branch above.
                     all_measures.append((_rest_beats_for(measure_quarter_len), staff_ts))
                     continue
                 durations_q = _infer_measure_rhythm(m_cols, measure_quarter_len, m_hi)
@@ -2290,13 +2420,6 @@ def _extract(doc, pdf_path, time_signature: tuple[int, int] | None) -> Extractio
         warnings.append(
             f"{multivoice_bars} bar(s) were transcribed as two concurrent voices, split by the "
             "direction of the stems the score engraves them with"
-        )
-    if inferred_rest_quarters:
-        warnings.append(
-            f"about {inferred_rest_quarters:.4g} quarter note(s) of rest across those bars were "
-            "deduced from the time signature rather than read from a rest printed in the score - "
-            "a voice with a note missing from it is padded with silence the same way a genuinely "
-            "resting voice is"
         )
     if unmatched_columns_glyph:
         warnings.append(
@@ -2412,6 +2535,9 @@ def _extract(doc, pdf_path, time_signature: tuple[int, int] | None) -> Extractio
         bars_short=conformance.short,
         bars_defective=conformance.defective,
         bars_measured=conformance.counted,
+        bars_padded=conformance.padded,
+        padded_bars=list(conformance.padded_bars),
+        inferred_rest_quarters=conformance.inferred_quarters,
         tab_staff_count=tab_count,
         standard_staff_count=std_count,
         pages_processed=len(pages_with_tab),

--- a/server/fermata/tabextract.py
+++ b/server/fermata/tabextract.py
@@ -156,6 +156,13 @@ class ExtractionResult:
     bars_padded: int = 0
     padded_bars: list[int] = field(default_factory=list)
     inferred_rest_quarters: float = 0.0
+    # Bars nothing was read from at all, and which ones. These are NOT counted
+    # into bars_defective: the bar of rests they emit does add up to its meter,
+    # so folding them in would make these figures disagree with what a consumer
+    # computes from the emitted file. They are a separate statement - "nothing
+    # here was read" - and they do count towards the reported confidence.
+    bars_unread: int = 0
+    unread_bars: list[int] = field(default_factory=list)
     # Total tab / standard staff systems found across the whole document
     # (summed across pages) - same definition analyze() uses, not a
     # per-page maximum.
@@ -193,6 +200,8 @@ class ExtractionResult:
             "bars_padded": self.bars_padded,
             "padded_bars": list(self.padded_bars),
             "inferred_rest_quarters": self.inferred_rest_quarters,
+            "bars_unread": self.bars_unread,
+            "unread_bars": list(self.unread_bars),
             "tab_staff_count": self.tab_staff_count,
             "standard_staff_count": self.standard_staff_count,
             "pages_processed": self.pages_processed,
@@ -1614,11 +1623,32 @@ _TIE_WARNING = (
 
 _DOT_FACTORS = (1.0, 1.5, 1.75)
 
-# How many padded bar numbers the warning names before summarising the rest.
-# Enough to check a handful against the PDF without turning one warning into a
-# wall of a hundred numbers; the count beside them is always complete, and the
-# MusicXML carries every one of them.
-_PADDED_BARS_LISTED = 12
+# How many bar numbers a warning names before summarising the rest. At 12 the
+# cap bound 131 of the 271 affected scores in the library, so the prose lost the
+# fact for half of them; 60 leaves 25 scores capped and is still one readable
+# line. The count beside the list is always complete, and the full list is
+# reported as data (ExtractionResult.padded_bars / unread_bars) for anything
+# that wants all of it.
+_BARS_LISTED = 60
+
+
+def _bar_list(numbers) -> str:
+    """Bar numbers for a warning: the first _BARS_LISTED of them, then how many
+    were left out - never a silently truncated list."""
+    listed = ", ".join(str(n) for n in numbers[:_BARS_LISTED])
+    left = len(numbers) - _BARS_LISTED
+    return f"{listed} and {left} more" if left > 0 else listed
+
+
+def _quarters_text(quarters) -> str:
+    """A quarter-note count as an exact decimal.
+
+    Every duration this extractor emits is a multiple of a 32nd, so a quarter
+    count is exact and has to print that way. A %.4g format silently rounded
+    43.875 to "43.88" and 104.25 to "104.2" - a wrong number, in a sentence
+    whose entire purpose is to say how much of a score was invented.
+    """
+    return f"{quarters:.5f}".rstrip("0").rstrip(".")
 
 
 def _beat_quarters(code, dots) -> float:
@@ -1679,18 +1709,28 @@ class _BarConformance(NamedTuple):
     short: int
     defective: int
     counted: int
-    # Of `counted`, how many bars hold silence that was deduced from the meter
-    # rather than read from the page, and which bars those are (1-based, in the
-    # same numbering the emitted measures use). A padded bar is normally also a
-    # SHORT one - that is the point - but not always: padding a voice that lost
-    # a note to exactly the meter can coincide with another voice that decoded
-    # correctly, and a bar padded by less than the tolerance is not short.
+    # How many bars hold silence that was deduced from the meter rather than
+    # read from the page, and which bars those are (1-based, in the same
+    # numbering the emitted measures use).
+    #
+    # A padded bar with a meter is ALWAYS also a short one, not merely usually:
+    # the padding only fires for a voice under its budget by more than the
+    # tolerance, and the sums below measure exactly that pre-padding total, so
+    # min(voices) is under budget by construction. `padded` can still exceed
+    # `short` in principle, because a bar with no meter is padded but not
+    # measured - which no score reaches today, since the meter falls back to
+    # 4/4.
     padded: int = 0
     padded_bars: tuple[int, ...] = ()
     # And how much of it there is, in quarter notes, across the whole score.
     # Read off the marked beats rather than accumulated as the padding happens,
     # so the figure reported and the silence emitted cannot disagree.
     inferred_quarters: float = 0.0
+    # Which bars are the defective ones. Needed because the confidence
+    # downgrade is over defective bars UNION bars nothing was read from (see
+    # _rhythm_report), and a bar can be both - adding the two counts would
+    # double-count it and could put the ratio over 1.
+    defective_bars: tuple[int, ...] = ()
 
 
 def _bar_conformance(measures) -> _BarConformance:
@@ -1724,32 +1764,38 @@ def _bar_conformance(measures) -> _BarConformance:
     """
     overfull = 0
     short = 0
-    defective = 0
     counted = 0
     padded_bars = []
+    defective_bars = []
     inferred_quarters = 0.0
     for index, (beats, ts) in enumerate(measures, start=1):
-        if not ts:
-            continue
-        counted += 1
-        budget = _measure_quarter_length(ts)
-        voices = _voice_quarters(beats, count_inferred=False)
+        # The padding accounting comes FIRST, before the meterless-bar skip: a
+        # bar with no meter is not measured against one, but if it holds
+        # inferred silence it still carries a `<forward>` into the file, and a
+        # count of padded bars that the file disagrees with is exactly what this
+        # whole mechanism exists to prevent.
         bar_inferred = sum(_beat_quarters(code, dots)
                            for v in _voices_of(beats) for code, dots, notes in v
                            if mxl.is_inferred_rest(notes))
         if bar_inferred:
             padded_bars.append(index)
             inferred_quarters += bar_inferred
+        if not ts:
+            continue
+        counted += 1
+        budget = _measure_quarter_length(ts)
+        voices = _voice_quarters(beats, count_inferred=False)
         if not voices:
             continue
         over = max(voices) > budget + 1e-6
         under = min(voices) < budget - 1e-6
         overfull += over
         short += under
-        defective += over or under
-    return _BarConformance(overfull, short, defective, counted,
+        if over or under:
+            defective_bars.append(index)
+    return _BarConformance(overfull, short, len(defective_bars), counted,
                            len(padded_bars), tuple(padded_bars),
-                           inferred_quarters)
+                           inferred_quarters, tuple(defective_bars))
 
 
 def _overfull_bars(measures) -> tuple[int, int]:
@@ -1759,7 +1805,7 @@ def _overfull_bars(measures) -> tuple[int, int]:
     return bars.overfull, bars.counted
 
 
-def _rhythm_report(counts, details, conformance=None):
+def _rhythm_report(counts, details, conformance=None, unread_bars=()):
     """Derive the document's rhythm warnings and confidence string from the
     collected per-staff provenances - the single place that decides both, so
     they cannot drift out of step with each other or with the measure loop.
@@ -1767,6 +1813,8 @@ def _rhythm_report(counts, details, conformance=None):
     `counts` is a Counter over the PROV_* values; `details` maps each
     provenance to the distinct per-staff explanations collected for it.
     `conformance` is a _BarConformance, or None where no bars were measured.
+    `unread_bars` is the numbers of bars nothing was read from at all - see the
+    warning below for why they are reported here rather than as Rule 8 defects.
     """
     conformance = conformance or _BarConformance(0, 0, 0, 0)
     overfull, short = conformance.overfull, conformance.short
@@ -1832,37 +1880,80 @@ def _rhythm_report(counts, details, conformance=None):
         warnings.append(
             f"{short} of {bars} bar(s) hold less than their time signature allows - a note whose "
             "duration was read short, or one dropped for want of a fret number, leaves the bar "
-            "with a gap at the end. The emitted score says so rather than padding it out, so any "
-            "MusicXML tool will report those bars too"
+            "with less music in it than the meter says it holds. Where such a bar has more than "
+            "one voice the missing part is filled with silence deduced from the meter, at the "
+            "front of the voice if that is where it entered late, so the voices still play in time "
+            "with each other - that silence is not counted here and is not written as a rest. "
+            "Either way the emitted MusicXML falls short by the same amount, so any MusicXML tool "
+            "will report those bars too"
         )
     # Which bars were padded, not just how much silence was added across the
     # score. A total says a score is partly invented; the bar numbers say WHERE,
     # which is what lets somebody check those bars against the PDF.
     if padded:
-        listed = ", ".join(str(n) for n in padded_bars[:_PADDED_BARS_LISTED])
-        rest = len(padded_bars) - _PADDED_BARS_LISTED
-        if rest > 0:
-            listed += f" and {rest} more"
         warnings.append(
             f"{padded} of {bars} bar(s) contain silence that was deduced from the time signature "
-            f"rather than read from a rest printed in the score - about {inferred_quarters:.4g} "
-            f"quarter note(s) of it, in bar(s) {listed}. A voice with a note missing from it is "
-            "filled out the same way a genuinely resting voice is, so that the voices of the bar "
-            "still play in time with each other; the inferred silence is NOT counted towards those "
-            "bars adding up, and is written into the MusicXML as <forward> rather than as a rest so "
-            "no consumer mistakes it for one the engraver printed"
+            "rather than read from a rest printed in the score, "
+            f"{_quarters_text(inferred_quarters)} quarter note(s) of it in total. The bars are: "
+            f"{_bar_list(padded_bars)}. A voice with a note missing from it is filled out the same "
+            "way a genuinely resting voice is, so that the voices of the bar still play in time "
+            "with each other; the inferred silence is NOT counted towards those bars adding up, and "
+            "is written into the MusicXML as <forward> rather than as a rest so no consumer "
+            "mistakes it for one the engraver printed"
         )
-    # The downgrade is driven by bars that fail Rule 8 in EITHER direction. A
-    # score whose bars are mostly SHORT because notes were dropped is just as
-    # unplayable as one whose bars overflow, and reporting "high - decoded
-    # directly from the ... engraving" over a warning list saying most bars do
-    # not add up is exactly the kind of confident-but-wrong claim the rest of
-    # this module exists to avoid.
-    if bars and defective / bars >= 0.25:
+    # A bar nothing was read from is reported SEPARATELY from the Rule 8 counts,
+    # and deliberately so. It holds a whole bar of rests that do add up to its
+    # meter, so it conforms to Rule 8 in the emitted file, and folding it into
+    # `defective` would make the figures reported here disagree with what any
+    # consumer computes from the file - the one property the padding fix exists
+    # to establish. But it is not a reading either: a 40-bar score read as
+    # nothing at all was reporting 40 of 40 bars conformant at high confidence
+    # with no warning mentioning emptiness. So it is counted, named, and folded
+    # into the confidence downgrade below instead.
+    if unread_bars:
+        warnings.append(
+            f"{len(unread_bars)} of {bars} bar(s) hold nothing that was read from the score - no "
+            "fret number and no rest glyph fell inside them - and are emitted as a whole bar of "
+            f"rests so the bar numbering still matches the source. The bars are: "
+            f"{_bar_list(unread_bars)}. Those bars add up to their time signature and so pass every "
+            "arithmetic check, but nothing in them was read: they are not evidence that the score "
+            "was transcribed, and a bar that is genuinely silent in the source cannot be told from "
+            "one whose contents were missed"
+        )
+    # The downgrade is driven by bars that fail Rule 8 in EITHER direction, plus
+    # bars nothing was read from. A score whose bars are mostly SHORT because
+    # notes were dropped is just as unplayable as one whose bars overflow, and
+    # one whose bars are mostly EMPTY was not read at all; reporting "high -
+    # decoded directly from the ... engraving" over either is exactly the kind
+    # of confident-but-wrong claim the rest of this module exists to avoid.
+    #
+    # A union, not a sum: a bar can be defective and unread at once (a meter
+    # whose rests cannot be spelled within the beat limit), and adding the two
+    # counts would double-count it and could put the ratio over 1. `defective`
+    # stays the term that carries it, with only the overlap subtracted off the
+    # unread ones, so the downgrade is still driven by the same count it always
+    # was and does not depend on the per-bar list being populated.
+    unreliable = defective + len(set(unread_bars) - set(conformance.defective_bars))
+    reason = f"{defective} of {bars} bar(s) do not add up to their time signature"
+    if unread_bars:
+        reason = (
+            f"{unreliable} of {bars} bar(s) either do not add up to their time signature "
+            f"({defective}) or hold nothing that was read from the score ({len(unread_bars)})"
+        )
+    if bars and unreliable / bars >= 0.25:
         confidence = (
             "low overall - individual durations were read from the score's own engraving, but "
-            f"{defective} of {bars} bar(s) do not add up to their time signature"
+            + reason
         )
+    elif bars and unreliable:
+        # Below the threshold is not the same as clean, and a binary gate threw
+        # away everything the counts above just established: sixteen of the
+        # nineteen scores in the library that still rated "high" sat just under
+        # the quarter, one of them with invented silence in 7 of its 33 bars,
+        # and said "decoded directly from the ... engraving" with nothing
+        # qualifying it. The threshold decides the LABEL; the sentence says what
+        # is known either way.
+        confidence = f"{confidence}; {reason}"
 
     # Surface the concrete per-staff reasons behind any downgrade, capped so
     # a long score can't turn the warning list into a wall of text.
@@ -2286,6 +2377,14 @@ def _extract(doc, pdf_path, time_signature: tuple[int, int] | None) -> Extractio
     # beats instead (see _bar_conformance), so "the voices add up" can be told
     # apart from "the voices were padded until they added up".
     multivoice_bars = 0
+    # Bars nothing was read from at all - no fret column and no rest glyph fell
+    # inside them - emitted as a whole bar of rests so the bar numbering still
+    # matches the source. Tracked here because it cannot be recovered from the
+    # beats afterwards: the bar of rests it emits is indistinguishable from a
+    # bar of rests that WAS read, and there is exactly one of those in the
+    # library. See the _rhythm_report warning for why they are reported outside
+    # the Rule 8 counts.
+    unread_bars = []
     font_warnings_seen = []
     for page_idx, page, tab_staves, std_staves in pages_with_tab:
         tokens = _extract_digit_tokens(page)
@@ -2380,8 +2479,10 @@ def _extract(doc, pdf_path, time_signature: tuple[int, int] | None) -> Extractio
                         # across 172 scores take this branch. Keeping the
                         # marker to silence that COMPLETES a voice that was
                         # read is what keeps every reported figure equal to
-                        # what a consumer computes from the file.
+                        # what a consumer computes from the file. The bar is
+                        # counted and named instead - see unread_bars.
                         voices = [_rest_beats_for(measure_quarter_len)]
+                        unread_bars.append(len(all_measures) + 1)
                     all_measures.append((voices, staff_ts))
                     continue
                 if not m_cols:
@@ -2393,7 +2494,9 @@ def _extract(doc, pdf_path, time_signature: tuple[int, int] | None) -> Extractio
                     # Rests that ADD UP to the meter, not one snapped to the
                     # nearest plain value: a 3/4 bar's 3.0 quarters snap to a
                     # whole rest, which is a third longer than the bar. Left
-                    # unmarked for the same reason as the glyph branch above.
+                    # unmarked for the same reason as the glyph branch above,
+                    # and counted as unread for the same reason too.
+                    unread_bars.append(len(all_measures) + 1)
                     all_measures.append((_rest_beats_for(measure_quarter_len), staff_ts))
                     continue
                 durations_q = _infer_measure_rhythm(m_cols, measure_quarter_len, m_hi)
@@ -2404,7 +2507,7 @@ def _extract(doc, pdf_path, time_signature: tuple[int, int] | None) -> Extractio
     # actually resolved to.
     conformance = _bar_conformance(all_measures)
     rhythm_warnings, rhythm_confidence = _rhythm_report(
-        prov_counts, prov_details, conformance
+        prov_counts, prov_details, conformance, tuple(unread_bars)
     )
     warnings.extend(rhythm_warnings)
     # Font-level problems that weren't already the reason a staff degraded
@@ -2476,12 +2579,21 @@ def _extract(doc, pdf_path, time_signature: tuple[int, int] | None) -> Extractio
     title = Path(pdf_path).stem
     alphatex = _build_alphatex(title, tempo, tuning, ts, all_measures)
     musicxml = mxl.build(title, tempo, tuning, ts, all_measures, fifths=key_fifths)
-    beats_total = sum(len(v) for beats, _ in all_measures for v in _voices_of(beats))
-    # What the emitted score actually HOLDS, not what was read off the page:
-    # `unwritable` notes have no expressible pitch and are left out of the
-    # MusicXML (their beat stays, as a rest, so beats_total is unaffected).
+    # Both of these are what the emitted score actually HOLDS, not what was
+    # read off the page, and both need the emitter's own rule for it rather
+    # than a second copy of it here.
+    #
+    # `beats` therefore comes from mxl.written_beats: a beat of silence deduced
+    # from the meter is written as `<forward>` and is not a beat of the score,
+    # so counting the beats model instead reported more beats than the
+    # canonical output contains - 6386 more across the library, which is
+    # exactly its number of `<forward>` elements.
+    #
+    # `notes` subtracts `unwritable`: those have no expressible pitch and are
+    # left out (their beat stays, as a rest, so the beat count is unaffected).
     # Reporting the pre-emission figure made `notes` larger than the canonical
     # output it is reported beside.
+    beats_total = mxl.written_beats(all_measures)
     notes_total = sum(len(notes) for beats, _ in all_measures
                       for v in _voices_of(beats) for _, _, notes in v) - unwritable
 
@@ -2538,6 +2650,8 @@ def _extract(doc, pdf_path, time_signature: tuple[int, int] | None) -> Extractio
         bars_padded=conformance.padded,
         padded_bars=list(conformance.padded_bars),
         inferred_rest_quarters=conformance.inferred_quarters,
+        bars_unread=len(unread_bars),
+        unread_bars=list(unread_bars),
         tab_staff_count=tab_count,
         standard_staff_count=std_count,
         pages_processed=len(pages_with_tab),

--- a/server/tests/test_engraved_fixtures.py
+++ b/server/tests/test_engraved_fixtures.py
@@ -45,7 +45,7 @@ import xml.etree.ElementTree as ET
 import fitz
 import pytest
 
-from fermata import glyph_rhythm, tabextract
+from fermata import glyph_rhythm, musicxml, tabextract
 
 from conftest import ENGRAVED_DIR
 from test_tabextract import _parse_with_alphatab
@@ -667,9 +667,17 @@ def test_an_unrecognised_notehead_is_reported_however_few_there_are(engraved):
     assert any("not been calibrated" in w for w in result.warnings)
     assert any("U+E0DB" in w for w in result.warnings), (
         "the unrecognised codepoint is named, so it can be calibrated later")
-    # ...and the bars all add up, so nothing else on the page would have said
-    # a word about it
-    assert (result.bars_overfull, result.bars_short, result.bars_defective) == (0, 0, 0)
+    # The bar that lost those two noteheads now says so. It used to report as
+    # adding up, because the voice they were dropped from was padded back to
+    # its meter with invented silence before the arithmetic was checked - so
+    # the gate above was the ONLY thing on the page that said a word about
+    # them. It is no longer alone: the padding is marked, excluded from the
+    # sums, and the bar is reported short by exactly what went missing.
+    assert (result.bars_overfull, result.bars_short, result.bars_defective) == (0, 1, 1)
+    assert result.bars_padded == 1
+    assert result.padded_bars == [1]
+    assert result.inferred_rest_quarters > 0
+    assert any("deduced from the time signature" in w for w in result.warnings)
 
     doc = fitz.open(engraved("harmonics_dense"))
     degraded = 0
@@ -943,7 +951,10 @@ def test_bars_wrong_in_each_direction_are_counted_and_reported(engraved):
     assert result.bars == 8
     assert result.bars_measured == 8
     assert result.bars_overfull == 4
-    assert result.bars_short == 2
+    # Was 2. The two extra are bars whose short voice used to be padded back to
+    # the meter before the arithmetic was checked, so they reported as adding
+    # up - see test_a_short_voice_beside_an_overfull_one_is_reported_short.
+    assert result.bars_short == 4
     assert result.bars_defective == 6
     assert result.bars_defective <= result.bars_measured
     assert max(result.bars_overfull, result.bars_short) <= result.bars_defective
@@ -956,29 +967,60 @@ def test_bars_wrong_in_each_direction_are_counted_and_reported(engraved):
     assert sum(q for q, _n in bars[1][0]) == 3.0, "and the short one is not padded out"
 
 
-def test_a_short_voice_beside_an_overfull_one_is_padded_not_reported_short(engraved):
+def test_a_short_voice_beside_an_overfull_one_is_reported_short(engraved):
     """The bar the library has no example of: five quarters in the upper voice
-    against three in the lower, wrong in both directions at once.
+    against three in the lower, wrong in both directions at once - engraved
+    here on purpose.
 
-    It is engraved here, and what these assertions record is a DEFECT being
-    pinned, not a behaviour being endorsed. The short voice is padded to the
-    meter with inferred silence - which is what stops voices drifting against
-    each other - so the bar is reported overfull and NOT short, and the rest
-    that fills it is written into the transcription indistinguishably from
-    one the engraver printed. That the padding is announced at all is the
-    only thing keeping it honest, and it is a weaker guarantee than the
-    figures beside it suggest.
+    This assertion used to pin a DEFECT: the short voice was padded to the
+    meter before the arithmetic was checked, so the bar reported overfull and
+    NOT short, and the rest that filled it went into the transcription
+    indistinguishably from one the engraver printed. Extraction could therefore
+    never produce a both-directions bar, and the reason was the padding rather
+    than anything about the score.
 
-    `_bar_conformance` counts a both-directions bar once and has a unit test
-    for that shape; this is why extraction has not so far produced one, and
-    the reason is the padding rather than anything about the score."""
+    The padding is still there - it is what stops voices drifting against each
+    other - but it is marked, so it no longer counts towards the bar adding up.
+    The bar is now reported wrong in both directions at once, which is what it
+    is, and this is the only place extraction produces that shape."""
     result = tabextract.extract(engraved("defective_bars"))
+
+    # The alphaTex still carries the padding, because the renderer needs it:
+    # the short voice is written out to the full four quarters of the meter.
     both = emitted_bars(result.alphatex)[2]
     assert len(both) == 2, both
     lengths = sorted(sum(q for q, _n in voice) for voice in both)
     assert lengths == [4.0, 5.0], both
+
+    # The MusicXML does not: the padding is a <forward>, which holds the
+    # position without claiming a rest, so the short voice's notes and rests
+    # sum to THREE quarters and the measure fails Rule 8 for any consumer.
+    root = ET.fromstring(result.musicxml)
+    measure = root.findall("./part/measure")[2]
+    sums = {}
+    for note in measure.findall("note"):
+        if note.find("chord") is not None:
+            continue
+        voice = note.findtext("voice")
+        sums[voice] = sums.get(voice, 0) + int(note.findtext("duration"))
+    assert sorted(sums.values()) == [3 * musicxml.DIVISIONS, 5 * musicxml.DIVISIONS], sums
+    forwards = measure.findall("forward")
+    assert len(forwards) == 1, ET.tostring(measure, encoding="unicode")
+    assert int(forwards[0].findtext("duration")) == musicxml.DIVISIONS
+    assert "deduced from the time signature" in forwards[0].findtext("footnote")
+    # ...and it says which voice it belongs to, or it could not be attributed
+    assert forwards[0].findtext("voice") == min(sums, key=lambda v: sums[v])
+
+    # This bar is wrong in both directions AT ONCE, counted once as defective.
+    assert 3 in result.padded_bars, result.padded_bars
+    assert result.bars_overfull >= 1 and result.bars_short >= 1
+    assert result.bars_defective <= result.bars_overfull + result.bars_short
     assert any("deduced from the time signature" in w for w in result.warnings)
     assert any("concurrent voices" in w for w in result.warnings)
+    # the warning names the bar, not just the total
+    padded_warning = next(w for w in result.warnings
+                          if "deduced from the time signature" in w)
+    assert "bar(s) 3" in padded_warning or ", 3" in padded_warning, padded_warning
 
 
 # ---------------------------------------------------------------------------

--- a/server/tests/test_engraved_fixtures.py
+++ b/server/tests/test_engraved_fixtures.py
@@ -614,6 +614,33 @@ def test_the_rest_fixture_matches_the_score_it_was_engraved_from(engraved):
     assert (result.bars_overfull, result.bars_short, result.bars_defective) == (0, 0, 0)
 
 
+def test_engraved_rests_are_never_reported_as_inferred_silence(engraved):
+    """The negative control for Rule 14. This fixture is fourteen printed rests
+    across every value the vocabulary spells, all read from the glyph that
+    spells them - so nothing here was deduced from the meter, and nothing may
+    say it was. A marker that fired on engraved silence would put a `<forward>`
+    where the engraver wrote a rest and under-report the bar, which is the same
+    class of lie in the other direction."""
+    result = tabextract.extract(engraved("rests_and_flags"))
+    rests = [(q, notes) for bar in emitted_bars(result.alphatex)
+             for voice in bar for q, notes in voice if not notes]
+    assert len(rests) == 14, rests
+    assert result.bars_padded == 0
+    assert result.padded_bars == []
+    assert result.inferred_rest_quarters == 0.0
+    assert result.bars_unread == 0
+    assert "<forward>" not in result.musicxml
+    assert not any("deduced from the time signature" in w for w in result.warnings)
+    # every rest in the file is a real rest element, and the beat count is the
+    # same either way because nothing was inferred
+    root = ET.fromstring(result.musicxml)
+    written = [n for n in root.findall("./part/measure/note")
+               if n.find("rest") is not None]
+    assert len(written) == 14
+    assert result.confidence["rhythm"].startswith("high")
+    assert "bar(s)" not in result.confidence["rhythm"], "nothing to qualify it with"
+
+
 def test_a_repeat_with_ending_brackets_leaves_its_staves_alone(engraved):
     """An engraved repeat with "1." / "2." brackets, which is what the
     library files that regressed actually contain. This engraver leaves a
@@ -639,6 +666,21 @@ def test_a_repeat_with_ending_brackets_leaves_its_staves_alone(engraved):
     assert len(bars) == 9
     assert bars[4][0] == [(4.0, [])], bars[4]
     assert [len(v[0]) for v in bars] == [4, 4, 4, 4, 1, 4, 4, 4, 4]
+    # ...and that phantom bar is reported as a bar nothing was read from, which
+    # is the only signal it leaves: its whole rest adds up to the meter, so
+    # Rule 8 passes and the file cannot distinguish it from an engraved silence.
+    # Nine bars for eight written is exactly the kind of thing a reader has to
+    # be told about by number rather than left to notice.
+    assert result.bars_unread == 1
+    assert result.unread_bars == [5]
+    assert (result.bars_overfull, result.bars_short, result.bars_defective) == (0, 0, 0)
+    assert "<forward>" not in result.musicxml
+    unread = next(w for w in result.warnings if "hold nothing that was read" in w)
+    assert "1 of 9 bar(s)" in unread and "The bars are: 5." in unread
+    # one bar in nine is under the downgrade threshold, and the confidence still
+    # says so rather than reading as an unqualified high
+    assert result.confidence["rhythm"].startswith("high")
+    assert "hold nothing that was read from the score (1)" in result.confidence["rhythm"]
 
 
 # ---------------------------------------------------------------------------
@@ -667,17 +709,25 @@ def test_an_unrecognised_notehead_is_reported_however_few_there_are(engraved):
     assert any("not been calibrated" in w for w in result.warnings)
     assert any("U+E0DB" in w for w in result.warnings), (
         "the unrecognised codepoint is named, so it can be calibrated later")
-    # The bar that lost those two noteheads now says so. It used to report as
-    # adding up, because the voice they were dropped from was padded back to
-    # its meter with invented silence before the arithmetic was checked - so
-    # the gate above was the ONLY thing on the page that said a word about
-    # them. It is no longer alone: the padding is marked, excluded from the
-    # sums, and the bar is reported short by exactly what went missing.
+    # No note is lost here - all 96 are read, the two uncalibrated noteheads
+    # included, with their durations inferred from what their bar had left over.
+    # What bar 1 loses is a BEAT: one digit token beside the staff could not be
+    # assigned to a string, so its voice holds seven eighths where the meter
+    # wants eight. That bar used to report as adding up, because the voice was
+    # padded back to its meter with invented silence before the arithmetic was
+    # checked, which left the honesty gate above as the only thing on the page
+    # saying a word about any of it. It is no longer alone: the padding is
+    # marked, excluded from the sums, and the bar is reported short by exactly
+    # the eighth that went missing.
+    assert result.notes == 96, "nothing was dropped - this is a missing beat, not a note"
     assert (result.bars_overfull, result.bars_short, result.bars_defective) == (0, 1, 1)
     assert result.bars_padded == 1
     assert result.padded_bars == [1]
-    assert result.inferred_rest_quarters > 0
+    assert result.inferred_rest_quarters == 0.5, "one eighth note of it"
     assert any("deduced from the time signature" in w for w in result.warnings)
+    # and the confidence string states the defect even though one bar in eight
+    # is under the downgrade threshold
+    assert "1 of 8 bar(s) do not add up" in result.confidence["rhythm"]
 
     doc = fitz.open(engraved("harmonics_dense"))
     degraded = 0
@@ -1017,10 +1067,11 @@ def test_a_short_voice_beside_an_overfull_one_is_reported_short(engraved):
     assert result.bars_defective <= result.bars_overfull + result.bars_short
     assert any("deduced from the time signature" in w for w in result.warnings)
     assert any("concurrent voices" in w for w in result.warnings)
-    # the warning names the bar, not just the total
+    # the warning names the bars, not just the total
     padded_warning = next(w for w in result.warnings
                           if "deduced from the time signature" in w)
-    assert "bar(s) 3" in padded_warning or ", 3" in padded_warning, padded_warning
+    named = padded_warning.split("The bars are: ")[1].split(".")[0]
+    assert 3 in [int(n) for n in named.split(", ")], padded_warning
 
 
 # ---------------------------------------------------------------------------

--- a/server/tests/test_musicxml.py
+++ b/server/tests/test_musicxml.py
@@ -314,6 +314,99 @@ def test_voice_durations_reports_the_same_totals_the_xml_carries():
 
 
 # ---------------------------------------------------------------------------
+# Rule 14: inferred silence
+# ---------------------------------------------------------------------------
+
+
+def _padded_bar(ts=(3, 4)):
+    """A 3/4 bar whose second voice sounds one quarter and was filled out to
+    the meter with a half note of silence nothing on the page said was there."""
+    return [
+        [(4, 0, [(1, 0)]), (4, 0, [(1, 2)]), (4, 0, [(1, 3)])],
+        [(4, 0, [(5, 0)]), (2, 0, musicxml.inferred_rest())],
+    ]
+
+
+def test_inferred_silence_is_a_forward_and_not_a_rest():
+    """Rule 14. A rest is a claim that somebody engraved one. Writing invented
+    silence as a rest makes the measure add up, so Rule 8 passes and the notes
+    that went missing leave no trace anywhere."""
+    measure = _root(_one_bar(_padded_bar(), ts=(3, 4))).find("./part/measure")
+    rests = [n for n in measure.findall("note") if n.find("rest") is not None]
+    assert rests == [], "inferred silence must not be written as a rest"
+    (forward,) = measure.findall("forward")
+    assert int(forward.findtext("duration")) == 2 * musicxml.DIVISIONS
+    assert forward.findtext("voice") == "2", "and it says which voice it belongs to"
+    assert forward.findtext("footnote") == musicxml.INFERRED_REST_FOOTNOTE
+
+
+def test_forward_children_are_in_schema_order():
+    """forward's sequence is duration, footnote?, level?, voice?, staff? - the
+    footnote comes BEFORE the voice. Any other order fails validation outright.
+    """
+    measure = _root(_one_bar(_padded_bar(), ts=(3, 4))).find("./part/measure")
+    (forward,) = measure.findall("forward")
+    assert [c.tag for c in forward] == ["duration", "footnote", "voice"]
+
+
+def test_a_padded_measure_fails_rule_8_for_a_consumer_that_never_heard_of_us():
+    """The point of the whole mechanism. A consumer summing each voice's notes
+    and rests has to see the measure fall short by exactly what was not read -
+    otherwise the producer's own defect count and everyone else's disagree, and
+    emitting a standard format buys nothing."""
+    measure = _root(_one_bar(_padded_bar(), ts=(3, 4))).find("./part/measure")
+    expected = musicxml.measure_divisions((3, 4))
+    sums = _voice_sums(measure)
+    assert sums["1"] == expected, "the voice that was fully read still adds up"
+    assert sums["2"] == musicxml.DIVISIONS, "the padded one falls short by the padding"
+    # and the figure the emitter's own helper reports is that same number
+    assert musicxml.voice_durations(_padded_bar()) == [expected, musicxml.DIVISIONS]
+
+
+def test_a_forward_still_advances_the_position_for_the_following_voice():
+    """Inferred silence is emitted because the bar has to play: a voice that
+    entered late still enters late. So the position it holds has to be real -
+    a <backup> after it must return to the START of the measure, not to
+    wherever the notes alone reached."""
+    beats = [
+        [(4, 0, [(1, 0)]), (2, 0, musicxml.inferred_rest())],
+        [(4, 0, [(5, 0)]), (4, 0, [(5, 2)]), (4, 0, [(5, 3)])],
+    ]
+    measure = _root(_one_bar(beats, ts=(3, 4))).find("./part/measure")
+    (backup,) = measure.findall("backup")
+    assert int(backup.findtext("duration")) == 3 * musicxml.DIVISIONS
+    # the leading case too: silence first, then the note it enters on
+    leading = [
+        [(2, 0, musicxml.inferred_rest()), (4, 0, [(1, 0)])],
+        [(4, 0, [(5, 0)]), (4, 0, [(5, 2)]), (4, 0, [(5, 3)])],
+    ]
+    measure = _root(_one_bar(leading, ts=(3, 4))).find("./part/measure")
+    children = [c.tag for c in measure if c.tag in ("forward", "note", "backup")]
+    assert children[:2] == ["forward", "note"], children
+    (backup,) = measure.findall("backup")
+    assert int(backup.findtext("duration")) == 3 * musicxml.DIVISIONS
+
+
+def test_an_inferred_rest_is_still_an_ordinary_rest_to_everything_else():
+    """The marker rides in the beat's notes slot, so it must stay falsy and
+    empty - every existing reader of the beats model asks only whether a beat
+    has notes, and a marker that changed that answer would turn inferred
+    silence into a note with no strings."""
+    marked = musicxml.inferred_rest()
+    assert not marked
+    assert len(marked) == 0
+    assert marked == []
+    assert musicxml.is_inferred_rest(marked)
+    assert not musicxml.is_inferred_rest([])
+    assert not musicxml.is_inferred_rest(None)
+    assert not musicxml.is_inferred_rest([(1, 0)])
+    # ...and it is a fresh list each time, not one shared mutable instance
+    other = musicxml.inferred_rest()
+    marked.append((1, 0))
+    assert other == []
+
+
+# ---------------------------------------------------------------------------
 # Rules 9-13: fret, string and pitch
 # ---------------------------------------------------------------------------
 
@@ -481,6 +574,16 @@ def _emitted_samples():
                 ([[(4, 0, [(1, 12)])], [(4, 0, [(6, 3)])]], (1, 4)),
                 ([[(2, 0, [(3, 0)])]], (2, 4)),
             ], fifths=-2, capo=3),
+        # Rule 14: a `<forward>` carrying a footnote, in both the leading and
+        # the trailing position. Nothing else here emits one, so without this
+        # sample the schema never sees the element or its child order.
+        "inferred-silence": musicxml.build(
+            "Inferred Silence", None, DEFAULT_TUNING, (3, 4), [
+                ([[(4, 0, [(1, 0)]), (4, 0, [(1, 2)]), (4, 0, [(1, 3)])],
+                  [(4, 0, [(5, 0)]), (2, 0, musicxml.inferred_rest())]], (3, 4)),
+                ([[(2, 0, musicxml.inferred_rest()), (4, 0, [(1, 5)])],
+                  [(4, 0, [(6, 0)]), (4, 0, [(6, 2)]), (4, 0, [(6, 3)])]], (3, 4)),
+            ]),
     }
 
 

--- a/server/tests/test_musicxml.py
+++ b/server/tests/test_musicxml.py
@@ -313,6 +313,43 @@ def test_voice_durations_reports_the_same_totals_the_xml_carries():
     assert sorted(from_model) == sorted(from_xml.values())
 
 
+def test_voice_durations_is_the_left_hand_side_of_rule_8_for_every_shape():
+    """The Rule 8 left-hand side is what every reported conformance figure is
+    computed from, and one test guarding it means one deletion removes all of
+    its coverage. Each of these is a shape that can change the answer: a dotted
+    beat, a chord (one beat, not one per note), a rest, a beat with no writable
+    pitch, and inferred silence.
+    """
+    D = musicxml.DIVISIONS
+    cases = [
+        ([[(4, 0, [(1, 0)])]], [D]),
+        ([[(4, 1, [(1, 0)])]], [D + D // 2]),
+        ([[(4, 2, [(1, 0)])]], [D + D // 2 + D // 4]),
+        # a four-note chord is ONE beat (Rule 7)
+        ([[(4, 0, [(6, 0), (5, 2), (4, 2), (3, 1)])]], [D]),
+        # a printed rest counts; an inferred one does not (Rule 14)
+        ([[(4, 0, [])]], [D]),
+        ([[(4, 0, musicxml.inferred_rest())]], [0]),
+        ([[(4, 0, [(1, 0)]), (4, 0, musicxml.inferred_rest())]], [D]),
+        # a note with no writable pitch keeps its beat, as a rest (Rule 11)
+        ([[(4, 0, [(1, 78)])]], [D]),
+        # two voices, in voice order
+        ([[(2, 0, [(1, 0)])], [(4, 0, [(5, 0)]), (4, 0, [(5, 2)])]], [2 * D, 2 * D]),
+        # a flat list of beats is the one-voice case
+        ([(4, 0, [(1, 0)]), (8, 0, [(1, 2)])], [D + D // 2]),
+        ([], []),
+    ]
+    for beats, expected in cases:
+        assert musicxml.voice_durations(beats) == expected, beats
+        if not beats:
+            continue
+        # ...and it agrees with what the emitted file carries, which is the
+        # only reason the number is worth reporting
+        measure = _root(_one_bar(beats, ts=(4, 4))).find("./part/measure")
+        sums = _voice_sums(measure)
+        assert sorted(sums.values()) == sorted(v for v in expected if v), beats
+
+
 # ---------------------------------------------------------------------------
 # Rule 14: inferred silence
 # ---------------------------------------------------------------------------
@@ -629,6 +666,23 @@ def _example_paths():
     if not root.is_dir():
         pytest.skip("docs/examples is not present in this checkout")
     return sorted(root.glob("*.musicxml"))
+
+
+def test_the_profile_document_quotes_the_footnote_this_emitter_writes():
+    """Rule 14 publishes the footnote text as the words a consumer may match on,
+    and that text is hand-copied into the document. Two copies of a string are
+    two chances to disagree, and the one in the document is the one a third
+    party implements against - so a change here has to fail until the document
+    is changed with it."""
+    import pathlib
+
+    root = pathlib.Path(__file__).resolve().parents[2] / "docs"
+    profile = root / "musicxml-tab-profile.md"
+    if not profile.is_file():
+        pytest.skip("docs/musicxml-tab-profile.md is not present in this checkout")
+    text = profile.read_text(encoding="utf-8")
+    assert musicxml.INFERRED_REST_FOOTNOTE in text, (
+        "the footnote in musicxml.py is not the one Rule 14 publishes")
 
 
 def test_the_published_examples_exist_and_conform():

--- a/server/tests/test_tabextract.py
+++ b/server/tests/test_tabextract.py
@@ -10,6 +10,7 @@ import fitz
 import pytest
 
 from fermata import glyph_rhythm
+from fermata import musicxml
 from fermata import tabextract
 
 
@@ -500,6 +501,21 @@ def _measure(cols, events, budget=None, x_tol=12.0, spacing=5.125):
         x_tol=x_tol, notation_spacing=spacing, budget=budget)
 
 
+def _inferred_quarters(voices):
+    """Quarter notes of silence the builder MARKED as inferred, read off the
+    beats it produced.
+
+    Deliberately not a number the builder returns alongside them: what has to
+    be true is that the beats themselves carry the mark, because the mark is
+    what the conformance count and both emitters read. A returned total can be
+    right while the beats it describes are unmarked - which is the whole bug
+    this pins - so measuring it here would be measuring the wrong artifact.
+    """
+    return sum(tabextract._beat_quarters(code, dots)
+               for voice in voices for code, dots, notes in voice
+               if musicxml.is_inferred_rest(notes))
+
+
 def test_second_voice_rest_under_a_note_is_not_an_extra_beat():
     """Standard two-voice fingerstyle engraving - the library's core content.
     A voice-2 quarter rest engraved under a voice-1 note is the same beat,
@@ -510,7 +526,7 @@ def test_second_voice_rest_under_a_note_is_not_an_extra_beat():
         _note_event(102.0, 4), _note_event(122.0, 4), _note_event(142.0, 4),
         _note_event(102.3, 4, rest=True, y=118.0),  # voice 2 rest, same onset
     ]
-    voices, unmatched_cols, unmatched_notes, _ = _measure(cols, events)
+    voices, unmatched_cols, unmatched_notes = _measure(cols, events)
     assert len(voices) == 1, voices
     beats = voices[0]
     assert len(beats) == 3, beats
@@ -524,7 +540,7 @@ def test_simultaneous_rests_in_two_voices_collapse_to_one_beat():
         _note_event(100.4, 4, rest=True, y=118.0),
         _note_event(142.0, 4),
     ]
-    voices, _, _, _ = _measure(cols, events)
+    voices, _, _ = _measure(cols, events)
     assert len(voices) == 1, voices
     rests = [b for b in voices[0] if not b[2]]
     assert len(rests) == 1, voices
@@ -534,7 +550,7 @@ def test_a_genuinely_separate_rest_is_still_its_own_beat():
     """The dedupe must not swallow a real rest that sits on its own onset."""
     cols = _cols(100.0)
     events = [_note_event(102.0, 4), _note_event(140.0, 4, rest=True)]
-    voices, _, _, _ = _measure(cols, events)
+    voices, _, _ = _measure(cols, events)
     assert len(voices) == 1
     assert [bool(n) for _, _, n in voices[0]] == [True, False]
 
@@ -559,13 +575,13 @@ def test_stem_direction_splits_a_bar_into_concurrent_voices():
     cols = [_col(100.0, (1, "7"), (5, "3")), _col(120.0, (4, "5")),
             _col(140.0, (1, "7"), (2, "3")), _col(160.0, (3, "5")),
             _col(180.0, (1, "7"), (2, "5")), _col(200.0, (2, "7"))]
-    voices, _, unmatched_notes, inferred = _measure(cols, events, budget=3.0)
+    voices, _, unmatched_notes = _measure(cols, events, budget=3.0)
 
     assert len(voices) == 2, voices
     assert unmatched_notes == 0
     assert _quarters(voices[0]) == 3.0
     assert _quarters(voices[1]) == 3.0
-    assert inferred == 0.0, "both voices already account for the bar"
+    assert _inferred_quarters(voices) == 0.0, "both voices already account for the bar"
     # The upper voice is the melody: three quarters, each one note.
     assert [(c, d) for c, d, _n in voices[0]] == [(4, 0)] * 3
     assert [(c, d) for c, d, _n in voices[1]] == [(8, 0)] * 6
@@ -581,7 +597,7 @@ def test_a_shared_onset_splits_its_tab_digits_by_pitch_between_the_voices():
         _note_event(100.0, 8, y=120.0, stem="down"),  # bass, low
     ]
     cols = [_col(100.0, (1, "7"), (5, "3"))]
-    voices, _, _, _ = _measure(cols, events, budget=3.0)
+    voices, _, _ = _measure(cols, events, budget=3.0)
     assert len(voices) == 2
     assert voices[0][0][2] == [(1, "7")], "the melody takes the high string"
     assert voices[1][0][2] == [(5, "3")], "the bass takes the low string"
@@ -597,7 +613,7 @@ def test_a_chord_on_one_stem_stays_one_beat_in_one_voice():
         _note_event(100.0, 4, y=80.0, stem="down", stem_id="A"),
     ]
     cols = [_col(100.0, (1, "7"), (2, "8"), (3, "5"))]
-    voices, unmatched_cols, unmatched_notes, _ = _measure(cols, events, budget=3.0)
+    voices, unmatched_cols, unmatched_notes = _measure(cols, events, budget=3.0)
     assert len(voices) == 1, "a chord is not two voices"
     assert len(voices[0]) == 1, voices
     assert voices[0][0][2] == [(1, "7"), (2, "8"), (3, "5")]
@@ -615,7 +631,7 @@ def test_a_chord_takes_the_duration_of_the_notehead_that_saw_the_stem():
         _note_event(100.0, 4, y=80.0, stem="up", stem_id="A"),
     ]
     cols = [_col(100.0, (1, "7"), (2, "8"), (3, "5"))]
-    voices, _, _, _ = _measure(cols, events)
+    voices, _, _ = _measure(cols, events)
     assert [(c, d) for c, d, _n in voices[0]] == [(8, 0)]
 
 
@@ -626,7 +642,7 @@ def test_a_chord_with_no_stem_found_is_not_mistaken_for_two_voices():
     voice out of one chord and left both halves short."""
     events = [_note_event(100.0, 4, y=y) for y in (60.0, 70.0, 80.0, 95.0)]
     cols = [_col(100.0, (2, "5"), (3, "5"), (4, "5"), (5, "8"))]
-    voices, _, _, _ = _measure(cols, events, budget=4.0)
+    voices, _, _ = _measure(cols, events, budget=4.0)
     assert len(voices) == 1, voices
     assert len(voices[0]) == 1, "one chord, one beat"
     assert len(voices[0][0][2]) == 4
@@ -640,7 +656,7 @@ def test_two_stems_the_same_way_up_at_one_onset_are_one_chord():
         _note_event(100.0, 4, y=75.0, stem="down", stem_id="B"),
     ]
     cols = [_col(100.0, (1, "7"), (3, "5"))]
-    voices, _, _, _ = _measure(cols, events, budget=3.0)
+    voices, _, _ = _measure(cols, events, budget=3.0)
     assert len(voices) == 1, voices
     assert len(voices[0]) == 1
 
@@ -655,10 +671,10 @@ def test_a_monophonic_bar_stays_one_voice_when_its_stems_flip():
         _note_event(180.0, 4, y=55.0, stem="down"),
     ]
     cols = [_col(100.0, (1, "5")), _col(140.0, (5, "3")), _col(180.0, (1, "7"))]
-    voices, _, _, inferred = _measure(cols, events, budget=3.0)
+    voices, _, _ = _measure(cols, events, budget=3.0)
     assert len(voices) == 1, voices
     assert len(voices[0]) == 3
-    assert inferred == 0.0, "a monophonic bar is never padded with inferred rests"
+    assert _inferred_quarters(voices) == 0.0, "a monophonic bar is never padded"
 
 
 def test_a_whole_note_with_no_stem_joins_the_voice_below_the_melody():
@@ -668,7 +684,7 @@ def test_a_whole_note_with_no_stem_joins_the_voice_below_the_melody():
     events.append(_note_event(100.0, 1, y=130.0, kind="notehead_whole"))
     cols = [_col(100.0, (1, "7"), (6, "3")), _col(140.0, (1, "8")),
             _col(180.0, (1, "9")), _col(220.0, (1, "10"))]
-    voices, _, _, _ = _measure(cols, events, budget=4.0)
+    voices, _, _ = _measure(cols, events, budget=4.0)
     assert len(voices) == 2, voices
     assert _quarters(voices[0]) == 4.0
     assert _quarters(voices[1]) == 4.0
@@ -676,19 +692,45 @@ def test_a_whole_note_with_no_stem_joins_the_voice_below_the_melody():
 
 
 def test_a_silent_voice_is_padded_with_rests_so_it_fills_the_bar():
-    """This is what actually makes the arithmetic work: without it every
-    voice but the busiest reads as a short bar and drifts against it."""
+    """The padding is what keeps the voices in time with each other: without it
+    every voice but the busiest reads as a short bar and drifts against it."""
     events = [_note_event(100.0, 4, y=60.0, stem="up")]
     events += [_note_event(x, 4, y=130.0, stem="down") for x in (100.0, 140.0, 180.0)]
     cols = [_col(100.0, (1, "7"), (5, "3")), _col(140.0, (5, "5")), _col(180.0, (5, "7"))]
-    voices, _, _, inferred = _measure(cols, events, budget=3.0)
+    voices, _, _ = _measure(cols, events, budget=3.0)
     assert len(voices) == 2
     assert _quarters(voices[0]) == 3.0
     assert _quarters(voices[1]) == 3.0
-    assert inferred == 2.0, "the upper voice was silent for two of the three beats"
+    assert _inferred_quarters(voices) == 2.0, "the upper voice was silent for two of three beats"
     # the note sounds first, then the inferred silence - spelled as the one
     # half rest that covers it, not two quarter rests
     assert voices[0] == [(4, 0, [(1, "7")]), (2, 0, [])], voices[0]
+
+
+def test_every_padding_rest_is_marked_as_inferred_not_just_counted():
+    """The mark has to be on the BEATS, because the beats are what the
+    conformance count and both emitters read. A padded voice whose filling
+    rests look like engraved ones is exactly how a score missing sixty-five
+    notes came to report every bar as adding up at high confidence."""
+    events = [_note_event(100.0, 4, y=60.0, stem="up")]
+    events += [_note_event(x, 4, y=130.0, stem="down") for x in (100.0, 140.0, 180.0)]
+    cols = [_col(100.0, (1, "7"), (5, "3")), _col(140.0, (5, "5")), _col(180.0, (5, "7"))]
+    voices, _, _ = _measure(cols, events, budget=3.0)
+
+    marked = [(c, d) for v in voices for c, d, n in v if musicxml.is_inferred_rest(n)]
+    assert marked == [(2, 0)], voices
+    # the notes that WERE read carry no such mark, and neither would a rest
+    # decoded from a glyph on the page
+    assert not any(musicxml.is_inferred_rest(n) for v in voices for _c, _d, n in v if n)
+
+    # ...and the bar it fills still reports SHORT by what was missing, which is
+    # the whole point: counting the padding made min(voices) == budget by
+    # construction, so no padded bar could ever be reported short.
+    counts = tabextract._bar_conformance([(voices, (3, 4))])
+    assert counts.short == 1, counts
+    assert counts.defective == 1, counts
+    assert counts.padded == 1 and counts.padded_bars == (1,), counts
+    assert counts.inferred_quarters == 2.0, counts
 
 
 def test_a_voice_that_enters_late_is_padded_at_the_front():
@@ -696,17 +738,34 @@ def test_a_voice_that_enters_late_is_padded_at_the_front():
     events += [_note_event(x, 4, y=130.0, stem="down") for x in (100.0, 140.0, 180.0)]
     cols = [_col(100.0, (5, "3")), _col(140.0, (5, "5")),
             _col(180.0, (1, "7"), (5, "7"))]
-    voices, _, _, _ = _measure(cols, events, budget=3.0)
+    voices, _, _ = _measure(cols, events, budget=3.0)
     assert len(voices) == 2
     assert _quarters(voices[0]) == 3.0
     assert voices[0][0][2] == [], "silence first"
     assert voices[0][-1][2] == [(1, "7")], "then the note it enters on"
+    # The leading silence is why the padding is KEPT rather than dropped: the
+    # note it precedes enters on beat three, and a voice written without it
+    # enters on beat one instead - two beats early against the other voice.
+    assert musicxml.is_inferred_rest(voices[0][0][2]), "and it is marked as inferred"
 
 
 def test_rest_beats_for_fills_a_meter_exactly():
     assert tabextract._rest_beats_for(3.0) == [(2, 0, []), (4, 0, [])]
     assert tabextract._rest_beats_for(4.0) == [(1, 0, [])]
     assert tabextract._rest_beats_for(1.5) == [(4, 0, []), (8, 0, [])]
+
+
+def test_rest_beats_are_only_marked_inferred_when_asked():
+    """An inferred rest compares equal to a plain one on purpose - every reader
+    of the beats model that only asks "is this a rest" must keep working - so
+    equality cannot be what distinguishes them, and a caller that forgot to ask
+    for the mark would look identical in a diff. Assert the mark directly."""
+    plain = tabextract._rest_beats_for(3.0)
+    assert not any(musicxml.is_inferred_rest(n) for _c, _d, n in plain)
+
+    marked = tabextract._rest_beats_for(3.0, inferred=True)
+    assert marked == plain, "same rests, spelled the same way"
+    assert all(musicxml.is_inferred_rest(n) for _c, _d, n in marked)
 
 
 def test_an_empty_bar_is_filled_with_rests_that_add_up():
@@ -755,7 +814,7 @@ def test_an_onset_short_of_digits_does_not_eat_the_next_onsets_column():
         _note_event(110.0, 4, y=122.0, stem="down"),
     ]
     cols = [_col(100.0, (1, "7")), _col(110.0, (5, "3"))]
-    voices, _, unmatched_notes, _ = _measure(cols, events, budget=3.0)
+    voices, _, unmatched_notes = _measure(cols, events, budget=3.0)
     lower = [b for b in voices[1] if b[2]]
     assert lower == [(4, 0, [(5, "3")])], voices
     # and it is the SECOND beat of that voice, not the first
@@ -775,7 +834,7 @@ def test_one_stem_shared_across_two_onsets_is_not_one_chord():
         _note_event(140.0, 4, y=62.0, stem="up"),
     ]
     cols = [_col(100.0, (2, "5")), _col(106.0, (5, "3")), _col(140.0, (5, "7"))]
-    voices, _, _, _ = _measure(cols, events, budget=3.0)
+    voices, _, _ = _measure(cols, events, budget=3.0)
     assert len(voices) == 1, voices
     assert len(voices[0]) == 3, "three onsets, three beats"
     assert tabextract._bar_quarters(voices) == 3.0
@@ -791,7 +850,7 @@ def test_a_rest_matching_no_onset_is_dropped_not_added_to_a_sounding_voice():
     events += [_note_event(145.4, 4, y=62.0, rest=True)]  # 5.4pt from any onset
     cols = [_col(100.0, (1, "7"), (5, "3")), _col(140.0, (1, "8")),
             _col(180.0, (1, "9"), (5, "5")), _col(220.0, (1, "10"))]
-    voices, _, _, _ = _measure(cols, events, budget=4.0)
+    voices, _, _ = _measure(cols, events, budget=4.0)
     assert len(voices) == 2
     assert _quarters(voices[0]) == 4.0, voices[0]
     assert _quarters(voices[1]) == 4.0, voices[1]
@@ -808,17 +867,17 @@ def test_a_voice_whose_notes_all_lost_their_digits_is_not_emitted():
         _note_event(100.0, 4, y=120.0, stem="down"),
     ]
     cols = [_col(100.0, (1, "7"))]  # one digit for two noteheads
-    voices, _, unmatched_notes, inferred = _measure(cols, events, budget=3.0)
+    voices, _, unmatched_notes = _measure(cols, events, budget=3.0)
     assert len(voices) == 1, voices
     assert voices[0] == [(4, 0, [(1, "7")])]
-    assert inferred == 0.0, "no silence is inferred for a voice that never played"
+    assert _inferred_quarters(voices) == 0.0, "no silence is inferred for a voice that never played"
     assert unmatched_notes == 1
 
 
 def test_a_bar_of_nothing_but_rests_still_keeps_them():
     """The phantom-voice filter must not throw away a genuinely silent bar."""
     events = [_note_event(100.0, 4, rest=True)]
-    voices, _, _, _ = _measure([], events, budget=3.0)
+    voices, _, _ = _measure([], events, budget=3.0)
     assert voices == [[(4, 0, [])]], voices
 
 
@@ -904,6 +963,28 @@ def test_reference_score_bars_mostly_add_up(zanarkand_pdf):
     assert overfull <= 6, f"{overfull} bars overfull (was 37 before voices)"
     assert error <= 12.0, f"{error} quarters of error (was 72.5 before voices)"
     assert multivoice >= 30, f"only {multivoice} bars came out as two voices"
+
+
+def test_reference_score_reports_the_bars_it_invented_silence_in(zanarkand_pdf):
+    """The emitted alphaTex bars mostly add up (above) BECAUSE some of them
+    were filled out from the meter. Both facts have to be reported, and the
+    second one by bar number: the padding is why a score with notes missing
+    could report every bar conformant at high confidence.
+    """
+    result = tabextract.extract(zanarkand_pdf)
+    assert result.bars_padded > 0
+    assert len(result.padded_bars) == result.bars_padded
+    assert result.padded_bars == sorted(result.padded_bars)
+    assert all(1 <= n <= result.bars for n in result.padded_bars)
+    assert result.inferred_rest_quarters > 0
+
+    padded = [w for w in result.warnings if "deduced from the time signature" in w]
+    assert len(padded) == 1, result.warnings
+    assert f"{result.bars_padded} of {result.bars_measured} bar(s)" in padded[0]
+    assert str(result.padded_bars[0]) in padded[0]
+    # every padded bar is a bar whose reading came up short of its meter, so
+    # the short count cannot be smaller than nothing while padding happened
+    assert result.bars_short > 0
 
 
 def test_reference_score_still_reports_the_bars_that_do_not_add_up(zanarkand_pdf):
@@ -1168,18 +1249,25 @@ def test_bar_conformance_counts_both_directions():
     wrong in either direction and both have to be visible - only the overfull
     count existed before, so a bar with a note missing from it looked clean.
 
-    The fields are (overfull, short, defective, counted)."""
+    The fields are (overfull, short, defective, counted, padded, padded_bars,
+    inferred_quarters)."""
     exact = [[(4, 0, [(1, 0)])] * 3]
     over = [[(4, 0, [(1, 0)])] * 4]
     short = [[(4, 0, [(1, 0)])] * 2]
-    assert tabextract._bar_conformance([(exact, (3, 4))]) == (0, 0, 0, 1)
-    assert tabextract._bar_conformance([(over, (3, 4))]) == (1, 0, 1, 1)
-    assert tabextract._bar_conformance([(short, (3, 4))]) == (0, 1, 1, 1)
+    assert tabextract._bar_conformance([(exact, (3, 4))]) == (0, 0, 0, 1, 0, (), 0.0)
+    assert tabextract._bar_conformance([(over, (3, 4))]) == (1, 0, 1, 1, 0, (), 0.0)
+    assert tabextract._bar_conformance([(short, (3, 4))]) == (0, 1, 1, 1, 0, (), 0.0)
     # A bar with one voice over its meter and another under it is wrong ONCE.
     # overfull + short would count it twice and can exceed the bar count, which
     # is why `defective` is a field of its own.
     both = [[(4, 0, [(1, 0)])] * 4, [(4, 0, [(2, 0)])] * 2]
-    assert tabextract._bar_conformance([(both, (3, 4))]) == (1, 1, 1, 1)
+    assert tabextract._bar_conformance([(both, (3, 4))]) == (1, 1, 1, 1, 0, (), 0.0)
+    # A voice padded out to its meter with inferred silence is still SHORT by
+    # what was missing, and the padding is reported separately: bar 2 here.
+    padded = [[(4, 0, [(1, 0)])] * 3,
+              [(4, 0, [(2, 0)]), (2, 0, musicxml.inferred_rest())]]
+    assert tabextract._bar_conformance([(exact, (3, 4)), (padded, (3, 4))]) == (
+        0, 1, 1, 2, 1, (2,), 2.0)
     # _overfull_bars keeps its old shape for the callers that want just that
     assert tabextract._overfull_bars([(over, (3, 4))]) == (1, 1)
 
@@ -1193,6 +1281,39 @@ def test_short_bars_are_reported_not_padded():
     # and the emitted score really does carry the short bar as-is
     from fermata import musicxml
     assert musicxml.voice_durations(short[0][0]) == [2 * musicxml.DIVISIONS]
+
+
+def test_the_padded_bars_are_named_not_just_counted():
+    """A total says a score is partly invented; the bar numbers say WHERE,
+    which is the only form of the fact a reader can check against the PDF."""
+    counts = collections.Counter({tabextract.PROV_GLYPHS: 1})
+    warnings, _c = tabextract._rhythm_report(
+        counts, {}, tabextract._BarConformance(0, 3, 3, 20, 3, (2, 7, 13), 6.5))
+    padded = [w for w in warnings if "deduced from the time signature" in w]
+    assert len(padded) == 1, warnings
+    assert "3 of 20 bar(s)" in padded[0]
+    assert "bar(s) 2, 7, 13" in padded[0]
+    assert "6.5 quarter note(s)" in padded[0]
+
+    # Nothing is said at all when nothing was padded - a warning that fires on
+    # a clean score teaches a reader to ignore it.
+    quiet, _c = tabextract._rhythm_report(
+        counts, {}, tabextract._BarConformance(0, 0, 0, 20))
+    assert not any("deduced from the time signature" in w for w in quiet)
+
+
+def test_a_hundred_padded_bars_do_not_become_a_wall_of_numbers():
+    """The list is capped and says how many it left out; the COUNT beside it is
+    always the whole truth."""
+    counts = collections.Counter({tabextract.PROV_GLYPHS: 1})
+    bars = tuple(range(1, 101))
+    warnings, _c = tabextract._rhythm_report(
+        counts, {}, tabextract._BarConformance(0, 100, 100, 100, 100, bars, 200.0))
+    padded = next(w for w in warnings if "deduced from the time signature" in w)
+    assert "100 of 100 bar(s)" in padded
+    assert str(tabextract._PADDED_BARS_LISTED) in padded
+    assert f"and {100 - tabextract._PADDED_BARS_LISTED} more" in padded
+    assert "13," not in padded, "the list stops at the cap"
 
 
 def test_short_bars_downgrade_confidence_the_same_way_overfull_ones_do():
@@ -1340,6 +1461,32 @@ def test_reported_conformance_matches_the_emitted_measures(zanarkand_pdf):
     # than summing to it
     assert result.bars_defective <= result.bars_overfull + result.bars_short
     assert max(result.bars_overfull, result.bars_short) <= result.bars_defective
+
+
+def test_no_voice_is_written_as_inferred_silence_alone(zanarkand_pdf):
+    """What makes the check above valid for a consumer as well as for us.
+
+    Inferred silence is a `<forward>`, which is not counted by Rule 8 - so a
+    voice consisting of NOTHING but inferred silence would contribute no notes
+    and no rests to its measure at all, and a consumer enumerating voices from
+    `<note>` elements would not see that voice, or its shortfall, at all. Every
+    voice that reaches the emitter has at least one decoded note in it (see
+    _build_measure_beats_glyph's phantom-voice filter), which is what keeps the
+    two counts equal. Assert it on the reference score rather than trusting it.
+    """
+    import xml.etree.ElementTree as ET
+
+    result = tabextract.extract(zanarkand_pdf)
+    root = ET.fromstring(result.musicxml)
+    forwards = 0
+    for measure in root.findall("./part/measure"):
+        sounding = {n.findtext("voice") for n in measure.findall("note")}
+        for forward in measure.findall("forward"):
+            forwards += 1
+            assert forward.findtext("voice") in sounding, (
+                f"measure {measure.get('number')} writes a voice as silence alone")
+    assert forwards > 0, "this score does have inferred silence in it to check"
+    assert result.bars_padded > 0
 
 
 def test_a_bar_wrong_in_both_directions_is_counted_once():

--- a/server/tests/test_tabextract.py
+++ b/server/tests/test_tabextract.py
@@ -48,6 +48,44 @@ def _parse_with_alphatab(tex: str) -> dict:
     return json.loads(proc.stdout.strip().splitlines()[-1])
 
 
+def _load_musicxml_with_alphatab(xml: str, onsets: bool = False) -> dict:
+    """Load `xml` with the real alphaTab MusicXML importer the web player uses,
+    via tools/tab_extract/verify_musicxml.mjs.
+
+    A stored transcription IS MusicXML and the player imports it with this
+    exact loader, so nothing about how the file is written can be called safe
+    on the strength of the emitter agreeing with itself. Rule 14's `<forward>`
+    is the sharp case: a loader that ignored it would still load the file, and
+    every voice that entered late would collapse onto the downbeat. Skips
+    (rather than fails) when node or the web project's installed alphaTab build
+    aren't available, since neither is present in the production server's own
+    runtime image.
+    """
+    if shutil.which("node") is None:
+        pytest.skip("node not available")
+    repo_root = Path(__file__).resolve().parents[2]
+    alphatab = repo_root / "web" / "node_modules" / "@coderline" / "alphatab" / "dist" / "alphaTab.mjs"
+    if not alphatab.is_file():
+        pytest.skip("alphaTab.mjs not found - run `npm ci` in web/ first")
+    script = Path(__file__).resolve().parents[1] / "tools" / "tab_extract" / "verify_musicxml.mjs"
+
+    with tempfile.NamedTemporaryFile("w", suffix=".musicxml", delete=False,
+                                     encoding="utf-8") as f:
+        f.write(xml)
+        xml_path = f.name
+    try:
+        args = ["node", str(script), str(alphatab)]
+        if onsets:
+            args.append("--onsets")
+        proc = subprocess.run(args + [xml_path], capture_output=True, text=True, timeout=60)
+    finally:
+        Path(xml_path).unlink(missing_ok=True)
+
+    parsed = json.loads(proc.stdout.strip().splitlines()[-1])
+    assert parsed.get("ok"), f"MusicXML failed to load: {parsed.get('error')}"
+    return parsed
+
+
 def _make_tab_pdf(path, pages):
     """Build a minimal PDF with one 6-line tab staff per page - good enough
     to exercise _detect_staves / _detect_barlines / _extract_digit_tokens
@@ -148,11 +186,21 @@ def test_glyph_decoded_alphatex_parses_with_dotted_beats(zanarkand_pdf):
     string first: the piece is Drop D, and its first written note (`0.1`)
     must sound MIDI 64 (high E untouched by the drop), not 38/40 (the
     mirrored low string a low-to-high tuning emission would produce)."""
+    import xml.etree.ElementTree as ET
+
     result = tabextract.extract(zanarkand_pdf, time_signature=(3, 4))
     assert result.extractable
     parsed = _parse_with_alphatab(result.alphatex)
     assert parsed["bars"] == result.bars
-    assert parsed["beats"] == result.beats
+    # `beats` is what the CANONICAL output holds, and the two formats no longer
+    # hold the same number: inferred silence is a plain rest in alphaTex (which
+    # has nothing to mark it with) and a `<forward>` in the MusicXML, which is
+    # not a beat of the score. So the alphaTex has exactly one beat more per
+    # `<forward>`, and stating the relationship pins both artefacts instead of
+    # letting `beats` drift towards whichever one is checked.
+    forwards = len(ET.fromstring(result.musicxml).findall("./part/measure/forward"))
+    assert forwards > 0, "this score does have inferred silence in it"
+    assert parsed["beats"] == result.beats + forwards
     assert parsed["notes"] == result.notes
     assert parsed["dottedBeats"] > 0
     assert parsed["firstNoteMidi"] == 64
@@ -293,6 +341,21 @@ def test_rest_only_bar_is_emitted_not_skipped(tmp_path):
     assert "3.1" in lines[0]
     assert lines[1].strip() == ":1 r |"
     assert "5.5" in lines[2]
+
+    # ...and that bar is REPORTED as one nothing was read from. Its rests add up
+    # to the meter, so Rule 8 passes and it is not a defect - which is exactly
+    # why it has to be said some other way, or a score read as nothing at all
+    # reports every bar conformant. The rest is left unmarked deliberately: a
+    # whole voice of `<forward>` would carry no notes and no rests, so no
+    # consumer enumerating voices from <note> would see the bar at all.
+    assert result.bars_unread == 1
+    assert result.unread_bars == [2]
+    assert result.bars_defective == 0, "a bar of rests does add up"
+    assert result.bars_padded == 0
+    assert "<forward>" not in result.musicxml
+    unread = next(w for w in result.warnings if "hold nothing that was read" in w)
+    assert "1 of 3 bar(s)" in unread
+    assert "The bars are: 2." in unread
 
 
 def test_last_column_duration_uses_barline_not_average_gap():
@@ -1250,24 +1313,29 @@ def test_bar_conformance_counts_both_directions():
     count existed before, so a bar with a note missing from it looked clean.
 
     The fields are (overfull, short, defective, counted, padded, padded_bars,
-    inferred_quarters)."""
+    inferred_quarters, defective_bars)."""
     exact = [[(4, 0, [(1, 0)])] * 3]
     over = [[(4, 0, [(1, 0)])] * 4]
     short = [[(4, 0, [(1, 0)])] * 2]
-    assert tabextract._bar_conformance([(exact, (3, 4))]) == (0, 0, 0, 1, 0, (), 0.0)
-    assert tabextract._bar_conformance([(over, (3, 4))]) == (1, 0, 1, 1, 0, (), 0.0)
-    assert tabextract._bar_conformance([(short, (3, 4))]) == (0, 1, 1, 1, 0, (), 0.0)
+    assert tabextract._bar_conformance([(exact, (3, 4))]) == (0, 0, 0, 1, 0, (), 0.0, ())
+    assert tabextract._bar_conformance([(over, (3, 4))]) == (1, 0, 1, 1, 0, (), 0.0, (1,))
+    assert tabextract._bar_conformance([(short, (3, 4))]) == (0, 1, 1, 1, 0, (), 0.0, (1,))
     # A bar with one voice over its meter and another under it is wrong ONCE.
     # overfull + short would count it twice and can exceed the bar count, which
     # is why `defective` is a field of its own.
     both = [[(4, 0, [(1, 0)])] * 4, [(4, 0, [(2, 0)])] * 2]
-    assert tabextract._bar_conformance([(both, (3, 4))]) == (1, 1, 1, 1, 0, (), 0.0)
+    assert tabextract._bar_conformance([(both, (3, 4))]) == (1, 1, 1, 1, 0, (), 0.0, (1,))
     # A voice padded out to its meter with inferred silence is still SHORT by
     # what was missing, and the padding is reported separately: bar 2 here.
     padded = [[(4, 0, [(1, 0)])] * 3,
               [(4, 0, [(2, 0)]), (2, 0, musicxml.inferred_rest())]]
     assert tabextract._bar_conformance([(exact, (3, 4)), (padded, (3, 4))]) == (
-        0, 1, 1, 2, 1, (2,), 2.0)
+        0, 1, 1, 2, 1, (2,), 2.0, (2,))
+    # A bar with no meter is not measured against one, but its padding is still
+    # counted: it carries a <forward> into the file either way, and a padded
+    # count the file disagrees with is what this whole mechanism prevents.
+    assert tabextract._bar_conformance([(padded, None)]) == (
+        0, 0, 0, 0, 1, (1,), 2.0, ())
     # _overfull_bars keeps its old shape for the callers that want just that
     assert tabextract._overfull_bars([(over, (3, 4))]) == (1, 1)
 
@@ -1292,8 +1360,8 @@ def test_the_padded_bars_are_named_not_just_counted():
     padded = [w for w in warnings if "deduced from the time signature" in w]
     assert len(padded) == 1, warnings
     assert "3 of 20 bar(s)" in padded[0]
-    assert "bar(s) 2, 7, 13" in padded[0]
-    assert "6.5 quarter note(s)" in padded[0]
+    assert "The bars are: 2, 7, 13." in padded[0]
+    assert "6.5 quarter note(s) of it in total" in padded[0]
 
     # Nothing is said at all when nothing was padded - a warning that fires on
     # a clean score teaches a reader to ignore it.
@@ -1302,18 +1370,49 @@ def test_the_padded_bars_are_named_not_just_counted():
     assert not any("deduced from the time signature" in w for w in quiet)
 
 
+def test_a_quarter_note_count_is_exact_not_rounded():
+    """The sentence's whole purpose is to say how much of a score was invented,
+    so the number in it has to be the number. A %.4g format printed 43.875 as
+    "43.88" and 104.25 as "104.2" - wrong, in ten of the library's scores."""
+    counts = collections.Counter({tabextract.PROV_GLYPHS: 1})
+    for quarters, text in ((43.875, "43.875"), (104.25, "104.25"), (126.0, "126"),
+                           (0.125, "0.125"), (2.5, "2.5")):
+        warnings, _c = tabextract._rhythm_report(
+            counts, {}, tabextract._BarConformance(0, 1, 1, 20, 1, (2,), quarters))
+        padded = next(w for w in warnings if "deduced from the time signature" in w)
+        assert f"{text} quarter note(s)" in padded, padded
+
+
 def test_a_hundred_padded_bars_do_not_become_a_wall_of_numbers():
     """The list is capped and says how many it left out; the COUNT beside it is
-    always the whole truth."""
+    always the whole truth, and ExtractionResult carries every number as data.
+
+    The cap VALUE is asserted, not just that some cap exists: at twelve it bound
+    131 of the library's 271 affected scores, so the prose lost the fact for half
+    of them, and a test that only checks "some numbers are missing" would have
+    called that healthy.
+    """
     counts = collections.Counter({tabextract.PROV_GLYPHS: 1})
-    bars = tuple(range(1, 101))
+    cap = tabextract._BARS_LISTED
+    assert cap == 60, "the cap is a measured choice - see _BARS_LISTED"
+    bars = tuple(range(1, cap + 41))
     warnings, _c = tabextract._rhythm_report(
-        counts, {}, tabextract._BarConformance(0, 100, 100, 100, 100, bars, 200.0))
+        counts, {}, tabextract._BarConformance(
+            0, len(bars), len(bars), len(bars), len(bars), bars, 200.0))
     padded = next(w for w in warnings if "deduced from the time signature" in w)
-    assert "100 of 100 bar(s)" in padded
-    assert str(tabextract._PADDED_BARS_LISTED) in padded
-    assert f"and {100 - tabextract._PADDED_BARS_LISTED} more" in padded
-    assert "13," not in padded, "the list stops at the cap"
+    assert f"{len(bars)} of {len(bars)} bar(s)" in padded
+    listed = padded.split("The bars are: ")[1].split(" and ")[0]
+    assert [int(n) for n in listed.split(", ")] == list(bars[:cap])
+    assert f"and {len(bars) - cap} more" in padded
+
+    # A list that fits is not truncated and says nothing about "more"
+    short_list = tuple(range(1, cap + 1))
+    warnings, _c = tabextract._rhythm_report(
+        counts, {}, tabextract._BarConformance(
+            0, cap, cap, cap, cap, short_list, 1.0))
+    padded = next(w for w in warnings if "deduced from the time signature" in w)
+    assert "more." not in padded
+    assert str(cap) in padded
 
 
 def test_short_bars_downgrade_confidence_the_same_way_overfull_ones_do():
@@ -1341,6 +1440,177 @@ def test_short_bars_downgrade_confidence_the_same_way_overfull_ones_do():
     _w, still_high = tabextract._rhythm_report(
         counts, {}, tabextract._BarConformance(2, 2, 2, 10))
     assert still_high.startswith("high"), still_high
+
+
+def test_a_confidence_below_the_threshold_still_says_what_is_wrong():
+    """The threshold decides the LABEL, not whether anything is said. Sixteen of
+    the nineteen library scores that still rated "high" sat just under the
+    quarter - one with invented silence in 7 of its 33 bars - and read
+    "decoded directly from the ... engraving" with nothing qualifying it, which
+    makes a score with known defective bars indistinguishable from a clean
+    one at the single figure the application uses to summarise a
+    transcription."""
+    counts = collections.Counter({tabextract.PROV_GLYPHS: 1})
+    _w, high = tabextract._rhythm_report(
+        counts, {}, tabextract._BarConformance(0, 2, 2, 10))
+    assert high.startswith("high"), "still high: two of ten is under the quarter"
+    assert "2 of 10 bar(s) do not add up" in high, high
+
+    # A genuinely clean score says nothing extra - the qualifier has to mean
+    # something, and one that appears on every score would not.
+    _w, clean = tabextract._rhythm_report(
+        counts, {}, tabextract._BarConformance(0, 0, 0, 10))
+    assert clean.startswith("high")
+    assert "bar(s)" not in clean, clean
+
+
+def test_bars_nothing_was_read_from_are_counted_and_named():
+    """A bar holding a whole bar of rests nothing was read from adds up to its
+    meter, so it passes Rule 8 and is NOT counted as defective - folding it in
+    would make these figures disagree with the emitted file. It is still not a
+    reading: a 40-bar score read as nothing at all was reporting 40 of 40 bars
+    conformant at high confidence with no warning mentioning emptiness."""
+    counts = collections.Counter({tabextract.PROV_GLYPHS: 1})
+    warnings, confidence = tabextract._rhythm_report(
+        counts, {}, tabextract._BarConformance(0, 0, 0, 40), tuple(range(1, 41)))
+    unread = [w for w in warnings if "hold nothing that was read" in w]
+    assert len(unread) == 1, warnings
+    assert "40 of 40 bar(s)" in unread[0]
+    assert "The bars are: 1, 2," in unread[0]
+    assert confidence.startswith("low overall"), confidence
+    assert "hold nothing that was read from the score (40)" in confidence
+
+    # Below the threshold they are still named, and still qualify the string.
+    warnings, confidence = tabextract._rhythm_report(
+        counts, {}, tabextract._BarConformance(0, 0, 0, 40), (7, 9))
+    assert any("2 of 40 bar(s) hold nothing" in w for w in warnings), warnings
+    assert confidence.startswith("high")
+    assert "(2)" in confidence, confidence
+
+    # And a bar that is BOTH defective and unread counts once, or the ratio
+    # could exceed 1 and a 4-bar score could report 5 unreliable bars.
+    _w, both = tabextract._rhythm_report(
+        counts, {}, tabextract._BarConformance(0, 4, 4, 4, 0, (), 0.0, (1, 2, 3, 4)),
+        (1, 2, 3, 4))
+    assert "4 of 4 bar(s) either" in both, both
+
+
+def _onsets_by_voice(parsed):
+    """{voice index: [(start, duration, is_rest), ...]} from an --onsets load."""
+    out = collections.defaultdict(list)
+    for _bar, voice, start, duration, is_rest in parsed["onsets"]:
+        out[voice].append((start, duration, is_rest))
+    for beats in out.values():
+        beats.sort()
+    return dict(out)
+
+
+@pytest.mark.parametrize("where", ["leading", "trailing", "middle"])
+def test_the_renderer_puts_a_note_after_inferred_silence_where_a_rest_would(where):
+    """The one assumption the whole of Rule 14 rests on, checked against the
+    real importer rather than against this emitter agreeing with itself.
+
+    Inferred silence is written as `<forward>` instead of a rest so that it does
+    not claim the source printed one. That is only safe if a consumer advances
+    its position across it. If the renderer ever stopped doing so, every voice
+    that enters late would collapse onto the downbeat and sound its notes early
+    - a file that still loads, still validates and plays wrong. So build the
+    same bar twice, once with the silence marked inferred and once as an
+    ordinary rest, and require the onsets to be IDENTICAL. Comparing against
+    the rest version rather than against a tick figure keeps this about the
+    property and not about alphaTab's units.
+    """
+    note, silence = (4, 0, [(1, 5)]), (2, 0, None)
+    shapes = {
+        "leading": [silence, note],
+        "trailing": [note, silence],
+        "middle": [(4, 0, [(1, 5)]), (4, 0, None), (4, 0, [(1, 7)])],
+    }
+
+    def build(marked):
+        def fill(beat):
+            code, dots, notes = beat
+            if notes is not None:
+                return beat
+            return (code, dots, musicxml.inferred_rest() if marked else [])
+        upper = [fill(b) for b in shapes[where]]
+        lower = [(4, 0, [(6, 0)]), (4, 0, [(6, 2)]), (4, 0, [(6, 3)])]
+        return musicxml.build("T", None, tabextract.DEFAULT_TUNING, (3, 4),
+                              [([upper, lower], (3, 4))])
+
+    inferred = _load_musicxml_with_alphatab(build(True), onsets=True)
+    engraved = _load_musicxml_with_alphatab(build(False), onsets=True)
+
+    assert "<forward>" in build(True), "the inferred version really does write one"
+    assert "<forward>" not in build(False)
+
+    def sounding(parsed):
+        return {v: [b for b in beats if not b[2]]
+                for v, beats in _onsets_by_voice(parsed).items()}
+
+    assert sounding(inferred) == sounding(engraved), (
+        f"a {where} <forward> did not hold the position a rest holds - every note "
+        "after it moved")
+
+    if where == "trailing":
+        # A trailing forward is the one case a consumer may legitimately drop:
+        # this renderer ends the voice there rather than showing silence, and
+        # nothing sounds after it, so no note moves. Recorded because it is the
+        # only place the two spellings differ at all.
+        assert _onsets_by_voice(inferred)[0] != _onsets_by_voice(engraved)[0]
+        return
+
+    # Otherwise the position really was held, rather than two voices merely both
+    # starting on the downbeat: the padded voice covers the same span as the one
+    # that plays throughout, and where it entered late its NOTE is not first.
+    voices = _onsets_by_voice(inferred)
+    upper, lower = voices[0], voices[1]
+
+    def end(beats):
+        return max(start + duration for start, duration, _rest in beats)
+
+    assert end(upper) == end(lower), "the padded voice does not cover the bar"
+    if where == "leading":
+        starts = [start for start, _d, is_rest in upper if not is_rest]
+        assert starts and min(starts) > upper[0][0], (
+            "the late-entering voice sounds on the downbeat - the forward was ignored")
+
+
+def test_reported_beat_count_matches_what_the_musicxml_holds():
+    """`beats` is reported beside the MusicXML, so it has to be what the file
+    contains. Inferred silence is written as `<forward>` and is not a beat of
+    the score, so counting the beats model instead reported more beats than the
+    canonical output holds - 6386 more across the library, exactly its number
+    of `<forward>` elements, on 271 of 293 scores."""
+    import xml.etree.ElementTree as ET
+
+    from fermata import musicxml
+
+    measures = [
+        # one voice fully read, one padded out with inferred silence
+        ([[(4, 0, [(1, 0)]), (4, 0, [(1, 2)]), (4, 0, [(1, 3)])],
+          [(4, 0, [(5, 0)]), (2, 0, musicxml.inferred_rest())]], (3, 4)),
+        # a chord is ONE beat however many notes it has (Rule 7), and a beat
+        # whose notes have no writable pitch keeps its place as a rest
+        ([[(4, 0, [(6, 0), (5, 2), (4, 2)]), (4, 0, [(1, 78)]), (4, 0, [(1, 1)])]], (3, 4)),
+    ]
+    assert musicxml.written_beats(measures) == 7
+    root = ET.fromstring(
+        musicxml.build("T", None, tabextract.DEFAULT_TUNING, (3, 4), measures))
+    holds = len([n for n in root.findall("./part/measure/note") if n.find("chord") is None])
+    assert holds == musicxml.written_beats(measures)
+    assert len(root.findall("./part/measure/forward")) == 1
+
+
+def test_reported_beat_count_matches_the_reference_scores_musicxml(zanarkand_pdf):
+    """The same invariant on a real score, where the padding actually happens."""
+    import xml.etree.ElementTree as ET
+
+    result = tabextract.extract(zanarkand_pdf)
+    root = ET.fromstring(result.musicxml)
+    holds = len([n for n in root.findall("./part/measure/note") if n.find("chord") is None])
+    assert holds == result.beats
+    assert len(root.findall("./part/measure/forward")) > 0
 
 
 def test_reported_note_count_matches_what_the_musicxml_holds():

--- a/server/tests/test_transcription_api.py
+++ b/server/tests/test_transcription_api.py
@@ -301,7 +301,8 @@ def test_edit_format_is_read_off_the_content(content, expected):
 # ---------------------------------------------------------------------------
 
 
-BAR_KEYS = ("bars_overfull", "bars_short", "bars_defective", "bars_measured")
+BAR_KEYS = ("bars_overfull", "bars_short", "bars_defective", "bars_measured",
+            "bars_padded")
 
 
 def test_bar_conformance_survives_a_reload(app_env, engraved, monkeypatch, insert_score):
@@ -327,6 +328,7 @@ def test_bar_conformance_survives_a_reload(app_env, engraved, monkeypatch, inser
     assert fetched["bars_measured"] > 0
     assert fetched["bars_overfull"] > 0, "this fixture has bars over their meter"
     assert fetched["bars_short"] > 0, "...and bars under it"
+    assert fetched["bars_padded"] > 0, "...and bars filled out with inferred silence"
     # The invariant that makes `defective` the only figure comparable against
     # the total: it never exceeds the bars measured, whereas overfull + short
     # may. A client comparing the wrong pair can print "13 of 12 bars".

--- a/server/tests/test_transcription_api.py
+++ b/server/tests/test_transcription_api.py
@@ -302,7 +302,12 @@ def test_edit_format_is_read_off_the_content(content, expected):
 
 
 BAR_KEYS = ("bars_overfull", "bars_short", "bars_defective", "bars_measured",
-            "bars_padded")
+            "bars_padded", "bars_unread")
+# Which bars, and how much silence - the figures that only exist as data. The
+# warning prose caps its bar list, and the profile document promises a consumer
+# that `inferred_rest_quarters` is the sum of the `<forward>` durations in the
+# file, so the application has to actually offer the number.
+BAR_DETAIL_KEYS = ("padded_bars", "unread_bars", "inferred_rest_quarters")
 
 
 def test_bar_conformance_survives_a_reload(app_env, engraved, monkeypatch, insert_score):
@@ -329,6 +334,19 @@ def test_bar_conformance_survives_a_reload(app_env, engraved, monkeypatch, inser
     assert fetched["bars_overfull"] > 0, "this fixture has bars over their meter"
     assert fetched["bars_short"] > 0, "...and bars under it"
     assert fetched["bars_padded"] > 0, "...and bars filled out with inferred silence"
+    for key in BAR_DETAIL_KEYS:
+        assert posted[key] == fetched[key], key
+    assert fetched["padded_bars"] and all(
+        isinstance(n, int) for n in fetched["padded_bars"])
+    assert len(fetched["padded_bars"]) == fetched["bars_padded"]
+    assert fetched["unread_bars"] == []
+    assert fetched["inferred_rest_quarters"] > 0
+    # The warning prose names the same bars the data does, so a reader of either
+    # gets the same answer - and the number in it is the exact one.
+    padded_warning = next(w for w in fetched["warnings"]
+                          if "deduced from the time signature" in w)
+    named = padded_warning.split("The bars are: ")[1].split(".")[0]
+    assert [int(n) for n in named.split(", ")] == fetched["padded_bars"]
     # The invariant that makes `defective` the only figure comparable against
     # the total: it never exceeds the bars measured, whereas overfull + short
     # may. A client comparing the wrong pair can print "13 of 12 bars".
@@ -353,7 +371,7 @@ def test_a_row_stored_before_the_bar_figures_reports_them_unrecorded(app_env, in
 
     fetched = api.get_transcription(score_id)
     assert fetched["warnings"] == ["something was odd"]
-    for key in BAR_KEYS:
+    for key in BAR_KEYS + BAR_DETAIL_KEYS:
         assert key in fetched, key
         assert fetched[key] is None, key
 
@@ -381,7 +399,7 @@ def test_an_edit_states_that_nothing_measured_it(app_env, extractable_pdf, monke
     for state in (edited, api.get_transcription(score_id)):
         assert state["source"] == "edited"
         assert state["warnings"] == []
-        for key in BAR_KEYS:
+        for key in BAR_KEYS + BAR_DETAIL_KEYS:
             assert key in state, key
             assert state[key] is None, key
 
@@ -410,6 +428,9 @@ def test_a_corrupt_blob_does_not_yield_a_bar_count(app_env, insert_score):
                     "bars_defective": None,
                     "bars_overfull": True,
                     "bars_short": 2,
+                    "padded_bars": [1, "two", 3],
+                    "unread_bars": [4, 5],
+                    "inferred_rest_quarters": "a lot",
                 }
             ),
         ),
@@ -422,6 +443,9 @@ def test_a_corrupt_blob_does_not_yield_a_bar_count(app_env, insert_score):
     assert fetched["bars_defective"] is None
     assert fetched["bars_overfull"] is None, "a bool is not a bar count"
     assert fetched["bars_short"] == 2
+    assert fetched["padded_bars"] is None, "a list with a string in it is not bar numbers"
+    assert fetched["unread_bars"] == [4, 5]
+    assert fetched["inferred_rest_quarters"] is None, "a quarter count is a number"
 
 
 # ---------------------------------------------------------------------------

--- a/server/tools/tab_extract/verify_musicxml.mjs
+++ b/server/tools/tab_extract/verify_musicxml.mjs
@@ -8,11 +8,20 @@
 // re-implementation of it.
 //
 // Usage:
-//   node verify_musicxml.mjs <path-to-alphaTab.mjs> <file-or-dir> [...more]
+//   node verify_musicxml.mjs <path-to-alphaTab.mjs> [--onsets] <file-or-dir> [...]
 //
 // Prints one JSON line per file: {file, ok, bars, voices, beats, notes,
 // dottedBeats, firstNoteMidi, firstNoteString, firstNoteFret, tuning} or
 // {file, ok: false, error}. Exits 1 if any file failed to load.
+//
+// With --onsets each line also carries `onsets`: one entry per beat, as
+// [barIndex, voiceIndex, playbackStart, playbackDuration, isRest]. That is
+// what checks the profile's Rule 14 - inferred silence is written as
+// <forward>, which is only safe if a consumer advances its position across
+// one, so a note following a <forward> has to sound where a note following a
+// rest of the same duration would. A file whose leading <forward> is ignored
+// still loads, still validates, and plays every late-entering voice on the
+// downbeat, so nothing but a position tells you.
 //
 // firstNoteString/Fret and tuning are the ones that matter beyond "it
 // parsed": MusicXML numbers staff LINES from the bottom and STRINGS from the
@@ -27,9 +36,11 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 
 async function main() {
-    const [alphaTabPath, ...targets] = process.argv.slice(2);
+    const [alphaTabPath, ...rest] = process.argv.slice(2);
+    const wantOnsets = rest.includes("--onsets");
+    const targets = rest.filter((a) => a !== "--onsets");
     if (!alphaTabPath || targets.length === 0) {
-        console.error("usage: node verify_musicxml.mjs <alphaTab.mjs> <file-or-dir> [...]");
+        console.error("usage: node verify_musicxml.mjs <alphaTab.mjs> [--onsets] <file-or-dir> [...]");
         process.exit(2);
     }
 
@@ -60,6 +71,7 @@ async function main() {
             let bars = 0, voices = 0, beats = 0, notes = 0, dottedBeats = 0;
             let firstNoteMidi = null, firstNoteString = null, firstNoteFret = null;
             let tuning = null;
+            const onsets = [];
             for (const track of score.tracks) {
                 for (const staff of track.staves) {
                     bars = Math.max(bars, staff.bars.length);
@@ -77,6 +89,13 @@ async function main() {
                             for (const beat of voice.beats) {
                                 beats += 1;
                                 if (beat.dots > 0) dottedBeats += 1;
+                                if (wantOnsets) {
+                                    onsets.push([
+                                        bar.index, voice.index,
+                                        beat.playbackStart, beat.playbackDuration,
+                                        beat.isRest,
+                                    ]);
+                                }
                                 for (const note of beat.notes) {
                                     notes += 1;
                                     if (firstNoteMidi === null) {
@@ -94,6 +113,7 @@ async function main() {
                 ok: true, bars, voices, beats, notes, dottedBeats,
                 firstNoteMidi, firstNoteString, firstNoteFret, tuning,
             });
+            if (wantOnsets) result.onsets = onsets;
         } catch (e) {
             anyFailed = true;
             Object.assign(result, { ok: false, error: String(e && e.stack ? e.stack : e) });

--- a/web/scripts/check-warning-patterns.mjs
+++ b/web/scripts/check-warning-patterns.mjs
@@ -28,9 +28,34 @@ const OVERFULL_BARS_SENTENCE =
   "not, so playback timing will drift in those bars";
 const SHORT_BARS_SENTENCE =
   "1 of 50 bar(s) hold less than their time signature allows - a note whose duration " +
-  "was read short, or one dropped for want of a fret number, leaves the bar with a gap " +
-  "at the end. The emitted score says so rather than padding it out, so any MusicXML " +
-  "tool will report those bars too";
+  "was read short, or one dropped for want of a fret number, leaves the bar with less " +
+  "music in it than the meter says it holds. Where such a bar has more than one voice " +
+  "the missing part is filled with silence deduced from the meter, at the front of the " +
+  "voice if that is where it entered late, so the voices still play in time with each " +
+  "other - that silence is not counted here and is not written as a rest. Either way " +
+  "the emitted MusicXML falls short by the same amount, so any MusicXML tool will " +
+  "report those bars too";
+// The two per-bar sentences _rhythm_report adds for inferred silence and for
+// bars nothing was read from. These are facts about THIS score and belong in
+// the per-score list, so they must NOT match BAR_RE - a bar-conformance line is
+// folded into the headline count instead and deliberately not listed again, so
+// a rewording that made either of these start like one would delete it from the
+// summary with nothing failing anywhere.
+const PADDED_BARS_SENTENCE =
+  "2 of 50 bar(s) contain silence that was deduced from the time signature rather than " +
+  "read from a rest printed in the score, 5.5 quarter note(s) of it in total. The bars " +
+  "are: 7, 31. A voice with a note missing from it is filled out the same way a " +
+  "genuinely resting voice is, so that the voices of the bar still play in time with " +
+  "each other; the inferred silence is NOT counted towards those bars adding up, and is " +
+  "written into the MusicXML as <forward> rather than as a rest so no consumer mistakes " +
+  "it for one the engraver printed";
+const UNREAD_BARS_SENTENCE =
+  "1 of 50 bar(s) hold nothing that was read from the score - no fret number and no " +
+  "rest glyph fell inside them - and are emitted as a whole bar of rests so the bar " +
+  "numbering still matches the source. The bars are: 12. Those bars add up to their " +
+  "time signature and so pass every arithmetic check, but nothing in them was read: " +
+  "they are not evidence that the score was transcribed, and a bar that is genuinely " +
+  "silent in the source cannot be told from one whose contents were missed";
 
 const problems = [];
 
@@ -45,6 +70,32 @@ if (!BAR_RE.test(OVERFULL_BARS_SENTENCE)) {
 }
 if (!BAR_RE.test(SHORT_BARS_SENTENCE)) {
   problems.push("BAR_RE no longer matches _rhythm_report's short-bars sentence");
+}
+if (BAR_RE.test(PADDED_BARS_SENTENCE)) {
+  problems.push(
+    "BAR_RE now matches _rhythm_report's inferred-silence sentence - it would be " +
+      "folded into the headline bar count and dropped from the per-score list",
+  );
+}
+if (BAR_RE.test(UNREAD_BARS_SENTENCE)) {
+  problems.push(
+    "BAR_RE now matches _rhythm_report's bars-read-as-nothing sentence - it would be " +
+      "folded into the headline bar count and dropped from the per-score list",
+  );
+}
+for (const [name, sentence] of [
+  ["inferred-silence", PADDED_BARS_SENTENCE],
+  ["bars-read-as-nothing", UNREAD_BARS_SENTENCE],
+]) {
+  // Both name the affected bars after a fixed lead-in, which is what a reader
+  // checks against the PDF. A rewording that dropped it would leave a warning
+  // stating a count and nothing else.
+  if (!/The bars are: \d+/.test(sentence)) {
+    problems.push(`_rhythm_report's ${name} sentence no longer names the bars`);
+  }
+  if (STANDING_LIMITS.some((lim) => lim.test.test(sentence))) {
+    problems.push(`_rhythm_report's ${name} sentence reads as a standing limit`);
+  }
 }
 
 if (problems.length) {

--- a/web/src/lib/ScoreCompare.svelte
+++ b/web/src/lib/ScoreCompare.svelte
@@ -361,7 +361,8 @@
       // edit itself is the source of truth for content/source either way
       // `res` carries the format the server read off the content, which is
       // what the viewer dispatches on - so let it win over the loaded row's.
-      // `res` STATES warnings ([]) and the four bars_* figures (null) on
+      // `res` STATES warnings ([]) and every bar figure (null) - the bars_*
+      // counts plus padded_bars, unread_bars and inferred_rest_quarters - on
       // every response rather than omitting them for an edit, which has no
       // confidence to report - an absent key would be silently kept by this
       // spread, which is exactly how a saved edit once went on reporting the


### PR DESCRIPTION
Closes #85.

`_pad_voice_to_budget` fills a short voice with rests deduced from the time
signature, and it ran **before** `_bar_conformance` measured the bar. A padded
voice is exactly as long as its meter by construction, so `min(voices) < budget`
could never fire: every dropped harmonic, unmapped glyph and misread duration
left no trace in `bars_short` or `bars_defective`, and never reached the
confidence downgrade. The invented rests were also emitted as ordinary rests in
both formats, with nothing distinguishing them from engraved ones.

## The padding stays, and says what it is

It is not decoration. A voice that enters halfway through a bar has to enter
halfway through the bar; written without its leading silence it plays every note
early. Dropping the padding would turn a bar whose notes are in the wrong places
into a bar whose notes are in the wrong places *and* short — a second wrong
answer, not an honest one. So the silence stays and the claim it made goes:

- **Marked in the model.** `musicxml.InferredRest` marks the `notes` slot of a
  rest the extractor deduced. It subclasses `list` and is always empty, so every
  existing reader that only asks "does this beat have notes" is untouched.
- **Measured on what was read.** `_bar_conformance` leaves marked rests out of
  its sums — the same measurement as running it before the padding. A padded bar
  now reports short by exactly what was missing, and reaches the downgrade.
- **`<forward>`, not a rest, in the MusicXML.** The position still advances, so
  the bar plays and lays out as it did, but the measure's notes and rests
  genuinely fall short of its meter. **An independent Rule 8 check therefore
  returns the same defect count this extractor reports** — which is the entire
  argument for emitting a standard format. Each element carries a `<footnote>`
  saying so and the `<voice>` it belongs to.
- **Attributed per bar.** The warning names which bars were padded, and
  `bars_padded`, `padded_bars` and `inferred_rest_quarters` are stored with the
  transcription and returned by the API, so a reloaded transcription still
  carries them and the quarter total the profile promises a consumer is a number
  the application actually offers.

How much silence was inferred is read back off the marked beats instead of
accumulated as the padding happens, so the reported figure and the emitted
silence cannot disagree.

**Published as Rule 14** of `docs/musicxml-tab-profile.md`, with the reasoning,
the schema child order (`duration`, `footnote?`, `level?`, `voice?`), the
guidance that Rule 8 must enumerate voices from `<note>` *and* `<forward>` while
summing only notes and rests, and the rule's limits. alphaTex has no editorial
mechanism for this and keeps an ordinary rest; that is stated rather than
glossed.

## A bar read as nothing is no longer called conformant

337 bars across 172 scores hold a whole bar of rests nothing was read from — no
fret column and no rest glyph inside them. Their rests *do* add up, so Rule 8
passes and `bars_defective` must not count them or these figures would stop
agreeing with the file. But nothing else counted them either: A library score has 9 of its 33 bars read as nothing and reported "high —
decoded directly from the notehead, stem, flag, beam and dot glyphs" with not one
of its eight warnings mentioning emptiness. A 40-bar score read as nothing at all
reported 40 of 40 bars conformant at high confidence.

They are now counted (`bars_unread`), named by number, and folded into the
confidence — with the **representation left alone**, deliberately. A voice of
nothing but `<forward>` carries no notes and no rests, so a consumer enumerating
voices from `<note>` never sees the bar at all: strictly worse than an honest bar
of rests. The profile says that, and says a bar of rests may be either invented
or engraved because the file cannot tell you which — 338 such bars in this
library, exactly one of them printed that way.

Relatedly, the confidence string now states any known defect **below** the
threshold at which it changes label. Only 3 of the 19 scores that still rated
"high" had no defective bars; the other sixteen sat just under the quarter and
read as unqualified, so a score with invented silence in 7 of its 33 bars was
indistinguishable from a clean one at the single figure the application uses.

## The numbers get worse. That is the result

Every one of these bars was already wrong; the padding was hiding it. Across all
297 files (293 extractable, 0 errors, 10,946 bars measured):

| | before | after |
| --- | --- | --- |
| `bars_short` | 688 | **4,668** |
| `bars_overfull` | 2,335 | 2,335 (control) |
| `bars_defective` | 3,023 | **6,411** |
| scores with any short bar | 137 | 284 |
| rhythm confidence "high" | 159 | **15** (2 of them unqualified) |
| rhythm confidence "low overall" | 133 | **278** |
| `notes` | 98,688 | 98,688 (control) |
| `beats` | 88,809 | 82,423 (= what the file holds) |
| quarters of inferred silence | 5,831.62 | 5,831.62 (control) |
| bars padded | not reported | 3,980 across 271 scores |
| bars read as nothing | not reported | 337 across 172 scores |

Three controls: `bars_overfull`, `notes` and the total inferred silence are
unchanged, so nothing about how durations are read moved, and the marking
captures exactly the silence the old prose counted.

The three scores in the issue:

| score | before | after |
| --- | --- | --- |
| Score A | 11 short, 11/52 defective, **high** | 52 short, **52/52** defective, low overall |
| Score B | 0 short, 1/35 defective, **high** | 35 short, **35/35** defective, low overall |
| Score C | 0 short, 1/43 defective, **high** | 40 short, **41/43** defective, low overall |

## Fixtures

`defective_bars` stays and its assertions move deliberately: `bars_short` 2 → 4,
and the test that pinned "a short voice beside an overfull one is **padded, not
reported short**" now pins the bar being reported wrong in both directions at
once — the shape the reporting contract rests on, which extraction previously
could not produce *because of* the padding. It also asserts the alphaTex still
carries the padding (the renderer needs it) while the MusicXML voice sums to
three quarters of its four.

`harmonics_dense` loses "and the bars all add up, so nothing else on the page
would have said a word about it". Nothing is dropped there — all 96 notes are
read, the two uncalibrated diamond noteheads included — but bar 1 loses a *beat*,
because a digit token beside the staff could not be assigned to a string, and
that bar now reports short.

`volta`'s phantom bar (a repeat's thick-thin barline read as two barlines) is now
pinned as a bar read as nothing, and `rests_and_flags` is a negative control: 14
printed rests, zero bars padded, no `<forward>` emitted.

## Verification

- 609 pass with `FERMATA_TEST_LIBRARY` and the schema set (587 collected before
  this branch). CI-equivalent without the library: 586 passed / 23 skipped
  against 565 / 22 on `main`.
- **Both schema tests now run in CI.** The workflow fetches the MusicXML 4.0
  schema and repoints its imports, so the child-order rules are validated on
  every change rather than only on a maintainer's machine — the pattern #76
  existed to end.
- An independent Rule 8 check over all 293 emitted documents agrees with every
  reported figure — overfull, short, defective, measured, padded, the per-bar
  padded lists, `beats` against the non-chord `<note>` count, and
  `inferred_rest_quarters` against the summed `<forward>` durations. Zero
  disagreements.
- All 293 emitted documents load in the alphaTab importer the player uses, and a
  new test drives that importer to require every sounding note to be exactly
  where it is when the same silence is written as an ordinary rest — leading,
  trailing and mid-bar — via a new `--onsets` mode on `verify_musicxml.mjs`. It
  found one honest difference: a *trailing* `<forward>` is dropped rather than
  rendered, which moves no note because nothing sounds after it. Documented.
- **The marking does not survive a save by another program.** Measured with
  MuseScore 4: all 3,464 forwards lose their footnote and voice, and 306
  measures reported defective read as conforming afterwards. The profile now
  bounds its claim to the file as written and says to load without saving,
  rather than recommending a round trip that destroys what it is checking.
- 30 mutations were applied one at a time and every one turned at least one test
  red: unmarking the padding, counting it in conformance again, emitting it as a
  rest or as nothing at all, reordering or dropping `<forward>`'s children,
  failing to advance the position, counting inferred silence in
  `voice_durations` or `written_beats`, reverting `beats` to the beats model,
  suppressing either per-bar warning, uncapping or re-capping the bar list,
  losing the bar numbers or shifting them by one, dropping the unread-bar
  tracking on each of its two code paths, keeping unread bars out of the
  confidence, removing the below-threshold qualifier, rounding the quarter count,
  moving the padded accounting back below the meterless-bar skip, sharing one
  `InferredRest` instance, widening `is_inferred_rest` to any empty list,
  skipping the stored per-bar detail, not validating it on the way out, and
  changing the footnote without the profile.
