### PR TITLE
Say when the answer was a guess (#102, #103)

### DIFF
--- a/docs/musicxml-tab-profile.md
+++ b/docs/musicxml-tab-profile.md
@@ -837,17 +837,29 @@ into the reported confidence instead. That confidence also states any known
 defect below the threshold at which it changes label, so an unqualified
 high-confidence string means no measure was in question rather than not many.
 
-**How the meter, key and tuning were obtained** is reported the same way, and
-for the same reason: `time_signature` with `time_signature_source`, `key_fifths`
-with `key_signature_source`, and `tuning` with `tuning_label`. A source of
-`glyph-decoded` or `auto-detected` means the value was read off the page,
-`manual override` means the caller supplied it, and anything beginning
-`not detected` means the value is an assumption — 4/4, no key signature, or the
-standard six strings. A `tuning_label` is present only when a tuning was
-recognised, so its absence is the assumption. These are stored on the record
-rather than only echoed on the response that extracted them, because a value
-that was assumed has to still say so on the tenth reading of the same score,
-and none of it is recoverable from the warning prose.
+**How the meter and key were obtained** is reported the same way, and for the
+same reason: `time_signature` with `time_signature_source`, and `key_fifths`
+with `key_signature_source`. A source of `glyph-decoded` or `auto-detected`
+means the value was read off the page, `manual override` means the caller
+supplied it, and anything beginning `not detected` means the value is an
+assumption — 4/4, or no key signature. These are stored on the record rather
+than only echoed on the response that extracted them, because a value that was
+assumed has to still say so on the tenth reading of the same score, and none of
+it is recoverable from the warning prose.
+
+**The tuning is reported differently, because it is not known the same way.**
+`tuning` is the six strings in use and `tuning_label` is a name — and the name
+is found by matching text on the page, which is recognition of a label rather
+than a reading of the tuning. `tuning_unread` is what makes the difference
+sayable: printed tuning instructions found on the page and **not** applied to
+`tuning`. Today that is a direction to tune down a half step and a capo, neither
+of which is parsed; a non-empty list means `tuning` is known to be incomplete
+and no consumer may describe it as having been read. Measured across the
+library, 41 of the 100 scores carrying a `tuning_label` also carry one of these
+— 9 the half-step direction, so the array is a semitone out, and 32 a capo, so
+every sounding pitch is out. `tuning_unread` is detection only: it does not
+change `tuning`, the emitted `<staff-tuning>`, or any pitch. Parsing these
+properly is a separate piece of work.
 
 ## Out of scope
 

--- a/docs/musicxml-tab-profile.md
+++ b/docs/musicxml-tab-profile.md
@@ -837,6 +837,18 @@ into the reported confidence instead. That confidence also states any known
 defect below the threshold at which it changes label, so an unqualified
 high-confidence string means no measure was in question rather than not many.
 
+**How the meter, key and tuning were obtained** is reported the same way, and
+for the same reason: `time_signature` with `time_signature_source`, `key_fifths`
+with `key_signature_source`, and `tuning` with `tuning_label`. A source of
+`glyph-decoded` or `auto-detected` means the value was read off the page,
+`manual override` means the caller supplied it, and anything beginning
+`not detected` means the value is an assumption — 4/4, no key signature, or the
+standard six strings. A `tuning_label` is present only when a tuning was
+recognised, so its absence is the assumption. These are stored on the record
+rather than only echoed on the response that extracted them, because a value
+that was assumed has to still say so on the tenth reading of the same score,
+and none of it is recoverable from the warning prose.
+
 ## Out of scope
 
 An honest scope statement is more useful than an aspirational one. The

--- a/docs/practice-data.md
+++ b/docs/practice-data.md
@@ -63,6 +63,15 @@ so a reader is never handed an inferred day as though it were a recorded one.
 The practice page says which beside the date on every session row, because a
 distinction that only exists in the API is one nobody is ever told about.
 
+An inferred day is filed in whichever week UTC puts it in, while the page asks
+for the week around the practiser's own day — so west of Greenwich, an evening's
+practice from before this column existed can sit in the week after the one it
+happened in. Storing the day is what fixed that going forward and is the reason
+the column exists; a row that predates it cannot be fixed that way. Which is a
+reason to mark such a day rather than a reason to stop counting it, but the mark
+is carrying two facts at once: the day was not recorded, and the week it landed
+in is not necessarily the practiser's own.
+
 ### What is derived rather than stored
 
 - `reached_target` is `tempo_bpm >= target_tempo_bpm`, computed on read. A

--- a/docs/practice-data.md
+++ b/docs/practice-data.md
@@ -60,6 +60,8 @@ Rows written before this column existed hold `NULL`, and are attributed to
 `date(started_at)` because that is the only day they ever recorded. Every
 session response carries `local_date_source`, which is `recorded` or `utc_date`,
 so a reader is never handed an inferred day as though it were a recorded one.
+The practice page says which beside the date on every session row, because a
+distinction that only exists in the API is one nobody is ever told about.
 
 ### What is derived rather than stored
 
@@ -251,7 +253,8 @@ It also carries `sessions_inferred`: how many of the sessions behind those
 totals had no recorded practice day and were attributed to their UTC one. A
 single session already says which it is; a total said nothing, so a window
 spanning the upgrade quietly added two kinds of day together. Zero on any
-install that has only ever run this version.
+install that has only ever run this version, and the week's own statement says
+so when it is not.
 
 A `met_*` value is `null` when that target was not set, which is not the same
 as unmet - a goal with no minutes target has nothing to say about minutes, and

--- a/server/fermata/api.py
+++ b/server/fermata/api.py
@@ -1349,6 +1349,36 @@ def _stored_amount(value):
         return None
     return float(value)
 
+# WHAT WAS READ OFF THE PAGE, AND WHAT WAS ASSUMED - stored, for the same
+# reason the bar counts are, and STATED on every response for the same reason
+# they are.
+#
+# The extractor works out whether it read the meter, the key and the tuning or
+# fell back to an assumption, and until this was persisted that answer existed
+# only on the POST /transcribe response and died there. Every later read of the
+# same row - which is every ordinary visit to a score - got the assumed value
+# with nothing saying it was assumed, which is precisely the thing this project
+# exists not to do (issue #103). It is not recoverable from the warning prose
+# either: the meter's absence is narrated, the key's is narrated differently,
+# and a tuning nobody recognised produces no warning at all.
+#
+# The values travel with their provenance rather than being stored apart from
+# it. "assumed 4/4" is one fact, not two, and a reader that has the source
+# string without the digits it qualifies can only say something vaguer than
+# what is known.
+#
+# None means not recorded - a hand-edited row, or one extracted before this was
+# stored. It does not mean "standard tuning" or "no key signature", both of
+# which are real readings this must not invent.
+_PROVENANCE_KEYS = (
+    "time_signature",
+    "time_signature_source",
+    "key_fifths",
+    "key_signature_source",
+    "tuning",
+    "tuning_label",
+)
+
 
 def _transcription_dict(row) -> dict:
     d = dict(row)
@@ -1370,6 +1400,8 @@ def _transcription_dict(row) -> dict:
         d[key] = _stored_bar_list(stored.get(key))
     for key in _BAR_AMOUNT_KEYS:
         d[key] = _stored_amount(stored.get(key))
+    for key in _PROVENANCE_KEYS:
+        d[key] = stored.get(key)
     return d
 
 
@@ -1460,6 +1492,9 @@ def transcribe(score_id: RowId, body: TranscribeIn | None = Body(default=None)):
     # arithmetic over the two warning sentences recovers it. A reader that
     # reloads a transcription and has only the prose can therefore either say
     # nothing about bars or say something untrue - so it gets the numbers.
+    # The meter, key and tuning are stored WITH how each was obtained, for the
+    # reasons on _PROVENANCE_KEYS: an assumption that only says so on the
+    # response that created it is an assumption nobody will ever be told about.
     confidence_json = json.dumps(
         {
             "warnings": result.warnings,
@@ -1473,6 +1508,12 @@ def transcribe(score_id: RowId, body: TranscribeIn | None = Body(default=None)):
             "padded_bars": result.padded_bars,
             "unread_bars": result.unread_bars,
             "inferred_rest_quarters": result.inferred_rest_quarters,
+            "time_signature": list(result.time_signature) if result.time_signature else None,
+            "time_signature_source": result.time_signature_source,
+            "key_fifths": result.key_fifths,
+            "key_signature_source": result.key_signature_source,
+            "tuning": result.tuning,
+            "tuning_label": result.tuning_label,
         }
     )
     with tx() as tx_conn:
@@ -1489,22 +1530,17 @@ def transcribe(score_id: RowId, body: TranscribeIn | None = Body(default=None)):
     saved = conn.execute(
         "SELECT * FROM transcriptions WHERE score_id = ? AND source = 'extracted'", (score_id,)
     ).fetchone()
-    # `warnings` and the Rule 8 conformance figures are NOT set from `result`
-    # here. They come back out of the row that was just written, so that this
-    # response and a later GET of the same row are answered from one source
-    # rather than two that could drift. Everything below is extraction detail
-    # that is genuinely only available on this response.
+    # `warnings`, the Rule 8 conformance figures and the meter/key/tuning
+    # provenance are NOT set from `result` here. They come back out of the row
+    # that was just written, so that this response and a later GET of the same
+    # row are answered from one source rather than two that could drift.
+    # Everything below is extraction detail that is genuinely only available on
+    # this response.
     d = _transcription_dict(saved)
     d["bars"] = result.bars
     d["beats"] = result.beats
     d["notes"] = result.notes
     d["tempo"] = result.tempo
-    d["tuning"] = result.tuning
-    d["tuning_label"] = result.tuning_label
-    d["time_signature"] = list(result.time_signature) if result.time_signature else None
-    d["time_signature_source"] = result.time_signature_source
-    d["key_fifths"] = result.key_fifths
-    d["key_signature_source"] = result.key_signature_source
     return d
 
 

--- a/server/fermata/api.py
+++ b/server/fermata/api.py
@@ -1377,6 +1377,13 @@ _PROVENANCE_KEYS = (
     "key_signature_source",
     "tuning",
     "tuning_label",
+    # Tuning instructions the extractor recognised on the page and did NOT
+    # apply - see tabextract.unread_tuning_instructions. Stored with the tuning
+    # because it is what stops the tuning being describable as read: a text
+    # match on one tuning name is recognition of a label, not a reading of the
+    # tuning, and it cannot be reported as one while the same page carries
+    # further instructions nobody parsed.
+    "tuning_unread",
 )
 
 
@@ -1514,6 +1521,7 @@ def transcribe(score_id: RowId, body: TranscribeIn | None = Body(default=None)):
             "key_signature_source": result.key_signature_source,
             "tuning": result.tuning,
             "tuning_label": result.tuning_label,
+            "tuning_unread": result.tuning_unread,
         }
     )
     with tx() as tx_conn:

--- a/server/fermata/tabextract.py
+++ b/server/fermata/tabextract.py
@@ -109,6 +109,54 @@ from . import musicxml as mxl
 DEFAULT_TUNING = ["E2", "A2", "D3", "G3", "B3", "E4"]
 DROP_D_TUNING = ["D2", "A2", "D3", "G3", "B3", "E4"]
 
+# TUNING INSTRUCTIONS THIS EXTRACTOR RECOGNISES AND DOES NOT APPLY.
+#
+# Detection only, and deliberately nothing more. `tuning` is not adjusted, the
+# emitted MusicXML is unchanged, and no sounding pitch moves - parsing these
+# properly is issue #80's job. What is here is the narrower thing that has to
+# exist before the interface may describe a tuning at all: knowing that the page
+# carries an instruction we did not read, so the reading can be reported as
+# INCOMPLETE rather than as a reading.
+#
+# Measured across the library: of the 100 scores that carry a "Drop D" label,
+# 41 also carry one of these - 9 saying to tune every string down a half step
+# (so the recorded tuning array is a semitone out) and 32 naming a capo (so
+# every sounding pitch is out). That is 14% of the library, and until this
+# existed all 41 were describable as a tuning that had been read off the page.
+# Recognising a NAME is not reading a tuning.
+_HALF_STEP_DOWN_RE = re.compile(
+    r"(?:tune[d]?\s+)?(?:down|lower)\s+(?:a\s+|one\s+)?(?:half|1/2|½)[\s-]*(?:step|tone)"
+    r"|(?:half|1/2|½)[\s-]*(?:step|tone)\s+(?:down|lower|flat)",
+    re.IGNORECASE,
+)
+# "capo", but never the "da capo" of a repeat instruction, which is about where
+# to go back to and nothing to do with the left hand. Classical sheet music is
+# full of them, and matching one would be its own false statement: claiming the
+# page carries a tuning instruction it does not.
+#
+# The trailing number is for the message only - horizontal whitespace, so a
+# bare "Capo" at the end of a line cannot adopt a number from the next one.
+_CAPO_RE = re.compile(
+    r"(?<!da )(?<!dal )\bcapo\b[ \t]*[:\-]?[ \t]*(?:at[ \t]*|on[ \t]*)?(?:fret[ \t]*)?"
+    r"(\d{1,2}|[IVX]{1,4})?",
+    re.IGNORECASE,
+)
+
+
+def unread_tuning_instructions(text: str) -> list[str]:
+    """Tuning instructions present in this page's text that we do not apply.
+
+    Short phrases, written to be shown to a person as they are - each one names
+    what was seen, not what it would have meant.
+    """
+    found = []
+    if _HALF_STEP_DOWN_RE.search(text):
+        found.append("tune down a half step")
+    capo = _CAPO_RE.search(text)
+    if capo:
+        found.append(f"capo {capo.group(1)}" if capo.group(1) else "capo")
+    return found
+
 # Plain (non-dotted) duration budgets, in quarter-note units, used to snap
 # spacing-derived durations to an alphaTex duration code.
 _PLAIN_DURATIONS = [(4.0, 1), (2.0, 2), (1.0, 4), (0.5, 8), (0.25, 16), (0.125, 32)]
@@ -128,6 +176,10 @@ class ExtractionResult:
     tempo: int | None = None
     tuning: list[str] = field(default_factory=lambda: list(DEFAULT_TUNING))
     tuning_label: str | None = None
+    # Tuning instructions found printed on the page and NOT applied to `tuning`
+    # - see unread_tuning_instructions. Non-empty means `tuning` is known to be
+    # incomplete, so no reader may describe it as having been read.
+    tuning_unread: list[str] = field(default_factory=list)
     time_signature: tuple[int, int] | None = None
     time_signature_source: str = "not detected"
     # MusicXML's `fifths`: positive for sharps, negative for flats. Only ever
@@ -186,6 +238,7 @@ class ExtractionResult:
             "tempo": self.tempo,
             "tuning": self.tuning,
             "tuning_label": self.tuning_label,
+            "tuning_unread": self.tuning_unread,
             "time_signature": list(self.time_signature) if self.time_signature else None,
             "time_signature_source": self.time_signature_source,
             "key_fifths": self.key_fifths,
@@ -2244,6 +2297,7 @@ def _extract(doc, pdf_path, time_signature: tuple[int, int] | None) -> Extractio
     tempo = None
     tuning = list(DEFAULT_TUNING)
     tuning_label = None
+    tuning_unread: list[str] = []
     # tab_staff_count / standard_staff_count are the total number of tab /
     # standard staff systems found across the whole document (summed across
     # pages), matching analyze()'s definition - see ExtractionResult.
@@ -2283,6 +2337,15 @@ def _extract(doc, pdf_path, time_signature: tuple[int, int] | None) -> Extractio
         if tuning_label is None and "Drop D" in text:
             tuning_label = "Drop D"
             tuning = list(DROP_D_TUNING)
+
+        # Recognised and NOT applied - see unread_tuning_instructions. Collected
+        # whether or not a tuning name was found, because the two are
+        # independent: a score can name Drop D and then say to tune the lot down
+        # a half step, and it is the combination that makes `tuning` wrong while
+        # looking most like something that was read.
+        for instruction in unread_tuning_instructions(text):
+            if instruction not in tuning_unread:
+                tuning_unread.append(instruction)
 
         if tab_staves:
             pages_with_tab.append((page_no, page, tab_staves, std_staves))
@@ -2345,6 +2408,18 @@ def _extract(doc, pdf_path, time_signature: tuple[int, int] | None) -> Extractio
         # generic "assumed 4/4".
         for reason in list(dict.fromkeys(ts_reasons))[:3]:
             warnings.append(f"time signature: {reason}")
+
+    if tuning_unread:
+        # Said in the warnings as well as carried as data, because it is a
+        # caveat about the transcription and a reader who has only the API
+        # should not have to infer it from a tuning array that looks complete.
+        warnings.append(
+            "the score prints a tuning instruction that was not applied ("
+            + ", ".join(tuning_unread)
+            + ") - the fret numbers are transcribed as written and the tuning is recorded as "
+            "the strings are named, so the sounding pitches will be wrong by whatever that "
+            "instruction asks for"
+        )
 
     # The key signature, for enharmonic spelling only - see
     # _detect_key_signature and musicxml.spell_pitch.
@@ -2636,6 +2711,7 @@ def _extract(doc, pdf_path, time_signature: tuple[int, int] | None) -> Extractio
         tempo=tempo,
         tuning=tuning,
         tuning_label=tuning_label,
+        tuning_unread=tuning_unread,
         time_signature=ts,
         time_signature_source=ts_source,
         key_fifths=key_fifths,

--- a/server/tests/test_tabextract.py
+++ b/server/tests/test_tabextract.py
@@ -1787,3 +1787,61 @@ def test_a_bar_wrong_in_both_directions_is_counted_once():
     assert counts.overfull + counts.short > counts.counted, (
         "the sum overstates the music - this is the arithmetic no reader may do"
     )
+
+
+def test_a_printed_tuning_instruction_is_recognised_without_being_applied():
+    """The narrower thing that has to be true before the interface may describe a
+    tuning at all: knowing the page carries an instruction we did not read.
+
+    Measured across the library, 41 of the 100 scores carrying a "Drop D" label
+    also carry one of these - 9 saying to tune every string down a half step, so
+    the recorded array is a semitone out, and 32 naming a capo, so every sounding
+    pitch is out. That is 14% of the library, and until this existed all 41 were
+    describable as a tuning that had been READ off the page. A text match on one
+    tuning name is recognition of a label; it is not a reading of the tuning.
+
+    Detection only. Nothing here changes `tuning`, the emitted MusicXML, or any
+    sounding pitch - parsing these is issue #80's job.
+    """
+    from fermata.tabextract import unread_tuning_instructions as found
+
+    for text in [
+        "Tune down a half step",
+        "tune all strings down 1/2 step",
+        "Tuning: 1/2 step down",
+        "TUNE DOWN ONE HALF STEP",
+        "Lower a half tone",
+    ]:
+        assert found(text) == ["tune down a half step"], text
+
+    # The number is for the message, so a reader can check it against the page.
+    assert found("Capo 2") == ["capo 2"]
+    assert found("capo at fret III") == ["capo III"]
+    assert found("CAPO 3rd fret") == ["capo 3"]
+    # A bare instruction still counts - what matters is that one is there.
+    assert found("Play with capo") == ["capo"]
+    # A capo at the end of a line must not adopt a number from the next one.
+    assert found("Capo\n7 notes") == ["capo"]
+
+    # Both, in the order they are stated to a reader.
+    assert found("Tune down a half step, then Capo 2") == [
+        "tune down a half step",
+        "capo 2",
+    ]
+
+    # THE FALSE POSITIVE THAT MATTERS. "Da capo" is a repeat instruction - go
+    # back to the beginning - and has nothing to do with the left hand. Classical
+    # sheet music is full of them, and matching one would be its own false
+    # statement: claiming the page carries a tuning instruction it does not, which
+    # is the same fault as claiming a tuning was read.
+    for text in [
+        "Da Capo al Fine",
+        "da capo",
+        "Dal capo",
+        "D.C. al Fine",
+        "capotasto",
+        "a whole step down",
+        "Andante",
+        "",
+    ]:
+        assert found(text) == [], text

--- a/server/tests/test_transcription_api.py
+++ b/server/tests/test_transcription_api.py
@@ -52,6 +52,62 @@ def test_edited_transcription_survives_re_extraction(app_env, extractable_pdf, m
     assert {r["source"] for r in rows} == {"edited", "extracted"}
 
 
+def test_how_the_meter_key_and_tuning_were_obtained_survives_a_reload(
+    app_env, extractable_pdf, monkeypatch, insert_score
+):
+    """Whether each of those three was READ or ASSUMED has to outlive the
+    response that extracted it.
+
+    It did not. The extractor works the distinction out, POST /transcribe
+    echoed it, and every later read of the same row - which is every ordinary
+    visit to a score - handed back the assumed value with nothing saying it was
+    assumed. An interface cannot show what it is never told, and this is the
+    half of issue #103 that had to move on the server for the other half to be
+    possible at all.
+
+    Reading them back through GET and comparing against POST is the point: it
+    fails if the keys are echoed but not stored, which is exactly the state
+    this was in.
+    """
+    monkeypatch.setattr(api, "LIBRARY_DIR", extractable_pdf.parent)
+    conn = db.connect()
+    score_id = insert_score(conn, extractable_pdf.name)
+
+    posted = api.transcribe(score_id, body=None)
+    # The fixture's meter and key really are decoded off the engraving, so
+    # "read" is the true answer here and a test that only ever saw "assumed"
+    # could not tell the two apart.
+    assert posted["time_signature_source"] == "glyph-decoded"
+    assert posted["time_signature"] == [4, 4]
+    assert posted["key_signature_source"] == "glyph-decoded"
+    # Nothing labelled a tuning, which is the assumption #80 is about - the
+    # standard six strings, recorded as what was actually used.
+    assert posted["tuning_label"] is None
+    assert posted["tuning"] == ["E2", "A2", "D3", "G3", "B3", "E4"]
+
+    fetched = api.get_transcription(score_id)
+    for key in (
+        "time_signature",
+        "time_signature_source",
+        "key_fifths",
+        "key_signature_source",
+        "tuning",
+        "tuning_label",
+    ):
+        assert fetched[key] == posted[key], key
+
+    # A hand edit measures nothing, so it states "not recorded" rather than
+    # keeping the extraction's answer - the same rule the bar counts follow,
+    # and for the same reason: a client that merges this response over the one
+    # it already holds must not go on reporting provenance for content that has
+    # been replaced.
+    edited = api.save_transcription(
+        score_id, api.TranscriptionEditIn(content='\\title "hand edited"\n.\n:4 0.1 |')
+    )
+    for key in ("time_signature", "time_signature_source", "tuning", "tuning_label"):
+        assert edited[key] is None, key
+
+
 def test_get_transcription_404_when_none_exists(app_env, insert_score):
     conn = db.connect()
     score_id = insert_score(conn, "nope.pdf")

--- a/server/tests/test_transcription_api.py
+++ b/server/tests/test_transcription_api.py
@@ -81,9 +81,12 @@ def test_how_the_meter_key_and_tuning_were_obtained_survives_a_reload(
     assert posted["time_signature"] == [4, 4]
     assert posted["key_signature_source"] == "glyph-decoded"
     # Nothing labelled a tuning, which is the assumption #80 is about - the
-    # standard six strings, recorded as what was actually used.
+    # standard six strings, recorded as what was actually used - and no printed
+    # tuning instruction this fixture leaves unread, so nothing may be said
+    # about its tuning at all.
     assert posted["tuning_label"] is None
     assert posted["tuning"] == ["E2", "A2", "D3", "G3", "B3", "E4"]
+    assert posted["tuning_unread"] == []
 
     fetched = api.get_transcription(score_id)
     for key in (
@@ -93,6 +96,7 @@ def test_how_the_meter_key_and_tuning_were_obtained_survives_a_reload(
         "key_signature_source",
         "tuning",
         "tuning_label",
+        "tuning_unread",
     ):
         assert fetched[key] == posted[key], key
 
@@ -104,7 +108,13 @@ def test_how_the_meter_key_and_tuning_were_obtained_survives_a_reload(
     edited = api.save_transcription(
         score_id, api.TranscriptionEditIn(content='\\title "hand edited"\n.\n:4 0.1 |')
     )
-    for key in ("time_signature", "time_signature_source", "tuning", "tuning_label"):
+    for key in (
+        "time_signature",
+        "time_signature_source",
+        "tuning",
+        "tuning_label",
+        "tuning_unread",
+    ):
         assert edited[key] is None, key
 
 

--- a/web/src/lib/Library.svelte
+++ b/web/src/lib/Library.svelte
@@ -271,6 +271,24 @@
       </div>
     {/if}
 
+    {#if !scan?.scanning && scan?.restored}
+      <!-- The other half of the missing-file story, and until now the half
+           nobody was told. The scanner counts rows whose file turned up again
+           AT THE PATH IT LEFT FROM - deliberately not a content-hash relink,
+           which is a guess about identity - specifically so it can stand as
+           evidence that a remount really did recover. It stood as evidence to
+           nobody: the count was on /api/scan/status and nothing read it, so
+           somebody who put a drive back saw flags quietly disappear with no
+           statement that anything had been recovered (issue #103).
+
+           Attributed to the LAST SCAN rather than stated as a bare number,
+           because that is what it is - the counter resets when a scan starts. -->
+      <p class="scan-note">
+        Last scan: {scan.restored} score{scan.restored === 1 ? "" : "s"} found again
+        {scan.restored === 1 ? "at the path it" : "at the paths they"} went missing from.
+      </p>
+    {/if}
+
     {#if showDuplicates}
       <header>
         <span class="result-count">{duplicates.length} duplicate group{duplicates.length === 1 ? "" : "s"}</span>
@@ -682,6 +700,14 @@
     color: var(--ink-dim);
     font-size: 13px;
     margin: 8px 0 0;
+  }
+
+  /* A recovery is good news, so it is not styled as an alert - same register
+     as any other quiet statement of fact on this page. */
+  .scan-note {
+    color: var(--ink-dim);
+    font-size: 13px;
+    margin: 0 0 12px;
   }
 
   .alert-error {

--- a/web/src/lib/Metronome.svelte
+++ b/web/src/lib/Metronome.svelte
@@ -84,7 +84,9 @@
     //                   classical material in this library.
     //
     // Only "marked" is presented as a marking; the other two carry the same
-    // unobtrusive unverified mark the rest of the app uses.
+    // unobtrusive unverified mark the rest of the app uses. The third is
+    // SPELLED "assumed", which is the word this application uses everywhere
+    // for a value it chose rather than read - see provenance.js.
     tempoSource = "marked",
     // Only read when tempoSource is "default", and it decides which of two
     // different facts is stated. True means the score DOES declare a tempo,
@@ -464,16 +466,18 @@
 
   // "marked" is the only word here that claims something was read off a page,
   // so it is the only one that may be said when it was.
-  const TEMPO_WORD = { marked: "marked", transcribed: "transcribed", default: "default" };
   const tempoUnverified = $derived(tempoSource !== "marked");
-  // Two parts, kept separate so the markup can break between them rather than
-  // wherever a character count happens to fall - see the note on
-  // .metronome-base-aside. baseNote is the whole sentence, for the title.
-  const baseLabel = $derived(
-    proportionBase && mode === "proportion" && baseTempoLabel != null
-      ? `${TEMPO_WORD[tempoSource] ?? "default"} ♩ = ${baseTempoLabel}`
-      : null,
-  );
+  // ENGRAVER'S NOTATION FOR WHAT AN ENGRAVER WROTE, AND PLAIN WORDS FOR WHAT WE
+  // CHOSE. "♩ = 96" is how a tempo is printed on a page, and using it for 96 is
+  // right because somebody printed it. Using it for the fallback put our own
+  // choice in the notation of a marking, which quietly undercut the sentence
+  // saying it was not one - so that case reads "assumed 120 bpm" instead, in
+  // words that cannot be mistaken for something off a page.
+  const baseLabel = $derived.by(() => {
+    if (!(proportionBase && mode === "proportion" && baseTempoLabel != null)) return null;
+    if (tempoSource === "default") return `assumed ${baseTempoLabel} bpm`;
+    return `${tempoSource === "transcribed" ? "transcribed" : "marked"} ♩ = ${baseTempoLabel}`;
+  });
   const baseAside = $derived(
     tempoSource === "default" ? (tempoElsewhere ? "(none at the start)" : "(none in the score)") : null,
   );
@@ -482,8 +486,8 @@
     tempoSource !== "default"
       ? `Unverified: tempo ${baseTempoLabel} came from a transcription, not a printed marking`
       : tempoElsewhere
-        ? `Unverified: this score marks no tempo at its start, so ${baseTempoLabel} is a default rather than a marking`
-        : `Unverified: this score declares no tempo, so ${baseTempoLabel} is a default rather than a marking`,
+        ? `Unverified: this score marks no tempo at its start, so ${baseTempoLabel} bpm was assumed rather than read`
+        : `Unverified: this score declares no tempo, so ${baseTempoLabel} bpm was assumed rather than read`,
   );
 </script>
 
@@ -522,13 +526,24 @@
   {#if enabled || prominent}
     <div class="metronome-controls">
       {#if proportionBase}
+        <!-- "% of score tempo" is what this counts when there IS a score tempo.
+        Where there is not, the option said so while the note directly beside it
+        said the score declares none - two labels on one control contradicting
+        each other, which is worse than either being wrong alone. The control
+        itself is right to stay (the click has to run at something, and 100% of
+        the assumed tempo is exactly what it runs at), so the label changes
+        instead: it names the number it is a percentage OF. -->
         <select
           class="metronome-mode"
           value={mode}
           onchange={(ev) => chooseMode(ev.target.value)}
-          title="What the metronome counts - the score's own tempo, or a number set directly"
+          title={tempoSource === "default"
+            ? "What the metronome counts - the assumed tempo, since this score declares none, or a number set directly"
+            : "What the metronome counts - the score's own tempo, or a number set directly"}
         >
-          <option value="proportion">% of score tempo</option>
+          <option value="proportion">
+            {tempoSource === "default" ? "% of assumed tempo" : "% of score tempo"}
+          </option>
           <option value="bpm">Fixed BPM</option>
         </select>
       {/if}
@@ -635,7 +650,8 @@
             something unverified: a tempo we inferred from a transcription -
             or never had at all - must not read as one printed on a page. -->
             <span class="mark" aria-label={baseMarkLabel}>●</span>
-          {/if}{baseLabel}{#if baseAside}<span class="metronome-base-aside">{baseAside}</span>{/if}
+          {/if}
+          {baseLabel}{#if baseAside}<span class="metronome-base-aside">{baseAside}</span>{/if}
         </span>
       {/if}
       {#if !compact}

--- a/web/src/lib/Metronome.svelte
+++ b/web/src/lib/Metronome.svelte
@@ -69,10 +69,24 @@
     // and the click is a plain BPM - which is all a metronome standing on its
     // own ever was.
     proportionBase = false,
-    // True when that piece tempo was read off a transcription rather than a
-    // printed marking. A tempo we inferred must not look like one we read.
-    tempoInferred = false,
-    // The piece's own marking, for the "100% of what?" the percentages need
+    // Where that piece tempo came from, which decides what the control is
+    // allowed to CALL it. A tempo we did not read must not look like one we
+    // did, and there are three genuinely different cases:
+    //
+    //   "marked"      - printed on the page and read off it.
+    //   "transcribed" - lifted out of a transcription of a scanned page.
+    //   "default"     - the score declares no tempo at all, so the number
+    //                   beside the percentages is the renderer's fallback and
+    //                   nothing about it was read anywhere. This one is the
+    //                   defect issue #102 was about: it used to read
+    //                   "marked ♩ = 120" for an edition that prints
+    //                   *Andante* and no number, which is most of the
+    //                   classical material in this library.
+    //
+    // Only "marked" is presented as a marking; the other two carry the same
+    // unobtrusive unverified mark the rest of the app uses.
+    tempoSource = "marked",
+    // The piece's own tempo, for the "100% of what?" the percentages need
     // to be legible. Null when unknown.
     baseTempoLabel = null,
     // Pre-fills. null means "not known", which is not the same as a default:
@@ -405,6 +419,13 @@
   // the rest of the app uses for something unverified. Only in proportion
   // mode - a fixed BPM is a number the player typed, and there is nothing
   // inferred about it to disclose.
+  //
+  // The third case is a score that declares NO tempo, where the number is the
+  // renderer's own 120 fallback. It gets the same treatment and one more
+  // thing: it says outright that there was none to read, because "default
+  // ♩ = 120" on its own still leaves a reader to work out whether 120 came
+  // from somewhere. Nothing here is a percentage of a marking in that case,
+  // and the control says so instead of quietly implying otherwise.
   // Said plainly, in visible text, whenever the countable-range clamp rather
   // than the chosen setting is what decided the rate on screen. Without this,
   // a control reading "15%" beside a readout of "20" is a percentage that has
@@ -427,10 +448,20 @@
         : null,
   );
 
+  // "marked" is the only word here that claims something was read off a page,
+  // so it is the only one that may be said when it was.
+  const TEMPO_WORD = { marked: "marked", transcribed: "transcribed", default: "default" };
+  const tempoUnverified = $derived(tempoSource !== "marked");
   const baseNote = $derived(
     proportionBase && mode === "proportion" && baseTempoLabel != null
-      ? `${tempoInferred ? "transcribed" : "marked"} ♩ = ${baseTempoLabel}`
+      ? `${TEMPO_WORD[tempoSource] ?? "default"} ♩ = ${baseTempoLabel}` +
+          (tempoSource === "default" ? " (none in the score)" : "")
       : null,
+  );
+  const baseMarkLabel = $derived(
+    tempoSource === "default"
+      ? `Unverified: this score declares no tempo, so ${baseTempoLabel} is a default rather than a marking`
+      : `Unverified: tempo ${baseTempoLabel} came from a transcription, not a printed marking`,
   );
 </script>
 
@@ -572,14 +603,17 @@
         <span class="metronome-limit" title={limitWhy}>{limitNote}</span>
       {/if}
       {#if baseNote}
-        <span class="metronome-base" class:inferred={tempoInferred} title={`The tempo the percentages are of - ${baseNote}`}>
-          {#if tempoInferred}
+        <span
+          class="metronome-base"
+          class:inferred={tempoUnverified}
+          class:undeclared={tempoSource === "default"}
+          title={`The tempo the percentages are of - ${baseNote}`}
+        >
+          {#if tempoUnverified}
             <!-- The same unobtrusive mark the rest of the app uses for
-            something unverified: a tempo we inferred from a transcription
-            must not read as one printed on a page. -->
-            <span class="mark" aria-label={`Unverified: tempo ${baseTempoLabel} came from a transcription, not a printed marking`}
-              >●</span
-            >
+            something unverified: a tempo we inferred from a transcription -
+            or never had at all - must not read as one printed on a page. -->
+            <span class="mark" aria-label={baseMarkLabel}>●</span>
           {/if}
           {baseNote}
         </span>
@@ -768,6 +802,18 @@
     font-size: 11px;
     color: var(--ink-dim);
     white-space: nowrap;
+  }
+
+  /* The undeclared-tempo form is a short sentence rather than a three-token
+     label, and the score viewer's toolbar is a single non-wrapping flex row
+     with six other controls in it. Held on one line it is the widest thing in
+     the metronome block and pushes the row wide enough to clip the profile
+     buttons at the far end; allowed to wrap it costs one line of height and
+     nothing else. Only this state - the shorter forms have no reason to
+     break. */
+  .metronome-base.undeclared {
+    white-space: normal;
+    max-width: 15ch;
   }
 
   /* No colour, no weight change, no word like "unverified" in the visible

--- a/web/src/lib/Metronome.svelte
+++ b/web/src/lib/Metronome.svelte
@@ -75,10 +75,10 @@
     //
     //   "marked"      - printed on the page and read off it.
     //   "transcribed" - lifted out of a transcription of a scanned page.
-    //   "default"     - the score declares no tempo at all, so the number
-    //                   beside the percentages is the renderer's fallback and
-    //                   nothing about it was read anywhere. This one is the
-    //                   defect issue #102 was about: it used to read
+    //   "default"     - the score declares no tempo where this number comes
+    //                   from, so it is the renderer's fallback and nothing
+    //                   about it was read anywhere. This one is the defect
+    //                   issue #102 was about: it used to read
     //                   "marked ♩ = 120" for an edition that prints
     //                   *Andante* and no number, which is most of the
     //                   classical material in this library.
@@ -86,6 +86,14 @@
     // Only "marked" is presented as a marking; the other two carry the same
     // unobtrusive unverified mark the rest of the app uses.
     tempoSource = "marked",
+    // Only read when tempoSource is "default", and it decides which of two
+    // different facts is stated. True means the score DOES declare a tempo,
+    // just not one that applies where this number was taken from (a pickup
+    // bar, or an exporter that attached the mark to the first real note). The
+    // number is the fallback either way, but "this score has no tempo" is then
+    // false OF THE DOCUMENT - and printing a falsehood is worse than the
+    // omission #102 was about, so the two are kept apart.
+    tempoElsewhere = false,
     // The piece's own tempo, for the "100% of what?" the percentages need
     // to be legible. Null when unknown.
     baseTempoLabel = null,
@@ -420,12 +428,18 @@
   // mode - a fixed BPM is a number the player typed, and there is nothing
   // inferred about it to disclose.
   //
-  // The third case is a score that declares NO tempo, where the number is the
-  // renderer's own 120 fallback. It gets the same treatment and one more
-  // thing: it says outright that there was none to read, because "default
-  // ♩ = 120" on its own still leaves a reader to work out whether 120 came
-  // from somewhere. Nothing here is a percentage of a marking in that case,
-  // and the control says so instead of quietly implying otherwise.
+  // The third case is a tempo the score does not declare here, where the
+  // number is the renderer's own 120 fallback. It gets the same treatment and
+  // one more thing: it says outright that there was none to read, because
+  // "default ♩ = 120" on its own still leaves a reader to work out whether 120
+  // came from somewhere. Nothing here is a percentage of a marking in that
+  // case, and the control says so instead of quietly implying otherwise.
+  //
+  // Which "none" it is matters. "none in the score" is a claim ABOUT THE
+  // DOCUMENT and is only made when the document really carries no tempo
+  // anywhere; a score whose mark sits in a later bar gets "none at the start",
+  // which is a claim about this number and is true of both cases. Stating the
+  // stronger one where the weaker one holds would be exactly #102 in reverse.
   // Said plainly, in visible text, whenever the countable-range clamp rather
   // than the chosen setting is what decided the rate on screen. Without this,
   // a control reading "15%" beside a readout of "20" is a percentage that has
@@ -452,16 +466,24 @@
   // so it is the only one that may be said when it was.
   const TEMPO_WORD = { marked: "marked", transcribed: "transcribed", default: "default" };
   const tempoUnverified = $derived(tempoSource !== "marked");
-  const baseNote = $derived(
+  // Two parts, kept separate so the markup can break between them rather than
+  // wherever a character count happens to fall - see the note on
+  // .metronome-base-aside. baseNote is the whole sentence, for the title.
+  const baseLabel = $derived(
     proportionBase && mode === "proportion" && baseTempoLabel != null
-      ? `${TEMPO_WORD[tempoSource] ?? "default"} ♩ = ${baseTempoLabel}` +
-          (tempoSource === "default" ? " (none in the score)" : "")
+      ? `${TEMPO_WORD[tempoSource] ?? "default"} ♩ = ${baseTempoLabel}`
       : null,
   );
+  const baseAside = $derived(
+    tempoSource === "default" ? (tempoElsewhere ? "(none at the start)" : "(none in the score)") : null,
+  );
+  const baseNote = $derived(baseLabel && [baseLabel, baseAside].filter(Boolean).join(" "));
   const baseMarkLabel = $derived(
-    tempoSource === "default"
-      ? `Unverified: this score declares no tempo, so ${baseTempoLabel} is a default rather than a marking`
-      : `Unverified: tempo ${baseTempoLabel} came from a transcription, not a printed marking`,
+    tempoSource !== "default"
+      ? `Unverified: tempo ${baseTempoLabel} came from a transcription, not a printed marking`
+      : tempoElsewhere
+        ? `Unverified: this score marks no tempo at its start, so ${baseTempoLabel} is a default rather than a marking`
+        : `Unverified: this score declares no tempo, so ${baseTempoLabel} is a default rather than a marking`,
   );
 </script>
 
@@ -606,7 +628,6 @@
         <span
           class="metronome-base"
           class:inferred={tempoUnverified}
-          class:undeclared={tempoSource === "default"}
           title={`The tempo the percentages are of - ${baseNote}`}
         >
           {#if tempoUnverified}
@@ -614,8 +635,7 @@
             something unverified: a tempo we inferred from a transcription -
             or never had at all - must not read as one printed on a page. -->
             <span class="mark" aria-label={baseMarkLabel}>●</span>
-          {/if}
-          {baseNote}
+          {/if}{baseLabel}{#if baseAside}<span class="metronome-base-aside">{baseAside}</span>{/if}
         </span>
       {/if}
       {#if !compact}
@@ -808,12 +828,15 @@
      label, and the score viewer's toolbar is a single non-wrapping flex row
      with six other controls in it. Held on one line it is the widest thing in
      the metronome block and pushes the row wide enough to clip the profile
-     buttons at the far end; allowed to wrap it costs one line of height and
-     nothing else. Only this state - the shorter forms have no reason to
-     break. */
-  .metronome-base.undeclared {
-    white-space: normal;
-    max-width: 15ch;
+     buttons at the far end.
+     So it breaks in a stated place: the parenthetical takes its own line, and
+     both halves stay unbroken. An earlier version left it to `white-space:
+     normal` under a max-width in `ch`, which produced two lines only because
+     the longest half happened to land exactly on the cap - a font a hair wider
+     and it would have been three, with no way to see that from the rule. This
+     is exactly two lines by construction, on any string either half holds. */
+  .metronome-base-aside {
+    display: block;
   }
 
   /* No colour, no weight change, no word like "unverified" in the visible

--- a/web/src/lib/Practice.svelte
+++ b/web/src/lib/Practice.svelte
@@ -654,12 +654,21 @@
                        row's UTC timestamp, which is the difference between a
                        fact and an attribution. The server has always said
                        which (local_date_source) and nothing read it, so a day
-                       that was inferred looked exactly like one somebody's own
+                       that was assumed looked exactly like one somebody's own
                        clock reported - and for practice logged before the day
                        was stored at all, that is every row. Said next to the
-                       date it qualifies, in visible text. -->
+                       date it qualifies, in visible text.
+
+                       One word here, and the sentence under the list says what
+                       it means. "assumed" on its own says neither what was
+                       assumed nor from what, and the whole sentence will not
+                       fit beside a date without taking a quarter of the row's
+                       width from every row that does not need it - so the word
+                       marks the row and the note explains the word, once. It is
+                       the same word this application uses everywhere else for a
+                       value it chose rather than read (see provenance.js). -->
                   {#if session.local_date_source && session.local_date_source !== "recorded"}
-                    <span class="day-inferred">inferred</span>
+                    <span class="day-inferred">assumed</span>
                   {/if}
                 </span>
                 <span class="session-what" class:orphaned={session.score_missing}>
@@ -678,6 +687,17 @@
               </li>
             {/each}
           </ul>
+          {#if sessions.some((s) => s.local_date_source && s.local_date_source !== "recorded")}
+            <!-- What the word beside a date means, and where that day came
+                 from. Once, under the list, and only when a row carries it -
+                 stated for every row it would be nineteen words of repetition,
+                 and left unstated the word says neither what was assumed nor
+                 from what. -->
+            <p class="quiet day-note">
+              A day marked <span class="day-inferred">assumed</span> was taken from the session's
+              own timestamp rather than recorded when the practice happened.
+            </p>
+          {/if}
         {:else}
           <p class="quiet">Nothing logged in this period yet.</p>
         {/if}
@@ -1095,6 +1115,11 @@
     font-size: 11px;
     font-variant-numeric: normal;
     opacity: 0.75;
+  }
+
+  .day-note {
+    margin: 10px 0 0;
+    font-size: 12px;
   }
 
   /* NOT .session-detail: that is the post-session panel in the viewer, and two

--- a/web/src/lib/Practice.svelte
+++ b/web/src/lib/Practice.svelte
@@ -648,7 +648,20 @@
           <ul class="session-list">
             {#each sessions as session (session.id)}
               <li class="session" data-session={session.id}>
-                <span class="session-day">{session.local_date}</span>
+                <span class="session-day">
+                  {session.local_date}
+                  <!-- Whether that day was RECORDED or worked out from the
+                       row's UTC timestamp, which is the difference between a
+                       fact and an attribution. The server has always said
+                       which (local_date_source) and nothing read it, so a day
+                       that was inferred looked exactly like one somebody's own
+                       clock reported - and for practice logged before the day
+                       was stored at all, that is every row. Said next to the
+                       date it qualifies, in visible text. -->
+                  {#if session.local_date_source && session.local_date_source !== "recorded"}
+                    <span class="day-inferred">inferred</span>
+                  {/if}
+                </span>
                 <span class="session-what" class:orphaned={session.score_missing}>
                   {#if session.score_title}
                     <a href={"#/score/" + session.score_id}>{session.score_title}</a>
@@ -1059,6 +1072,14 @@
     color: var(--ink-dim);
     font-size: 13px;
     font-variant-numeric: tabular-nums;
+  }
+
+  /* Quieter than the date it sits beside, and not styled as a fault - nothing
+     went wrong, a day was attributed rather than recorded. */
+  .day-inferred {
+    font-size: 11px;
+    font-variant-numeric: normal;
+    opacity: 0.75;
   }
 
   /* NOT .session-detail: that is the post-session panel in the viewer, and two

--- a/web/src/lib/Practice.svelte
+++ b/web/src/lib/Practice.svelte
@@ -649,7 +649,7 @@
             {#each sessions as session (session.id)}
               <li class="session" data-session={session.id}>
                 <span class="session-day">
-                  {session.local_date}
+                  <span class="day-date">{session.local_date}</span>
                   <!-- Whether that day was RECORDED or worked out from the
                        row's UTC timestamp, which is the difference between a
                        fact and an attribution. The server has always said
@@ -1060,7 +1060,15 @@
 
   .session {
     display: grid;
-    grid-template-columns: 92px 1fr 70px;
+    /* 92px held the date and nothing else. The inferred badge has to sit
+       BESIDE the date rather than under it - it qualifies that date, and a
+       word wrapped onto its own line under a column of dates reads as a
+       layout accident rather than as a note about the day. The two together
+       need about 116px, measured rather than guessed, so the track is wide
+       enough for both. A fixed width and not `auto`: each row is its own
+       grid, so a track that sized to content would leave the middle column
+       starting at a different x on the rows that carry a badge. */
+    grid-template-columns: 120px 1fr 70px;
     gap: 10px;
     align-items: baseline;
     padding-bottom: 6px;
@@ -1075,7 +1083,14 @@
   }
 
   /* Quieter than the date it sits beside, and not styled as a fault - nothing
-     went wrong, a day was attributed rather than recorded. */
+     went wrong, a day was attributed rather than recorded. nowrap on both
+     halves, because "beside the date" is the whole point: without it the badge
+     breaks onto its own line the moment the track is a pixel too narrow, and a
+     test that asserts only the text cannot see that happen. */
+  .session-day {
+    white-space: nowrap;
+  }
+
   .day-inferred {
     font-size: 11px;
     font-variant-numeric: normal;

--- a/web/src/lib/ScoreCompare.svelte
+++ b/web/src/lib/ScoreCompare.svelte
@@ -3,7 +3,7 @@
   import { api } from "./api.js";
   import PdfViewer from "./PdfViewer.svelte";
   import TabViewer from "./TabViewer.svelte";
-  import { transcriptionProvenance } from "./provenance.js";
+  import { transcriptionProvenance, tuningStatement } from "./provenance.js";
   import { STANDING_LIMITS, BAR_RE } from "./warning-patterns.js";
 
   let {
@@ -179,20 +179,27 @@
     return parts.join(" · ");
   });
 
-  // The meter, the key and the tuning, each beside the word for how it was
-  // obtained. See provenance.js for the classification and why an
-  // unrecognised source says nothing at all.
+  // The meter and the key, each beside the word for how it was obtained. See
+  // provenance.js for the classification, why an unrecognised source says
+  // nothing at all, and why the tuning is NOT in these groups.
   //
-  // Shown as one quiet line rather than three marks: the values sit together
-  // on the staff below it (the meter in the signature, the tuning in the tab
-  // legend), so one line naming all three keeps each value next to its own
-  // provenance without three separate strips above a score. Visible text, not
-  // a title attribute - the reader is at a music stand, holding an
-  // instrument, and the tablet under it has no pointer.
+  // Shown as one quiet line rather than a mark per value: both sit together on
+  // the staff below it (the meter in the signature), so one line naming both
+  // keeps each value next to its own provenance without two separate strips
+  // above a score. Visible text, not a title attribute - the reader is at a
+  // music stand, holding an instrument, and the tablet under it has no pointer.
+  //
+  // The assumed clause comes FIRST. It is the one carrying information, and at
+  // the frequency it appears it is also the one that gets skimmed.
   let provenance = $derived(transcriptionProvenance(transcription));
   let hasProvenance = $derived(
     provenance.read.length + provenance.assumed.length + provenance.supplied.length > 0,
   );
+  // Its own sentence, on its own line, and usually absent - see
+  // tuningStatement. A recognised tuning name is not a reading of the tuning,
+  // and an assumed standard tuning on two thirds of the library is a mark on
+  // two thirds of the library.
+  let tuning = $derived(tuningStatement(transcription));
 
   // Gig mode drops the warnings block entirely (see the !gigMode guard
   // below) - performance isn't when anyone corrects a transcription. But an
@@ -208,11 +215,13 @@
       );
     }
     if (rhythmCapped) parts.push(`rhythm confidence: ${rhythmLabel}`);
-    // A meter or a tuning nobody read is the same class of fact, and the one a
-    // player on a stage is most likely to catch: the arrangement in their hands
-    // is in a tuning, and this says whether the staff agrees because it was
-    // read or because nothing contradicted the default.
+    // A meter nobody read is the same class of fact. So is a tuning whose
+    // printed instructions we could not read - and that one is what a player on
+    // a stage is most likely to catch, because the arrangement in their hands is
+    // in a tuning. A tuning merely ASSUMED standard is not here: it is true of
+    // most scores, and a mark most scores carry is a mark nobody reads.
     if (provenance.assumed.length) parts.push(`assumed: ${provenance.assumed.join(", ")}`);
+    if (tuning?.kind === "incomplete") parts.push("tuning instruction not read");
     return parts.join(" · ");
   });
 
@@ -520,28 +529,43 @@
           <p class="standing-footnote">Standing limits: {standingNotes.join("; ")}.</p>
         {/if}
       {/if}
-      {#if !gigMode && hasProvenance}
+      {#if !gigMode && (hasProvenance || tuning)}
         <!-- Outside the warnings block on purpose. This is not a warning and
              must not be collapsed behind one: a read meter is good news and
              an assumed one is a standing fact about this transcription, and
-             both are true whether or not the score has any warnings at all
-             (a clean extraction can still have assumed its tuning). -->
-        <p class="provenance">
-          {#if provenance.read.length}
-            <span class="prov-read">Read from the page: {provenance.read.join(", ")}.</span>
+             both are true whether or not the score has any warnings at all. -->
+        <div class="provenance">
+          {#if hasProvenance}
+            <p class="prov-line">
+              {#if provenance.assumed.length}
+                <!-- First, and with the same unobtrusive mark the rest of the
+                     app uses for something unverified. -->
+                <span class="prov-assumed">
+                  <span class="mark" aria-label="Unverified">●</span>
+                  Assumed, not read from the page: {provenance.assumed.join(", ")}.
+                </span>
+              {/if}
+              {#if provenance.supplied.length}
+                <span class="prov-supplied">As you supplied it: {provenance.supplied.join(", ")}.</span>
+              {/if}
+              {#if provenance.read.length}
+                <span class="prov-read">Read from the page: {provenance.read.join(", ")}.</span>
+              {/if}
+            </p>
           {/if}
-          {#if provenance.supplied.length}
-            <span class="prov-supplied">As you supplied it: {provenance.supplied.join(", ")}.</span>
+          {#if tuning}
+            <!-- A sentence rather than a list item, and on its own line,
+                 because what it has to say is not "assumed" or "read" but
+                 something narrower: what was recognised, and what that does
+                 not amount to. -->
+            <p class="prov-tuning" class:incomplete={tuning.kind === "incomplete"}>
+              {#if tuning.kind === "incomplete"}
+                <span class="mark" aria-label="Unverified">●</span>
+              {/if}
+              {tuning.text}
+            </p>
           {/if}
-          {#if provenance.assumed.length}
-            <!-- The same unobtrusive mark the rest of the app uses for
-                 something unverified. -->
-            <span class="prov-assumed">
-              <span class="mark" aria-label="Unverified">●</span>
-              Assumed, not read from the page: {provenance.assumed.join(", ")}.
-            </span>
-          {/if}
-        </p>
+        </div>
       {/if}
       {#if editorOpen}
         <div class="editor">
@@ -907,6 +931,13 @@
     margin: 10px 16px 0;
     font-size: 11.5px;
     color: var(--ink-dim);
+  }
+
+  .provenance p {
+    margin: 0;
+  }
+
+  .prov-line {
     display: flex;
     flex-wrap: wrap;
     gap: 4px 10px;

--- a/web/src/lib/ScoreCompare.svelte
+++ b/web/src/lib/ScoreCompare.svelte
@@ -3,6 +3,7 @@
   import { api } from "./api.js";
   import PdfViewer from "./PdfViewer.svelte";
   import TabViewer from "./TabViewer.svelte";
+  import { transcriptionProvenance } from "./provenance.js";
   import { STANDING_LIMITS, BAR_RE } from "./warning-patterns.js";
 
   let {
@@ -178,6 +179,21 @@
     return parts.join(" · ");
   });
 
+  // The meter, the key and the tuning, each beside the word for how it was
+  // obtained. See provenance.js for the classification and why an
+  // unrecognised source says nothing at all.
+  //
+  // Shown as one quiet line rather than three marks: the values sit together
+  // on the staff below it (the meter in the signature, the tuning in the tab
+  // legend), so one line naming all three keeps each value next to its own
+  // provenance without three separate strips above a score. Visible text, not
+  // a title attribute - the reader is at a music stand, holding an
+  // instrument, and the tablet under it has no pointer.
+  let provenance = $derived(transcriptionProvenance(transcription));
+  let hasProvenance = $derived(
+    provenance.read.length + provenance.assumed.length + provenance.supplied.length > 0,
+  );
+
   // Gig mode drops the warnings block entirely (see the !gigMode guard
   // below) - performance isn't when anyone corrects a transcription. But an
   // unverified rhythm silently drilled at tempo is the exact mistake the
@@ -192,6 +208,11 @@
       );
     }
     if (rhythmCapped) parts.push(`rhythm confidence: ${rhythmLabel}`);
+    // A meter or a tuning nobody read is the same class of fact, and the one a
+    // player on a stage is most likely to catch: the arrangement in their hands
+    // is in a tuning, and this says whether the staff agrees because it was
+    // read or because nothing contradicted the default.
+    if (provenance.assumed.length) parts.push(`assumed: ${provenance.assumed.join(", ")}`);
     return parts.join(" · ");
   });
 
@@ -498,6 +519,29 @@
         {:else if standingNotes.length}
           <p class="standing-footnote">Standing limits: {standingNotes.join("; ")}.</p>
         {/if}
+      {/if}
+      {#if !gigMode && hasProvenance}
+        <!-- Outside the warnings block on purpose. This is not a warning and
+             must not be collapsed behind one: a read meter is good news and
+             an assumed one is a standing fact about this transcription, and
+             both are true whether or not the score has any warnings at all
+             (a clean extraction can still have assumed its tuning). -->
+        <p class="provenance">
+          {#if provenance.read.length}
+            <span class="prov-read">Read from the page: {provenance.read.join(", ")}.</span>
+          {/if}
+          {#if provenance.supplied.length}
+            <span class="prov-supplied">As you supplied it: {provenance.supplied.join(", ")}.</span>
+          {/if}
+          {#if provenance.assumed.length}
+            <!-- The same unobtrusive mark the rest of the app uses for
+                 something unverified. -->
+            <span class="prov-assumed">
+              <span class="mark" aria-label="Unverified">●</span>
+              Assumed, not read from the page: {provenance.assumed.join(", ")}.
+            </span>
+          {/if}
+        </p>
       {/if}
       {#if editorOpen}
         <div class="editor">
@@ -852,6 +896,26 @@
     margin: 10px 16px 0;
     font-size: 11.5px;
     color: var(--ink-dim);
+  }
+
+  /* Stated in the same register as the value it qualifies. No colour, no
+     weight, no word like "warning": an assumed meter is a fact about this
+     transcription, not a fault, and the project's rule is that nothing which
+     is not a fault is styled as one. The mark plus the words "Assumed, not
+     read from the page" are the whole signal. */
+  .provenance {
+    margin: 10px 16px 0;
+    font-size: 11.5px;
+    color: var(--ink-dim);
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px 10px;
+  }
+
+  .provenance .mark {
+    font-size: 9px;
+    vertical-align: 1px;
+    margin-right: 3px;
   }
 
   .editor {

--- a/web/src/lib/TabViewer.svelte
+++ b/web/src/lib/TabViewer.svelte
@@ -88,9 +88,15 @@
   let metronomeMode = $state(null);
   let metronomeProportion = $state(null);
   let metronomeBpm = $state(null);
-  // The score's own declared tempo, so the percentages can say what they are
-  // percentages OF - see Metronome.svelte's baseTempoLabel.
+  // The tempo the percentages are percentages OF - see Metronome.svelte's
+  // baseTempoLabel - and whether the score DECLARED it or was handed the
+  // renderer's 120 fallback. Two values, because `score.tempo` alone cannot
+  // tell those apart and reporting only the number is how a score printing no
+  // tempo came to be described as "marked ♩ = 120" (issue #102). Nothing
+  // declared until a score says so: the number is meaningless before then, and
+  // "not yet loaded" must not read as "declared".
   let scoreTempo = $state(null);
+  let scoreTempoDeclared = $state(false);
   let countIn = $state(false);
   let loadError = $state("");
   let ladder = $state(false);
@@ -151,6 +157,7 @@
     metronomeTempo = null;
     metronomeLimit = null;
     scoreTempo = null;
+    scoreTempoDeclared = false;
     // unknown again for this score, not "same as the last one" - see the
     // comment on profileOptions's declaration
     profileOptions = null;
@@ -173,7 +180,10 @@
           metronomeTempo = bpm;
           metronomeLimit = limit;
         },
-        onScoreTempo: (t) => (scoreTempo = t),
+        onScoreTempo: (t, declared) => {
+          scoreTempo = t;
+          scoreTempoDeclared = declared;
+        },
         // Only which buttons to offer, not which one is highlighted - see
         // onProfileApplied for that. A score with nothing drawable reports an
         // empty array here, not a fallback list; the empty-state notice in
@@ -345,7 +355,12 @@
           meter change mid-piece is followed rather than assumed). compact,
           because over a piece the meter and subdivision come from the score
           and there is nothing there for a player to set; and nothing here
-          persists, for the reason on `metronome`'s declaration above. -->
+          persists, for the reason on `metronome`'s declaration above.
+
+          tempoSource is what the control is allowed to CALL that base tempo.
+          "not declared" beats both of the other two: a score that prints no
+          tempo hands the renderer's fallback to a transcription and to a
+          MusicXML file alike, and neither of them read it anywhere. -->
           <Metronome
             ownsClick={false}
             control={view?.metronome ?? null}
@@ -354,7 +369,7 @@
             limit={metronomeLimit}
             proportionBase={true}
             baseTempoLabel={scoreTempo}
-            tempoInferred={tex != null}
+            tempoSource={!scoreTempoDeclared ? "default" : tex != null ? "transcribed" : "marked"}
             bind:mode={metronomeMode}
             bind:proportion={metronomeProportion}
             bind:bpm={metronomeBpm}

--- a/web/src/lib/TabViewer.svelte
+++ b/web/src/lib/TabViewer.svelte
@@ -89,14 +89,14 @@
   let metronomeProportion = $state(null);
   let metronomeBpm = $state(null);
   // The tempo the percentages are percentages OF - see Metronome.svelte's
-  // baseTempoLabel - and whether the score DECLARED it or was handed the
-  // renderer's 120 fallback. Two values, because `score.tempo` alone cannot
-  // tell those apart and reporting only the number is how a score printing no
-  // tempo came to be described as "marked ♩ = 120" (issue #102). Nothing
-  // declared until a score says so: the number is meaningless before then, and
-  // "not yet loaded" must not read as "declared".
+  // baseTempoLabel - and where it came from: "start", "later" or "none" (see
+  // tempoProvenance in score-render.js). Two values, because `score.tempo`
+  // alone cannot tell a declared tempo from the renderer's 120 fallback, which
+  // is how a score printing no tempo came to be described as "marked ♩ = 120"
+  // (issue #102). "none" until a score says otherwise: the number is
+  // meaningless before then, and "not yet loaded" must not read as "declared".
   let scoreTempo = $state(null);
-  let scoreTempoDeclared = $state(false);
+  let scoreTempoFrom = $state("none");
   let countIn = $state(false);
   let loadError = $state("");
   let ladder = $state(false);
@@ -157,7 +157,7 @@
     metronomeTempo = null;
     metronomeLimit = null;
     scoreTempo = null;
-    scoreTempoDeclared = false;
+    scoreTempoFrom = "none";
     // unknown again for this score, not "same as the last one" - see the
     // comment on profileOptions's declaration
     profileOptions = null;
@@ -180,9 +180,9 @@
           metronomeTempo = bpm;
           metronomeLimit = limit;
         },
-        onScoreTempo: (t, declared) => {
+        onScoreTempo: (t, from) => {
           scoreTempo = t;
-          scoreTempoDeclared = declared;
+          scoreTempoFrom = from;
         },
         // Only which buttons to offer, not which one is highlighted - see
         // onProfileApplied for that. A score with nothing drawable reports an
@@ -358,9 +358,12 @@
           persists, for the reason on `metronome`'s declaration above.
 
           tempoSource is what the control is allowed to CALL that base tempo.
-          "not declared" beats both of the other two: a score that prints no
-          tempo hands the renderer's fallback to a transcription and to a
-          MusicXML file alike, and neither of them read it anywhere. -->
+          "not declared at the start" beats both of the other two: a score that
+          prints no tempo there hands the renderer's fallback to a
+          transcription and to a MusicXML file alike, and neither of them read
+          it anywhere. tempoElsewhere then separates "the document says nothing
+          about its tempo" from "it says something, just not here" - only the
+          first may be stated as a fact about the document. -->
           <Metronome
             ownsClick={false}
             control={view?.metronome ?? null}
@@ -369,7 +372,8 @@
             limit={metronomeLimit}
             proportionBase={true}
             baseTempoLabel={scoreTempo}
-            tempoSource={!scoreTempoDeclared ? "default" : tex != null ? "transcribed" : "marked"}
+            tempoSource={scoreTempoFrom !== "start" ? "default" : tex != null ? "transcribed" : "marked"}
+            tempoElsewhere={scoreTempoFrom === "later"}
             bind:mode={metronomeMode}
             bind:proportion={metronomeProportion}
             bind:bpm={metronomeBpm}

--- a/web/src/lib/practice.js
+++ b/web/src/lib/practice.js
@@ -303,9 +303,12 @@ export function periodStatement(facts, current = true) {
   // server has been reporting the figure to nobody ever since (issue #103).
   // Silent when there is nothing to disclose, which on any install that has
   // only ever run this version is always.
+  // "assumed", not "inferred": one word for a value this application chose
+  // rather than read, used at every site that has to say so - see
+  // provenance.js. The server's field keeps its own name.
   const inferred = facts.sessions_inferred ?? 0;
   if (!inferred) return total;
-  return `${total} (${inferred} session${inferred === 1 ? "" : "s"} on an inferred day)`;
+  return `${total} (${inferred} session${inferred === 1 ? "" : "s"} on an assumed day)`;
 }
 
 /** The bars of a week's per-day strip, scaled against the busiest day IN THAT

--- a/web/src/lib/practice.js
+++ b/web/src/lib/practice.js
@@ -295,7 +295,17 @@ export function periodStatement(facts, current = true) {
   if (!facts || !facts.days_practised) {
     return current ? "No practice recorded this week" : "No practice recorded";
   }
-  return `${formatDays(facts.days_practised)}, ${formatDuration(facts.seconds)}`;
+  const total = `${formatDays(facts.days_practised)}, ${formatDuration(facts.seconds)}`;
+  // How much of that total rests on a day nobody recorded. A single session
+  // has always said whether its day was recorded or taken from its UTC
+  // timestamp; the total said nothing, so a window spanning the upgrade added
+  // two different kinds of day together with nothing marking the join, and the
+  // server has been reporting the figure to nobody ever since (issue #103).
+  // Silent when there is nothing to disclose, which on any install that has
+  // only ever run this version is always.
+  const inferred = facts.sessions_inferred ?? 0;
+  if (!inferred) return total;
+  return `${total} (${inferred} session${inferred === 1 ? "" : "s"} on an inferred day)`;
 }
 
 /** The bars of a week's per-day strip, scaled against the busiest day IN THAT

--- a/web/src/lib/provenance.js
+++ b/web/src/lib/provenance.js
@@ -76,13 +76,23 @@ export function keySignatureLabel(fifths) {
   return `${count} ${accidental}${count === 1 ? "" : "s"}`;
 }
 
-/** A tuning as a person would say it. Named by its strings when it is neither
- * labelled nor the standard one, because "standard tuning" would then be a
- * claim about something nobody checked. */
+/**
+ * A tuning as a person would say it, or null when there is nothing this can
+ * say about it honestly.
+ *
+ * The null case is the interesting one: a tuning that is NEITHER labelled nor
+ * the standard one. Today the extractor cannot produce that - it recognises
+ * exactly one non-standard tuning and labels it - but the moment #80 widens
+ * the recognition it can, and the answer must not be "standard tuning
+ * assumed". A tuning that demonstrably differs from standard cannot have come
+ * from an assumption of standard, so calling it assumed is a false accusation,
+ * and nothing records where it did come from. Same rule sourceKind already
+ * follows on a source string it does not recognise: report neither rather than
+ * pick the safer-sounding wrong answer.
+ */
 export function tuningDescription(tuning, label) {
   if (typeof label === "string" && label) return `${label} tuning`;
   if (isStandardTuning(tuning)) return "standard tuning";
-  if (Array.isArray(tuning) && tuning.length) return `tuning ${tuning.join(" ")}`;
   return null;
 }
 
@@ -119,9 +129,10 @@ export function transcriptionProvenance(t) {
   // The tuning has no source field of its own, and does not need one: the
   // extractor recognises exactly one non-standard tuning, by finding the words
   // "Drop D" in the page text, and records the label when it does. So a label
-  // IS the reading, and its absence is the assumption - which is #80's whole
-  // complaint. Guarded on the tuning itself being present so an edited row,
-  // which records neither, is not reported as assuming anything.
+  // IS the reading, and the absence of one ALONGSIDE THE STANDARD SIX STRINGS
+  // is the assumption - which is #80's whole complaint. An unlabelled tuning
+  // that is not the standard one is neither, and tuningDescription returns null
+  // for it; so does an edited row, which records no tuning at all.
   const tuning = tuningDescription(t.tuning, t.tuning_label);
   if (tuning) groups[t.tuning_label ? "read" : "assumed"].push(tuning);
 

--- a/web/src/lib/provenance.js
+++ b/web/src/lib/provenance.js
@@ -3,15 +3,25 @@
 // The extractor has always known the difference. It records how the meter and
 // the key were obtained, and whether it recognised a tuning at all - and for a
 // long time nothing in the interface read any of it, so a person looking at a
-// transcription saw an assumed 4/4 and an assumed standard tuning presented
-// exactly like a meter decoded off the printed digits (issue #103). 18% of
-// first pages lose their printed meter (#90) and every score not literally
-// labelled "Drop D" is read as standard tuning (#80), so this is the common
-// case rather than the corner.
+// transcription saw an assumed 4/4 presented exactly like a meter decoded off
+// the printed digits (issue #103). 18% of first pages lose their printed meter
+// (#90), so this is the common case rather than the corner.
 //
 // The underlying detection is NOT fixed here and is not meant to be - #90 and
 // #80 are owned elsewhere. This turns a guess that was already being made into
 // a guess a person can see.
+//
+// TWO WORDS, USED EVERYWHERE. `read` is "the source told us this"; `assumed` is
+// "we chose this". An interface that spends a different word on each site -
+// read, assumed, default, inferred, transcribed - teaches a reader none of
+// them, because learning one says nothing about the next. So the tempo control
+// says "assumed" where it used to say "default", the practice page says
+// "assumed" where it used to say "inferred", and this file says both. The one
+// survivor is "marked", which is not a synonym: a tempo the engraver printed IS
+// a marking, and the word is the domain's own.
+//
+// THE TUNING IS NOT IN THAT SCHEME, and that is the interesting decision here.
+// See tuningStatement.
 //
 // Pure functions, in their own module, so the wording can be tested without a
 // browser. What actually renders is in ScoreCompare.svelte; a test that only
@@ -22,10 +32,10 @@
 // pattern-guessed, in both directions:
 //
 //   - a source string this does not recognise reports NOTHING rather than
-//     defaulting to either answer. Calling an unrecognised future source
-//     "assumed" would be a false accusation and calling it "read" would be the
-//     exact lie this file exists to prevent, so silence is the only safe
-//     third answer.
+//     defaulting to either answer. Calling an unrecognised future source "read"
+//     would be the exact lie this file exists to prevent and calling it
+//     "assumed" would be a false accusation, so silence is the only safe third
+//     answer.
 const READ_SOURCES = new Set([
   // Decoded from the engraved glyphs themselves.
   "glyph-decoded",
@@ -53,21 +63,6 @@ export function sourceKind(source) {
   return null;
 }
 
-/** The standard guitar tuning the extractor falls back to - tabextract.py's
- * DEFAULT_TUNING. Only used to decide whether "standard tuning" is a true
- * description of what was actually used; an unlabelled tuning that is NOT
- * this one is named by its own strings rather than described with a word that
- * would be wrong. */
-const STANDARD_TUNING = ["E2", "A2", "D3", "G3", "B3", "E4"];
-
-function isStandardTuning(tuning) {
-  return (
-    Array.isArray(tuning) &&
-    tuning.length === STANDARD_TUNING.length &&
-    tuning.every((note, i) => note === STANDARD_TUNING[i])
-  );
-}
-
 /** A MusicXML `fifths` count as a person would say it. */
 export function keySignatureLabel(fifths) {
   if (fifths === 0) return "no key signature";
@@ -77,39 +72,21 @@ export function keySignatureLabel(fifths) {
 }
 
 /**
- * A tuning as a person would say it, or null when there is nothing this can
- * say about it honestly.
+ * The meter and the key, each in the group naming how it was obtained.
  *
- * The null case is the interesting one: a tuning that is NEITHER labelled nor
- * the standard one. Today the extractor cannot produce that - it recognises
- * exactly one non-standard tuning and labels it - but the moment #80 widens
- * the recognition it can, and the answer must not be "standard tuning
- * assumed". A tuning that demonstrably differs from standard cannot have come
- * from an assumption of standard, so calling it assumed is a false accusation,
- * and nothing records where it did come from. Same rule sourceKind already
- * follows on a source string it does not recognise: report neither rather than
- * pick the safer-sounding wrong answer.
- */
-export function tuningDescription(tuning, label) {
-  if (typeof label === "string" && label) return `${label} tuning`;
-  if (isStandardTuning(tuning)) return "standard tuning";
-  return null;
-}
-
-/**
- * The three groups a transcription's meter, key and tuning fall into, each an
- * array of plain descriptions ready to read out.
- *
- * Takes the transcription object as the API presents it (see
- * _PROVENANCE_KEYS in server/fermata/api.py). Every field is optional: a
- * hand-edited row, or one extracted before the provenance was stored, records
- * none of this, and the honest answer there is three empty groups rather than
- * a claim in either direction.
+ * Takes the transcription object as the API presents it (see _PROVENANCE_KEYS
+ * in server/fermata/api.py). Every field is optional: a hand-edited row, or one
+ * extracted before the provenance was stored, records none of this, and the
+ * honest answer there is three empty groups rather than a claim in either
+ * direction.
  *
  * The value and its provenance always travel together - "4/4" appears in the
- * assumed group, never as a bare number somewhere else with the word
- * "assumed" a paragraph away. A reader who sees only one of the two learns
- * nothing they can act on.
+ * assumed group, never as a bare number somewhere else with the word "assumed"
+ * a paragraph away. A reader who sees only one of the two learns nothing they
+ * can act on.
+ *
+ * THE TUNING IS DELIBERATELY NOT HERE. It was, and it was wrong twice over -
+ * see tuningStatement.
  */
 export function transcriptionProvenance(t) {
   const groups = { read: [], assumed: [], supplied: [] };
@@ -126,15 +103,90 @@ export function transcriptionProvenance(t) {
     if (kind) groups[kind].push(keySignatureLabel(t.key_fifths));
   }
 
-  // The tuning has no source field of its own, and does not need one: the
-  // extractor recognises exactly one non-standard tuning, by finding the words
-  // "Drop D" in the page text, and records the label when it does. So a label
-  // IS the reading, and the absence of one ALONGSIDE THE STANDARD SIX STRINGS
-  // is the assumption - which is #80's whole complaint. An unlabelled tuning
-  // that is not the standard one is neither, and tuningDescription returns null
-  // for it; so does an edited row, which records no tuning at all.
-  const tuning = tuningDescription(t.tuning, t.tuning_label);
-  if (tuning) groups[t.tuning_label ? "read" : "assumed"].push(tuning);
-
   return groups;
+}
+
+/** The standard guitar tuning the extractor falls back to - tabextract.py's
+ * DEFAULT_TUNING. */
+const STANDARD_TUNING = ["E2", "A2", "D3", "G3", "B3", "E4"];
+
+function isStandardTuning(tuning) {
+  return (
+    Array.isArray(tuning) &&
+    tuning.length === STANDARD_TUNING.length &&
+    tuning.every((note, i) => note === STANDARD_TUNING[i])
+  );
+}
+
+/**
+ * What can honestly be said about the tuning, or null for "nothing" - which is
+ * the answer on most scores.
+ *
+ * WHY THIS IS NOT IN THE READ/ASSUMED GROUPS ABOVE. Two reasons, both found by
+ * measuring the library rather than by reasoning about it.
+ *
+ * 1. "READ" WAS NOT TRUE. The extractor finds a tuning by looking for the words
+ *    "Drop D" in the page text. 100 scores match, and all sampled matches are
+ *    genuine printed instructions - but 41 of those 100 carry a FURTHER printed
+ *    instruction the extractor discards: 9 say to tune every string down a half
+ *    step, so the recorded array is a semitone out, and 32 name a capo, so every
+ *    sounding pitch is out. Describing those as "read from the page" turned a
+ *    silent partial reading into a stated one, which is worse than saying
+ *    nothing. A text match on one tuning name is recognition of a LABEL; it is
+ *    not a reading of the tuning, and it cannot be called one while the same
+ *    page carries instructions nobody parsed.
+ *
+ * 2. "ASSUMED" WAS TRUE BUT NOT WORTH SAYING. An unlabelled tuning is the
+ *    standard six strings by assumption on 193 of 293 scores. Stating that on
+ *    two thirds of the library put the unverified mark on two thirds of the
+ *    library, which is the desensitisation the whole always-on argument exists
+ *    to avoid, one level down - and its commonest instance was also its least
+ *    informative.
+ *
+ * So the tuning speaks only when there is something real to say:
+ *
+ *   - an instruction we could not read     -> the reading is incomplete
+ *   - a recognised name, nothing unread    -> the name was recognised, and that
+ *                                             is all that was
+ *   - standard strings, nothing recognised -> silence
+ *
+ * `kind` is "incomplete" or "recognised"; only "incomplete" carries the
+ * unverified mark, so the mark stays rare enough to mean something.
+ */
+export function tuningStatement(t) {
+  if (!t) return null;
+  const unread = Array.isArray(t.tuning_unread) ? t.tuning_unread.filter(Boolean) : [];
+  const label = typeof t.tuning_label === "string" && t.tuning_label ? t.tuning_label : null;
+
+  if (unread.length) {
+    const instructions = unread.join(" and ");
+    const lead = label
+      ? `the page names ${label}, and also says ${instructions}`
+      : `the page says ${instructions}`;
+    return {
+      kind: "incomplete",
+      text:
+        `Tuning: ${lead}, which Fermata does not read — so the pitches sounded ` +
+        `are not the pitches printed.`,
+    };
+  }
+
+  if (label) {
+    return {
+      kind: "recognised",
+      text: `Tuning: the page names ${label}. Nothing else about the tuning was read.`,
+    };
+  }
+
+  // Standard strings and no name found. True, uninformative, and on two thirds
+  // of the library - see above. The staff below draws the tuning it is using,
+  // which is where a player who wants to check it looks.
+  if (isStandardTuning(t.tuning)) return null;
+
+  // Neither labelled nor standard. Reachable once #80 widens the recognition,
+  // and there is nothing recorded about where it came from: "assumed" would be
+  // a false accusation about a tuning that demonstrably differs from the one
+  // that would have been assumed. Same rule sourceKind follows on a source it
+  // does not recognise.
+  return null;
 }

--- a/web/src/lib/provenance.js
+++ b/web/src/lib/provenance.js
@@ -1,0 +1,129 @@
+// What a transcription READ off the page, and what it merely assumed.
+//
+// The extractor has always known the difference. It records how the meter and
+// the key were obtained, and whether it recognised a tuning at all - and for a
+// long time nothing in the interface read any of it, so a person looking at a
+// transcription saw an assumed 4/4 and an assumed standard tuning presented
+// exactly like a meter decoded off the printed digits (issue #103). 18% of
+// first pages lose their printed meter (#90) and every score not literally
+// labelled "Drop D" is read as standard tuning (#80), so this is the common
+// case rather than the corner.
+//
+// The underlying detection is NOT fixed here and is not meant to be - #90 and
+// #80 are owned elsewhere. This turns a guess that was already being made into
+// a guess a person can see.
+//
+// Pure functions, in their own module, so the wording can be tested without a
+// browser. What actually renders is in ScoreCompare.svelte; a test that only
+// checked these strings would prove nothing about whether they reach a screen.
+
+// The extractor's own vocabulary for how a value was obtained - see
+// tabextract.py's ts_source / key_source. Matched exactly rather than
+// pattern-guessed, in both directions:
+//
+//   - a source string this does not recognise reports NOTHING rather than
+//     defaulting to either answer. Calling an unrecognised future source
+//     "assumed" would be a false accusation and calling it "read" would be the
+//     exact lie this file exists to prevent, so silence is the only safe
+//     third answer.
+const READ_SOURCES = new Set([
+  // Decoded from the engraved glyphs themselves.
+  "glyph-decoded",
+  // Read off the page by the older digit-shape detector rather than the glyph
+  // decoder. Still read from the page, which is the distinction being drawn.
+  "auto-detected",
+]);
+// Supplied by the person, in the "Time signature" box beside the transcribe
+// button. Neither read nor assumed, and worth its own line: it is the one
+// case where a reader already knows where the number came from and seeing it
+// echoed back confirms it was actually used.
+const SUPPLIED_SOURCES = new Set(["manual override"]);
+// "not detected", "not detected (assumed 4/4)", "not detected (assumed no key
+// signature)" - the extractor states what it fell back to in the parenthesis,
+// which is why this is a prefix rather than a set.
+const ASSUMED_PREFIX = "not detected";
+
+/** "read" | "assumed" | "supplied" | null (nothing recorded, or a source
+ * string this version does not recognise). */
+export function sourceKind(source) {
+  if (typeof source !== "string" || !source) return null;
+  if (READ_SOURCES.has(source)) return "read";
+  if (SUPPLIED_SOURCES.has(source)) return "supplied";
+  if (source.startsWith(ASSUMED_PREFIX)) return "assumed";
+  return null;
+}
+
+/** The standard guitar tuning the extractor falls back to - tabextract.py's
+ * DEFAULT_TUNING. Only used to decide whether "standard tuning" is a true
+ * description of what was actually used; an unlabelled tuning that is NOT
+ * this one is named by its own strings rather than described with a word that
+ * would be wrong. */
+const STANDARD_TUNING = ["E2", "A2", "D3", "G3", "B3", "E4"];
+
+function isStandardTuning(tuning) {
+  return (
+    Array.isArray(tuning) &&
+    tuning.length === STANDARD_TUNING.length &&
+    tuning.every((note, i) => note === STANDARD_TUNING[i])
+  );
+}
+
+/** A MusicXML `fifths` count as a person would say it. */
+export function keySignatureLabel(fifths) {
+  if (fifths === 0) return "no key signature";
+  const count = Math.abs(fifths);
+  const accidental = fifths > 0 ? "sharp" : "flat";
+  return `${count} ${accidental}${count === 1 ? "" : "s"}`;
+}
+
+/** A tuning as a person would say it. Named by its strings when it is neither
+ * labelled nor the standard one, because "standard tuning" would then be a
+ * claim about something nobody checked. */
+export function tuningDescription(tuning, label) {
+  if (typeof label === "string" && label) return `${label} tuning`;
+  if (isStandardTuning(tuning)) return "standard tuning";
+  if (Array.isArray(tuning) && tuning.length) return `tuning ${tuning.join(" ")}`;
+  return null;
+}
+
+/**
+ * The three groups a transcription's meter, key and tuning fall into, each an
+ * array of plain descriptions ready to read out.
+ *
+ * Takes the transcription object as the API presents it (see
+ * _PROVENANCE_KEYS in server/fermata/api.py). Every field is optional: a
+ * hand-edited row, or one extracted before the provenance was stored, records
+ * none of this, and the honest answer there is three empty groups rather than
+ * a claim in either direction.
+ *
+ * The value and its provenance always travel together - "4/4" appears in the
+ * assumed group, never as a bare number somewhere else with the word
+ * "assumed" a paragraph away. A reader who sees only one of the two learns
+ * nothing they can act on.
+ */
+export function transcriptionProvenance(t) {
+  const groups = { read: [], assumed: [], supplied: [] };
+  if (!t) return groups;
+
+  const ts = t.time_signature;
+  if (Array.isArray(ts) && ts.length === 2) {
+    const kind = sourceKind(t.time_signature_source);
+    if (kind) groups[kind].push(`${ts[0]}/${ts[1]}`);
+  }
+
+  if (typeof t.key_fifths === "number") {
+    const kind = sourceKind(t.key_signature_source);
+    if (kind) groups[kind].push(keySignatureLabel(t.key_fifths));
+  }
+
+  // The tuning has no source field of its own, and does not need one: the
+  // extractor recognises exactly one non-standard tuning, by finding the words
+  // "Drop D" in the page text, and records the label when it does. So a label
+  // IS the reading, and its absence is the assumption - which is #80's whole
+  // complaint. Guarded on the tuning itself being present so an edited row,
+  // which records neither, is not reported as assuming anything.
+  const tuning = tuningDescription(t.tuning, t.tuning_label);
+  if (tuning) groups[t.tuning_label ? "read" : "assumed"].push(tuning);
+
+  return groups;
+}

--- a/web/src/lib/score-render.js
+++ b/web/src/lib/score-render.js
@@ -674,6 +674,41 @@ export async function playPitch(midi) {
 // 0, set once below and never touched again) so the two never sound at once.
 
 /**
+ * Whether the loaded score CARRIES a tempo of its own, as opposed to being
+ * handed the renderer's fallback.
+ *
+ * This exists because `score.tempo` cannot answer the question. It is a
+ * getter over the first bar's tempo automations that returns a hard-coded
+ * 120 when there are none, so a score printing no tempo at all and a score
+ * printing "quarter = 120" are indistinguishable through it - which is how
+ * the metronome came to report "marked quarter = 120" for editions that
+ * print *Andante* and no number at all (issue #102). A `?? null` guard on
+ * that getter is dead code: it never returns null.
+ *
+ * Nor can `score.tempoLabel` answer it, despite being the obvious candidate.
+ * It is the automation's `text`, and alphaTab's MusicXML importer never sets
+ * that - it is "" for a score with a printed metronome mark of 96 exactly as
+ * it is for a score with nothing. Measured against the real importer, on the
+ * three shapes that matter: a `<metronome>` mark, a bare `<sound tempo=>`,
+ * and a document with neither.
+ *
+ * What does answer it is `isVisible`. ModelUtils.consolidate() runs at the
+ * end of every import and, when the first bar has no tempo automation of its
+ * own, SYNTHESISES one carrying score.tempo (the 120 fallback) with
+ * `isVisible = false`. Every automation built from something actually in the
+ * document is visible. So "the first bar holds a visible tempo automation"
+ * is exactly "the document said what its tempo is".
+ *
+ * A non-empty tempoLabel still counts, for the formats whose importers do
+ * fill it in (the Guitar Pro readers set it from the file's own label) - a
+ * named tempo is a declared one however it arrived.
+ */
+function scoreDeclaresTempo(score) {
+  const automations = score?.masterBars?.[0]?.tempoAutomations ?? [];
+  return automations.some((a) => a?.isVisible !== false) || !!score?.tempoLabel;
+}
+
+/**
  * The score viewer's pre-fill for the general metronome: an engine, plus the
  * adapter that keeps it fed with this renderer's playhead and meter.
  *
@@ -858,11 +893,16 @@ function createScoreMetronome(api, onTempo, onClick) {
  *                          signal a caller should wait for before treating a
  *                          profile switch as having taken effect, rather than
  *                          assuming success the moment it is requested
- * @param opts.onScoreTempo (bpm|null) the score's OWN declared quarter-note
- *                          tempo, once one has loaded - what a proportion is
- *                          a proportion of. Reported so an interface can say
- *                          "70% of what" rather than showing a bare
- *                          percentage; null for a score that declares none.
+ * @param opts.onScoreTempo (bpm, declared) the quarter-note tempo a
+ *                          proportion is a proportion of, once a score has
+ *                          loaded - reported so an interface can say "70% of
+ *                          what" rather than showing a bare percentage - and
+ *                          whether the score DECLARED it or was handed the
+ *                          renderer's 120 fallback. Both, rather than a null
+ *                          for the second case, because the click still has
+ *                          to run at something and the interface still has to
+ *                          name it; what must not happen is naming it as a
+ *                          marking. See scoreDeclaresTempo.
  * @param opts.onMetronomeTempo  (bpm, limit) the tempo the metronome is actually
  *                          clicking at just changed - see
  *                          metronome-engine.js, and createScoreMetronome
@@ -1163,7 +1203,7 @@ export function createScoreView(host, opts = {}) {
       api.updateSettings();
     }
     metronome.scoreLoaded(loadedScore);
-    onScoreTempo(loadedScore?.tempo ?? null);
+    onScoreTempo(loadedScore?.tempo ?? null, scoreDeclaresTempo(loadedScore));
     publish();
     onProfiles(scoreProfiles, unrenderable);
   });

--- a/web/src/lib/score-render.js
+++ b/web/src/lib/score-render.js
@@ -674,8 +674,10 @@ export async function playPitch(midi) {
 // 0, set once below and never touched again) so the two never sound at once.
 
 /**
- * Whether the loaded score CARRIES a tempo of its own, as opposed to being
- * handed the renderer's fallback.
+ * Where the tempo `score.tempo` hands back actually came from: "start" (the
+ * document declares it), "later" (the document declares a tempo, but not one
+ * that applies at the start, so the reported number is still the fallback), or
+ * "none" (the document declares no tempo anywhere).
  *
  * This exists because `score.tempo` cannot answer the question. It is a
  * getter over the first bar's tempo automations that returns a hard-coded
@@ -693,19 +695,43 @@ export async function playPitch(midi) {
  * and a document with neither.
  *
  * What does answer it is `isVisible`. ModelUtils.consolidate() runs at the
- * end of every import and, when the first bar has no tempo automation of its
- * own, SYNTHESISES one carrying score.tempo (the 120 fallback) with
+ * end of every import and, when the first bar has no tempo automation at
+ * position zero, SYNTHESISES one carrying score.tempo (the 120 fallback) with
  * `isVisible = false`. Every automation built from something actually in the
- * document is visible. So "the first bar holds a visible tempo automation"
- * is exactly "the document said what its tempo is".
+ * document is visible.
  *
- * A non-empty tempoLabel still counts, for the formats whose importers do
+ * WHY THREE ANSWERS AND NOT TWO. The first version of this asked only whether
+ * the FIRST BAR held a visible automation, and reported anything else as
+ * "the score declares no tempo". A score whose tempo mark sits in a later bar
+ * - it opens with a pickup, or the exporter attached the mark to the first
+ * real note rather than to bar one - was therefore described as having none.
+ * The number was still right, because the fallback is genuinely what applies
+ * before the mark, but the interface then PRINTED that the document says
+ * nothing about its tempo, which is untrue of the document. That is #102 with
+ * the sign flipped, and worse than #102: failing to mention a fact is not the
+ * same as asserting a false one. So "not at the start" and "not anywhere" are
+ * kept apart, and only the second is allowed to say the score has none.
+ *
+ * The test for "start" is deliberately about `automations[0]` rather than
+ * about any visible automation in bar one, because index 0 is exactly the
+ * entry `score.tempo` reads: consolidate only ever APPENDS its synthesised
+ * one, so a real automation in bar one - even one attached part-way through
+ * it - is always index 0, and the number being labelled is then that
+ * automation's own value rather than the fallback.
+ *
+ * A non-empty tempoLabel counts as declared, for the formats whose importers
  * fill it in (the Guitar Pro readers set it from the file's own label) - a
- * named tempo is a declared one however it arrived.
+ * named tempo is a declared one however it arrived, and nothing invents a
+ * label.
  */
-function scoreDeclaresTempo(score) {
-  const automations = score?.masterBars?.[0]?.tempoAutomations ?? [];
-  return automations.some((a) => a?.isVisible !== false) || !!score?.tempoLabel;
+function tempoProvenance(score) {
+  const bars = score?.masterBars ?? [];
+  const opening = (bars[0]?.tempoAutomations ?? [])[0];
+  if (opening && (opening.isVisible !== false || !!score?.tempoLabel)) return "start";
+  for (const bar of bars) {
+    if ((bar?.tempoAutomations ?? []).some((a) => a?.isVisible !== false)) return "later";
+  }
+  return "none";
 }
 
 /**
@@ -893,16 +919,20 @@ function createScoreMetronome(api, onTempo, onClick) {
  *                          signal a caller should wait for before treating a
  *                          profile switch as having taken effect, rather than
  *                          assuming success the moment it is requested
- * @param opts.onScoreTempo (bpm, declared) the quarter-note tempo a
+ * @param opts.onScoreTempo (bpm, provenance) the quarter-note tempo a
  *                          proportion is a proportion of, once a score has
  *                          loaded - reported so an interface can say "70% of
  *                          what" rather than showing a bare percentage - and
- *                          whether the score DECLARED it or was handed the
- *                          renderer's 120 fallback. Both, rather than a null
- *                          for the second case, because the click still has
- *                          to run at something and the interface still has to
- *                          name it; what must not happen is naming it as a
- *                          marking. See scoreDeclaresTempo.
+ *                          where that number came from: "start", "later" or
+ *                          "none". Both, rather than a null for the cases
+ *                          where nothing was declared, because the click
+ *                          still has to run at something and the interface
+ *                          still has to name it; what must not happen is
+ *                          naming it as a marking. Reported once per load and
+ *                          not tracked afterwards, which is why it can be a
+ *                          fact about the score: the live playhead tempo goes
+ *                          to the engine (and so to the readout), not to this
+ *                          callback. See tempoProvenance.
  * @param opts.onMetronomeTempo  (bpm, limit) the tempo the metronome is actually
  *                          clicking at just changed - see
  *                          metronome-engine.js, and createScoreMetronome
@@ -1203,7 +1233,7 @@ export function createScoreView(host, opts = {}) {
       api.updateSettings();
     }
     metronome.scoreLoaded(loadedScore);
-    onScoreTempo(loadedScore?.tempo ?? null, scoreDeclaresTempo(loadedScore));
+    onScoreTempo(loadedScore?.tempo ?? null, tempoProvenance(loadedScore));
     publish();
     onProfiles(scoreProfiles, unrenderable);
   });

--- a/web/tests/browser/fixtures/metronome-score.js
+++ b/web/tests/browser/fixtures/metronome-score.js
@@ -23,6 +23,17 @@ const PITCHES = ["C", "D", "E", "F", "G", "A", "B", "C"];
 // describe as "marked ♩ = 120": alphaTab's Score.tempo is a getter that
 // answers 120 when the first bar holds no tempo automation, so nothing
 // downstream could tell it apart from a score that really did print 120.
+function tempoDirection(tempo) {
+  if (tempo == null) return "";
+  return `
+      <direction placement="above">
+        <direction-type>
+          <metronome><beat-unit>quarter</beat-unit><per-minute>${tempo}</per-minute></metronome>
+        </direction-type>
+        <sound tempo="${tempo}" />
+      </direction>`;
+}
+
 function timeAndTempoBlock(numerator, denominator, tempo) {
   return `
       <attributes>
@@ -33,17 +44,7 @@ function timeAndTempoBlock(numerator, denominator, tempo) {
           <beat-type>${denominator}</beat-type>
         </time>
         <clef><sign>G</sign><line>2</line></clef>
-      </attributes>${
-        tempo == null
-          ? ""
-          : `
-      <direction placement="above">
-        <direction-type>
-          <metronome><beat-unit>quarter</beat-unit><per-minute>${tempo}</per-minute></metronome>
-        </direction-type>
-        <sound tempo="${tempo}" />
-      </direction>`
-      }`;
+      </attributes>${tempoDirection(tempo)}`;
 }
 
 function notesForBar(numerator, denominator) {
@@ -71,8 +72,21 @@ function notesForBar(numerator, denominator) {
  * the end of that 1-based bar number, repeating from the start of the piece
  * (no forward repeat needed - the piece's own start is where a backward
  * repeat with nothing preceding it returns to).
+ *
+ * `tempoAt` is the 1-based bar the tempo direction is attached to. Anything
+ * other than 1 leaves the first bar carrying no tempo at all - the shape a
+ * score has when it opens with a pickup, or when an exporter attached the mark
+ * to the first real note rather than to bar one.
  */
-function buildMusicXml({ measures, numerator, denominator, tempo, repeatAfter = null, change = null }) {
+function buildMusicXml({
+  measures,
+  numerator,
+  denominator,
+  tempo,
+  repeatAfter = null,
+  change = null,
+  tempoAt = 1,
+}) {
   const bars = [];
   let curNum = numerator;
   let curDen = denominator;
@@ -84,13 +98,13 @@ function buildMusicXml({ measures, numerator, denominator, tempo, repeatAfter = 
       curDen = change.denominator;
     }
     const attrs = isFirst
-      ? timeAndTempoBlock(curNum, curDen, tempo)
-      : isChange
-        ? `
+      ? timeAndTempoBlock(curNum, curDen, tempoAt === 1 ? tempo : null)
+      : (isChange
+          ? `
       <attributes>
         <time><beats>${curNum}</beats><beat-type>${curDen}</beat-type></time>
       </attributes>`
-        : "";
+          : "") + (i === tempoAt ? tempoDirection(tempo) : "");
     const barline =
       repeatAfter === i
         ? `
@@ -196,6 +210,20 @@ export const METRONOME_MUSICXML_NO_TEMPO = buildMusicXml({
   tempo: null,
 });
 
+// A tempo the score DOES declare, just not at its start: bar one carries none
+// and bar two is marked 88. The number the renderer reports is still the 120
+// fallback, so the control must still call it a default - but the document does
+// say what its tempo is, so it must NOT say the score has none. That claim
+// would be #102 with the sign flipped, and worse than #102: the old code failed
+// to mention a fact, this would assert an untrue one.
+export const METRONOME_MUSICXML_LATE_TEMPO = buildMusicXml({
+  measures: 8,
+  numerator: 4,
+  denominator: 4,
+  tempo: 88,
+  tempoAt: 2,
+});
+
 function scoreMeta(id, title) {
   // file_type not "pdf" is what routes Viewer.svelte to TabViewer directly
   // (see Viewer.svelte) rather than through ScoreCompare/PdfViewer.
@@ -253,4 +281,14 @@ export async function stubMetronomeScoreRepeat(page) {
 /** Score id 6: 4/4 with no tempo direction at all. */
 export async function stubMetronomeScoreNoTempo(page) {
   await stubOneScore(page, 6, scoreMeta(6, "No-tempo metronome fixture"), METRONOME_MUSICXML_NO_TEMPO);
+}
+
+/** Score id 7: 4/4 whose only tempo direction is on bar two. */
+export async function stubMetronomeScoreLateTempo(page) {
+  await stubOneScore(
+    page,
+    7,
+    scoreMeta(7, "Late-tempo metronome fixture"),
+    METRONOME_MUSICXML_LATE_TEMPO,
+  );
 }

--- a/web/tests/browser/fixtures/metronome-score.js
+++ b/web/tests/browser/fixtures/metronome-score.js
@@ -17,6 +17,12 @@
 const DIVISIONS = 480; // ticks per quarter note
 const PITCHES = ["C", "D", "E", "F", "G", "A", "B", "C"];
 
+// `tempo` of null emits NO tempo direction at all - not a direction carrying
+// 120, and not a <words>Andante</words> either. That is the shape of the
+// editions this library is mostly made of, and the one the metronome used to
+// describe as "marked ♩ = 120": alphaTab's Score.tempo is a getter that
+// answers 120 when the first bar holds no tempo automation, so nothing
+// downstream could tell it apart from a score that really did print 120.
 function timeAndTempoBlock(numerator, denominator, tempo) {
   return `
       <attributes>
@@ -27,13 +33,17 @@ function timeAndTempoBlock(numerator, denominator, tempo) {
           <beat-type>${denominator}</beat-type>
         </time>
         <clef><sign>G</sign><line>2</line></clef>
-      </attributes>
+      </attributes>${
+        tempo == null
+          ? ""
+          : `
       <direction placement="above">
         <direction-type>
           <metronome><beat-unit>quarter</beat-unit><per-minute>${tempo}</per-minute></metronome>
         </direction-type>
         <sound tempo="${tempo}" />
-      </direction>`;
+      </direction>`
+      }`;
 }
 
 function notesForBar(numerator, denominator) {
@@ -170,6 +180,22 @@ export const METRONOME_MUSICXML_FAST = buildMusicXml({
   tempo: 144,
 });
 
+// 4/4 with NO tempo direction anywhere - the fixture the two existing honesty
+// tests for the tempo control did not have. Both of those declare a tempo (96
+// and 90), which is why the `?? null` guard meant to catch an undeclared one
+// was never exercised and was in fact dead code (issue #102).
+//
+// 4/4 rather than 6/8 so the click rate and the quarter-note tempo are the
+// same number: the base tempo IS the readout, and a test can tell "the
+// fallback was used" from "something else was used" without a meter
+// conversion in the way.
+export const METRONOME_MUSICXML_NO_TEMPO = buildMusicXml({
+  measures: 8,
+  numerator: 4,
+  denominator: 4,
+  tempo: null,
+});
+
 function scoreMeta(id, title) {
   // file_type not "pdf" is what routes Viewer.svelte to TabViewer directly
   // (see Viewer.svelte) rather than through ScoreCompare/PdfViewer.
@@ -222,4 +248,9 @@ export async function stubMetronomeScoreShortLoop(page) {
  * regression test. */
 export async function stubMetronomeScoreRepeat(page) {
   await stubOneScore(page, 4, scoreMeta(4, "Repeat metronome fixture"), METRONOME_MUSICXML_REPEAT);
+}
+
+/** Score id 6: 4/4 with no tempo direction at all. */
+export async function stubMetronomeScoreNoTempo(page) {
+  await stubOneScore(page, 6, scoreMeta(6, "No-tempo metronome fixture"), METRONOME_MUSICXML_NO_TEMPO);
 }

--- a/web/tests/browser/fixtures/transcription-warnings.js
+++ b/web/tests/browser/fixtures/transcription-warnings.js
@@ -173,9 +173,12 @@ export function transcriptionResponse({
 
 /** The provenance an extraction that read nothing records: no meter on the
  * page, no key on it, and no tuning named anywhere - so 4/4, no key
- * signature, and the standard six strings, every one of them an assumption.
- * The common case: 18% of first pages lose their printed meter (#90) and
- * every score not literally labelled "Drop D" reads as standard (#80). */
+ * signature, and the standard six strings.
+ *
+ * The meter and the key are stated as assumptions. The TUNING is not, and that
+ * is deliberate: it is the standard six on 193 of 293 scores, so saying so puts
+ * the unverified mark on two thirds of the library and the mark stops meaning
+ * anything. See tuningStatement in provenance.js. */
 export const ASSUMED_PROVENANCE = {
   time_signature: [4, 4],
   time_signature_source: "not detected (assumed 4/4)",
@@ -183,10 +186,11 @@ export const ASSUMED_PROVENANCE = {
   key_signature_source: "not detected (assumed no key signature)",
   tuning: ["E2", "A2", "D3", "G3", "B3", "E4"],
   tuning_label: null,
+  tuning_unread: [],
 };
 
-/** The provenance an extraction that read everything records - the meter and
- * key decoded off the engraved glyphs, and a tuning the page named. */
+/** The meter and key decoded off the engraved glyphs, and a tuning name
+ * recognised on the page with nothing else about it left unread. */
 export const READ_PROVENANCE = {
   time_signature: [6, 8],
   time_signature_source: "glyph-decoded",
@@ -194,6 +198,17 @@ export const READ_PROVENANCE = {
   key_signature_source: "glyph-decoded",
   tuning: ["D2", "A2", "D3", "G3", "B3", "E4"],
   tuning_label: "Drop D",
+  tuning_unread: [],
+};
+
+/** A Drop D label AND a printed instruction the extractor discards - the state
+ * 41 of the 100 labelled scores in the library are actually in. `tuning` is a
+ * semitone out (or every pitch is, for a capo) while looking exactly like
+ * something that was read, which is why "read from the page" could not be said
+ * of it. */
+export const INCOMPLETE_TUNING_PROVENANCE = {
+  ...READ_PROVENANCE,
+  tuning_unread: ["capo 2"],
 };
 
 /**

--- a/web/tests/browser/fixtures/transcription-warnings.js
+++ b/web/tests/browser/fixtures/transcription-warnings.js
@@ -122,8 +122,28 @@ export const STANDING_LIMITS_ONLY_WARNINGS = [
  * ScoreCompare.svelte's own defensive read: when true, `warnings` is
  * IsUnusual and only present nested inside the `confidence` JSON string,
  * not at the top level, and the frontend must still find it.
+ *
+ * `provenance` is the meter/key/tuning group - `{ time_signature,
+ * time_signature_source, key_fifths, key_signature_source, tuning,
+ * tuning_label }`, any subset - and mirrors _PROVENANCE_KEYS in
+ * server/fermata/api.py: stored in the blob AND lifted to the top level on
+ * both GET and POST, exactly like the bar counts. Omitted entirely by
+ * default, which is the shape of a row extracted before this was stored and
+ * of every hand-edited row.
+ *
+ * `content` and `format` override the rendered transcription itself, for the
+ * cases that are about what the staff/metronome make of the document rather
+ * than about the warning panel above it.
  */
-export function transcriptionResponse({ warnings, confidence, bars, nestWarningsOnly = false }) {
+export function transcriptionResponse({
+  warnings,
+  confidence,
+  bars,
+  nestWarningsOnly = false,
+  provenance = null,
+  content = SAMPLE_TEX,
+  format = "alphatex",
+}) {
   const blob = { warnings, confidence };
   if (bars) {
     blob.bars_overfull = bars.overfull ?? 0;
@@ -131,11 +151,12 @@ export function transcriptionResponse({ warnings, confidence, bars, nestWarnings
     blob.bars_defective = bars.defective;
     blob.bars_measured = bars.measured;
   }
+  if (provenance) Object.assign(blob, provenance);
   const body = {
     id: 1,
     score_id: 1,
-    format: "alphatex",
-    content: SAMPLE_TEX,
+    format,
+    content,
     source: "extracted",
     confidence: JSON.stringify(blob),
   };
@@ -146,8 +167,34 @@ export function transcriptionResponse({ warnings, confidence, bars, nestWarnings
     body.bars_defective = blob.bars_defective;
     body.bars_measured = blob.bars_measured;
   }
+  if (provenance) Object.assign(body, provenance);
   return body;
 }
+
+/** The provenance an extraction that read nothing records: no meter on the
+ * page, no key on it, and no tuning named anywhere - so 4/4, no key
+ * signature, and the standard six strings, every one of them an assumption.
+ * The common case: 18% of first pages lose their printed meter (#90) and
+ * every score not literally labelled "Drop D" reads as standard (#80). */
+export const ASSUMED_PROVENANCE = {
+  time_signature: [4, 4],
+  time_signature_source: "not detected (assumed 4/4)",
+  key_fifths: 0,
+  key_signature_source: "not detected (assumed no key signature)",
+  tuning: ["E2", "A2", "D3", "G3", "B3", "E4"],
+  tuning_label: null,
+};
+
+/** The provenance an extraction that read everything records - the meter and
+ * key decoded off the engraved glyphs, and a tuning the page named. */
+export const READ_PROVENANCE = {
+  time_signature: [6, 8],
+  time_signature_source: "glyph-decoded",
+  key_fifths: 2,
+  key_signature_source: "glyph-decoded",
+  tuning: ["D2", "A2", "D3", "G3", "B3", "E4"],
+  tuning_label: "Drop D",
+};
 
 /**
  * A saved hand edit's response shape, mirroring server/fermata/api.py's

--- a/web/tests/browser/metronome-everywhere.spec.js
+++ b/web/tests/browser/metronome-everywhere.spec.js
@@ -21,8 +21,10 @@
 import { expect, test } from "@playwright/test";
 
 import {
+  METRONOME_MUSICXML_NO_TEMPO,
   stubMetronomeScore,
   stubMetronomeScoreFast,
+  stubMetronomeScoreNoTempo,
   stubMetronomeScoreOther,
   stubMetronomeScoreRepeat,
 } from "./fixtures/metronome-score.js";
@@ -357,6 +359,35 @@ test("the same control over a transcription says transcribed, so the number it i
   await expect(baseNote(page).locator(".mark")).toHaveCount(1);
 });
 
+test("a transcription whose own document declares no tempo says default rather than transcribed - nothing was lifted off anything", async ({
+  page,
+}) => {
+  // The interaction between the two words, and the case that matters most in
+  // practice: the extractor emits no tempo direction at all when it read no
+  // tempo off the PDF (see musicxml.build - `if opening and tempo`), so this is
+  // the shape a great many real transcriptions have. "transcribed ♩ = 120"
+  // would claim a number was lifted out of a scanned page; the 120 is the
+  // renderer's fallback and came from nowhere.
+  await stubScoreApi(
+    page,
+    transcriptionResponse({
+      warnings: [],
+      confidence: CLEAN_CONFIDENCE,
+      content: METRONOME_MUSICXML_NO_TEMPO,
+      format: "musicxml",
+    }),
+  );
+  await page.goto("/#/score/1");
+  await expect(playButton(page)).toBeEnabled({ timeout: 30_000 });
+  await metronomeButton(page).click();
+  await expect(baseNote(page)).toHaveText(/default/);
+  await expect(baseNote(page)).toContainText("none in the score");
+  // Anchored on .metronome-base, which the transcription test above proves can
+  // match on this very route.
+  await expect(baseNote(page)).not.toContainText("transcribed");
+  await expect(baseNote(page)).not.toContainText("marked");
+});
+
 // ------------------------------------------------------ on the practice page
 
 test("the practice page has a click of its own, pre-filled from the tempo the last session was working towards, and it really clicks there", async ({
@@ -445,6 +476,48 @@ test("a tempo set up before stepping into gig mode is still set when stepping ba
   const rate = await measuredRate(page, 4, 30_000);
   expect(rate, `measured ${rate}`).toBeGreaterThan(66);
   expect(rate, `measured ${rate}`).toBeLessThan(68);
+});
+
+test("a score that prints no tempo at all calls the number a default and says there was none to read", async ({
+  page,
+}) => {
+  // Issue #102, and the reason the two tests above could both pass while this
+  // was broken: they use fixtures that DECLARE a tempo. alphaTab's
+  // Score.tempo is a getter answering 120 whenever the first bar holds no
+  // tempo automation, so an edition printing *Andante* and no number - most of
+  // the classical material in this library - was reported as
+  // "marked ♩ = 120". A value we invented, presented as one we read, on the
+  // most visible number on the control.
+  await stubMetronomeScoreNoTempo(page);
+  await page.goto("/#/score/6");
+  await expect(playButton(page)).toBeEnabled({ timeout: 30_000 });
+  await metronomeButton(page).click();
+
+  // The word first: "default", never "marked". Asserted on .metronome-base,
+  // which the two tests above prove can match, so "no such element" cannot be
+  // what makes the negative assertion pass.
+  await expect(baseNote(page)).toHaveText(/default/);
+  await expect(baseNote(page)).not.toContainText("marked");
+  await expect(baseNote(page)).not.toContainText("transcribed");
+  // ...and then, in visible text rather than a title attribute, that there was
+  // nothing to read. "default ♩ = 120" alone still leaves a reader working out
+  // whether 120 came from somewhere.
+  await expect(baseNote(page)).toContainText("none in the score");
+  await expect(baseNote(page)).toContainText("120");
+  // The same unobtrusive mark the app uses for anything unverified - present
+  // here, and absent on the printed-marking score above, which is what makes
+  // it mean anything.
+  await expect(baseNote(page).locator(".mark")).toHaveCount(1);
+
+  // The number is still the number the click actually runs at. Saying "default
+  // 120" beside a click running at something else would be a different lie,
+  // and 4/4 means the quarter-note base and the click rate are one number.
+  await expect(readout(page)).toHaveText("120");
+  await page.locator('button:has-text("Loop")').click();
+  await playButton(page).click();
+  const rate = await measuredRate(page, 8);
+  expect(rate, `measured ${rate}`).toBeGreaterThan(119);
+  expect(rate, `measured ${rate}`).toBeLessThan(121);
 });
 
 // ------------------------------------------- where the range runs out

--- a/web/tests/browser/metronome-everywhere.spec.js
+++ b/web/tests/browser/metronome-everywhere.spec.js
@@ -360,7 +360,7 @@ test("the same control over a transcription says transcribed, so the number it i
   await expect(baseNote(page).locator(".mark")).toHaveCount(1);
 });
 
-test("a transcription whose own document declares no tempo says default rather than transcribed - nothing was lifted off anything", async ({
+test("a transcription whose own document declares no tempo says assumed rather than transcribed - nothing was lifted off anything", async ({
   page,
 }) => {
   // The interaction between the two words, and the case that matters most in
@@ -381,7 +381,7 @@ test("a transcription whose own document declares no tempo says default rather t
   await page.goto("/#/score/1");
   await expect(playButton(page)).toBeEnabled({ timeout: 30_000 });
   await metronomeButton(page).click();
-  await expect(baseNote(page)).toHaveText(/default/);
+  await expect(baseNote(page)).toHaveText(/assumed 120 bpm/);
   await expect(baseNote(page)).toContainText("none in the score");
   // Anchored on .metronome-base, which the transcription test above proves can
   // match on this very route.
@@ -479,7 +479,7 @@ test("a tempo set up before stepping into gig mode is still set when stepping ba
   expect(rate, `measured ${rate}`).toBeLessThan(68);
 });
 
-test("a score that prints no tempo at all calls the number a default and says there was none to read", async ({
+test("a score that prints no tempo at all calls the number assumed and says there was none to read", async ({
   page,
 }) => {
   // Issue #102, and the reason the two tests above could both pass while this
@@ -489,17 +489,25 @@ test("a score that prints no tempo at all calls the number a default and says th
   // the classical material in this library - was reported as
   // "marked ♩ = 120". A value we invented, presented as one we read, on the
   // most visible number on the control.
+  //
+  // And it is said in PLAIN WORDS, not in engraver's notation. "♩ = 96" is how
+  // a tempo is printed on a page and is right for a tempo somebody printed;
+  // using it for our own fallback put the invention in the notation of a
+  // marking, which undercut the very sentence saying it was not one.
   await stubMetronomeScoreNoTempo(page);
   await page.goto("/#/score/6");
   await expect(playButton(page)).toBeEnabled({ timeout: 30_000 });
   await metronomeButton(page).click();
 
-  // The word first: "default", never "marked". Asserted on .metronome-base,
-  // which the two tests above prove can match, so "no such element" cannot be
-  // what makes the negative assertion pass.
-  await expect(baseNote(page)).toHaveText(/default/);
+  // The word first: "assumed", never "marked" - the same word this application
+  // uses at every other site for a value it chose rather than read. Asserted on
+  // .metronome-base, which the two tests above prove can match, so "no such
+  // element" cannot be what makes the negative assertion pass.
+  await expect(baseNote(page)).toHaveText(/assumed 120 bpm/);
   await expect(baseNote(page)).not.toContainText("marked");
   await expect(baseNote(page)).not.toContainText("transcribed");
+  // ...and not in the notation of a marking.
+  await expect(baseNote(page)).not.toContainText("♩ =");
   // ...and then, in visible text rather than a title attribute, that there was
   // nothing to read. "default ♩ = 120" alone still leaves a reader working out
   // whether 120 came from somewhere.
@@ -528,6 +536,16 @@ test("a score that prints no tempo at all calls the number a default and says th
   }));
   expect(toolbar.scrollWidth, JSON.stringify(toolbar)).toBeLessThanOrEqual(toolbar.clientWidth);
 
+  // The control beside it must not contradict it. Keeping the proportion mode
+  // is right - the click has to run at something, and 100% of the assumed tempo
+  // is what it runs at - but an option reading "% of score tempo" next to a note
+  // saying the score declares none is two labels on one control disagreeing,
+  // which is worse than either being wrong alone.
+  await expect(modeSelect(page).locator("option[value=proportion]")).toHaveText(
+    "% of assumed tempo",
+  );
+  await expect(modeSelect(page)).not.toContainText("% of score tempo");
+
   // The number is still the number the click actually runs at. Saying "default
   // 120" beside a click running at something else would be a different lie,
   // and 4/4 means the quarter-note base and the click rate are one number.
@@ -555,8 +573,7 @@ test("a score whose tempo mark sits in a later bar is not told it has none - tha
   await expect(playButton(page)).toBeEnabled({ timeout: 30_000 });
   await metronomeButton(page).click();
 
-  await expect(baseNote(page)).toHaveText(/default/);
-  await expect(baseNote(page)).toContainText("120");
+  await expect(baseNote(page)).toHaveText(/assumed 120 bpm/);
   // The weaker claim, which is true here: nothing at the start.
   await expect(baseNote(page)).toContainText("none at the start");
   // NOT the stronger one, which is false here. Anchored on .metronome-base,
@@ -568,6 +585,11 @@ test("a score whose tempo mark sits in a later bar is not told it has none - tha
   await expect(baseNote(page).locator(".mark")).toHaveAttribute(
     "aria-label",
     /marks no tempo at its start/,
+  );
+  // The word is the same one everywhere else, in the label as in the text.
+  await expect(baseNote(page).locator(".mark")).toHaveAttribute(
+    "aria-label",
+    /was assumed rather than read/,
   );
 });
 

--- a/web/tests/browser/metronome-everywhere.spec.js
+++ b/web/tests/browser/metronome-everywhere.spec.js
@@ -24,6 +24,7 @@ import {
   METRONOME_MUSICXML_NO_TEMPO,
   stubMetronomeScore,
   stubMetronomeScoreFast,
+  stubMetronomeScoreLateTempo,
   stubMetronomeScoreNoTempo,
   stubMetronomeScoreOther,
   stubMetronomeScoreRepeat,
@@ -509,6 +510,24 @@ test("a score that prints no tempo at all calls the number a default and says th
   // it mean anything.
   await expect(baseNote(page).locator(".mark")).toHaveCount(1);
 
+  // TWO LINES, and the toolbar no wider than its own box. This is a sentence
+  // where the other two states are a three-token label, and the toolbar is a
+  // single non-wrapping flex row with six other controls in it - held on one
+  // line it clips the profile buttons at the far end, and left to wrap wherever
+  // a character cap falls it can take three. Measured, because no assertion on
+  // the TEXT can see either happen.
+  const lines = await baseNote(page).evaluate((el) => {
+    const style = getComputedStyle(el);
+    const lineHeight = parseFloat(style.lineHeight) || parseFloat(style.fontSize) * 1.2;
+    return Math.round(el.getBoundingClientRect().height / lineHeight);
+  });
+  expect(lines, "the base note is expected to occupy exactly two lines").toBe(2);
+  const toolbar = await page.locator(".toolbar").evaluate((el) => ({
+    scrollWidth: el.scrollWidth,
+    clientWidth: el.clientWidth,
+  }));
+  expect(toolbar.scrollWidth, JSON.stringify(toolbar)).toBeLessThanOrEqual(toolbar.clientWidth);
+
   // The number is still the number the click actually runs at. Saying "default
   // 120" beside a click running at something else would be a different lie,
   // and 4/4 means the quarter-note base and the click rate are one number.
@@ -518,6 +537,38 @@ test("a score that prints no tempo at all calls the number a default and says th
   const rate = await measuredRate(page, 8);
   expect(rate, `measured ${rate}`).toBeGreaterThan(119);
   expect(rate, `measured ${rate}`).toBeLessThan(121);
+});
+
+test("a score whose tempo mark sits in a later bar is not told it has none - that would be the same fault with the sign flipped", async ({
+  page,
+}) => {
+  // The false-assertion direction, and the one to be most suspicious of in a
+  // change like this. This fixture DOES declare a tempo - 88, on bar two, which
+  // is what a score looks like when it opens with a pickup or when the exporter
+  // attached the mark to the first real note. The number the renderer reports
+  // is still the 120 fallback, so "default" is right; but the first version of
+  // this work looked only at bar one and went on to PRINT that the score
+  // declares no tempo, which is untrue of the document. Failing to mention a
+  // fact (#102) and asserting a false one are not the same size of mistake.
+  await stubMetronomeScoreLateTempo(page);
+  await page.goto("/#/score/7");
+  await expect(playButton(page)).toBeEnabled({ timeout: 30_000 });
+  await metronomeButton(page).click();
+
+  await expect(baseNote(page)).toHaveText(/default/);
+  await expect(baseNote(page)).toContainText("120");
+  // The weaker claim, which is true here: nothing at the start.
+  await expect(baseNote(page)).toContainText("none at the start");
+  // NOT the stronger one, which is false here. Anchored on .metronome-base,
+  // which the tests above prove can match.
+  await expect(baseNote(page)).not.toContainText("none in the score");
+  await expect(baseNote(page)).not.toContainText("marked");
+  // The accessible label carries the same distinction, rather than the mark
+  // saying one thing and its label another.
+  await expect(baseNote(page).locator(".mark")).toHaveAttribute(
+    "aria-label",
+    /marks no tempo at its start/,
+  );
 });
 
 // ------------------------------------------- where the range runs out

--- a/web/tests/browser/practice.spec.js
+++ b/web/tests/browser/practice.spec.js
@@ -72,53 +72,107 @@ test.beforeEach(async ({ page, request }) => {
   await expect(week(page)).toBeVisible();
 });
 
-test("a practice day nobody recorded says so beside the date, and the week's total says how much of it rests on one", async ({
-  page,
-  request,
-}) => {
-  // Issue #103. The server has always answered `local_date_source` on a
-  // session and `sessions_inferred` on a period's facts, and nothing in the
-  // interface read either - so a day worked out from a UTC timestamp looked
-  // exactly like one a person's own clock reported. For practice logged before
-  // the day was stored at all, that is every row an existing install has.
-  //
-  // Logged with no local_date, which is what produces an inferred day - the
-  // same shape those older rows have.
-  const inferred = await request.post("/api/practice/sessions", {
-    data: { activity: "technique", seconds: 1800 },
+// UTC, deliberately and specifically, because an inferred session is the one
+// row whose week the server and this page derive DIFFERENTLY. A session with no
+// recorded day is filed under date(started_at) - its UTC day - while the page
+// asks for the week around its own local day (see api.js: every practice call
+// carries `today=`). In any negative offset late on a Sunday those are
+// different weeks, and the session the test just created is not in the one on
+// screen: a real failure, not a theoretical one, and one that would have
+// arrived as a mystery on somebody else's afternoon.
+//
+// Pinning the zone makes the test deterministic. It does not make the
+// disagreement go away, and the disagreement is the more interesting finding:
+// it is the same shape as the defect local_date was introduced to fix, which
+// was fixed by STORING the day rather than deriving it. A row that predates the
+// column cannot be fixed that way, so an inferred day is filed in whichever
+// week UTC puts it in, and for a practiser west of Greenwich that can be the
+// week after the one they practised in. Which is a reason to say "inferred"
+// beside it rather than a reason to stop counting it - but it is worth knowing
+// that the badge is marking two facts at once: the day was not recorded, and
+// the week it landed in is not necessarily the practiser's own.
+test.describe("with a practice day that was inferred rather than recorded", () => {
+  test.use({ timezoneId: "UTC" });
+
+  test("the day says so beside the date, and the week's total says how much of it rests on one", async ({
+    page,
+    request,
+  }) => {
+    // Issue #103. The server has always answered `local_date_source` on a
+    // session and `sessions_inferred` on a period's facts, and nothing in the
+    // interface read either - so a day worked out from a UTC timestamp looked
+    // exactly like one a person's own clock reported. For practice logged
+    // before the day was stored at all, that is every row an existing install
+    // has.
+    //
+    // Logged with no local_date, which is what produces an inferred day - the
+    // same shape those older rows have.
+    const inferred = await request.post("/api/practice/sessions", {
+      data: { activity: "technique", seconds: 1800 },
+    });
+    expect(inferred.ok(), await inferred.text()).toBe(true);
+    const inferredSession = await inferred.json();
+    expect(
+      inferredSession.local_date_source,
+      "the server is expected to call this day inferred, or this test proves nothing",
+    ).toBe("utc_date");
+
+    // The day the PAGE thinks it is, asked of the page rather than assumed, and
+    // checked against UTC - so if the timezone pin above ever stops taking
+    // effect this fails here with a clear reason instead of failing later as a
+    // missing row.
+    const browserDay = await page.evaluate(() => {
+      const now = new Date();
+      const pad = (n) => String(n).padStart(2, "0");
+      return `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}`;
+    });
+    expect(browserDay, "the timezone pin is what makes this test deterministic").toBe(
+      new Date().toISOString().slice(0, 10),
+    );
+
+    // ...and one whose day WAS recorded, on that same day, so the mark below is
+    // known to be about one row rather than about every row.
+    await logPractice(request, { day: browserDay, minutes: 20 });
+
+    await page.reload();
+    await expect(week(page)).toBeVisible();
+    await expect(sessionRows(page)).toHaveCount(2);
+    // On THAT row, identified by its own id rather than by position - both
+    // sessions land on the same date here, so "one row is marked" would also be
+    // satisfied by marking the wrong one.
+    const marked = page.locator(
+      `.session-list .session[data-session="${inferredSession.id}"] .session-day`,
+    );
+    await expect(marked.locator(".day-inferred")).toHaveText("inferred");
+    // ...and on no other. Anchored on .session-day, which the row assertions
+    // elsewhere in this file prove can match.
+    await expect(page.locator(".session-list .session .session-day .day-inferred")).toHaveCount(1);
+
+    // BESIDE the date, not under it. The badge shares a fixed grid track with
+    // the date, so a track a few pixels too narrow drops it onto its own line -
+    // and every assertion above still passes, because text is all they look at.
+    // Same lesson as anchoring a negative assertion: presence is not placement.
+    const box = async (locator) => locator.boundingBox();
+    const date = await box(marked.locator(".day-date"));
+    const badge = await box(marked.locator(".day-inferred"));
+    expect(badge.x, `date ${JSON.stringify(date)} badge ${JSON.stringify(badge)}`).toBeGreaterThan(
+      date.x + date.width - 1,
+    );
+    // Same line: their vertical midpoints are within one line of each other.
+    expect(
+      Math.abs(badge.y + badge.height / 2 - (date.y + date.height / 2)),
+      `date ${JSON.stringify(date)} badge ${JSON.stringify(badge)}`,
+    ).toBeLessThan(date.height);
+
+    // And the total says how much of itself rests on such a day. Without this a
+    // window spanning the upgrade adds two different kinds of day together with
+    // nothing marking the join.
+    await expect(week(page).locator(".no-goal")).toContainText("1 session on an inferred day");
+    // Still said in the vocabulary this feature is allowed to use - nothing
+    // here is a reprimand.
+    const said = await week(page).locator(".no-goal").textContent();
+    expect(forbiddenWord(said), said).toBeNull();
   });
-  expect(inferred.ok(), await inferred.text()).toBe(true);
-  const inferredSession = await inferred.json();
-  expect(
-    inferredSession.local_date_source,
-    "the server is expected to call this day inferred, or this test proves nothing",
-  ).toBe("utc_date");
-  // ...and one whose day WAS recorded, so the mark below is known to be about
-  // the first row rather than about every row.
-  await logPractice(request, { day: today, minutes: 20 });
-
-  const inferredId = inferredSession.id;
-
-  await page.reload();
-  await expect(week(page)).toBeVisible();
-  await expect(sessionRows(page)).toHaveCount(2);
-  // On THAT row, identified by its own id rather than by position - both
-  // sessions land on the same date here, so "one row is marked" would also be
-  // satisfied by marking the wrong one.
-  const marked = page.locator(`.session-list .session[data-session="${inferredId}"]`);
-  await expect(marked.locator(".session-day .day-inferred")).toHaveText("inferred");
-  // ...and on no other. Anchored on .session-day, which the row assertions
-  // elsewhere in this file prove can match.
-  await expect(page.locator(".session-list .session .session-day .day-inferred")).toHaveCount(1);
-
-  // And the total says how much of itself rests on such a day. Without this a
-  // window spanning the upgrade adds two different kinds of day together with
-  // nothing marking the join.
-  await expect(week(page).locator(".no-goal")).toContainText("1 session on an inferred day");
-  // Still said in the vocabulary this feature is allowed to use - nothing here
-  // is a reprimand.
-  const said = await week(page).locator(".no-goal").textContent();
-  expect(forbiddenWord(said), said).toBeNull();
 });
 
 test("with no goal set, the week says so and shows seven empty days", async ({ page }) => {

--- a/web/tests/browser/practice.spec.js
+++ b/web/tests/browser/practice.spec.js
@@ -72,6 +72,55 @@ test.beforeEach(async ({ page, request }) => {
   await expect(week(page)).toBeVisible();
 });
 
+test("a practice day nobody recorded says so beside the date, and the week's total says how much of it rests on one", async ({
+  page,
+  request,
+}) => {
+  // Issue #103. The server has always answered `local_date_source` on a
+  // session and `sessions_inferred` on a period's facts, and nothing in the
+  // interface read either - so a day worked out from a UTC timestamp looked
+  // exactly like one a person's own clock reported. For practice logged before
+  // the day was stored at all, that is every row an existing install has.
+  //
+  // Logged with no local_date, which is what produces an inferred day - the
+  // same shape those older rows have.
+  const inferred = await request.post("/api/practice/sessions", {
+    data: { activity: "technique", seconds: 1800 },
+  });
+  expect(inferred.ok(), await inferred.text()).toBe(true);
+  const inferredSession = await inferred.json();
+  expect(
+    inferredSession.local_date_source,
+    "the server is expected to call this day inferred, or this test proves nothing",
+  ).toBe("utc_date");
+  // ...and one whose day WAS recorded, so the mark below is known to be about
+  // the first row rather than about every row.
+  await logPractice(request, { day: today, minutes: 20 });
+
+  const inferredId = inferredSession.id;
+
+  await page.reload();
+  await expect(week(page)).toBeVisible();
+  await expect(sessionRows(page)).toHaveCount(2);
+  // On THAT row, identified by its own id rather than by position - both
+  // sessions land on the same date here, so "one row is marked" would also be
+  // satisfied by marking the wrong one.
+  const marked = page.locator(`.session-list .session[data-session="${inferredId}"]`);
+  await expect(marked.locator(".session-day .day-inferred")).toHaveText("inferred");
+  // ...and on no other. Anchored on .session-day, which the row assertions
+  // elsewhere in this file prove can match.
+  await expect(page.locator(".session-list .session .session-day .day-inferred")).toHaveCount(1);
+
+  // And the total says how much of itself rests on such a day. Without this a
+  // window spanning the upgrade adds two different kinds of day together with
+  // nothing marking the join.
+  await expect(week(page).locator(".no-goal")).toContainText("1 session on an inferred day");
+  // Still said in the vocabulary this feature is allowed to use - nothing here
+  // is a reprimand.
+  const said = await week(page).locator(".no-goal").textContent();
+  expect(forbiddenWord(said), said).toBeNull();
+});
+
 test("with no goal set, the week says so and shows seven empty days", async ({ page }) => {
   const thisWeek = week(page).locator(".no-goal");
   await expect(thisWeek).toContainText("No goal set for this week");

--- a/web/tests/browser/practice.spec.js
+++ b/web/tests/browser/practice.spec.js
@@ -91,7 +91,7 @@ test.beforeEach(async ({ page, request }) => {
 // beside it rather than a reason to stop counting it - but it is worth knowing
 // that the badge is marking two facts at once: the day was not recorded, and
 // the week it landed in is not necessarily the practiser's own.
-test.describe("with a practice day that was inferred rather than recorded", () => {
+test.describe("with a practice day that was assumed rather than recorded", () => {
   test.use({ timezoneId: "UTC" });
 
   test("the day says so beside the date, and the week's total says how much of it rests on one", async ({
@@ -143,7 +143,7 @@ test.describe("with a practice day that was inferred rather than recorded", () =
     const marked = page.locator(
       `.session-list .session[data-session="${inferredSession.id}"] .session-day`,
     );
-    await expect(marked.locator(".day-inferred")).toHaveText("inferred");
+    await expect(marked.locator(".day-inferred")).toHaveText("assumed");
     // ...and on no other. Anchored on .session-day, which the row assertions
     // elsewhere in this file prove can match.
     await expect(page.locator(".session-list .session .session-day .day-inferred")).toHaveCount(1);
@@ -164,10 +164,19 @@ test.describe("with a practice day that was inferred rather than recorded", () =
       `date ${JSON.stringify(date)} badge ${JSON.stringify(badge)}`,
     ).toBeLessThan(date.height);
 
+    // ...and the word beside the date is explained, once, under the list: what
+    // was assumed and what from. The badge alone says neither, and the whole
+    // sentence will not fit beside a date. Present only because a row carries
+    // it - the test above proves this element is absent when none does.
+    const note = page.locator(".day-note");
+    await expect(note).toBeVisible();
+    await expect(note).toContainText("taken from the session's own timestamp");
+    await expect(note).toContainText("rather than recorded when the practice happened");
+
     // And the total says how much of itself rests on such a day. Without this a
     // window spanning the upgrade adds two different kinds of day together with
     // nothing marking the join.
-    await expect(week(page).locator(".no-goal")).toContainText("1 session on an inferred day");
+    await expect(week(page).locator(".no-goal")).toContainText("1 session on an assumed day");
     // Still said in the vocabulary this feature is allowed to use - nothing
     // here is a reprimand.
     const said = await week(page).locator(".no-goal").textContent();
@@ -209,6 +218,13 @@ test("once there is practice, the review appears", async ({ page, request }) => 
   await expect(page.locator(".nothing-yet")).toHaveCount(0);
   await expect(page.locator("section.review")).toBeVisible();
   await expect(pastWeeks(page)).toHaveCount(7);
+  // This day WAS recorded, so nothing says otherwise: neither the badge nor the
+  // sentence explaining it. Asserted here, on a page that is otherwise showing
+  // a full session list, so the "a day nobody recorded says so" test below is
+  // known to be about the assumed row rather than about every row.
+  await expect(sessionRows(page)).toHaveCount(1);
+  await expect(page.locator(".session-list .session .day-inferred")).toHaveCount(0);
+  await expect(page.locator(".day-note")).toHaveCount(0);
 });
 
 test("a goal is set from this page and its progress is stated as counts", async ({

--- a/web/tests/browser/score-compare-warnings.spec.js
+++ b/web/tests/browser/score-compare-warnings.spec.js
@@ -23,6 +23,8 @@
 // fixture is the only way to exercise it.
 import { test, expect } from "@playwright/test";
 import {
+  ASSUMED_PROVENANCE,
+  READ_PROVENANCE,
   SCORE,
   NINE_WARNINGS,
   NINE_WARNINGS_EXPECTED_SUMMARY,
@@ -303,6 +305,117 @@ test.describe("ScoreCompare warnings summary", () => {
     await page.locator('.seg button:has-text("Staff")').click();
     await page.locator('button:has-text("Gig mode")').click();
     await expect(page.locator(".gig-mark")).toHaveCount(0);
+  });
+
+  // ------------------------------- what was read, and what was assumed
+
+  test("a meter and a tuning nobody read say so beside the staff, naming the values they qualify", async ({
+    page,
+  }) => {
+    // Issue #103. The extractor already knew it had assumed all three; the
+    // interface showed the assumptions and not the fact that they were
+    // assumptions, which is the same defect as an invented rest presented as a
+    // read one, at the scale of a whole score.
+    await stubScoreApi(
+      page,
+      transcriptionResponse({
+        warnings: [],
+        confidence: CLEAN_CONFIDENCE,
+        provenance: ASSUMED_PROVENANCE,
+      }),
+    );
+    await page.goto("/#/score/1");
+    await page.waitForSelector(".staff-render");
+
+    const assumed = page.locator(".provenance .prov-assumed");
+    await expect(assumed).toBeVisible();
+    // The value travels WITH the word: "4/4" in the assumed sentence, not a
+    // bare "assumed" with the digits a paragraph away on the staff.
+    await expect(assumed).toContainText("Assumed, not read from the page");
+    await expect(assumed).toContainText("4/4");
+    await expect(assumed).toContainText("no key signature");
+    await expect(assumed).toContainText("standard tuning");
+    // Visible text, not a title attribute - the reader is at a music stand
+    // holding an instrument and the tablet under it has no pointer.
+    await expect(assumed).not.toHaveAttribute("title", /.+/);
+    // Nothing was read, so there is no read sentence to make. Anchored inside
+    // .provenance, which this test has just proven can match, so "the whole
+    // block is missing" cannot be what satisfies this.
+    await expect(page.locator(".provenance .prov-read")).toHaveCount(0);
+    // This score is otherwise clean: no warnings at all. The provenance line
+    // is not a warning and is not collapsed behind one.
+    await expect(page.locator(".warnings")).toHaveCount(0);
+  });
+
+  test("a meter and a tuning that WERE read say that instead, so the assumed wording means something", async ({
+    page,
+  }) => {
+    await stubScoreApi(
+      page,
+      transcriptionResponse({
+        warnings: [],
+        confidence: CLEAN_CONFIDENCE,
+        provenance: READ_PROVENANCE,
+      }),
+    );
+    await page.goto("/#/score/1");
+    await page.waitForSelector(".staff-render");
+
+    const read = page.locator(".provenance .prov-read");
+    await expect(read).toBeVisible();
+    await expect(read).toContainText("Read from the page");
+    await expect(read).toContainText("6/8");
+    await expect(read).toContainText("2 sharps");
+    await expect(read).toContainText("Drop D tuning");
+    await expect(page.locator(".provenance .prov-assumed")).toHaveCount(0);
+  });
+
+  test("a transcription that records no provenance claims neither - it says nothing rather than something safe-sounding", async ({
+    page,
+  }) => {
+    // A hand-edited row, or one extracted before the provenance was stored,
+    // has measured nothing. Reporting "standard tuning assumed" there would be
+    // inventing a reading of content nothing has looked at; reporting "read
+    // from the page" would be worse. Both are refused.
+    await stubScoreApi(
+      page,
+      transcriptionResponse({ warnings: NINE_WARNINGS, confidence: CAPPED_CONFIDENCE }),
+    );
+    await page.goto("/#/score/1");
+    await page.waitForSelector(".staff-render");
+    // The warnings block IS present on this fixture, which is what makes the
+    // absence below an absence of the provenance line specifically rather than
+    // of the whole pane.
+    await expect(page.locator(".warnings-summary")).toBeVisible();
+    await expect(page.locator(".provenance")).toHaveCount(0);
+  });
+
+  test("gig mode keeps a mark for an assumed meter or tuning, since that is exactly what a player would catch", async ({
+    page,
+  }) => {
+    // Gig mode drops the warnings block - a performance is not when anyone
+    // corrects a transcription - but a tuning nobody read is the one fact a
+    // player looking at their own arrangement catches instantly, so it keeps
+    // the single unobtrusive mark the two other never-lose-this facts keep.
+    await stubScoreApi(
+      page,
+      transcriptionResponse({
+        warnings: [],
+        confidence: CLEAN_CONFIDENCE,
+        provenance: ASSUMED_PROVENANCE,
+      }),
+    );
+    await page.goto("/#/score/1");
+    await page.waitForSelector(".staff-render");
+    await page.locator('.seg button:has-text("Staff")').click();
+    await page.locator('button:has-text("Gig mode")').click();
+
+    const mark = page.locator(".gig-mark");
+    await expect(mark).toHaveCount(1);
+    await expect(mark).toHaveAttribute(
+      "title",
+      "assumed: 4/4, no key signature, standard tuning",
+    );
   });
 
   test("the #/demo route still renders with no console errors", async ({ page }) => {

--- a/web/tests/browser/score-compare-warnings.spec.js
+++ b/web/tests/browser/score-compare-warnings.spec.js
@@ -24,6 +24,7 @@
 import { test, expect } from "@playwright/test";
 import {
   ASSUMED_PROVENANCE,
+  INCOMPLETE_TUNING_PROVENANCE,
   READ_PROVENANCE,
   SCORE,
   NINE_WARNINGS,
@@ -309,10 +310,10 @@ test.describe("ScoreCompare warnings summary", () => {
 
   // ------------------------------- what was read, and what was assumed
 
-  test("a meter and a tuning nobody read say so beside the staff, naming the values they qualify", async ({
+  test("a meter nobody read says so beside the staff, first and naming the value it qualifies", async ({
     page,
   }) => {
-    // Issue #103. The extractor already knew it had assumed all three; the
+    // Issue #103. The extractor already knew it had assumed these; the
     // interface showed the assumptions and not the fact that they were
     // assumptions, which is the same defect as an invented rest presented as a
     // read one, at the scale of a whole score.
@@ -334,20 +335,32 @@ test.describe("ScoreCompare warnings summary", () => {
     await expect(assumed).toContainText("Assumed, not read from the page");
     await expect(assumed).toContainText("4/4");
     await expect(assumed).toContainText("no key signature");
-    await expect(assumed).toContainText("standard tuning");
     // Visible text, not a title attribute - the reader is at a music stand
     // holding an instrument and the tablet under it has no pointer.
     await expect(assumed).not.toHaveAttribute("title", /.+/);
+    // FIRST in the line. It is the clause carrying information, and the one
+    // that gets skimmed at the frequency it appears on.
+    const order = await page
+      .locator(".provenance .prov-line > span")
+      .evaluateAll((els) => els.map((el) => el.className));
+    expect(order[0], JSON.stringify(order)).toBe("prov-assumed");
     // Nothing was read, so there is no read sentence to make. Anchored inside
     // .provenance, which this test has just proven can match, so "the whole
     // block is missing" cannot be what satisfies this.
     await expect(page.locator(".provenance .prov-read")).toHaveCount(0);
+    // AND NOTHING AT ALL ABOUT THE TUNING. It is the standard six strings by
+    // assumption here, which is true of 193 of the 293 scores in the library -
+    // saying so would put the unverified mark on two thirds of them and the
+    // mark would stop meaning anything. The staff below draws the tuning it is
+    // using, which is where a player who wants to check it looks.
+    await expect(page.locator(".provenance .prov-tuning")).toHaveCount(0);
+    await expect(page.locator(".provenance")).not.toContainText("tuning");
     // This score is otherwise clean: no warnings at all. The provenance line
     // is not a warning and is not collapsed behind one.
     await expect(page.locator(".warnings")).toHaveCount(0);
   });
 
-  test("a meter and a tuning that WERE read say that instead, so the assumed wording means something", async ({
+  test("a meter that WAS read says that instead, so the assumed wording means something", async ({
     page,
   }) => {
     await stubScoreApi(
@@ -366,8 +379,72 @@ test.describe("ScoreCompare warnings summary", () => {
     await expect(read).toContainText("Read from the page");
     await expect(read).toContainText("6/8");
     await expect(read).toContainText("2 sharps");
-    await expect(read).toContainText("Drop D tuning");
     await expect(page.locator(".provenance .prov-assumed")).toHaveCount(0);
+  });
+
+  test("a recognised tuning name is reported as a name, never as a tuning that was read", async ({
+    page,
+  }) => {
+    // The extractor finds a tuning by looking for the words "Drop D" in the
+    // page text. That is recognition of a LABEL. Putting it in the "Read from
+    // the page" clause claimed the six strings had been read, which is a
+    // different and stronger statement - and one that is measurably false on 41
+    // of the 100 scores that match, because they carry a further printed
+    // instruction the extractor discards.
+    await stubScoreApi(
+      page,
+      transcriptionResponse({
+        warnings: [],
+        confidence: CLEAN_CONFIDENCE,
+        provenance: READ_PROVENANCE,
+      }),
+    );
+    await page.goto("/#/score/1");
+    await page.waitForSelector(".staff-render");
+
+    const tuning = page.locator(".provenance .prov-tuning");
+    await expect(tuning).toBeVisible();
+    await expect(tuning).toContainText("the page names Drop D");
+    await expect(tuning).toContainText("Nothing else about the tuning was read");
+    // Its own sentence, and NOT inside the read clause - which this file proves
+    // can match, in the test directly above, on this very fixture.
+    await expect(page.locator(".provenance .prov-read")).not.toContainText("Drop D");
+    // Not styled as unverified either: a recognised name is a partial reading,
+    // not an assumption, and the sentence says so in words.
+    await expect(tuning.locator(".mark")).toHaveCount(0);
+  });
+
+  test("a printed tuning instruction the extractor discards is stated, because the tuning is then not what sounds", async ({
+    page,
+  }) => {
+    // 41 of the 100 labelled scores: 9 say to tune every string down a half
+    // step, 32 name a capo. The recorded tuning array is wrong by a semitone or
+    // every pitch is, and before this it looked exactly like something read off
+    // the page. 14% of the library.
+    await stubScoreApi(
+      page,
+      transcriptionResponse({
+        warnings: [],
+        confidence: CLEAN_CONFIDENCE,
+        provenance: INCOMPLETE_TUNING_PROVENANCE,
+      }),
+    );
+    await page.goto("/#/score/1");
+    await page.waitForSelector(".staff-render");
+
+    const tuning = page.locator(".provenance .prov-tuning");
+    await expect(tuning).toBeVisible();
+    await expect(tuning).toContainText("the page names Drop D");
+    // The instruction itself, named, and what it costs.
+    await expect(tuning).toContainText("capo 2");
+    await expect(tuning).toContainText("which Fermata does not read");
+    await expect(tuning).toContainText("the pitches sounded are not the pitches printed");
+    // THIS one is unverified, and carries the mark - unlike the recognised-name
+    // case above, which the test before this proves renders without one.
+    await expect(tuning.locator(".mark")).toHaveCount(1);
+    // The meter and key were genuinely read, and still say so - the tuning
+    // sentence does not contaminate them.
+    await expect(page.locator(".provenance .prov-read")).toContainText("6/8");
   });
 
   test("a transcription that records no provenance claims neither - it says nothing rather than something safe-sounding", async ({
@@ -390,19 +467,20 @@ test.describe("ScoreCompare warnings summary", () => {
     await expect(page.locator(".provenance")).toHaveCount(0);
   });
 
-  test("gig mode keeps a mark for an assumed meter or tuning, since that is exactly what a player would catch", async ({
+  test("gig mode keeps a mark for an assumed meter and for a tuning instruction nobody read", async ({
     page,
   }) => {
     // Gig mode drops the warnings block - a performance is not when anyone
-    // corrects a transcription - but a tuning nobody read is the one fact a
-    // player looking at their own arrangement catches instantly, so it keeps
-    // the single unobtrusive mark the two other never-lose-this facts keep.
+    // corrects a transcription - but a printed tuning instruction we discarded
+    // is the one fact a player looking at their own arrangement catches
+    // instantly, so it keeps the single unobtrusive mark the two other
+    // never-lose-this facts keep.
     await stubScoreApi(
       page,
       transcriptionResponse({
         warnings: [],
         confidence: CLEAN_CONFIDENCE,
-        provenance: ASSUMED_PROVENANCE,
+        provenance: { ...ASSUMED_PROVENANCE, tuning_label: "Drop D", tuning_unread: ["capo 2"] },
       }),
     );
     await page.goto("/#/score/1");
@@ -414,8 +492,32 @@ test.describe("ScoreCompare warnings summary", () => {
     await expect(mark).toHaveCount(1);
     await expect(mark).toHaveAttribute(
       "title",
-      "assumed: 4/4, no key signature, standard tuning",
+      "assumed: 4/4, no key signature \u00b7 tuning instruction not read",
     );
+  });
+
+  test("gig mode shows no mark for a tuning that is merely assumed standard", async ({ page }) => {
+    // The 193-of-293 case. It was marked, and a mark on two thirds of the
+    // library is the desensitisation the always-on argument exists to avoid -
+    // one level down. The gig-mark selector is proven to match by the test
+    // above, on a fixture differing only in the tuning.
+    await stubScoreApi(
+      page,
+      transcriptionResponse({
+        warnings: [],
+        confidence: CLEAN_CONFIDENCE,
+        provenance: {
+          ...ASSUMED_PROVENANCE,
+          time_signature_source: "glyph-decoded",
+          key_signature_source: "glyph-decoded",
+        },
+      }),
+    );
+    await page.goto("/#/score/1");
+    await page.waitForSelector(".staff-render");
+    await page.locator('.seg button:has-text("Staff")').click();
+    await page.locator('button:has-text("Gig mode")').click();
+    await expect(page.locator(".gig-mark")).toHaveCount(0);
   });
 
   test("the #/demo route still renders with no console errors", async ({ page }) => {

--- a/web/tests/browser/zz-library-missing.spec.js
+++ b/web/tests/browser/zz-library-missing.spec.js
@@ -149,6 +149,49 @@ test("a score whose file has gone is shown as missing rather than vanishing", as
   await expect(restored.locator(".missing-flag")).toHaveCount(0);
 });
 
+test("a scan that found a missing file again says so, rather than only clearing the flag", async ({
+  page,
+  request,
+}) => {
+  // Issue #103. The scanner counts rows whose file turned up again AT THE PATH
+  // IT LEFT FROM - deliberately not a content-hash relink, which is a guess
+  // about identity - specifically so the count can stand as evidence that a
+  // remount really did recover. It stood as evidence to nobody: `restored` was
+  // on /api/scan/status and nothing in the interface read it, so somebody who
+  // put a drive back saw flags quietly disappear and no statement that
+  // anything had been recovered.
+  const first = await upload(request, FIRST);
+  await upload(request, SECOND);
+  await scanAndWait(request);
+  const bytes = fs.readFileSync(filePath(FIRST));
+
+  // Gone, and marked - the other one stays, so this is an ordinary
+  // reconciliation rather than the refused empty-library case.
+  fs.rmSync(filePath(FIRST));
+  const marked = await scanAndWait(request);
+  expect(marked.refused, JSON.stringify(marked)).toBe(false);
+  expect(marked.missing).toBe(1);
+  // Nothing to report yet, so nothing is reported. Asserted before the notice
+  // appears, so the notice below is known to be caused by the recovery rather
+  // than being permanently on the page.
+  await page.goto("/#/");
+  await expect(page.locator(`.card[href="#/score/${first.id}"] .missing-flag`)).toBeVisible();
+  await expect(page.locator(".scan-note")).toHaveCount(0);
+
+  // Back at the path it left from.
+  fs.writeFileSync(filePath(FIRST), bytes);
+  const recovered = await scanAndWait(request);
+  expect(recovered.restored, JSON.stringify(recovered)).toBe(1);
+
+  await page.reload();
+  const note = page.locator(".scan-note");
+  await expect(note).toBeVisible();
+  await expect(note).toContainText("1 score found again");
+  await expect(note).toContainText("at the path it went missing from");
+  // ...and the flag really has gone, so the statement and the library agree.
+  await expect(page.locator(`.card[href="#/score/${first.id}"] .missing-flag`)).toHaveCount(0);
+});
+
 test("a refused scan says so on the page, and can be confirmed", async ({ page, request }) => {
   await upload(request, FIRST);
   await upload(request, SECOND);

--- a/web/tests/browser/zz-library-missing.spec.js
+++ b/web/tests/browser/zz-library-missing.spec.js
@@ -149,49 +149,6 @@ test("a score whose file has gone is shown as missing rather than vanishing", as
   await expect(restored.locator(".missing-flag")).toHaveCount(0);
 });
 
-test("a scan that found a missing file again says so, rather than only clearing the flag", async ({
-  page,
-  request,
-}) => {
-  // Issue #103. The scanner counts rows whose file turned up again AT THE PATH
-  // IT LEFT FROM - deliberately not a content-hash relink, which is a guess
-  // about identity - specifically so the count can stand as evidence that a
-  // remount really did recover. It stood as evidence to nobody: `restored` was
-  // on /api/scan/status and nothing in the interface read it, so somebody who
-  // put a drive back saw flags quietly disappear and no statement that
-  // anything had been recovered.
-  const first = await upload(request, FIRST);
-  await upload(request, SECOND);
-  await scanAndWait(request);
-  const bytes = fs.readFileSync(filePath(FIRST));
-
-  // Gone, and marked - the other one stays, so this is an ordinary
-  // reconciliation rather than the refused empty-library case.
-  fs.rmSync(filePath(FIRST));
-  const marked = await scanAndWait(request);
-  expect(marked.refused, JSON.stringify(marked)).toBe(false);
-  expect(marked.missing).toBe(1);
-  // Nothing to report yet, so nothing is reported. Asserted before the notice
-  // appears, so the notice below is known to be caused by the recovery rather
-  // than being permanently on the page.
-  await page.goto("/#/");
-  await expect(page.locator(`.card[href="#/score/${first.id}"] .missing-flag`)).toBeVisible();
-  await expect(page.locator(".scan-note")).toHaveCount(0);
-
-  // Back at the path it left from.
-  fs.writeFileSync(filePath(FIRST), bytes);
-  const recovered = await scanAndWait(request);
-  expect(recovered.restored, JSON.stringify(recovered)).toBe(1);
-
-  await page.reload();
-  const note = page.locator(".scan-note");
-  await expect(note).toBeVisible();
-  await expect(note).toContainText("1 score found again");
-  await expect(note).toContainText("at the path it went missing from");
-  // ...and the flag really has gone, so the statement and the library agree.
-  await expect(page.locator(`.card[href="#/score/${first.id}"] .missing-flag`)).toHaveCount(0);
-});
-
 test("a refused scan says so on the page, and can be confirmed", async ({ page, request }) => {
   await upload(request, FIRST);
   await upload(request, SECOND);
@@ -243,4 +200,55 @@ test("a refused scan says so on the page, and can be confirmed", async ({ page, 
     expect(row, `${name} was deleted rather than marked`).toBeTruthy();
     expect(row.missing_since).toBeTruthy();
   }
+});
+
+// LAST IN THIS FILE, and that is not tidiness. Sitting between the two tests
+// above it, this one changed what scans had happened just before the refusal
+// test ran, and that test began failing in CI on an assertion about the
+// acknowledge token - green locally, red on a slower runner. The file's other
+// tests are older than this one and were passing; the ordering that keeps them
+// seeing exactly the state they saw before is the ordering they had. Anything
+// added here belongs after them, for the same reason the whole file is named to
+// sort last.
+test("a scan that found a missing file again says so, rather than only clearing the flag", async ({
+  page,
+  request,
+}) => {
+  // Issue #103. The scanner counts rows whose file turned up again AT THE PATH
+  // IT LEFT FROM - deliberately not a content-hash relink, which is a guess
+  // about identity - specifically so the count can stand as evidence that a
+  // remount really did recover. It stood as evidence to nobody: `restored` was
+  // on /api/scan/status and nothing in the interface read it, so somebody who
+  // put a drive back saw flags quietly disappear and no statement that
+  // anything had been recovered.
+  const first = await upload(request, FIRST);
+  await upload(request, SECOND);
+  await scanAndWait(request);
+  const bytes = fs.readFileSync(filePath(FIRST));
+
+  // Gone, and marked - the other one stays, so this is an ordinary
+  // reconciliation rather than the refused empty-library case.
+  fs.rmSync(filePath(FIRST));
+  const marked = await scanAndWait(request);
+  expect(marked.refused, JSON.stringify(marked)).toBe(false);
+  expect(marked.missing).toBe(1);
+  // Nothing to report yet, so nothing is reported. Asserted before the notice
+  // appears, so the notice below is known to be caused by the recovery rather
+  // than being permanently on the page.
+  await page.goto("/#/");
+  await expect(page.locator(`.card[href="#/score/${first.id}"] .missing-flag`)).toBeVisible();
+  await expect(page.locator(".scan-note")).toHaveCount(0);
+
+  // Back at the path it left from.
+  fs.writeFileSync(filePath(FIRST), bytes);
+  const recovered = await scanAndWait(request);
+  expect(recovered.restored, JSON.stringify(recovered)).toBe(1);
+
+  await page.reload();
+  const note = page.locator(".scan-note");
+  await expect(note).toBeVisible();
+  await expect(note).toContainText("1 score found again");
+  await expect(note).toContainText("at the path it went missing from");
+  // ...and the flag really has gone, so the statement and the library agree.
+  await expect(page.locator(`.card[href="#/score/${first.id}"] .missing-flag`)).toHaveCount(0);
 });

--- a/web/tests/minimum-tests.js
+++ b/web/tests/minimum-tests.js
@@ -37,7 +37,24 @@
 // that a refused reconciliation says so on the page and can be confirmed. Both
 // were shown to fail against a mutation of the behaviour they claim - the whole
 // point of them is that the guard #95 added was invisible until they existed.
-export const MINIMUM_TESTS = 185;
+// Plus 14 for issues #102 and #103 - the application knowing it guessed and
+// not saying so. 2 in tests/browser/metronome-everywhere.spec.js (a score that
+// prints no tempo, and a transcription whose document declares none, both of
+// which used to read "marked ♩ = 120"; the two honesty tests that were already
+// there both use fixtures that DECLARE a tempo, which is why the guard meant to
+// catch this was never exercised and was in fact dead code), 4 in
+// tests/browser/score-compare-warnings.spec.js (an assumed meter/key/tuning
+// saying so beside the staff, a read one saying that instead, a row that
+// records neither claiming neither, and the mark gig mode keeps), 1 in
+// tests/browser/practice.spec.js (a practice day that was inferred rather than
+// recorded), 1 in tests/browser/zz-library-missing.spec.js (a scan that found a
+// missing file again saying so), 5 in tests/unit/provenance.spec.js (the
+// read-versus-assumed sorting itself, including what it does with a source
+// string it does not recognise) and 1 in tests/unit/practice.spec.js (how much
+// of a week's total rests on an inferred day). Raised deliberately, and every
+// one of the 14 was shown to fail against a mutation of the behaviour it claims
+// - see the pull request.
+export const MINIMUM_TESTS = 199;
 
 export default class MinimumTests {
   constructor() {

--- a/web/tests/minimum-tests.js
+++ b/web/tests/minimum-tests.js
@@ -37,12 +37,14 @@
 // that a refused reconciliation says so on the page and can be confirmed. Both
 // were shown to fail against a mutation of the behaviour they claim - the whole
 // point of them is that the guard #95 added was invisible until they existed.
-// Plus 14 for issues #102 and #103 - the application knowing it guessed and
-// not saying so. 2 in tests/browser/metronome-everywhere.spec.js (a score that
+// Plus 15 for issues #102 and #103 - the application knowing it guessed and
+// not saying so. 3 in tests/browser/metronome-everywhere.spec.js (a score that
 // prints no tempo, and a transcription whose document declares none, both of
 // which used to read "marked ♩ = 120"; the two honesty tests that were already
 // there both use fixtures that DECLARE a tempo, which is why the guard meant to
-// catch this was never exercised and was in fact dead code), 4 in
+// catch this was never exercised and was in fact dead code - plus the opposite
+// error, a score whose tempo mark sits in a later bar, which the first version
+// of that fix affirmatively told the reader had no tempo at all), 4 in
 // tests/browser/score-compare-warnings.spec.js (an assumed meter/key/tuning
 // saying so beside the staff, a read one saying that instead, a row that
 // records neither claiming neither, and the mark gig mode keeps), 1 in
@@ -52,9 +54,11 @@
 // read-versus-assumed sorting itself, including what it does with a source
 // string it does not recognise) and 1 in tests/unit/practice.spec.js (how much
 // of a week's total rests on an inferred day). Raised deliberately, and every
-// one of the 14 was shown to fail against a mutation of the behaviour it claims
-// - see the pull request.
-export const MINIMUM_TESTS = 199;
+// one of the 15 was shown to fail against a mutation of the behaviour it claims
+// - see the pull request. Two of them also assert PLACEMENT and not only text,
+// because both of those facts were rendered in the wrong place while every
+// assertion about their wording passed.
+export const MINIMUM_TESTS = 200;
 
 export default class MinimumTests {
   constructor() {

--- a/web/tests/minimum-tests.js
+++ b/web/tests/minimum-tests.js
@@ -37,28 +37,38 @@
 // that a refused reconciliation says so on the page and can be confirmed. Both
 // were shown to fail against a mutation of the behaviour they claim - the whole
 // point of them is that the guard #95 added was invisible until they existed.
-// Plus 15 for issues #102 and #103 - the application knowing it guessed and
-// not saying so. 3 in tests/browser/metronome-everywhere.spec.js (a score that
-// prints no tempo, and a transcription whose document declares none, both of
-// which used to read "marked ♩ = 120"; the two honesty tests that were already
-// there both use fixtures that DECLARE a tempo, which is why the guard meant to
-// catch this was never exercised and was in fact dead code - plus the opposite
-// error, a score whose tempo mark sits in a later bar, which the first version
-// of that fix affirmatively told the reader had no tempo at all), 4 in
-// tests/browser/score-compare-warnings.spec.js (an assumed meter/key/tuning
-// saying so beside the staff, a read one saying that instead, a row that
-// records neither claiming neither, and the mark gig mode keeps), 1 in
-// tests/browser/practice.spec.js (a practice day that was inferred rather than
+// Plus 20 for issues #102 and #103 - the application knowing it guessed and
+// not saying so.
+//
+// 3 in tests/browser/metronome-everywhere.spec.js: a score that prints no
+// tempo, and a transcription whose document declares none, both of which used
+// to read "marked ♩ = 120" (the two honesty tests already there both use
+// fixtures that DECLARE a tempo, which is why the guard meant to catch this was
+// never exercised and was in fact dead code) - plus the opposite error, a score
+// whose tempo mark sits in a later bar, which the first version of that fix
+// affirmatively told the reader had no tempo at all.
+//
+// 7 in tests/browser/score-compare-warnings.spec.js: an assumed meter saying so
+// beside the staff and first in the line, a read one saying that instead, a row
+// that records neither claiming neither, a recognised tuning NAME reported as a
+// name rather than as a tuning that was read, a printed tuning instruction the
+// extractor discards being stated, and the two gig-mode cases - the mark kept
+// for an unread tuning instruction, and NOT kept for a tuning merely assumed
+// standard, which is two thirds of the library.
+//
+// 1 in tests/browser/practice.spec.js (a practice day assumed rather than
 // recorded), 1 in tests/browser/zz-library-missing.spec.js (a scan that found a
-// missing file again saying so), 5 in tests/unit/provenance.spec.js (the
-// read-versus-assumed sorting itself, including what it does with a source
-// string it does not recognise) and 1 in tests/unit/practice.spec.js (how much
-// of a week's total rests on an inferred day). Raised deliberately, and every
-// one of the 15 was shown to fail against a mutation of the behaviour it claims
-// - see the pull request. Two of them also assert PLACEMENT and not only text,
-// because both of those facts were rendered in the wrong place while every
-// assertion about their wording passed.
-export const MINIMUM_TESTS = 200;
+// missing file again saying so), 7 in tests/unit/provenance.spec.js (the
+// read-versus-assumed sorting, what it does with a source string it does not
+// recognise, and the three things it may say about a tuning - name recognised,
+// instruction unread, nothing) and 1 in tests/unit/practice.spec.js (how much
+// of a week's total rests on an assumed day).
+//
+// Raised deliberately, and every one of the 20 was shown to fail against a
+// mutation of the behaviour it claims - see the pull request. Two of them also
+// assert PLACEMENT and not only text, because both of those facts were rendered
+// in the wrong place while every assertion about their wording passed.
+export const MINIMUM_TESTS = 205;
 
 export default class MinimumTests {
   constructor() {

--- a/web/tests/unit/practice.spec.js
+++ b/web/tests/unit/practice.spec.js
@@ -316,6 +316,31 @@ test("a week states its days and its total, or says plainly there was none", () 
   expect(periodStatement(null)).toBe("No practice recorded this week");
 });
 
+test("a week says how much of its total rests on a day nobody recorded, and says nothing when none does", () => {
+  // Issue #103. A single session has always said whether its day was recorded
+  // or taken from its UTC timestamp; the total said nothing, so a window
+  // spanning the upgrade added two different kinds of day together with
+  // nothing marking the join - and the server had been reporting the figure to
+  // nobody ever since.
+  expect(periodStatement({ days_practised: 4, seconds: 12000, sessions_inferred: 2 })).toBe(
+    "4 days, 3h 20m (2 sessions on an inferred day)",
+  );
+  expect(periodStatement({ days_practised: 1, seconds: 600, sessions_inferred: 1 })).toBe(
+    "1 day, 10m (1 session on an inferred day)",
+  );
+  // Silent when there is nothing to disclose, which on any install that has
+  // only ever run this version is always - a note that appears every week
+  // stops being read.
+  expect(periodStatement({ days_practised: 4, seconds: 12000, sessions_inferred: 0 })).toBe(
+    "4 days, 3h 20m",
+  );
+  expect(periodStatement({ days_practised: 4, seconds: 12000 })).toBe("4 days, 3h 20m");
+  // And it is still said in the vocabulary this feature is allowed to use.
+  expect(
+    forbiddenWord(periodStatement({ days_practised: 4, seconds: 12000, sessions_inferred: 2 })),
+  ).toBeNull();
+});
+
 test("a past week does not call itself this week", () => {
   // It did, for every row in the review - so a quiet spell in July rendered as
   // three consecutive rows reading "No practice recorded this week" beside

--- a/web/tests/unit/practice.spec.js
+++ b/web/tests/unit/practice.spec.js
@@ -323,10 +323,10 @@ test("a week says how much of its total rests on a day nobody recorded, and says
   // nothing marking the join - and the server had been reporting the figure to
   // nobody ever since.
   expect(periodStatement({ days_practised: 4, seconds: 12000, sessions_inferred: 2 })).toBe(
-    "4 days, 3h 20m (2 sessions on an inferred day)",
+    "4 days, 3h 20m (2 sessions on an assumed day)",
   );
   expect(periodStatement({ days_practised: 1, seconds: 600, sessions_inferred: 1 })).toBe(
-    "1 day, 10m (1 session on an inferred day)",
+    "1 day, 10m (1 session on an assumed day)",
   );
   // Silent when there is nothing to disclose, which on any install that has
   // only ever run this version is always - a note that appears every week

--- a/web/tests/unit/provenance.spec.js
+++ b/web/tests/unit/provenance.spec.js
@@ -14,12 +14,11 @@ import {
   keySignatureLabel,
   sourceKind,
   transcriptionProvenance,
-  tuningDescription,
+  tuningStatement,
 } from "../../src/lib/provenance.js";
 
 // The extraction result for a score where nothing could be read - the common
-// case, not the corner one: 18% of first pages lose their printed meter and
-// every score not literally labelled "Drop D" reads as standard tuning.
+// case, not the corner one: 18% of first pages lose their printed meter.
 const ASSUMED_EVERYTHING = {
   time_signature: [4, 4],
   time_signature_source: "not detected (assumed 4/4)",
@@ -27,12 +26,13 @@ const ASSUMED_EVERYTHING = {
   key_signature_source: "not detected (assumed no key signature)",
   tuning: ["E2", "A2", "D3", "G3", "B3", "E4"],
   tuning_label: null,
+  tuning_unread: [],
 };
 
 test("what the extractor read and what it assumed end up in different groups", () => {
   const assumed = transcriptionProvenance(ASSUMED_EVERYTHING);
   expect(assumed.read).toEqual([]);
-  expect(assumed.assumed).toEqual(["4/4", "no key signature", "standard tuning"]);
+  expect(assumed.assumed).toEqual(["4/4", "no key signature"]);
   expect(assumed.supplied).toEqual([]);
 
   const read = transcriptionProvenance({
@@ -40,10 +40,8 @@ test("what the extractor read and what it assumed end up in different groups", (
     time_signature_source: "glyph-decoded",
     key_fifths: -3,
     key_signature_source: "glyph-decoded",
-    tuning: ["D2", "A2", "D3", "G3", "B3", "E4"],
-    tuning_label: "Drop D",
   });
-  expect(read.read).toEqual(["6/8", "3 flats", "Drop D tuning"]);
+  expect(read.read).toEqual(["6/8", "3 flats"]);
   expect(read.assumed).toEqual([]);
 
   // A meter the person typed into the box beside the transcribe button is
@@ -54,7 +52,19 @@ test("what the extractor read and what it assumed end up in different groups", (
     time_signature_source: "manual override",
   });
   expect(supplied.supplied).toEqual(["3/4"]);
-  expect(supplied.assumed).toEqual(["no key signature", "standard tuning"]);
+  expect(supplied.assumed).toEqual(["no key signature"]);
+
+  // THE TUNING IS NOT IN ANY OF THEM, whatever it holds - see tuningStatement
+  // for both reasons. It was, and it was wrong in one direction and useless in
+  // the other.
+  for (const tuning of [
+    { tuning: ["E2", "A2", "D3", "G3", "B3", "E4"], tuning_label: null },
+    { tuning: ["D2", "A2", "D3", "G3", "B3", "E4"], tuning_label: "Drop D" },
+  ]) {
+    const groups = transcriptionProvenance({ ...ASSUMED_EVERYTHING, ...tuning });
+    const said = [...groups.read, ...groups.assumed, ...groups.supplied].join(" ");
+    expect(said, JSON.stringify(tuning)).not.toMatch(/tuning|Drop D/);
+  }
 });
 
 test("a row that records nothing claims nothing, in either direction", () => {
@@ -66,6 +76,7 @@ test("a row that records nothing claims nothing, in either direction", () => {
     expect(groups.read, JSON.stringify(t)).toEqual([]);
     expect(groups.assumed, JSON.stringify(t)).toEqual([]);
     expect(groups.supplied, JSON.stringify(t)).toEqual([]);
+    expect(tuningStatement(t), JSON.stringify(t)).toBeNull();
   }
 });
 
@@ -92,29 +103,61 @@ test("a source string this version does not know is reported as neither, rather 
   expect(groups.assumed).not.toContain("4/4");
 });
 
-test("an unlabelled tuning that is not the standard one is neither read nor assumed", () => {
-  expect(tuningDescription(["E2", "A2", "D3", "G3", "B3", "E4"], null)).toBe("standard tuning");
-  expect(tuningDescription(["D2", "A2", "D3", "G3", "B3", "E4"], "Drop D")).toBe("Drop D tuning");
-  // The case #80 makes reachable. A tuning that demonstrably differs from
-  // standard cannot have come from an assumption OF standard, so "assumed"
-  // there is a false accusation - and nothing records where it did come from.
-  // Same rule sourceKind follows on an unrecognised source: report neither.
-  expect(tuningDescription(["C2", "G2", "C3", "F3", "A3", "D4"], null)).toBeNull();
-  // Seven strings, the first six of them standard - length has to count, or an
-  // extended-range instrument is described as a six-string in standard.
-  expect(tuningDescription(["E2", "A2", "D3", "G3", "B3", "E4", "A4"], null)).toBeNull();
-  expect(tuningDescription(null, null)).toBeNull();
-  expect(tuningDescription([], null)).toBeNull();
+test("a recognised tuning name is stated as a name, and never as a tuning that was read", () => {
+  // The extractor finds a tuning by matching the words "Drop D" in the page
+  // text. That is recognition of a label. 100 scores match and all sampled
+  // matches are genuine - but a name is not the six strings, and the words for
+  // the two must differ.
+  const named = tuningStatement({ ...ASSUMED_EVERYTHING, tuning_label: "Drop D" });
+  expect(named.kind).toBe("recognised");
+  expect(named.text).toBe("Tuning: the page names Drop D. Nothing else about the tuning was read.");
+  expect(named.text).not.toMatch(/\bread from the page\b/i);
+});
 
-  // ...and it reaches no group at all, rather than quietly landing in
-  // "assumed" the way an unlabelled standard tuning correctly does.
-  const groups = transcriptionProvenance({
+test("a printed tuning instruction the extractor discards makes the tuning incomplete, and says which", () => {
+  // 41 of those 100 carry one of these: 9 a half-step-down direction, 32 a
+  // capo. The recorded array is then a semitone out, or every sounding pitch
+  // is, while looking exactly like something that was read.
+  const capo = tuningStatement({
     ...ASSUMED_EVERYTHING,
-    tuning: ["C2", "G2", "C3", "F3", "A3", "D4"],
-    tuning_label: null,
+    tuning_label: "Drop D",
+    tuning_unread: ["capo 2"],
   });
-  expect(groups.assumed).toEqual(["4/4", "no key signature"]);
-  expect(groups.read).toEqual([]);
+  expect(capo.kind).toBe("incomplete");
+  expect(capo.text).toBe(
+    "Tuning: the page names Drop D, and also says capo 2, which Fermata does not read " +
+      "— so the pitches sounded are not the pitches printed.",
+  );
+
+  // With no name recognised at all, and with more than one instruction.
+  const bare = tuningStatement({
+    ...ASSUMED_EVERYTHING,
+    tuning_unread: ["tune down a half step", "capo 3"],
+  });
+  expect(bare.kind).toBe("incomplete");
+  expect(bare.text).toBe(
+    "Tuning: the page says tune down a half step and capo 3, which Fermata does not read " +
+      "— so the pitches sounded are not the pitches printed.",
+  );
+});
+
+test("a tuning with nothing real to say about it says nothing", () => {
+  // The 193-of-293 case: standard strings, no name found. True, uninformative,
+  // and stating it put the unverified mark on two thirds of the library.
+  expect(tuningStatement(ASSUMED_EVERYTHING)).toBeNull();
+  // And the case #80 makes reachable: unlabelled and NOT standard. A tuning
+  // that demonstrably differs from standard cannot have come from an assumption
+  // OF standard, so "assumed" there is a false accusation - and nothing records
+  // where it did come from. Same rule sourceKind follows on an unrecognised
+  // source.
+  expect(
+    tuningStatement({ ...ASSUMED_EVERYTHING, tuning: ["C2", "G2", "C3", "F3", "A3", "D4"] }),
+  ).toBeNull();
+  // Seven strings, the first six of them standard - length has to count, or an
+  // extended-range instrument is treated as a six-string in standard.
+  expect(
+    tuningStatement({ ...ASSUMED_EVERYTHING, tuning: ["E2", "A2", "D3", "G3", "B3", "E4", "A4"] }),
+  ).toBeNull();
 });
 
 test("a key signature is said the way a person would say it", () => {

--- a/web/tests/unit/provenance.spec.js
+++ b/web/tests/unit/provenance.spec.js
@@ -1,0 +1,118 @@
+// How a transcription's meter, key and tuning are sorted into "read off the
+// page" and "assumed", called directly - no browser, no backend. provenance.js
+// has no runes and no imports precisely so this can import it.
+//
+// The wording IS the feature here, the same way it is in practice.js: a line
+// that puts an assumed 4/4 in the read group has failed at the one thing it
+// exists for. What is NOT tested here is whether any of it reaches a screen -
+// that is tests/browser/score-compare-warnings.spec.js's job, and a suite that
+// only checked these strings would have proved nothing about the defect issue
+// #103 is actually about, which was six fields computed and never displayed.
+import { expect, test } from "@playwright/test";
+
+import {
+  keySignatureLabel,
+  sourceKind,
+  transcriptionProvenance,
+  tuningDescription,
+} from "../../src/lib/provenance.js";
+
+// The extraction result for a score where nothing could be read - the common
+// case, not the corner one: 18% of first pages lose their printed meter and
+// every score not literally labelled "Drop D" reads as standard tuning.
+const ASSUMED_EVERYTHING = {
+  time_signature: [4, 4],
+  time_signature_source: "not detected (assumed 4/4)",
+  key_fifths: 0,
+  key_signature_source: "not detected (assumed no key signature)",
+  tuning: ["E2", "A2", "D3", "G3", "B3", "E4"],
+  tuning_label: null,
+};
+
+test("what the extractor read and what it assumed end up in different groups", () => {
+  const assumed = transcriptionProvenance(ASSUMED_EVERYTHING);
+  expect(assumed.read).toEqual([]);
+  expect(assumed.assumed).toEqual(["4/4", "no key signature", "standard tuning"]);
+  expect(assumed.supplied).toEqual([]);
+
+  const read = transcriptionProvenance({
+    time_signature: [6, 8],
+    time_signature_source: "glyph-decoded",
+    key_fifths: -3,
+    key_signature_source: "glyph-decoded",
+    tuning: ["D2", "A2", "D3", "G3", "B3", "E4"],
+    tuning_label: "Drop D",
+  });
+  expect(read.read).toEqual(["6/8", "3 flats", "Drop D tuning"]);
+  expect(read.assumed).toEqual([]);
+
+  // A meter the person typed into the box beside the transcribe button is
+  // neither, and saying so confirms it was actually used.
+  const supplied = transcriptionProvenance({
+    ...ASSUMED_EVERYTHING,
+    time_signature: [3, 4],
+    time_signature_source: "manual override",
+  });
+  expect(supplied.supplied).toEqual(["3/4"]);
+  expect(supplied.assumed).toEqual(["no key signature", "standard tuning"]);
+});
+
+test("a row that records nothing claims nothing, in either direction", () => {
+  // Every hand-edited row, and every row extracted before the provenance was
+  // stored. "standard tuning assumed" would be inventing a reading of content
+  // nothing has looked at; "read from the page" would be worse.
+  for (const t of [null, undefined, {}, { source: "edited", warnings: [] }]) {
+    const groups = transcriptionProvenance(t);
+    expect(groups.read, JSON.stringify(t)).toEqual([]);
+    expect(groups.assumed, JSON.stringify(t)).toEqual([]);
+    expect(groups.supplied, JSON.stringify(t)).toEqual([]);
+  }
+});
+
+test("a source string this version does not know is reported as neither, rather than guessed at", () => {
+  // The safe-looking default in both directions is wrong: calling an
+  // unrecognised future source "read" is the exact lie this file exists to
+  // prevent, and calling it "assumed" is a false accusation about a value that
+  // may well have been decoded off the page.
+  expect(sourceKind("decoded-by-some-later-method")).toBeNull();
+  expect(sourceKind("")).toBeNull();
+  expect(sourceKind(null)).toBeNull();
+  expect(sourceKind(undefined)).toBeNull();
+  expect(sourceKind("glyph-decoded")).toBe("read");
+  expect(sourceKind("auto-detected")).toBe("read");
+  expect(sourceKind("manual override")).toBe("supplied");
+  expect(sourceKind("not detected")).toBe("assumed");
+  expect(sourceKind("not detected (assumed 4/4)")).toBe("assumed");
+
+  const groups = transcriptionProvenance({
+    ...ASSUMED_EVERYTHING,
+    time_signature_source: "decoded-by-some-later-method",
+  });
+  expect(groups.read).not.toContain("4/4");
+  expect(groups.assumed).not.toContain("4/4");
+});
+
+test("a tuning is described by what it actually is, never by a word that would be wrong", () => {
+  expect(tuningDescription(["E2", "A2", "D3", "G3", "B3", "E4"], null)).toBe("standard tuning");
+  expect(tuningDescription(["D2", "A2", "D3", "G3", "B3", "E4"], "Drop D")).toBe("Drop D tuning");
+  // Unlabelled and NOT the standard six: "standard tuning" would be a claim
+  // about something nobody checked, so the strings are named instead.
+  expect(tuningDescription(["C2", "G2", "C3", "F3", "A3", "D4"], null)).toBe(
+    "tuning C2 G2 C3 F3 A3 D4",
+  );
+  // Seven strings, the first five of them standard - length has to count, or
+  // an extended-range instrument is described as a six-string in standard.
+  expect(tuningDescription(["B1", "E2", "A2", "D3", "G3", "B3", "E4"], null)).toBe(
+    "tuning B1 E2 A2 D3 G3 B3 E4",
+  );
+  expect(tuningDescription(null, null)).toBeNull();
+  expect(tuningDescription([], null)).toBeNull();
+});
+
+test("a key signature is said the way a person would say it", () => {
+  expect(keySignatureLabel(0)).toBe("no key signature");
+  expect(keySignatureLabel(1)).toBe("1 sharp");
+  expect(keySignatureLabel(4)).toBe("4 sharps");
+  expect(keySignatureLabel(-1)).toBe("1 flat");
+  expect(keySignatureLabel(-5)).toBe("5 flats");
+});

--- a/web/tests/unit/provenance.spec.js
+++ b/web/tests/unit/provenance.spec.js
@@ -92,21 +92,29 @@ test("a source string this version does not know is reported as neither, rather 
   expect(groups.assumed).not.toContain("4/4");
 });
 
-test("a tuning is described by what it actually is, never by a word that would be wrong", () => {
+test("an unlabelled tuning that is not the standard one is neither read nor assumed", () => {
   expect(tuningDescription(["E2", "A2", "D3", "G3", "B3", "E4"], null)).toBe("standard tuning");
   expect(tuningDescription(["D2", "A2", "D3", "G3", "B3", "E4"], "Drop D")).toBe("Drop D tuning");
-  // Unlabelled and NOT the standard six: "standard tuning" would be a claim
-  // about something nobody checked, so the strings are named instead.
-  expect(tuningDescription(["C2", "G2", "C3", "F3", "A3", "D4"], null)).toBe(
-    "tuning C2 G2 C3 F3 A3 D4",
-  );
-  // Seven strings, the first five of them standard - length has to count, or
-  // an extended-range instrument is described as a six-string in standard.
-  expect(tuningDescription(["B1", "E2", "A2", "D3", "G3", "B3", "E4"], null)).toBe(
-    "tuning B1 E2 A2 D3 G3 B3 E4",
-  );
+  // The case #80 makes reachable. A tuning that demonstrably differs from
+  // standard cannot have come from an assumption OF standard, so "assumed"
+  // there is a false accusation - and nothing records where it did come from.
+  // Same rule sourceKind follows on an unrecognised source: report neither.
+  expect(tuningDescription(["C2", "G2", "C3", "F3", "A3", "D4"], null)).toBeNull();
+  // Seven strings, the first six of them standard - length has to count, or an
+  // extended-range instrument is described as a six-string in standard.
+  expect(tuningDescription(["E2", "A2", "D3", "G3", "B3", "E4", "A4"], null)).toBeNull();
   expect(tuningDescription(null, null)).toBeNull();
   expect(tuningDescription([], null)).toBeNull();
+
+  // ...and it reaches no group at all, rather than quietly landing in
+  // "assumed" the way an unlabelled standard tuning correctly does.
+  const groups = transcriptionProvenance({
+    ...ASSUMED_EVERYTHING,
+    tuning: ["C2", "G2", "C3", "F3", "A3", "D4"],
+    tuning_label: null,
+  });
+  expect(groups.assumed).toEqual(["4/4", "no key signature"]);
+  expect(groups.read).toEqual([]);
 });
 
 test("a key signature is said the way a person would say it", () => {


### PR DESCRIPTION
Closes #102. Closes #103.

Two issues, one defect: the application already works out that it guessed, and then presents the guess indistinguishably from a reading. #102 is the sharpest single instance; #103 is the pattern.

## #102 — a score that prints no tempo is no longer "marked ♩ = 120"

alphaTab's `Score.tempo` is a getter that answers a hard-coded 120 whenever the first bar holds no tempo automation. So the `?? null` guard meant to catch an undeclared tempo was dead code, and an edition printing *Andante* and no number — most of the classical material in this library — was reported as **"marked ♩ = 120"**.

**The discriminator is not the obvious one.** `score.tempoLabel` is the automation's `text`, and alphaTab's MusicXML importer never sets it: it is `""` for a printed metronome mark of 96 exactly as it is for a document with nothing. What does answer the question is `isVisible` — `ModelUtils.consolidate()` runs at the end of every import and synthesises an invisible automation carrying the 120 fallback when the first bar has none, while every automation built from something actually in the document is visible. Measured against the real importer on three shapes: a `<metronome>` mark, a bare `<sound tempo=>`, and a document with neither.

| the score | before | after |
| --- | --- | --- |
| prints ♩ = 96 | `marked ♩ = 96` | unchanged |
| a transcription of a scanned page | `● transcribed ♩ = 90` | unchanged |
| prints no tempo anywhere | `marked ♩ = 120` | `● assumed 120 bpm (none in the score)` |
| marks a tempo, but in a later bar | `marked ♩ = 120` | `● assumed 120 bpm (none at the start)` |

The renderer now reports the number **and** where it came from, rather than a null the getter can never produce. "Nothing declared" beats "transcribed": the extractor emits no tempo direction at all when it read none off the PDF, so a great many real transcriptions have this shape, and the 120 was not lifted out of a scanned page either.

**The last row is a correction from review, and it is the important one.** The first version of this fix looked only at the *first* master bar, so a score whose tempo mark sits further in - it opens with a pickup, or the exporter attached the mark to the first real note - was classified as declaring no tempo, and the control then *printed* that the score has none. The number was still right, because the fallback is genuinely what applies before the mark; the statement about the document was not. That is #102 with the sign flipped and strictly worse than #102: failing to mention a fact is not the same size of mistake as asserting a false one, and it is exactly the false-accusation direction this work was meant to guard.

So the provenance is three-valued - `"start"`, `"later"`, `"none"` - and only `"none"` may say the score carries no tempo. `"(none at the start)"` is a claim about the number rather than about the document, and is true in both cases. The test for `"start"` is about `automations[0]` rather than about any visible automation in bar one, because index 0 is exactly the entry `score.tempo` reads: `consolidate()` only ever *appends* its synthesised entry, so a real automation in bar one - even one attached part-way through it - is always index 0.

**And the fallback is not written in engraver's notation.** "default ♩ = 120" put our own choice in the notation of a marking, for a number nobody engraved, which quietly undercut the sentence saying it was not one. Notation for what an engraver wrote; plain words for what we chose.

The clause is visible text, not a title attribute, and takes a second line in the viewer's toolbar rather than pushing the profile buttons off the end of it.

**The mode selector no longer contradicts it.** Where the score declares no tempo it offers "% of assumed tempo" rather than "% of score tempo" — two labels on one control disagreeing is worse than either being wrong alone. The control itself stays: the click has to run at something, and 100% of the assumed tempo is exactly what it runs at.

## #103 — provenance that was computed and never displayed

All six fields now reach the screen, each next to the value it qualifies, in visible text. The pattern is the rhythm confidence mark and the warning summary: state the fact quietly beside the thing it describes, and never behind a hover.

**`time_signature_source`, `key_signature_source`** — one quiet line directly above the staff, the assumed clause first:

> ● Assumed, not read from the page: 4/4, no key signature.

> Read from the page: 6/8, 2 sharps.

Outside the collapsible warnings block on purpose: a read meter is good news, an assumed one is a standing fact about the transcription, and both are true whether or not the score has any warnings.

**`tuning_label` — and this is where review changed the design.** The first version put the tuning in those same two groups, and it was wrong in one direction and noise in the other.

*Wrong:* the extractor finds a tuning by matching the words "Drop D" in the page text. 100 scores match, and the matches are genuine — but **41 of those 100 carry a further printed instruction the extractor discards**: 9 say to tune every string down a half step, so the recorded array is a semitone out, and 32 name a capo, so every sounding pitch is out. That is 14% of the library described as a tuning "read from the page". Before this work the partial reading was silent, which is exactly #103's complaint; promoting it to an affirmative claim made it worse.

*Noise:* an unlabelled tuning is standard by assumption on **193 of 293** scores. Stating that put the unverified mark on two thirds of the library — the desensitisation the always-on argument exists to prevent, one level down — and it was the least informative thing the line said.

So the extractor now **detects what it discards** and records it as `tuning_unread`. Detection only: nothing changes `tuning`, the emitted MusicXML, or any sounding pitch. Parsing them is #80's job; knowing we cannot claim a complete reading is this change's. The interface then says one of three things, or nothing:

> Tuning: the page names Drop D. Nothing else about the tuning was read.

> ● Tuning: the page names Drop D, and also says capo 2, which Fermata does not read — so the pitches sounded are not the pitches printed.

> *(a standard tuning nobody named — silence)*

The one false positive that matters is guarded and tested: **"da capo" is a repeat instruction**, classical sheet music is full of them, and matching one would be its own false statement. Only the *incomplete* case carries the unverified mark, in the line and in gig mode, so the mark now lands on the scores that have a real caveat rather than on two thirds of the library.

**On #80's argument that the tuning belongs on the staff at the first bar:** not reached, and it is worth saying why rather than quietly settling. Drawing into the staff means either the renderer's own glyph layer or a `<staff-details>` change in `musicxml.py`, which this work was asked to leave alone. What it did reach is the line immediately above the rendered staff — which, on a tab score, is immediately above alphaTab's own "Guitar Standard Tuning" legend. That is close, and it is not the same thing.

**`local_date_source`** — beside the date on every session row: `2026-08-22 assumed`, with one sentence under the list saying what that means and where the day came from. Only when the day was worked out from the row's UTC timestamp, which for practice logged before the day was stored at all is every row.

**`sessions_inferred`** — in the week's own statement: `4 days, 3h 20m (2 sessions on an assumed day)`. Silent at zero, which on any install that has only ever run this version is always.

**`restored`** — a quiet line on the library page: `Last scan: 1 score found again at the path it went missing from.` The scanner computes this precisely so it can stand as evidence that a remount really did recover (deliberately not counting a content-hash relink, which is a guess about identity) — and it stood as evidence to nobody.

A source string this version does not recognise is reported as **neither**. Calling an unrecognised future source "read" would be the exact lie this exists to prevent, and calling it "assumed" would be a false accusation about a value that may well have been decoded off the page.

The same rule covers a tuning that is neither labelled nor standard: it cannot have come from an assumption *of* standard, so it reports neither. Unreachable today, reachable the moment #80 widens the recognition.

**Two words, used everywhere.** `read` for what a source told us, `assumed` for what we chose. Four were in use — read, assumed, default, inferred — and learning one taught a reader none of the others. "marked" survives because it is not a synonym: a tempo the engraver printed *is* a marking.

## One server change, and why

The meter, key and tuning now travel into the stored `confidence` blob **with their sources**, exactly the way the Rule 8 bar counts already do, and are lifted back out on both GET and POST so the two answer from one source. They existed only on the `POST /transcribe` response, so every later read of the same row — every ordinary visit to a score — handed back the assumed value with nothing saying it was assumed. It is not recoverable from the warning prose either: the meter's absence is narrated, the key's is narrated differently, and a tuning nobody recognised produces no warning at all. A hand-edited row states them as `null` — "not recorded" — rather than keeping the extraction's answer, the same rule and for the same reason as the bar counts.

**One further server change, added at review's request:** `tabextract.py` now recognises the tuning instructions it discards — a half-step-down direction, a capo — and reports them as `tuning_unread`, plus one warning sentence so a reader with only the API learns of it too. Recognition, not parsing: `tuning`, the emitted `<staff-tuning>` and every sounding pitch are untouched. Without it there is no way to know a reading is partial, and no way to avoid claiming it is complete.

## Not in scope

The underlying detection bugs are untouched. #90 (18% of first pages lose their printed meter) and #80 (every score not literally labelled "Drop D" reads as standard tuning) are owned elsewhere. This change makes an existing guess visible, nothing more.

## Tests

**185 → 205** browser/unit tests, plus two server tests. Every one of the 20 new tests was shown red against a mutation of the behaviour it claims:

| test | mutation that reddened it |
| --- | --- |
| a score that prints no tempo calls the number a default | `tempoProvenance` → `return "start"` |
| a score marked in a later bar is not told it has none | `tempoProvenance` → stop scanning past bar one (the reviewed defect, reinstated) |
| the default note occupies exactly two lines, toolbar unclipped | the parenthetical back to `display: inline` |
| a transcription declaring none says default, not transcribed | swap the ternary so `tex != null` wins over "not declared" |
| an assumed meter says so beside the staff, first in the line | `sourceKind`: assumed prefix → `"read"`; and separately, the read clause moved back in front |
| a meter that WAS read says that instead | `sourceKind`: read sources → `"assumed"` |
| a row recording no provenance claims neither | `tuningDescription`: absent tuning → `"standard tuning"` |
| a recognised tuning name is a name, not a reading | the tuning back in the read/assumed groups; and separately, the name reported as `"read from the page"` |
| a discarded tuning instruction is stated | `tuningStatement` ignores `tuning_unread` |
| the mode selector does not contradict its neighbour | the option label back to `"% of score tempo"` |
| gig mode keeps a mark for an unread tuning instruction | drop the provenance clause from `gigMarkTitle`; ignore `tuning_unread` |
| gig mode keeps NO mark for a merely-assumed standard tuning | the tuning back in the assumed group |
| a practice day nobody recorded says so | invert the condition to `=== "recorded"`; drop the `sessions_inferred` clause; and put the grid track back to 92px, which drops the badge below the date |
| a scan that found a file again says so | render `scan.missing` in place of `scan.restored`; and `{#if scan?.missing}` for the condition |
| read/assumed/supplied sorting (unit) | both `sourceKind` mutations above |
| a row recording nothing claims nothing (unit) | `tuningDescription` mutation above |
| an unrecognised source is neither (unit) | `sourceKind`: assumed prefix → `"read"` |
| the three things that may be said about a tuning (unit) | each of the three mutations above |
| "da capo" is not a capo instruction (server) | drop the lookbehind from the capo pattern |
| a key signature is said as a person would (unit) | drop the pluralisation |
| a week says how much rests on an inferred day (unit) | drop the `sessions_inferred` clause |
| provenance survives a reload (server) | stop writing the keys into the stored blob; stop writing `tuning_unread` |

Three things the new tests were written to avoid, the third added by review. Every assertion is on **rendered** text, never on a value the component derived on the way there — including the #102 test, which also measures the real audio-clock rate to prove the number called a default is the number actually clicked. And every "this is not shown" assertion is anchored on an element another test proves can match: `.provenance .prov-read` inside a block the sibling test renders, `.metronome-base` on the same route, `.session-day` proven by the row assertions already in that file. The practice test identifies the marked row by its own session id, because both sessions land on the same date and "one row is marked" would otherwise be satisfied by marking the wrong one.

**Presence is not placement.** Two of these facts rendered in the wrong place while every assertion about their wording passed: the default-tempo note wrapped to a fragile number of lines under a `ch` cap, and the inferred-day badge landed *below* the date instead of beside it, sharing a 92px grid track with it. Both are now asserted on geometry - line count, and the badge's own box against the date's - and both mutations above are exactly the states that shipped.

**The timezone flake was real, not theoretical.** An inferred session has no recorded day, so the server files it under its UTC day while the page asks for the week around the practiser's local one; in a negative offset late on a Sunday those are different weeks and the row is simply not on screen. The test pins UTC and checks the pin took effect, so a pin that stops working fails with a reason rather than as a missing row. The disagreement itself is written down in `docs/practice-data.md`: storing the day is what fixed this going forward and is why the column exists, and a row predating the column cannot be fixed that way - so the badge is carrying two facts at once, that the day was not recorded and that the week it landed in is not necessarily the practiser's own.

The new no-tempo fixture closes the coverage gap that let #102 through in the first place: both existing honesty tests for that control use fixtures which **declare** a tempo, which is why the dead guard was never exercised.

## What a person should look at

This change is about what a human reads, so the parts that cannot be settled by a test:

- **The wording.** "Assumed, not read from the page", "assumed 120 bpm (none in the score)" / "(none at the start)", "Tuning: the page names Drop D", and "assumed" beside a date are judgement calls. They are pinned character for character in the tests, so changing one is a deliberate act, but whether they are the *right* words is a reading decision.
- **The provenance line's weight.** The meter/key line is still always present on any transcription that recorded provenance, including the good case where both were read. That is deliberate — a notice that only appears when something is wrong teaches people to read it as an error — but it is one more line above every staff. Worth knowing before judging how informative it is: **158 of the 240 meters reported as read are 4/4, and 92 of 289 read keys have no accidentals**, so two thirds of "read" meter claims are textually identical to an assumed score's apart from the verb. Not a defect — a genuine 4/4 decoded from glyphs is a real reading — but it is the honest ceiling on what that line tells a reader.
- **Whether the tuning should say anything at all when it is merely assumed standard.** It now says nothing, on the 193-of-293 case. The argument for silence is that the mark has to stay rare to mean anything and that the staff draws its own tuning legend right below; the argument against is that silence is what #103 was filed about. This is the judgement I am least certain of.
- **Whether the metronome should still offer a proportion at all** when the score declares no tempo. It does, now labelled "% of assumed tempo", because removing a control hides the fact rather than stating it and #102 asks for the latter. A percentage of an assumed tempo is still a percentage of a number nobody printed.
- **How well the discarded-instruction detection actually fires on the real library.** The patterns are unit-tested against the phrasings review reported and against the "da capo" trap, but I have no sheet music library here, so the 41-of-100 figure is review's measurement and not something I re-ran end to end. If the real phrasings are more varied than the tested set, the effect is silence rather than a false claim — which is the safe direction, but it means the coverage figure is unverified by me.
- **Narrow viewports.** The two-line assumed-tempo note is measured not to overflow the toolbar at 1280px, and review measured it adding zero overflow from 1280 down to 430. The toolbar's own pre-existing clipping is being filed separately. The practice list's first column went 92px → 120px, which every row pays for so that the rows carrying a badge can put it beside the date; the alternative, an auto track, would have left the middle column starting at a different x on those rows, since each row is its own grid.
