### PR TITLE
Hear a note, name it (#61)

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,17 @@ them.
   section work or a run-through, and how it went. Practice that is not a piece
   at all — technique, ear training, simply playing — is recorded the same way
   and in the same history ([the data model](docs/practice-data.md)).
+- **Hear a note, name it** — the first exercise: a pitch sounds, and you name it
+  from four. The three you did not hear are chosen to be worth confusing — a
+  semitone away, the same name an octave out, and one a step or two off — because
+  four notes far apart teaches nothing. Hear it again as often as you like,
+  before and after answering, and nothing counts that. With one instrument
+  defined the drill draws from that instrument's own range; with several it uses
+  a plain four octaves, because Fermata knows what you own and not which one is
+  in your hands. Two counts are stated and nothing is graded: there is no
+  accuracy percentage and no streak, and a note you could not name is what the
+  practice consists of. The time lands in your practice history as ear training
+  and counts towards a weekly goal like anything else.
 - **Weekly goals, and an honest review** — how many days you mean to practise
   and for how long, on what. While the week runs it says where you stand so the
   goal can still change it; afterwards it states plainly what happened and asks

--- a/docs/practice-data.md
+++ b/docs/practice-data.md
@@ -318,6 +318,27 @@ back. See the Backups section of [deployment.md](deployment.md).
   inventing its shape before one exists would be guessing. What the `activity`
   vocabulary guarantees is that when a trainer arrives, the time it accounts
   for lands in the same history and the same goals as everything else.
+
+  One now has. *Hear a note, name it* (`web/src/lib/EarTraining.svelte`) writes
+  one ordinary session with `activity = 'ear_training'`, and everything it knows
+  beyond the time goes in the `note`: how many notes were asked, how many were
+  named as heard, and the range they were drawn from. Nothing about the drill is
+  special-cased anywhere - it shows on the practice page and counts towards a
+  goal exactly as a piece does, which was the whole point of there being one
+  session table.
+
+  That is deliberately still not a per-attempt schema. One exercise is not
+  enough to know what such a table needs: the second and third - fret-to-note,
+  chord recognition - are what should decide whether the unit is a position, an
+  interval, or a pitch, and designing it around the first would be the same
+  guess this section was written to avoid. What the note already proves is that
+  a drill's time and a drill's counts can live here without one.
+
+  Note that a drill records **counts and never a rate**. There is no accuracy
+  percentage in the note, on the page, or anywhere a query could produce one,
+  for the same reason there is no best week: a number out of a hundred is a mark
+  rather than a fact, and it invites a colour. Nothing counts consecutive
+  correct answers either.
 - **Key, tempo and difficulty per score** - musical metadata about the piece
   rather than about the practice.
 - **Achievements** - looking back at what has been accomplished, where a goal

--- a/docs/rendering.md
+++ b/docs/rendering.md
@@ -490,6 +490,61 @@ main-thread task across the whole run is **102 ms**, with none over 250 ms —
 because the renderer chunks the work into partials and only draws the ones on
 screen. That is the trade this one constant represents, if it ever bites.
 
+### Sounding one pitch, and the one number it must never report
+
+`playPitch` makes a single note audible with no score in play. The synthesiser
+is the renderer's, so this seam belongs here; everything above it — a tuning
+check, an ear exercise — does not.
+
+**It resolves with the note actually sounded, read back off the note-on event it
+handed over, or `null`.** Not a success flag, and above all not the note it was
+asked for. That distinction is the whole contract, and it is here because the
+alternative has already cost this project a defect: the instruments editor once
+auditioned the open string instead of the capo'd one, and every assertion passed,
+because they all read the row rather than what crossed this boundary.
+
+The same function then made the same mistake one layer down. It used to end
+`return noteOn ? noteOn.noteKey : key` — substituting the **input** when no
+note-on could be found. The cost of that is worth stating precisely, because it
+is a general lesson about what a green suite means:
+
+| what was broken | noticed, with the fallback | noticed, returning `null` |
+| --- | --- | --- |
+| `playPitch` made unavailable — the path cannot run | **15** | **15** |
+| the note-on never emitted — it runs and sounds nothing | **0** | **15** |
+
+Every caller and every assertion saw the number it expected, because the
+function still returned one. A suite that fails loudly on a **missing**
+dependency while silently accepting that dependency **doing nothing** inspires
+confidence in proportion to what it does not cover, and fifteen-to-zero is a
+measure of how convincing that can feel.
+
+The two columns now agree, and they agree on the *same fifteen tests* — ten in
+`tests/browser/ear-training.spec.js` and five in `tests/browser/instruments.spec.js`,
+which are every test that asks for a pitch to be sounded. That is the shape to
+want: the audio path has one set of watchers, and both ways of breaking it trip
+all of them.
+
+Note what this coverage is and is not. All fifteen notice **indirectly** — the
+drill and the editor stop working. Nothing asserts the contract at this boundary
+directly, and nothing can: there is no input for which the requested note and the
+note-on's key differ, which is precisely why the fallback was invisible, so no
+test can reach the distinguishing state without changing this source. The
+guarantee is held by the code shape and by mutation testing, not by an assertion.
+
+So: no fallback, and no other value substituted for a result anywhere in that
+function. If a caller cannot tell why it got `null` — an unplayable pitch and a
+note that never reached the synth both answer `null` — it should say what
+happened rather than name a cause it did not check. Both call sites do.
+
+Note also that **the voice and the note length are parameters**, not properties
+of this module. They default to what checking a tuning wants; a caller with a
+different task passes its own rather than inheriting constants chosen for that
+one. In the soundfont shipped here, the tuning check's nylon guitar (program 24)
+has three sample zones for the whole keyboard, which costs nothing across one
+instrument's strings and stretches a single recording by up to two octaves
+across four.
+
 ### Asking the renderer what it can draw
 
 Not every score can be drawn under every profile. A score with no tablature has

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -4,6 +4,7 @@
   import Settings from "./lib/Settings.svelte";
   import Practice from "./lib/Practice.svelte";
   import MetronomePage from "./lib/MetronomePage.svelte";
+  import EarTraining from "./lib/EarTraining.svelte";
 
   function parse(hash) {
     const m = hash.match(/^#\/score\/(\d+)/);
@@ -12,6 +13,7 @@
     if (hash.startsWith("#/settings")) return { page: "settings" };
     if (hash.startsWith("#/practice")) return { page: "practice" };
     if (hash.startsWith("#/metronome")) return { page: "metronome" };
+    if (hash.startsWith("#/ear-training")) return { page: "ear-training" };
     return { page: "library" };
   }
 
@@ -34,6 +36,8 @@
   <Practice />
 {:else if route.page === "metronome"}
   <MetronomePage />
+{:else if route.page === "ear-training"}
+  <EarTraining />
 {:else}
   <Library />
 {/if}

--- a/web/src/lib/EarTraining.svelte
+++ b/web/src/lib/EarTraining.svelte
@@ -36,6 +36,8 @@
   import { api } from "./api.js";
   import {
     DEFAULT_RANGE,
+    DRILL_SECONDS,
+    DRILL_VOICE,
     buildChoices,
     instrumentRange,
     loggedStatement,
@@ -133,9 +135,15 @@
   async function sound(midi) {
     soundError = "";
     try {
-      const heard = await playPitch(midi);
+      // The drill's OWN voice and note length, not the tuning check's defaults -
+      // see DRILL_VOICE and DRILL_SECONDS for the measurement behind the voice.
+      const heard = await playPitch(midi, { voice: DRILL_VOICE, seconds: DRILL_SECONDS });
       if (heard == null) {
-        soundError = "That pitch is outside what the synthesiser can play.";
+        // Says what is true and stops there. Null means no note reached the
+        // synthesiser, and this cannot tell whether that was the pitch being
+        // unplayable or the note never being handed over - so it names neither
+        // cause rather than asserting the likelier one.
+        soundError = "No note was sounded, so there is nothing to name yet.";
         return null;
       }
       lastSounded = heard;

--- a/web/src/lib/EarTraining.svelte
+++ b/web/src/lib/EarTraining.svelte
@@ -1,0 +1,636 @@
+<script>
+  // Hear a note, name it. The first exercise in Fermata (issue #61).
+  //
+  // WHAT MAKES THIS ONE HONEST, which is the whole of its design:
+  //
+  //   The question is built from what was SOUNDED, never from what was asked
+  //   for. score-render.js's playPitch resolves with the MIDI note actually
+  //   written into the note-on event, and that number - not the target this
+  //   component picked - is what gets spelled, offered, and marked correct. So
+  //   there is no state in which the interface can be confident about a note
+  //   the synthesiser never played: delete the audio path and there is no
+  //   question, rather than a question about silence. That is deliberate.
+  //   Instruments.svelte publishes its audition the same way, for the same
+  //   reason, and the note there says what went wrong when it did not.
+  //
+  //   Nothing here grades anybody. Two counts, stated. No percentage, no
+  //   streak, no colour for a wrong answer - a wrong answer in ear training is
+  //   the practice, not a shortfall, and the phrasing rules it follows are
+  //   practice.js's and are tested against practice.js's own word list. The
+  //   statement about what the note was is worded and styled identically
+  //   whether or not it was named, and there is no --danger anywhere in this
+  //   file.
+  //
+  //   The time goes in the same history as everything else. One
+  //   practice_sessions row with activity 'ear_training' - which the vocabulary
+  //   in docs/practice-data.md has always had a slot for, precisely so that the
+  //   first trainer would not need a table of its own. It shows on the practice
+  //   page and counts towards a weekly goal with no special case anywhere.
+  //
+  // NO METRONOME. The click is a general tool and this page could have one in
+  // two lines, which is not a reason to put one here: naming a heard pitch has
+  // no tempo, and a control that does nothing for the exercise is decoration
+  // that has to be looked past every time.
+  import { onDestroy } from "svelte";
+
+  import { api } from "./api.js";
+  import {
+    DEFAULT_RANGE,
+    buildChoices,
+    instrumentRange,
+    loggedStatement,
+    pickTarget,
+    progressStatement,
+    rangeIsAskable,
+    rangeSourceStatement,
+    rangeStatement,
+    referenceStatement,
+    roundStatement,
+    sessionNote,
+  } from "./ear-training.js";
+  import { getInstruments, loadInstruments } from "./instruments.svelte.js";
+  import { spellMidi } from "./pitch.js";
+  import { formatDuration, localDay } from "./practice.js";
+  // Straight from score-render.js rather than through instruments.svelte.js's
+  // auditionPitch, which is the same call under a name about strings. There is
+  // one audio path in this application and this is a second caller of it, not a
+  // second implementation.
+  import { playPitch } from "./score-render.js";
+
+  const instruments = getInstruments();
+
+  $effect(() => {
+    loadInstruments();
+  });
+
+  // Which range the drill draws from: "" is the plain default, otherwise an
+  // instrument's id as a string (the value a <select> gives back).
+  let source = $state("");
+  // Latched the first time the instruments land, so the adoption below happens
+  // once and can never overwrite a range somebody has since picked by hand. A
+  // plain `let` rather than $state because nothing renders from it.
+  let sourceSettled = false;
+
+  // ONE instrument gets adopted; two do not. Fermata has a list of instruments
+  // and no notion of which one is in somebody's hands, so picking among several
+  // would be a guess - and a drill silently fitted to the wrong instrument is
+  // worse than one that says it is using a plain range. With exactly one
+  // defined there is nothing to guess.
+  $effect(() => {
+    if (!instruments.loaded || sourceSettled) return;
+    sourceSettled = true;
+    if (instruments.list.length === 1) source = String(instruments.list[0].id);
+  });
+
+  const instrument = $derived(instruments.list.find((i) => String(i.id) === source) ?? null);
+  const range = $derived(instrument ? instrumentRange(instrument) : DEFAULT_RANGE);
+  const askable = $derived(rangeIsAskable(range));
+
+  let running = $state(false);
+  // How many notes have been answered, and how many were named as heard. Reset
+  // per drill: they describe the stretch of practice that gets logged.
+  let asked = $state(0);
+  let named = $state(0);
+  // { sounded, choices, chosen }. `sounded` is what came back from the
+  // synthesiser; `choices` are built around it.
+  let round = $state(null);
+  let waiting = $state(false);
+  let soundError = $state("");
+  // How many times a pitch has actually been sounded this drill, and the last
+  // note the synthesiser was handed. Published onto the section (data-sounded-*)
+  // for the same reason the instruments editor publishes its audition: it is the
+  // only way to see from outside that the audio path ran rather than that a
+  // counter was incremented next to it. Replays are in here and deliberately not
+  // in `asked` - hearing a note five times is practising, not cheating.
+  let sounded = $state(0);
+  let lastSounded = $state(null);
+  let startedAt = 0;
+  let previousTarget = null;
+
+  let logged = $state(null);
+  let logError = $state("");
+  let logging = $state(false);
+  // The length of a drill whose log failed, kept so the time can be sent again
+  // rather than lost. Practice history is the one thing in Fermata that cannot
+  // be regenerated from the files on disk.
+  let unlogged = $state(null);
+
+  function elapsed() {
+    // Floored at one second because that is the shortest session the server
+    // will store, and a drill that took less than a second still happened.
+    return Math.max(1, Math.round((Date.now() - startedAt) / 1000));
+  }
+
+  function drillNote() {
+    return sessionNote({
+      asked,
+      named,
+      range,
+      instrumentName: instrument?.name ?? "",
+    });
+  }
+
+  async function sound(midi) {
+    soundError = "";
+    try {
+      const heard = await playPitch(midi);
+      if (heard == null) {
+        soundError = "That pitch is outside what the synthesiser can play.";
+        return null;
+      }
+      lastSounded = heard;
+      sounded += 1;
+      return heard;
+    } catch (e) {
+      // `||` not `??`: an Error with an empty message renders as nothing at all,
+      // which is a failure that looks like a working click.
+      soundError = e?.message || "The synthesiser could not be loaded.";
+      return null;
+    }
+  }
+
+  async function nextNote() {
+    if (!askable) return;
+    round = null;
+    waiting = true;
+    try {
+      const heard = await sound(pickTarget(range, previousTarget));
+      if (heard == null) return;
+      previousTarget = heard;
+      // Built around the note that SOUNDED, not the one that was asked for.
+      round = { sounded: heard, choices: buildChoices(heard, range), chosen: null };
+    } finally {
+      waiting = false;
+    }
+  }
+
+  // Available before AND after answering, because the point of the exercise is
+  // attaching the sound to the name and the moment you learn what it was is the
+  // moment worth hearing it again. Counted as a sounding and as nothing else.
+  async function hearAgain() {
+    if (round?.sounded == null) return;
+    await sound(round.sounded);
+  }
+
+  function choose(midi) {
+    if (!round || round.chosen != null) return;
+    const asHeard = midi === round.sounded;
+    round = { ...round, chosen: midi };
+    asked += 1;
+    if (asHeard) named += 1;
+  }
+
+  function start() {
+    if (!askable) return;
+    running = true;
+    startedAt = Date.now();
+    asked = 0;
+    named = 0;
+    sounded = 0;
+    lastSounded = null;
+    previousTarget = null;
+    logged = null;
+    logError = "";
+    unlogged = null;
+    nextNote();
+  }
+
+  async function stopAndLog() {
+    if (!running) return;
+    const seconds = elapsed();
+    const heard = sounded;
+    running = false;
+    round = null;
+    waiting = false;
+    // Nothing was ever sounded, so nothing was practised - a start immediately
+    // stopped is a mis-click, and a one-second row in the history is noise
+    // somebody would have to delete by hand.
+    if (!heard) return;
+    await send(seconds);
+  }
+
+  async function send(seconds) {
+    logging = true;
+    logError = "";
+    try {
+      const session = await api.logSession({
+        activity: "ear_training",
+        seconds,
+        local_date: localDay(),
+        note: drillNote(),
+      });
+      // What the SERVER stored, not what was sent.
+      logged = { seconds: session?.seconds ?? seconds, id: session?.id ?? null };
+      unlogged = null;
+    } catch (e) {
+      logError = e?.message || "That practice could not be logged.";
+      unlogged = seconds;
+    } finally {
+      logging = false;
+    }
+  }
+
+  function retryLog() {
+    if (unlogged == null) return;
+    send(unlogged);
+  }
+
+  // Leaving mid-drill logs what was done. A hash route change unmounts this
+  // component, and the alternative is that walking away from a stopped-but-not-
+  // logged drill silently throws away practice that happened - which is the one
+  // thing this application promises never to do. Fire and forget: there is
+  // nobody left to show a failure to, and the request is already on the wire.
+  onDestroy(() => {
+    if (!running || sounded < 1) return;
+    api
+      .logSession({
+        activity: "ear_training",
+        seconds: elapsed(),
+        local_date: localDay(),
+        note: drillNote(),
+      })
+      .catch(() => {});
+  });
+</script>
+
+<div class="page">
+  <header>
+    <a class="back" href="#/">← Library</a>
+    <h1>Hear a note, name it</h1>
+  </header>
+
+  <main>
+    <section
+      class="drill"
+      data-running={running ? "1" : "0"}
+      data-asked={asked}
+      data-named={named}
+      data-sounded-count={sounded}
+      data-sounded-midi={lastSounded ?? ""}
+      data-range={`${range?.low ?? ""}-${range?.high ?? ""}`}
+    >
+      <p class="hint">
+        A note sounds; name it from four. The three you did not hear are chosen to be worth
+        confusing — a semitone away, the same name an octave out, and one a step or two off —
+        because four notes far apart teaches nothing.
+      </p>
+
+      <!-- ------------------------------------------------------ the range -->
+      <div class="row range-row">
+        <label>
+          <span>Notes from</span>
+          <select class="range-source" bind:value={source} disabled={running}>
+            <option value="">C2 to C6</option>
+            {#each instruments.list as owned (owned.id)}
+              <option value={String(owned.id)}>{owned.name}</option>
+            {/each}
+          </select>
+        </label>
+        <span class="quiet range-label">{rangeStatement(range, instrument?.name ?? "")}</span>
+      </div>
+
+      {#if instruments.error}
+        <p class="notice instruments-error">
+          {instruments.error} The drill below uses its plain range instead.
+        </p>
+      {/if}
+
+      {#if rangeSourceStatement(range)}
+        <p class="quiet range-source-note">{rangeSourceStatement(range)}</p>
+      {/if}
+
+      {#if referenceStatement(instrument)}
+        <!-- The synthesiser is fixed at A440 and this drill does not pretend
+             otherwise. See ear-training.js and playPitch's own note. -->
+        <p class="quiet reference-note">{referenceStatement(instrument)}</p>
+      {/if}
+
+      {#if !askable}
+        <p class="statement narrow-range">
+          This definition spans {range && range.low === range.high ? "one note" : "too few notes"}, so
+          there are not four to choose between. Pick another range above.
+        </p>
+      {/if}
+
+      <!-- ------------------------------------------------------- the drill -->
+      {#if soundError}
+        <p class="notice sound-error">
+          {soundError}
+          <button class="retry-sound" onclick={nextNote}>Try again</button>
+        </p>
+      {/if}
+
+      {#if running}
+        <p class="statement progress">{progressStatement({ asked, named })}</p>
+
+        <!-- The statement about what the note was lives ABOVE the choices and
+             its space is reserved whether or not there is one, so answering
+             does not shift the four buttons out from under the cursor. A drill
+             that moves as you use it is a drill that collects wrong answers it
+             did not earn. -->
+        <!-- The live region is the SLOT and not the statement, because a region
+             announces changes to itself and one that arrives already populated
+             announces nothing. An exercise about listening is the last place to
+             leave the answer unspoken. -->
+        <div class="statement-slot" role="status" aria-live="polite">
+          {#if round?.chosen != null}
+            <p class="statement round-statement">{roundStatement(round)}</p>
+          {/if}
+        </div>
+
+        <ul class="choices">
+          {#each round?.choices ?? [] as choice (choice)}
+            <li>
+              <button
+                class="choice"
+                class:correct={round.chosen != null && choice === round.sounded}
+                class:picked={round.chosen === choice && choice !== round.sounded}
+                data-midi={choice}
+                disabled={round.chosen != null}
+                onclick={() => choose(choice)}
+              >
+                <!-- Rendered empty rather than absent, so the mark appearing
+                     cannot change the button's size and move the row. -->
+                <span class="tick" aria-hidden="true"
+                  >{round.chosen != null && choice === round.sounded ? "✓" : ""}</span
+                >
+                <span class="choice-pitch">{spellMidi(choice)}</span>
+              </button>
+            </li>
+          {/each}
+        </ul>
+
+        <div class="row controls">
+          <!-- First in the row in both states, so it does not move when Next
+               appears beside it. -->
+          <button class="hear-again" onclick={hearAgain} disabled={round?.sounded == null}>
+            ♪ Hear it again
+          </button>
+          {#if round?.chosen != null}
+            <button class="primary next-note" onclick={nextNote}>Next note</button>
+          {/if}
+          <button class="ghost stop-drill" onclick={stopAndLog} disabled={logging}>
+            {logging ? "Logging…" : "Stop and log this practice"}
+          </button>
+        </div>
+
+        {#if waiting}
+          <p class="quiet waiting">Sounding a note…</p>
+        {/if}
+      {:else}
+        {#if askable}
+          <div class="row controls">
+            <button class="primary start-drill" onclick={start}>Start</button>
+          </div>
+        {/if}
+
+        {#if logged}
+          <p class="statement logged">
+            {loggedStatement(logged.seconds)}
+            {progressStatement({ asked, named })}
+            <a href="#/practice">Practice &amp; goals →</a>
+          </p>
+        {/if}
+
+        {#if logError}
+          <p class="notice log-error">
+            {logError}
+            <button class="retry-log" onclick={retryLog} disabled={logging}>
+              {logging ? "Trying…" : "Try again"}
+            </button>
+          </p>
+        {/if}
+      {/if}
+    </section>
+
+    <p class="quiet footnote">
+      The time you spend here is logged as ear training, in the same history as everything
+      else, so it counts towards a weekly goal like any other practice. Hearing a note again
+      is not counted at all.
+    </p>
+  </main>
+</div>
+
+<style>
+  .page {
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+  }
+
+  header {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    padding: 14px 20px;
+    border-bottom: 1px solid var(--line);
+  }
+
+  h1 {
+    margin: 0;
+    font-size: 18px;
+    font-weight: 600;
+  }
+
+  .back {
+    color: var(--ink-dim);
+    font-size: 14px;
+  }
+
+  .back:hover {
+    color: var(--brass);
+  }
+
+  main {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 20px;
+    padding: 32px 20px 48px;
+  }
+
+  .drill {
+    width: 100%;
+    max-width: 540px;
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+    padding: 22px;
+    background: var(--bg-raised);
+    border: 1px solid var(--line);
+    border-radius: var(--radius);
+  }
+
+  .hint,
+  .quiet {
+    margin: 0;
+    color: var(--ink-dim);
+    font-size: 13px;
+    line-height: 1.5;
+  }
+
+  .row {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    flex-wrap: wrap;
+  }
+
+  .range-row label {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 14px;
+  }
+
+  select {
+    background: var(--surface);
+    color: var(--ink);
+    border: 1px solid var(--line);
+    border-radius: 6px;
+    padding: 5px 8px;
+    font: inherit;
+    font-size: 14px;
+  }
+
+  /* Every statement on this page is the same statement. There is deliberately
+     no variant for a note that was not named: the wording differs, the
+     rendering does not, and nothing here is ever coloured by outcome. There is
+     no --danger in this file and a test checks the two cases render
+     identically. */
+  .statement {
+    margin: 0;
+    font-size: 15px;
+    color: var(--ink);
+    line-height: 1.5;
+  }
+
+  /* Two lines' worth, held open whether or not there is a statement in it, so
+     the choices below do not move when one appears. */
+  .statement-slot {
+    min-height: 46px;
+    display: flex;
+    align-items: center;
+  }
+
+  .choices {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 10px;
+  }
+
+  /* One geometry for every state of a choice: the border width, the padding and
+     the font never change, so marking an answer cannot resize a button. Only
+     colour does. */
+  .choice {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    padding: 14px 10px;
+    background: var(--surface);
+    color: var(--ink);
+    border: 1px solid var(--line);
+    border-radius: var(--radius);
+    font: inherit;
+    font-size: 20px;
+    font-variant-numeric: tabular-nums;
+    cursor: pointer;
+  }
+
+  .choice:hover:enabled {
+    border-color: var(--brass);
+  }
+
+  /* NOT dimmed, unlike every other disabled control here. The four buttons stop
+     being actionable the moment one is clicked, and the answer is the thing a
+     person is reading at exactly that moment - fading it out along with the
+     other three is the interface withdrawing the information it was asked for. */
+  .choice:disabled {
+    opacity: 1;
+    cursor: default;
+  }
+
+  .choice.correct {
+    border-color: var(--brass);
+    color: var(--brass-bright);
+  }
+
+  /* The note that was picked when it was a different one. Marked so it can be
+     seen which it was, in the same brass as everything else on this page - a
+     second colour here would be a verdict. */
+  .choice.picked {
+    border-color: var(--ink-dim);
+  }
+
+  .tick {
+    display: inline-block;
+    width: 1em;
+    text-align: center;
+    color: var(--brass);
+    font-size: 16px;
+  }
+
+  button {
+    background: var(--surface);
+    color: var(--ink);
+    border: 1px solid var(--line);
+    border-radius: 6px;
+    padding: 8px 14px;
+    font: inherit;
+    font-size: 14px;
+    cursor: pointer;
+  }
+
+  button:hover:enabled {
+    border-color: var(--brass);
+  }
+
+  button:disabled {
+    opacity: 0.55;
+    cursor: default;
+  }
+
+  button.primary {
+    background: var(--brass);
+    border-color: var(--brass);
+    color: #1a1509;
+    font-weight: 600;
+  }
+
+  button.ghost {
+    background: none;
+    color: var(--ink-dim);
+  }
+
+  /* Not an error style. A notice on this page is something that did not happen
+     yet - a synthesiser still loading badly, a log that has to be sent again -
+     and it is worded and coloured as information. */
+  .notice {
+    margin: 0;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    flex-wrap: wrap;
+    font-size: 14px;
+    color: var(--ink);
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: 6px;
+    padding: 8px 12px;
+  }
+
+  .logged a {
+    color: var(--brass);
+  }
+
+  .footnote {
+    max-width: 46ch;
+    text-align: center;
+  }
+</style>

--- a/web/src/lib/Instruments.svelte
+++ b/web/src/lib/Instruments.svelte
@@ -178,7 +178,11 @@
     try {
       const sounded = await auditionPitch(string.sounding_midi);
       if (sounded == null) {
-        auditionError = "That pitch is outside what can be played.";
+        // playPitch answers null both for a pitch it will not play and for a
+        // note that never reached the synthesiser at all, and this cannot tell
+        // which - so it says what it knows rather than naming the likelier
+        // cause as though it had checked.
+        auditionError = "That string was not sounded.";
         return;
       }
       const hz = instrument ? instrument.reference_pitch : reference;

--- a/web/src/lib/Library.svelte
+++ b/web/src/lib/Library.svelte
@@ -220,6 +220,7 @@
       </button>
       <a class="demo-link practice-link" href="#/practice">◴ Practice &amp; goals</a>
       <a class="demo-link" href="#/metronome">♩ Metronome</a>
+      <a class="demo-link ear-training-link" href="#/ear-training">♪ Hear a note, name it</a>
       <a class="demo-link" href="#/demo">Notation/tab demo →</a>
       <a class="demo-link" href="#/settings">⚙ Settings</a>
     </div>

--- a/web/src/lib/Practice.svelte
+++ b/web/src/lib/Practice.svelte
@@ -482,7 +482,8 @@
         </div>
         <p class="hint">
           Technique, ear training, or simply playing. Practice at a score is timed in the
-          viewer; this is for everything else.
+          viewer, and <a class="ear-training-link" href="#/ear-training">hear a note, name it</a>
+          logs its own time; this is for everything else.
         </p>
         <div class="row">
           <select bind:value={otherActivity} class="other-activity">

--- a/web/src/lib/ear-training.js
+++ b/web/src/lib/ear-training.js
@@ -1,0 +1,287 @@
+// The first exercise: a pitch sounds, and you name it from four candidates.
+//
+// Everything here is arithmetic and phrasing - no runes and no browser - so all
+// of it is callable straight from tests/unit/ear-training.spec.js. The pattern
+// is pitch.js's and practice.js's, and for the same reason: the part of a drill
+// worth getting right is which four notes it offers and what it says about the
+// answer, and neither of those needs a page to be checked.
+//
+// THIS IS ONE EXERCISE, NOT A FRAMEWORK. There is no notion of a generic drill,
+// no registry, and no shared question type. A second exercise is what should
+// motivate any abstraction here, and until one exists an abstraction would be a
+// guess about what it needs. What IS shared is deliberately shared: the audio
+// path is score-render.js's playPitch, the pitch spelling is pitch.js's, and
+// the way practice is put into words is practice.js's.
+//
+// THE TONE RULES ARE practice.js's, and they bind harder here than anywhere
+// else in this project. A drill is the easiest place in a practice tool to
+// start grading somebody. So:
+//
+//   No accuracy percentage.       A count is a fact; a percentage out of a
+//                                 hundred is a mark, and it invites a colour.
+//   No streak, no run.            Nothing here counts consecutive anything.
+//   A wrong answer is the point.  Naming a note you could not hear is what the
+//                                 practice consists of. It is stated and
+//                                 nothing else happens.
+//   Replays are free.             Hearing a note five times is practising, not
+//                                 cheating, so nothing counts them.
+//
+// tests/unit/ear-training.spec.js checks every string this module produces
+// against practice.js's own FORBIDDEN_WORDS list, so the rules above are
+// enforced rather than merely written down.
+import { MAX_MIDI, MIN_MIDI, spellMidi } from "./pitch.js";
+import { countOrNone, formatDuration } from "./practice.js";
+
+/** Four: one right and three worth confusing. From the issue - the exercise is
+ * "play sound pick correct note one of 4". */
+export const CHOICE_COUNT = 4;
+
+/** A range has to hold the answer and three others, so three semitones is the
+ * narrowest one a question can be asked in. Reachable through the ordinary
+ * interface: a one-string unfretted instrument's definition spans a single
+ * note. */
+export const MIN_RANGE_SEMITONES = CHOICE_COUNT - 1;
+
+/** The range used when the drill is not following an instrument: C2 to C6, four
+ * octaves. Wide enough that an octave confusion is always available and low
+ * enough to sit inside a guitar's, a bass's and a cello's own ranges rather
+ * than above them. */
+export const DEFAULT_RANGE = { low: 36, high: 84, top: "chosen" };
+
+/** The synthesiser's reference pitch, which is fixed. score-render.js's
+ * playPitch says the same thing in prose: alphaTab's synth is equal-tempered
+ * around A440 and takes no reference, so an instrument defined at A415 has its
+ * frequencies SHOWN at A415 and is SOUNDED at A440. This drill does not pretend
+ * otherwise - see referenceStatement. */
+export const SYNTH_REFERENCE_HZ = 440;
+
+function clamp(midi) {
+  return Math.min(MAX_MIDI, Math.max(MIN_MIDI, Math.round(midi)));
+}
+
+export function rangeWidth(range) {
+  return (range?.high ?? 0) - (range?.low ?? 0);
+}
+
+/** Whether four distinct notes can be drawn from a range at all. A range that
+ * cannot is not a broken definition and not an error - a single-string
+ * unfretted instrument is a real thing to own - so the interface says what is
+ * true of it rather than refusing to explain. */
+export function rangeIsAskable(range) {
+  if (!range || !Number.isFinite(range.low) || !Number.isFinite(range.high)) return false;
+  return rangeWidth(range) >= MIN_RANGE_SEMITONES;
+}
+
+/** "E2 to D6" - the two ends, named. */
+export function rangeLabel(range) {
+  if (!range) return "";
+  return `${spellMidi(range.low)} to ${spellMidi(range.high)}`;
+}
+
+/** The range, and the instrument it came from when it came from one. */
+export function rangeStatement(range, instrumentName = "") {
+  const label = rangeLabel(range);
+  return instrumentName ? `${label}, ${instrumentName}` : label;
+}
+
+/** The notes an instrument's own definition says it sounds.
+ *
+ * The bottom is its lowest string. The top is its highest string plus the frets
+ * it declares - which is the whole of what a definition knows about how high it
+ * reaches, and on an unfretted one is nothing at all, so an unfretted range
+ * stops at its top string and `top` says so. Inventing a couple of octaves
+ * above a violin's E string would be this module guessing at a technique
+ * ceiling it has no information about.
+ *
+ * Reads `sounding_midi`, so a capo counts: the capo decides what the instrument
+ * sounds, which is the same rule the instruments editor auditions by. */
+export function instrumentRange(instrument) {
+  const midis = (instrument?.strings ?? [])
+    .map((s) => Number(s?.sounding_midi))
+    .filter((n) => Number.isFinite(n));
+  if (!midis.length) return null;
+  const frets = instrument?.fretted ? Math.max(0, Number(instrument.fret_count) || 0) : 0;
+  return {
+    low: clamp(Math.min(...midis)),
+    high: clamp(Math.max(...midis) + frets),
+    top: frets > 0 ? "frets" : "strings",
+  };
+}
+
+/** Why an instrument's range stops where it does, when that needs saying.
+ *
+ * Only for an unfretted one, and only because the answer is surprising: a
+ * cello's range on screen ends at its top string, which is nowhere near where a
+ * cellist plays. Saying so is better than either silently narrowing the drill
+ * or inventing a ceiling. */
+export function rangeSourceStatement(range) {
+  if (range?.top !== "strings") return "";
+  return (
+    "An unfretted definition says what its strings are tuned to and nothing about how high " +
+    "it is played, so this drill stays inside what its strings sound."
+  );
+}
+
+/** That the pitches sounded here are at A440 whatever the instrument says, when
+ * the instrument says something else. Empty when there is nothing to disclose,
+ * which is most instruments - a disclosure printed unconditionally is one
+ * nobody reads. */
+export function referenceStatement(instrument) {
+  const hz = Number(instrument?.reference_pitch);
+  if (!Number.isFinite(hz) || hz === SYNTH_REFERENCE_HZ) return "";
+  const name = instrument?.name ? `${instrument.name} is` : "This instrument is";
+  return (
+    `${name} defined at A${Number(hz.toFixed(2))}, and the synthesiser here is fixed at ` +
+    `A${SYNTH_REFERENCE_HZ}. The names are the ones you are naming; the reference is not yours.`
+  );
+}
+
+/** Which note to sound next.
+ *
+ * Uniform across the range, except that it never repeats the note just heard:
+ * the same pitch twice running reads as the drill having failed to advance
+ * rather than as a second question, and it is the one repeat a person would
+ * notice. Not a memory of everything asked so far - that would drift the drill
+ * away from uniform towards whatever has not come up yet, which is a different
+ * exercise. */
+export function pickTarget(range, previous = null, rand = Math.random) {
+  if (!range || !Number.isFinite(range.low) || rangeWidth(range) < 0) return null;
+  const span = rangeWidth(range) + 1;
+  const excluded = previous != null && previous >= range.low && previous <= range.high;
+  const count = excluded ? span - 1 : span;
+  if (count <= 0) return null;
+  // Math.min guards the rand() === 1 case, which Math.random never returns but
+  // a caller's own generator may.
+  const index = Math.min(count - 1, Math.floor(rand() * count));
+  const midi = range.low + index;
+  return excluded && midi >= previous ? midi + 1 : midi;
+}
+
+// The three kinds of distractor, from the issue: "near neighbours, or the same
+// note in another octave, rather than four notes far apart which teaches
+// nothing". They are three different confusions and a drill that offers one of
+// each asks about all three at once -
+//
+//   a semitone away  the hardest and the most useful: a semitone is the
+//                    interval a beginner cannot hear at all and the one an
+//                    intermediate player mishears under pressure;
+//   an octave away    the same NAME in the wrong place, which is the error that
+//                    survives longest because the note sounds right;
+//   two to five away  a step or a third - close enough to need listening,
+//                    far enough that getting it wrong means something
+//                    different from the semitone case.
+const SEMITONE_OFFSETS = [-1, 1];
+const OCTAVE_OFFSETS = [-12, 12, -24, 24];
+const NEARBY_OFFSETS = [-5, -4, -3, -2, 2, 3, 4, 5];
+
+/** The candidates of each kind that a range actually allows. Exported because
+ * "the offered notes span all three kinds" is the claim worth testing, and it
+ * is far easier to check against the pools than to infer from a shuffled four. */
+export function distractorKinds(sounded, range) {
+  const inside = (midi) =>
+    midi !== sounded &&
+    midi >= MIN_MIDI &&
+    midi <= MAX_MIDI &&
+    midi >= (range?.low ?? MIN_MIDI) &&
+    midi <= (range?.high ?? MAX_MIDI);
+  const from = (offsets) => offsets.map((o) => sounded + o).filter(inside);
+  return {
+    semitone: from(SEMITONE_OFFSETS),
+    octave: from(OCTAVE_OFFSETS),
+    nearby: from(NEARBY_OFFSETS),
+  };
+}
+
+/** The four notes to offer, given the note that actually SOUNDED.
+ *
+ * Takes the sounded note rather than the intended one on purpose. The caller
+ * builds a question out of what came back from the synthesiser, so a drill that
+ * sounded something other than what it meant to offers choices around what was
+ * heard - and a drill that sounded nothing at all has no question to ask, which
+ * is the only honest behaviour when the audio path is what the exercise is for.
+ *
+ * One of each kind where the range allows all three. Where it does not - a
+ * range narrower than an octave has no octave to offer - the shortfall is
+ * filled nearest-first from what is left, because the nearest is the most worth
+ * confusing. Four distinct notes always come back when the range can hold them;
+ * an empty array when it cannot. */
+export function buildChoices(sounded, range, rand = Math.random) {
+  if (!Number.isFinite(sounded) || !rangeIsAskable(range)) return [];
+  const kinds = distractorKinds(sounded, range);
+  const picked = [];
+  const takeFrom = (list) => {
+    const free = list.filter((m) => !picked.includes(m));
+    if (!free.length) return;
+    picked.push(free[Math.min(free.length - 1, Math.floor(rand() * free.length))]);
+  };
+  for (const kind of ["semitone", "octave", "nearby"]) takeFrom(kinds[kind]);
+  if (picked.length < CHOICE_COUNT - 1) {
+    const rest = [...new Set([...kinds.semitone, ...kinds.nearby, ...kinds.octave])]
+      .filter((m) => !picked.includes(m))
+      .sort((a, b) => Math.abs(a - sounded) - Math.abs(b - sounded));
+    while (picked.length < CHOICE_COUNT - 1 && rest.length) picked.push(rest.shift());
+  }
+  return shuffle([sounded, ...picked], rand);
+}
+
+function shuffle(items, rand) {
+  const out = [...items];
+  for (let i = out.length - 1; i > 0; i--) {
+    const j = Math.min(i, Math.floor(rand() * (i + 1)));
+    [out[i], out[j]] = [out[j], out[i]];
+  }
+  return out;
+}
+
+/** What happened, once an answer has been given.
+ *
+ * The note is named either way, in the same words and in the same place. When
+ * the answer was a different note that is said too, because knowing WHICH note
+ * you took it for is the whole of the information - "wrong" tells a person
+ * nothing they can practise with, and a G heard as a G an octave down is a
+ * different thing to work on from a G heard as an F sharp.
+ *
+ * There is no verdict word in either branch, and no third branch for "well
+ * done". A wrong answer in ear training is not a shortfall, it is the practice. */
+export function roundStatement(round) {
+  const sounded = round?.sounded;
+  const chosen = round?.chosen;
+  if (!Number.isFinite(sounded) || !Number.isFinite(chosen)) return "";
+  const was = `That was ${spellMidi(sounded)}.`;
+  if (chosen === sounded) return was;
+  return `${was} You chose ${spellMidi(chosen)}.`;
+}
+
+/** How the drill has gone so far. Two counts and nothing else: no percentage,
+ * no ratio drawn as a bar, and no adjective. The practice page's "3 of 4
+ * planned days" is the model. */
+export function progressStatement({ asked = 0, named = 0 } = {}) {
+  const total = Math.max(0, Math.floor(Number(asked) || 0));
+  if (!total) return "Nothing named yet.";
+  const notes = total === 1 ? "1 note" : `${total} notes`;
+  return `${notes}, ${countOrNone(named)} named as heard.`;
+}
+
+/** What goes in the session's `note` when the drill is logged.
+ *
+ * docs/practice-data.md says per-attempt trainer results - which notes were
+ * missed, and how long each took - are not in the schema, and that inventing
+ * their shape before a trainer existed would be guessing. One now exists and
+ * this is deliberately still not that: the counts go in the free-text note,
+ * where they are readable in the practice history beside every other kind of
+ * work, and the shape of a per-attempt table can be decided by the second and
+ * third exercises rather than by this one alone. */
+export function sessionNote({ asked = 0, named = 0, range, instrumentName = "" } = {}) {
+  return `Hear a note, name it. ${progressStatement({ asked, named })} ${rangeStatement(
+    range,
+    instrumentName,
+  )}.`;
+}
+
+/** What was logged, said back once the drill has stopped. States the length and
+ * where it went, and links nothing to a verdict - the practice page is where
+ * this now lives, and it counts towards a goal about ear training exactly as
+ * any other session does. */
+export function loggedStatement(seconds) {
+  return `${formatDuration(seconds)} of ear training is in your practice history.`;
+}

--- a/web/src/lib/ear-training.js
+++ b/web/src/lib/ear-training.js
@@ -48,6 +48,50 @@ export const MIN_RANGE_SEMITONES = CHOICE_COUNT - 1;
  * than above them. */
 export const DEFAULT_RANGE = { low: 36, high: 84, top: "chosen" };
 
+// ------------------------------------------- what the drill sounds, and for how long
+//
+// Both are this exercise's own, passed to playPitch rather than inherited from
+// it. They used to be its defaults, which were chosen for CHECKING A TUNING -
+// a different task, and the reason a constant should not be shared between the
+// two just because one of them was written first.
+
+/** The voice the drill sounds, as a raw (0-based) midi program: 0, Acoustic
+ * Grand Piano.
+ *
+ * NOT the nylon guitar (24) the tuning check uses, and this is measured rather
+ * than preferred. In the soundfont Fermata ships (sonivox.sf2), program 24 has
+ * **three** sample zones for the whole keyboard, so a note is a single recording
+ * pitch-shifted a long way: over this drill's default C2-C6 the worst case is
+ * **24 semitones - two full octaves** - from its sample's root, and over a
+ * guitar's own E2-D6 it is 26. A note transposed two octaves is a thin,
+ * formant-shifted artefact, so at the ends of the range the exercise would be
+ * testing the soundfont rather than the ear.
+ *
+ * Program 0 has **eleven** zones, roughly one per octave: the same worst case is
+ * 12 semitones, and 7 over a violin's range and 6 over a cello's. It is also the
+ * right voice on its own merits - a piano is the reference instrument ear
+ * training is taught on, its attack is unambiguous and its fundamental clear,
+ * and this exercise is about the NAME of a pitch rather than the timbre of an
+ * instrument somebody may not even play.
+ *
+ * The tuning check keeps the guitar deliberately: matching a string by ear wants
+ * something like the instrument in hand, and its range is one instrument's
+ * strings rather than four octaves. */
+export const DRILL_VOICE = 0;
+
+/** How long the note is held, in seconds.
+ *
+ * Longer than the tuning check's 1.6, which is enough to hear a string against
+ * the one you are tuning and is not the same task: identifying a pitch cold
+ * needs the attack to pass and the sustain to be heard AS a pitch rather than as
+ * a transient, and it wants long enough to hum against. Short enough that four
+ * notes in a row is not a wait.
+ *
+ * A round number chosen for stated reasons rather than a measured one - nobody
+ * has listened to this yet, and it is a parameter precisely so that whoever
+ * does can change it here without touching the tuning check. */
+export const DRILL_SECONDS = 2.5;
+
 /** The synthesiser's reference pitch, which is fixed. score-render.js's
  * playPitch says the same thing in prose: alphaTab's synth is equal-tempered
  * around A440 and takes no reference, so an instrument defined at A415 has its

--- a/web/src/lib/score-render.js
+++ b/web/src/lib/score-render.js
@@ -479,14 +479,24 @@ const RENDER_IN_WORKER = false;
 // actually clicked.
 
 const AUDITION_CHANNEL = 0;
+// The two below are DEFAULTS chosen for checking a tuning, not properties of
+// this module. playPitch takes both as parameters, because a caller with a
+// different task has no business inheriting a constant that was tuned for this
+// one - see the ear exercise's DRILL_VOICE, which is a different voice for a
+// measured reason.
+//
 // Raw midi program numbers are 0-based, so 24 is Acoustic Guitar (nylon) -
 // the same voice server/fermata/musicxml.py writes, where MusicXML's 1-based
 // numbering calls it 25. What a tuning check needs is a clear fundamental
-// with some decay, not the exact timbre of the instrument in hand.
+// with some decay, not the exact timbre of the instrument in hand. Note that in
+// the soundfont shipped here it has only three sample zones for the whole
+// keyboard, which is unimportant across one instrument's strings and matters a
+// great deal across four octaves.
 const AUDITION_PROGRAM = 24;
 const AUDITION_VELOCITY = 100;
 // Long enough to hear against a plucked string and let it decay, short enough
-// that clicking down a set of six is not a wait.
+// that clicking down a set of six is not a wait. Identifying a pitch cold is a
+// different task and wants longer; that is the caller's to say.
 const AUDITION_SECONDS = 1.6;
 // The renderer's own division, and a tempo that makes a quarter note half a
 // second. Both are stated rather than left to the sequencer's defaults so the
@@ -601,21 +611,45 @@ function toError(e, fallback) {
  * Sound one pitch on its own, as a MIDI note number.
  *
  * Resolves with THE MIDI NOTE ACTUALLY SOUNDED - the number written into the
- * note-on event - or null if it is not one the synthesiser can play. Returning
- * the note rather than a success flag is deliberate: it lets a caller display
- * and publish what crossed this boundary instead of restating what it asked
- * for, which is the only way an interface can be observed to have played the
- * right pitch rather than merely to have intended one.
+ * note-on event - or **null if no note was handed over at all**. Returning the
+ * note rather than a success flag is deliberate: it lets a caller display and
+ * publish what crossed this boundary instead of restating what it asked for,
+ * which is the only way an interface can be observed to have played the right
+ * pitch rather than merely to have intended one.
+ *
+ * THE NULL IS THE WHOLE OF THAT GUARANTEE, and it was once not kept. This used
+ * to end `return noteOn ? noteOn.noteKey : key` - falling back to the INPUT when
+ * no note-on could be found, which is the one number this function must never
+ * report, because reporting it makes "sounded the note" and "sounded nothing"
+ * the same answer. Removing the note-on event therefore left every caller and
+ * every test seeing exactly what it expected: fifteen tests catch this module
+ * being UNAVAILABLE and not one caught it running and sounding nothing. An
+ * absent note-on means nothing was handed to the synthesiser, and there is no
+ * honest number to give back.
+ *
+ * That matters beyond any one caller. This is the shared audition path, and it
+ * is where the capo defect lived - the interface displaying one pitch while the
+ * synthesiser played another, both agreeing with each other while being wrong.
+ * A fallback here reporting the request as though it were the result is that
+ * same defect one layer down, pre-armed for every future caller.
  *
  * Rejects if the synthesiser could not be loaded, so a caller can say so rather
  * than leaving a silent click looking like a working one.
+ *
+ * `voice` is a raw (0-based) midi program and `seconds` is how long the note is
+ * held. Both default to what checking a tuning wants, and both are parameters
+ * rather than constants because a caller with a different task should not
+ * inherit values chosen for that one.
  *
  * Note that the synthesiser is equal-tempered around A440 and takes no
  * reference pitch, so an instrument defined at A415 has its frequencies shown
  * at A415 but is auditioned at A440. Fine for finding a note by ear against
  * itself; not yet a period-pitch reference.
  */
-export async function playPitch(midi) {
+export async function playPitch(
+  midi,
+  { voice = AUDITION_PROGRAM, seconds = AUDITION_SECONDS } = {},
+) {
   const key = Math.round(Number(midi));
   if (!Number.isFinite(key) || key < MIN_MIDI || key > MAX_MIDI) return null;
   const player = await auditionPlayer();
@@ -630,11 +664,11 @@ export async function playPitch(midi) {
     NoteOffEvent,
     EndOfTrackEvent,
   } = alphaTab.midi;
-  const end = Math.round(AUDITION_SECONDS * TICKS_PER_SECOND);
+  const end = Math.round(Math.max(0.1, Number(seconds) || AUDITION_SECONDS) * TICKS_PER_SECOND);
   const file = new MidiFile();
   file.division = TICKS_PER_QUARTER;
   file.addEvent(new TempoChangeEvent(0, MICROSECONDS_PER_QUARTER));
-  file.addEvent(new ProgramChangeEvent(0, 0, AUDITION_CHANNEL, AUDITION_PROGRAM));
+  file.addEvent(new ProgramChangeEvent(0, 0, AUDITION_CHANNEL, Math.round(Number(voice)) || 0));
   // The channel is fresh each time only in the sense that the file is; the
   // synth's channel volume is whatever the last thing to play left behind, so
   // it is set rather than assumed.
@@ -649,8 +683,11 @@ export async function playPitch(midi) {
   player.playOneTimeMidiFile(file);
   // Read back off the events that were handed over rather than off the input,
   // so what this reports is the note the synthesiser actually received.
+  //
+  // NULL, never `key`, when there is no note-on. See the guarantee above: the
+  // input is the one value that must not be reported here.
   const noteOn = file.events.find((e) => e instanceof NoteOnEvent);
-  return noteOn ? noteOn.noteKey : key;
+  return noteOn ? noteOn.noteKey : null;
 }
 
 // ------------------------------------------------- the practice metronome

--- a/web/tests/browser/ear-training.spec.js
+++ b/web/tests/browser/ear-training.spec.js
@@ -1,0 +1,634 @@
+// Hear a note, name it - against the real backend, the real build and the real
+// synthesiser.
+//
+// What these are for that tests/unit/ear-training.spec.js cannot do: whether a
+// question exists at all depends on a soundfont arriving over HTTP and on
+// alphaTab building a player with no score loaded, and the one property this
+// exercise lives or dies by is that the question is built from WHAT WAS
+// SOUNDED rather than from what the component meant to sound. A mocked audio
+// path cannot tell us that; it is exactly the assertion a mock would make true
+// for free.
+//
+// So every test below reads the correct answer out of data-sounded-midi, which
+// the component sets from the value playPitch RESOLVED with - the number
+// written into the note-on event - and never from the target it picked. Delete
+// the audio path and there is no correct answer to read and no choices to
+// click, which is what makes these tests fail rather than pass more quietly.
+import { expect, test } from "@playwright/test";
+
+import { spellMidi } from "../../src/lib/pitch.js";
+import { forbiddenWord, localDay } from "../../src/lib/practice.js";
+
+const drill = (page) => page.locator("section.drill");
+const choices = (page) => page.locator(".choice");
+const statement = (page) => page.locator(".round-statement");
+const progress = (page) => page.locator(".progress");
+const startButton = (page) => page.locator(".start-drill");
+const referenceNote = (page) => page.locator(".reference-note");
+// Shared so that every "nothing went wrong" assertion uses the SAME selector a
+// test in this file proves can match something. A toHaveCount(0) built from an
+// inline literal is permanently true the moment a class is renamed.
+const notices = (page) => page.locator("section.drill .notice");
+
+const today = localDay();
+
+async function reset(request) {
+  const existing = await (await request.get("/api/instruments")).json();
+  for (const instrument of existing) await request.delete(`/api/instruments/${instrument.id}`);
+  const goals = (await (await request.get(`/api/practice/goals?today=${today}`)).json()).goals;
+  for (const goal of goals) await request.delete(`/api/practice/goals/${goal.id}`);
+  const sessions = (
+    await (await request.get("/api/practice/sessions?limit=1000")).json()
+  ).sessions;
+  for (const session of sessions) await request.delete(`/api/practice/sessions/${session.id}`);
+}
+
+/** An instrument, created through the API rather than through the editor - the
+ * editor has its own suite and what this file needs is a definition with known
+ * strings. */
+async function addInstrument(request, definition) {
+  const res = await request.post("/api/instruments", { data: definition });
+  expect(res.ok(), await res.text()).toBe(true);
+  return res.json();
+}
+
+const BASS = {
+  kind: "string",
+  name: "Bass (four string)",
+  fretted: true,
+  string_count: 4,
+  string_pitches: ["E1", "A1", "D2", "G2"],
+  fret_count: 24,
+  capo: 0,
+  reference_pitch: 440,
+};
+
+test.beforeEach(async ({ page, request }) => {
+  // Refuses to touch anything that is not the throwaway instance this suite
+  // starts. The reset above DELETES instruments and practice sessions, and
+  // practice history is the one thing in this application that cannot be
+  // regenerated from the files on disk.
+  const scores = await (await request.get("/api/scores")).json();
+  expect(
+    scores,
+    "refusing to run: this backend has scores in its library, so it is not the " +
+      "throwaway instance the suite creates - and these tests delete practice history",
+  ).toEqual([]);
+
+  await reset(request);
+
+  // Independent evidence that a click reaches real audio machinery and not a
+  // counter beside it.
+  await page.addInitScript(() => {
+    window.__audioContexts = 0;
+    for (const name of ["AudioContext", "webkitAudioContext"]) {
+      const Original = window[name];
+      if (!Original) continue;
+      window[name] = class extends Original {
+        constructor(...args) {
+          super(...args);
+          window.__audioContexts += 1;
+        }
+      };
+    }
+  });
+
+  await page.goto("/#/ear-training");
+  await expect(drill(page)).toBeVisible();
+});
+
+/** The MIDI note the synthesiser was actually handed, off the section. Never
+ * the note the component intended - that is the whole point. */
+async function soundedMidi(page) {
+  const value = await drill(page).getAttribute("data-sounded-midi");
+  expect(value, "nothing has been sounded, so there is no answer to read").not.toBe("");
+  return Number(value);
+}
+
+async function choiceMidis(page) {
+  return choices(page).evaluateAll((els) => els.map((el) => Number(el.dataset.midi)));
+}
+
+async function startDrill(page) {
+  await expect(drill(page)).toHaveAttribute("data-sounded-count", "0");
+  await startButton(page).click();
+  // The whole audio path has to run for this to move: a player built with no
+  // score loaded, a soundfont fetched over HTTP, and a hand-built MidiFile the
+  // synth accepts. Generous - the soundfont is about a megabyte.
+  await expect(drill(page)).toHaveAttribute("data-sounded-count", "1", { timeout: 30_000 });
+  await expect(choices(page)).toHaveCount(4);
+}
+
+async function nextNote(page, expectedSoundings) {
+  await page.locator(".next-note").click();
+  await expect(drill(page)).toHaveAttribute(
+    "data-sounded-count",
+    String(expectedSoundings),
+    { timeout: 30_000 },
+  );
+  await expect(choices(page)).toHaveCount(4);
+}
+
+/** Answer the round on screen: the note that sounded, or a different one. */
+async function answer(page, { as }) {
+  const sounded = await soundedMidi(page);
+  const midis = await choiceMidis(page);
+  const pick = as === "heard" ? sounded : midis.find((m) => m !== sounded);
+  await page.locator(`.choice[data-midi="${pick}"]`).click();
+  await expect(statement(page)).toBeVisible();
+  return { sounded, chosen: pick };
+}
+
+test("a drill sounds a note and offers four notes built around what was heard", async ({
+  page,
+}) => {
+  const soundfontRequests = [];
+  page.on("request", (r) => {
+    if (/soundfont|\.sf2/.test(r.url())) soundfontRequests.push(r.url());
+  });
+
+  await startDrill(page);
+
+  const sounded = await soundedMidi(page);
+  const midis = await choiceMidis(page);
+  expect(midis).toHaveLength(4);
+  expect(new Set(midis).size, `choices ${midis}`).toBe(4);
+  // The note that ACTUALLY sounded is one of the four. Not the note the
+  // component picked: this attribute is set from what playPitch resolved with,
+  // so a drill that sounded something else would be offering choices around the
+  // wrong note and this is where that shows.
+  expect(midis, `sounded ${sounded}`).toContain(sounded);
+
+  // And the other three are worth confusing rather than four notes far apart:
+  // one a semitone away, one the same name in another octave, one a step or two
+  // off. Checked on the notes the interface actually put on screen.
+  const others = midis.filter((m) => m !== sounded);
+  expect(others.filter((m) => Math.abs(m - sounded) === 1), `choices ${midis}`).toHaveLength(1);
+  expect(others.filter((m) => (m - sounded) % 12 === 0), `choices ${midis}`).toHaveLength(1);
+  expect(
+    others.filter((m) => Math.abs(m - sounded) >= 2 && Math.abs(m - sounded) <= 5),
+    `choices ${midis}`,
+  ).toHaveLength(1);
+  // Each is spelled where a person can read it.
+  const shown = await choices(page)
+    .locator(".choice-pitch")
+    .evaluateAll((els) => els.map((el) => el.textContent.trim()));
+  expect(shown).toEqual(midis.map((m) => spellMidi(m)));
+
+  // Nothing on screen marks which is right until an answer is given. Anchored:
+  // the test below proves this selector matches after one is.
+  await expect(page.locator(".choice.correct")).toHaveCount(0);
+  await expect(statement(page)).toHaveCount(0);
+  await expect(notices(page)).toHaveCount(0);
+
+  expect(soundfontRequests.length).toBeGreaterThan(0);
+  expect(await page.evaluate(() => window.__audioContexts)).toBeGreaterThan(0);
+});
+
+test("naming the note that sounded says what it was, and the counts move", async ({ page }) => {
+  await startDrill(page);
+  await expect(progress(page)).toHaveText("Nothing named yet.");
+
+  const { sounded } = await answer(page, { as: "heard" });
+
+  await expect(statement(page)).toHaveText(`That was ${spellMidi(sounded)}.`);
+  await expect(drill(page)).toHaveAttribute("data-asked", "1");
+  await expect(drill(page)).toHaveAttribute("data-named", "1");
+  await expect(progress(page)).toHaveText("1 note, 1 named as heard.");
+
+  // The mark is on the note that sounded, and on no other. Presence is not
+  // placement: a tick rendered at section level reads as belonging to a row.
+  const marked = page.locator(".choice.correct");
+  await expect(marked).toHaveCount(1);
+  await expect(marked).toHaveAttribute("data-midi", String(sounded));
+  const tick = marked.locator(".tick");
+  const inside = await tick.boundingBox();
+  const button = await marked.boundingBox();
+  expect(inside.x, JSON.stringify({ inside, button })).toBeGreaterThanOrEqual(button.x - 1);
+  expect(inside.x + inside.width).toBeLessThanOrEqual(button.x + button.width + 1);
+  expect(inside.y).toBeGreaterThanOrEqual(button.y - 1);
+  expect(inside.y + inside.height).toBeLessThanOrEqual(button.y + button.height + 1);
+
+  await expect(notices(page)).toHaveCount(0);
+});
+
+test("naming a different note says which one, in exactly the words and colours of the other case", async ({
+  page,
+}) => {
+  // The tone rule, and the reason this exercise is the easiest place in a
+  // practice tool to get it wrong. A wrong answer in ear training is the
+  // practice, not a shortfall: it is stated, and nothing else happens to it.
+  const style = (locator) =>
+    locator.evaluate((el) => {
+      const s = getComputedStyle(el);
+      return {
+        color: s.color,
+        background: s.backgroundColor,
+        weight: s.fontWeight,
+        size: s.fontSize,
+      };
+    });
+
+  await startDrill(page);
+  const first = await answer(page, { as: "something else" });
+  expect(first.chosen).not.toBe(first.sounded);
+
+  await expect(statement(page)).toHaveText(
+    `That was ${spellMidi(first.sounded)}. You chose ${spellMidi(first.chosen)}.`,
+  );
+  await expect(drill(page)).toHaveAttribute("data-asked", "1");
+  await expect(drill(page)).toHaveAttribute("data-named", "0");
+  await expect(progress(page)).toHaveText("1 note, none named as heard.");
+  // The mark still names what the note WAS - which is the information - and the
+  // note that was picked is shown as picked rather than as an error.
+  await expect(page.locator(".choice.correct")).toHaveAttribute(
+    "data-midi",
+    String(first.sounded),
+  );
+  await expect(page.locator(".choice.picked")).toHaveAttribute("data-midi", String(first.chosen));
+  const unnamed = await style(statement(page));
+  // Read now, while there is a picked-but-not-heard note to read: the next round
+  // is answered as heard, and there is deliberately no such mark then.
+  const pickedColour = await page
+    .locator(".choice.picked")
+    .evaluate((el) => getComputedStyle(el).borderColor);
+
+  // ...and now the same page after a note that WAS named as heard.
+  await nextNote(page, 2);
+  const second = await answer(page, { as: "heard" });
+  await expect(statement(page)).toHaveText(`That was ${spellMidi(second.sounded)}.`);
+  const named = await style(statement(page));
+
+  expect(unnamed, JSON.stringify({ unnamed, named })).toEqual(named);
+
+  // And specifically not red: --danger is how this application spells a fault,
+  // and nothing about a wrong answer here is one. The token is read off the page
+  // and resolved through a probe, because it holds a hex string while
+  // getComputedStyle answers in rgb().
+  const danger = await page.evaluate(() =>
+    getComputedStyle(document.documentElement).getPropertyValue("--danger").trim(),
+  );
+  expect(danger, "--danger is expected to exist, or this assertion proves nothing").not.toBe("");
+  const dangerRgb = await page.evaluate((hex) => {
+    const probe = document.createElement("span");
+    probe.style.color = hex;
+    document.body.appendChild(probe);
+    const value = getComputedStyle(probe).color;
+    probe.remove();
+    return value;
+  }, danger);
+  expect(unnamed.color).not.toBe(dangerRgb);
+  expect(pickedColour).not.toBe(dangerRgb);
+  // And no mark at all on a round that was named as heard - "you chose this" is
+  // information about a note you did not hear, and there is nothing to add when
+  // the one you chose is the one that sounded.
+  await expect(page.locator(".choice.picked")).toHaveCount(0);
+});
+
+test("the note can be heard again before and after answering, and that is not counted", async ({
+  page,
+}) => {
+  // From the issue: "the option to hear it again before and after answering,
+  // because the point is to attach the sound to the name". Hearing a note five
+  // times is practising, not cheating, so nothing counts it - a number that only
+  // ever rises when somebody struggles is a score wearing a different name.
+  await startDrill(page);
+  const sounded = await soundedMidi(page);
+
+  await page.locator(".hear-again").click();
+  await expect(drill(page)).toHaveAttribute("data-sounded-count", "2", { timeout: 30_000 });
+  // The REPLAY sounded the same note, which is what makes it a replay: read off
+  // what the synthesiser was handed the second time, not off what was stored.
+  await expect(drill(page)).toHaveAttribute("data-sounded-midi", String(sounded));
+  await expect(drill(page)).toHaveAttribute("data-asked", "0");
+  // and the question is unchanged - a replay must not reshuffle the choices
+  expect(await choiceMidis(page)).toContain(sounded);
+
+  await answer(page, { as: "heard" });
+  await expect(drill(page)).toHaveAttribute("data-asked", "1");
+
+  // Again, now that the name is known - which is the more useful of the two.
+  await page.locator(".hear-again").click();
+  await expect(drill(page)).toHaveAttribute("data-sounded-count", "3", { timeout: 30_000 });
+  await expect(drill(page)).toHaveAttribute("data-sounded-midi", String(sounded));
+  await expect(drill(page)).toHaveAttribute("data-asked", "1");
+  await expect(progress(page)).toHaveText("1 note, 1 named as heard.");
+});
+
+test("answering does not move the choices out from under the cursor", async ({ page }) => {
+  // Placement, and only geometry can see it. The statement about what the note
+  // was appears above the four buttons, so unless its space is held open the
+  // whole question slides down at the exact moment a hand is over it - and every
+  // assertion about the wording still passes. The tick inside a button is the
+  // same problem one level down, which is why it is rendered empty rather than
+  // absent.
+  await startDrill(page);
+  const boxes = async () =>
+    choices(page).evaluateAll((els) =>
+      els.map((el) => {
+        const r = el.getBoundingClientRect();
+        return { midi: el.dataset.midi, x: Math.round(r.x), y: Math.round(r.y), w: Math.round(r.width), h: Math.round(r.height) };
+      }),
+    );
+  const before = await boxes();
+  const hearBefore = await page.locator(".hear-again").boundingBox();
+  // Anchored: this is the element whose arrival is what would move things, and
+  // the assertion after the click proves the selector matches.
+  await expect(statement(page)).toHaveCount(0);
+
+  await answer(page, { as: "heard" });
+  await expect(statement(page)).toHaveCount(1);
+
+  expect(await boxes()).toEqual(before);
+  const hearAfter = await page.locator(".hear-again").boundingBox();
+  expect(Math.round(hearAfter.x)).toBe(Math.round(hearBefore.x));
+  expect(Math.round(hearAfter.y)).toBe(Math.round(hearBefore.y));
+});
+
+test("stopping the drill logs one ear-training session, and the note says what was done", async ({
+  page,
+  request,
+}) => {
+  await startDrill(page);
+  await answer(page, { as: "heard" });
+  await nextNote(page, 2);
+  await answer(page, { as: "something else" });
+
+  await page.locator(".stop-drill").click();
+  const logged = page.locator(".logged");
+  await expect(logged).toBeVisible();
+  await expect(logged).toContainText("of ear training is in your practice history");
+  await expect(logged).toContainText("2 notes, 1 named as heard.");
+  await expect(notices(page)).toHaveCount(0);
+  // The drill is over, so there is nothing left to answer. Anchored on a
+  // selector the tests above prove can match.
+  await expect(choices(page)).toHaveCount(0);
+
+  const { sessions, total } = await (
+    await request.get("/api/practice/sessions?limit=1000")
+  ).json();
+  expect(total).toBe(1);
+  const [session] = sessions;
+  // The vocabulary docs/practice-data.md has always carried a slot for, so this
+  // lands in the same table as a piece and a stretch of technique.
+  expect(session.activity).toBe("ear_training");
+  expect(session.score_id).toBeNull();
+  expect(session.mode).toBeNull();
+  // The practiser's own calendar day, not the server's UTC one.
+  expect(session.local_date).toBe(today);
+  expect(session.local_date_source).toBe("recorded");
+  expect(session.seconds).toBeGreaterThanOrEqual(1);
+  // Nothing invented beside the time: no rating, no tempo. A drill has neither
+  // and a stored zero would be a number somebody could later average.
+  expect(session.rating).toBeNull();
+  expect(session.tempo_bpm).toBeNull();
+  expect(session.target_tempo_bpm).toBeNull();
+
+  // The counts and the range go in the free-text note. docs/practice-data.md
+  // says a per-attempt table is not being invented for the first trainer, and
+  // this is where that decision lands.
+  expect(session.note).toBe("Hear a note, name it. 2 notes, 1 named as heard. C2 to C6.");
+  expect(forbiddenWord(session.note), session.note).toBeNull();
+  expect(session.note).not.toMatch(/%/);
+});
+
+test("that session shows on the practice page and counts towards a goal about ear training", async ({
+  page,
+  request,
+}) => {
+  // The claim this exercise is worth building at all rests on: a drill's time
+  // is practice, in the same history, against the same goals, with no special
+  // case anywhere.
+  const goal = await request.post(`/api/practice/goals?today=${today}`, {
+    data: {
+      target_days: 1,
+      target_minutes: null,
+      scope: "activity",
+      activity: "ear_training",
+      intent: "hear the difference between a semitone and nothing",
+    },
+  });
+  expect(goal.ok(), await goal.text()).toBe(true);
+
+  await startDrill(page);
+  await answer(page, { as: "heard" });
+  await page.locator(".stop-drill").click();
+  await expect(page.locator(".logged")).toBeVisible();
+
+  await page.goto("/#/practice");
+  await expect(page.locator("section.week")).toBeVisible();
+
+  // The goal it was scoped to, counted from the session the drill just wrote.
+  await expect(page.locator("section.week .scope")).toHaveText("ear training");
+  await expect(page.locator('section.week .statement[data-statement="days"]')).toContainText(
+    "1 of 1 planned days",
+  );
+  // Stated, not graded: the reached mark is the only difference between a target
+  // met and one not, and this is the same tick the rest of the page uses.
+  await expect(page.locator('section.week .statement[data-statement="days"]')).toHaveClass(
+    /reached/,
+  );
+
+  // And the session itself, named as the kind of work it was.
+  const rows = page.locator(".session-list .session");
+  await expect(rows).toHaveCount(1);
+  await expect(rows.first().locator(".session-what")).toHaveText("Ear training");
+  await expect(rows.first().locator(".session-extra")).toContainText("Hear a note, name it.");
+  // The day was recorded rather than worked out from a timestamp.
+  await expect(rows.first().locator(".day-inferred")).toHaveCount(0);
+  // Where the time went knows what kind of work it was, too.
+  await expect(page.locator(".by-activity")).toContainText("Ear training");
+});
+
+test("leaving the page in the middle of a drill still logs the practice", async ({
+  page,
+  request,
+}) => {
+  // Practice history is the one thing in Fermata that cannot be regenerated
+  // from the files on disk, so walking away from a drill must not throw away
+  // the time it took. The route change unmounts the component, and the log goes
+  // out from its teardown.
+  await startDrill(page);
+  await answer(page, { as: "heard" });
+
+  await page.locator(".back").click();
+  await expect(page.locator("section.drill")).toHaveCount(0);
+
+  await expect(async () => {
+    const { total } = await (await request.get("/api/practice/sessions?limit=1000")).json();
+    expect(total).toBe(1);
+  }).toPass({ timeout: 10_000 });
+
+  const { sessions } = await (await request.get("/api/practice/sessions?limit=1000")).json();
+  expect(sessions[0].activity).toBe("ear_training");
+  expect(sessions[0].note).toBe("Hear a note, name it. 1 note, 1 named as heard. C2 to C6.");
+});
+
+test("with one instrument defined the drill follows it, and never leaves its range", async ({
+  page,
+  request,
+}) => {
+  // A range that follows the instrument is the version of this exercise worth
+  // doing - and with exactly one instrument defined there is nothing to guess
+  // about which one is in somebody's hands.
+  await addInstrument(request, BASS);
+  await page.reload();
+  await expect(drill(page)).toBeVisible();
+
+  await expect(page.locator(".range-source")).toHaveValue(/^\d+$/);
+  // E1 (28) is the lowest string; the top string G2 (43) plus the 24 frets the
+  // definition declares is G4 (67). Reading the strings alone would offer a
+  // drill two octaves narrower than the instrument.
+  await expect(page.locator(".range-label")).toHaveText("E1 to G4, Bass (four string)");
+  await expect(drill(page)).toHaveAttribute("data-range", "28-67");
+
+  await startDrill(page);
+  for (let round = 1; round <= 4; round++) {
+    if (round > 1) await nextNote(page, round);
+    const sounded = await soundedMidi(page);
+    expect(sounded, `round ${round}`).toBeGreaterThanOrEqual(28);
+    expect(sounded, `round ${round}`).toBeLessThanOrEqual(67);
+    for (const midi of await choiceMidis(page)) {
+      expect(midi, `round ${round} choices`).toBeGreaterThanOrEqual(28);
+      expect(midi, `round ${round} choices`).toBeLessThanOrEqual(67);
+    }
+    await answer(page, { as: "heard" });
+  }
+  await expect(progress(page)).toHaveText("4 notes, 4 named as heard.");
+
+  // ...and the range is what the session says it was practised in.
+  await page.locator(".stop-drill").click();
+  await expect(page.locator(".logged")).toBeVisible();
+  const { sessions } = await (await request.get("/api/practice/sessions?limit=1000")).json();
+  expect(sessions[0].note).toBe(
+    "Hear a note, name it. 4 notes, 4 named as heard. E1 to G4, Bass (four string).",
+  );
+});
+
+test("with two instruments defined neither is adopted, because which one is in your hands is not known", async ({
+  page,
+  request,
+}) => {
+  // Fermata has a list of instruments and no notion of a current one. Adopting
+  // the first alphabetically would be a guess, and a drill silently fitted to
+  // the wrong instrument is worse than one that says it is using a plain range.
+  await addInstrument(request, BASS);
+  await addInstrument(request, {
+    ...BASS,
+    name: "Violin",
+    fretted: false,
+    string_count: 4,
+    string_pitches: ["G3", "D4", "A4", "E5"],
+    fret_count: null,
+    capo: null,
+  });
+  await page.reload();
+  await expect(drill(page)).toBeVisible();
+
+  const options = page.locator(".range-source option");
+  // Proved to have loaded, so the empty selection below is a choice and not a
+  // failed fetch.
+  await expect(options).toHaveCount(3);
+  await expect(options.nth(1)).toHaveText("Bass (four string)");
+  await expect(options.nth(2)).toHaveText("Violin");
+  await expect(page.locator(".range-source")).toHaveValue("");
+  await expect(page.locator(".range-label")).toHaveText("C2 to C6");
+  await expect(drill(page)).toHaveAttribute("data-range", "36-84");
+
+  // Choosing one takes effect, and an unfretted definition says why its range
+  // stops where it does - a violinist looking at a range that ends on their top
+  // string deserves to know it is the definition talking.
+  await page.selectOption(".range-source", { label: "Violin" });
+  await expect(page.locator(".range-label")).toHaveText("G3 to E5, Violin");
+  await expect(drill(page)).toHaveAttribute("data-range", "55-76");
+  await expect(page.locator(".range-source-note")).toContainText("unfretted definition");
+  // and a fretted one has nothing to explain
+  await page.selectOption(".range-source", { label: "Bass (four string)" });
+  await expect(page.locator(".range-source-note")).toHaveCount(0);
+});
+
+test("a definition that spans one note says so instead of asking an impossible question", async ({
+  page,
+  request,
+}) => {
+  // Reachable through the ordinary interface: a one-string unfretted instrument
+  // is a real thing to own, and its definition names exactly one pitch.
+  await addInstrument(request, {
+    kind: "string",
+    name: "One string",
+    fretted: false,
+    string_count: 1,
+    string_pitches: ["G3"],
+    fret_count: null,
+    capo: null,
+    reference_pitch: 440,
+  });
+  await page.reload();
+  await expect(drill(page)).toBeVisible();
+
+  await expect(page.locator(".narrow-range")).toContainText("spans one note");
+  await expect(page.locator(".narrow-range")).toContainText("not four to choose between");
+  // No drill is offered, and the same selector is proved to match a moment
+  // later - so this is a button that is genuinely absent rather than a class
+  // that never existed.
+  await expect(startButton(page)).toHaveCount(0);
+
+  await page.selectOption(".range-source", "");
+  await expect(startButton(page)).toBeVisible();
+  await expect(page.locator(".narrow-range")).toHaveCount(0);
+});
+
+test("an instrument defined away from A440 is told it is not being sounded at its own reference", async ({
+  page,
+  request,
+}) => {
+  // playPitch's own note: the synthesiser is equal-tempered around A440 and
+  // takes no reference, so an instrument defined at A415 has its frequencies
+  // SHOWN at A415 and is SOUNDED at A440. A drill that used such a definition
+  // silently would be teaching names against pitches that are not the player's.
+  await addInstrument(request, { ...BASS, name: "Baroque bass", reference_pitch: 415 });
+  await page.reload();
+  await expect(drill(page)).toBeVisible();
+
+  await expect(referenceNote(page)).toContainText("Baroque bass is defined at A415");
+  await expect(referenceNote(page)).toContainText("fixed at A440");
+
+  // And nothing is said about an instrument that agrees with it - a disclosure
+  // printed unconditionally is one nobody reads. Anchored on the assertion
+  // above, which proves this selector matches something.
+  await addInstrument(request, { ...BASS, name: "Modern bass", reference_pitch: 440 });
+  await page.reload();
+  await expect(drill(page)).toBeVisible();
+  await page.selectOption(".range-source", { label: "Modern bass" });
+  await expect(page.locator(".range-label")).toHaveText("E1 to G4, Modern bass");
+  await expect(referenceNote(page)).toHaveCount(0);
+});
+
+test("a synthesiser that will not load says so rather than leaving a silent drill, and can be retried", async ({
+  page,
+}) => {
+  // Without this the click looks like it worked: no sound, no question, no
+  // explanation. The audition resets itself on failure precisely so the next
+  // attempt is a fresh one rather than a cached rejection for the life of the
+  // page.
+  let failing = true;
+  await page.route(/soundfont|\.sf2/, (route) =>
+    failing ? route.abort("failed") : route.continue(),
+  );
+
+  await startButton(page).click();
+  const failure = page.locator(".sound-error");
+  await expect(failure).toBeVisible({ timeout: 30_000 });
+  await expect(failure).toContainText("soundfont");
+  // No question is asked about a note that never sounded. Anchored: the retry
+  // below proves this selector matches when there is one.
+  await expect(choices(page)).toHaveCount(0);
+  await expect(drill(page)).toHaveAttribute("data-sounded-count", "0");
+  await expect(statement(page)).toHaveCount(0);
+
+  failing = false;
+  await failure.locator(".retry-sound").click();
+  await expect(drill(page)).toHaveAttribute("data-sounded-count", "1", { timeout: 30_000 });
+  await expect(choices(page)).toHaveCount(4);
+  await expect(notices(page)).toHaveCount(0);
+});

--- a/web/tests/browser/zz-library-missing.spec.js
+++ b/web/tests/browser/zz-library-missing.spec.js
@@ -190,10 +190,28 @@ test("a refused scan says so on the page, and can be confirmed", async ({ page, 
   await alert.getByRole("button", { name: /I meant to do that/i }).click();
   await expect(page.locator(".alert")).toHaveCount(0, { timeout: 30_000 });
 
-  const after = await (await request.get("/api/scan/status")).json();
-  expect(after.refused).toBe(false);
-  expect(after.missing).toBe(2);
-  // Marked, never deleted.
+  // Polled until the rescan the acknowledgement started has actually LANDED,
+  // rather than read once. The alert disappearing is a client-side signal - the
+  // page refetched and saw the refusal gone - while the reconciliation that
+  // marks both rows happens in the scan behind it, and this read goes out of
+  // band through the request context rather than through the page, so it is not
+  // ordered against that scan finishing. Read once, it overtook the scan and
+  // reported `missing: 0`: a real failure, seen once in a full-suite run and
+  // never in isolation, which is the signature of exactly this race.
+  //
+  // The same trap instruments.spec.js already names - "those assertions are
+  // barriers, not only checks" - and the same one this file's own comment below
+  // records having been caught by on a slower runner. Every assertion is kept;
+  // only the reading of them becomes a barrier.
+  await expect(async () => {
+    const after = await (await request.get("/api/scan/status")).json();
+    expect(after.scanning, JSON.stringify(after)).toBe(false);
+    expect(after.refused, JSON.stringify(after)).toBe(false);
+    expect(after.missing, JSON.stringify(after)).toBe(2);
+  }).toPass({ timeout: 30_000 });
+
+  // Marked, never deleted. Ordered after the barrier above, so this reads the
+  // library the reconciliation actually left behind.
   const listed = await scores(request);
   for (const name of OWN) {
     const row = listed.find((s) => s.path === name);

--- a/web/tests/minimum-tests.js
+++ b/web/tests/minimum-tests.js
@@ -68,7 +68,48 @@
 // mutation of the behaviour it claims - see the pull request. Two of them also
 // assert PLACEMENT and not only text, because both of those facts were rendered
 // in the wrong place while every assertion about their wording passed.
-export const MINIMUM_TESTS = 205;
+// Plus 31 for issue #61, the first exercise - hear a note, name it.
+//
+// 18 in tests/unit/ear-training.spec.js: which four notes get offered (that the
+// note heard is one of them exactly once, that the other three are one of each
+// kind worth confusing rather than four notes far apart, that which candidate of
+// each kind is taken is the caller's randomness rather than fixed, that no
+// choice ever leaves the range, and that a range with no octave in it still
+// offers four); what an instrument's own definition says its range is (strings
+// plus declared frets, moved by a capo, stopping at the strings when there are
+// no frets to declare, and absent rather than wrong when there are no strings);
+// a range too narrow to ask a question in at all; the note to sound never being
+// the note just heard; and every string the module can produce, checked against
+// practice.js's own forbidden-word list and against carrying a percentage - a
+// drill is the easiest place in a practice tool to start grading somebody, and
+// the rule against it is only real if something checks.
+//
+// 13 in tests/browser/ear-training.spec.js, which drive the real synthesiser
+// because the one property this exercise lives or dies by is that the question
+// is built from what was SOUNDED and not from what the component meant to
+// sound: the four choices are read back against data-sounded-midi, which is set
+// from the value playPitch resolved with, so deleting the audio path leaves no
+// answer to read and no choices to click. Then what happens on an answer either
+// way - the same words in the same place and, asserted on computed style, the
+// same colours, because a wrong answer in ear training is the practice and not a
+// shortfall; hearing a note again before and after answering and that not being
+// counted; the drill following a single defined instrument and never leaving its
+// range, not adopting one of two because which is in somebody's hands is not
+// known, and saying so when a definition spans one note or is pitched away from
+// the synthesiser's fixed A440; a soundfont that will not load saying so rather
+// than leaving a silent drill; and the session itself - one practice_sessions
+// row with activity 'ear_training', on the practice page, counted against a
+// weekly goal about ear training with no special case, and still logged when
+// somebody walks away from the drill mid-way.
+//
+// One of the 13 asserts PLACEMENT and not only text, because the statement about
+// what the note was renders above the four buttons: unless its space is held
+// open the whole question slides down at the moment a hand is over it, and every
+// assertion about the wording still passes.
+//
+// Raised deliberately, and every one of the 31 was shown to fail against a
+// mutation of the behaviour it claims - see the pull request.
+export const MINIMUM_TESTS = 236;
 
 export default class MinimumTests {
   constructor() {

--- a/web/tests/unit/ear-training.spec.js
+++ b/web/tests/unit/ear-training.spec.js
@@ -1,0 +1,312 @@
+// The ear exercise's arithmetic and its phrasing, called directly.
+//
+// What these are for that a browser test cannot do cheaply: WHICH four notes
+// get offered is the whole difference between an exercise and a coin toss, and
+// checking it through a page means driving a soundfont for every case. The
+// generator takes its randomness as a parameter precisely so this file can pin
+// it, and the interesting cases - a range with no octave in it, a range too
+// narrow to ask a question at all - are ones a page would have to be
+// constructed instrument-by-instrument to reach.
+//
+// The phrasing is here for the same reason practice.js's is: the words are the
+// feature. A drill is the easiest place in a practice tool to start grading
+// somebody, and the rule against it is only real if something checks.
+import { expect, test } from "@playwright/test";
+
+import {
+  CHOICE_COUNT,
+  DEFAULT_RANGE,
+  MIN_RANGE_SEMITONES,
+  SYNTH_REFERENCE_HZ,
+  buildChoices,
+  distractorKinds,
+  instrumentRange,
+  loggedStatement,
+  pickTarget,
+  progressStatement,
+  rangeIsAskable,
+  rangeLabel,
+  rangeSourceStatement,
+  rangeStatement,
+  referenceStatement,
+  roundStatement,
+  sessionNote,
+} from "../../src/lib/ear-training.js";
+import { spellMidi } from "../../src/lib/pitch.js";
+import { FORBIDDEN_WORDS, forbiddenWord } from "../../src/lib/practice.js";
+
+/** An instrument in the shape the API answers with - what matters here is
+ * `strings[].sounding_midi`, which already has any capo in it. */
+function instrument(over = {}) {
+  const pitches = over.midis ?? [40, 45, 50, 55, 59, 64]; // guitar, standard
+  return {
+    name: "Guitar (standard)",
+    fretted: true,
+    fret_count: 22,
+    reference_pitch: 440,
+    ...over,
+    strings: pitches.map((midi, index) => ({
+      number: pitches.length - index,
+      sounding_midi: midi,
+    })),
+  };
+}
+
+// A generator that walks a fixed list, so every pick in a test is chosen rather
+// than observed. Returns 0 once the list runs out, which selects the first
+// candidate of whatever is left.
+function fixed(...values) {
+  let i = 0;
+  return () => (i < values.length ? values[i++] : 0);
+}
+
+test("an instrument's range runs from its lowest string to its top fret", () => {
+  // A guitar's top string is E4 (64) and it declares 22 frets, so the highest
+  // note its own definition says it makes is D6 (86). Reading the strings alone
+  // would offer a drill two octaves narrower than the instrument.
+  expect(instrumentRange(instrument())).toEqual({ low: 40, high: 86, top: "frets" });
+  expect(rangeLabel(instrumentRange(instrument()))).toBe("E2 to D6");
+});
+
+test("a capo moves the range, because it moves what the instrument sounds", () => {
+  // sounding_midi is what the drill reads, which is the same rule the
+  // instruments editor auditions by: the capo decides what comes out.
+  const capoed = instrument({ midis: [45, 50, 55, 60, 64, 69] });
+  expect(instrumentRange(capoed)).toEqual({ low: 45, high: 91, top: "frets" });
+});
+
+test("an unfretted range stops at its strings, and says why", () => {
+  // A violin: G3 to E5. Its definition declares no frets and therefore says
+  // nothing at all about how high it is played, so the range stops at the top
+  // string rather than at an invented ceiling - and the interface has a sentence
+  // for that, because a cellist looking at a range ending on their top string
+  // deserves to know it is the definition talking and not the drill.
+  const violin = instrument({ name: "Violin", fretted: false, fret_count: null, midis: [55, 62, 69, 76] });
+  expect(instrumentRange(violin)).toEqual({ low: 55, high: 76, top: "strings" });
+  expect(rangeSourceStatement(instrumentRange(violin))).toContain("unfretted definition");
+  // and nothing is said about a fretted one, which needs no explaining
+  expect(rangeSourceStatement(instrumentRange(instrument()))).toBe("");
+});
+
+test("an instrument with no strings yields no range at all rather than a wrong one", () => {
+  expect(instrumentRange({ strings: [] })).toBeNull();
+  expect(instrumentRange(null)).toBeNull();
+});
+
+test("the four choices include the note that sounded, exactly once", () => {
+  for (const sounded of [36, 48, 60, 72, 84]) {
+    const choices = buildChoices(sounded, DEFAULT_RANGE, fixed(0, 0, 0, 0, 0, 0, 0));
+    expect(choices).toHaveLength(CHOICE_COUNT);
+    expect(choices.filter((c) => c === sounded)).toHaveLength(1);
+    expect(new Set(choices).size).toBe(CHOICE_COUNT);
+  }
+});
+
+test("the three notes you did not hear are one of each kind worth confusing", () => {
+  // The issue's requirement, and the difference between an exercise and a coin
+  // toss: "near neighbours, or the same note in another octave, rather than four
+  // notes far apart which teaches nothing."
+  const sounded = 60;
+  const choices = buildChoices(sounded, DEFAULT_RANGE, fixed(0, 0, 0, 0, 0, 0, 0));
+  const others = choices.filter((c) => c !== sounded);
+  expect(others).toHaveLength(3);
+
+  const semitoneAway = others.filter((c) => Math.abs(c - sounded) === 1);
+  const sameName = others.filter((c) => c !== sounded && (c - sounded) % 12 === 0);
+  const aStepOrTwo = others.filter((c) => {
+    const gap = Math.abs(c - sounded);
+    return gap >= 2 && gap <= 5;
+  });
+  expect(semitoneAway).toHaveLength(1);
+  expect(sameName).toHaveLength(1);
+  expect(aStepOrTwo).toHaveLength(1);
+  // and the same-name one really does read as the same name
+  expect(spellMidi(sameName[0]).replace(/-?\d+$/, "")).toBe(spellMidi(sounded).replace(/-?\d+$/, ""));
+  // Nothing is far away. The widest of the three is the octave.
+  expect(Math.max(...others.map((c) => Math.abs(c - sounded)))).toBeLessThanOrEqual(24);
+});
+
+test("which candidate of each kind is taken is the caller's randomness, not a fixed choice", () => {
+  // Otherwise the drill offers the same three distractors for a given note
+  // every single time, which is a pattern to learn instead of an ear to train.
+  const kinds = distractorKinds(60, DEFAULT_RANGE);
+  expect(kinds.semitone).toEqual([59, 61]);
+  expect(kinds.octave).toEqual([48, 72, 36, 84]);
+  expect(kinds.nearby).toEqual([55, 56, 57, 58, 62, 63, 64, 65]);
+
+  // rand() near 1 takes the last of each pool; near 0 the first. The shuffle
+  // consumes the tail of the sequence, so only the first three values decide
+  // WHICH notes are in the set.
+  const low = new Set(buildChoices(60, DEFAULT_RANGE, fixed(0, 0, 0)));
+  const high = new Set(buildChoices(60, DEFAULT_RANGE, fixed(0.99, 0.99, 0.99)));
+  expect([...low].sort()).toEqual([48, 55, 59, 60]);
+  expect([...high].sort()).toEqual([60, 61, 65, 84]);
+});
+
+test("every choice stays inside the range, so no note is offered the drill would not play", () => {
+  const narrow = { low: 60, high: 67, top: "chosen" };
+  for (const sounded of [60, 61, 63, 66, 67]) {
+    for (const seed of [0, 0.3, 0.7, 0.99]) {
+      const choices = buildChoices(sounded, narrow, () => seed);
+      expect(choices).toHaveLength(CHOICE_COUNT);
+      expect(new Set(choices).size).toBe(CHOICE_COUNT);
+      for (const choice of choices) {
+        expect(choice).toBeGreaterThanOrEqual(narrow.low);
+        expect(choice).toBeLessThanOrEqual(narrow.high);
+      }
+    }
+  }
+});
+
+test("a range with no octave in it still offers four, filled with the nearest instead", () => {
+  // A violin's range is under two octaves at the top of it, and a range narrower
+  // than an octave has no same-name distractor to give. The shortfall is taken
+  // nearest-first rather than the question shrinking to three.
+  const narrow = { low: 70, high: 76, top: "strings" };
+  const choices = buildChoices(76, narrow, fixed(0, 0, 0, 0));
+  expect(choices).toHaveLength(CHOICE_COUNT);
+  expect(new Set(choices).size).toBe(CHOICE_COUNT);
+  expect(distractorKinds(76, narrow).octave).toEqual([]);
+  // the semitone below, then the nearest of the rest
+  expect([...choices].sort((a, b) => a - b)).toEqual([71, 74, 75, 76]);
+});
+
+test("a range too narrow to hold four notes is not askable, and produces no question", () => {
+  // Reachable through the ordinary interface: a one-string unfretted instrument.
+  const single = instrumentRange(
+    instrument({ name: "One string", fretted: false, fret_count: null, midis: [55] }),
+  );
+  expect(single).toEqual({ low: 55, high: 55, top: "strings" });
+  expect(rangeIsAskable(single)).toBe(false);
+  expect(buildChoices(55, single, fixed(0))).toEqual([]);
+
+  // and the boundary is where it says it is
+  expect(rangeIsAskable({ low: 60, high: 60 + MIN_RANGE_SEMITONES - 1 })).toBe(false);
+  expect(rangeIsAskable({ low: 60, high: 60 + MIN_RANGE_SEMITONES })).toBe(true);
+  expect(rangeIsAskable(DEFAULT_RANGE)).toBe(true);
+});
+
+test("the note to sound is never the note just heard", () => {
+  // The one repeat a person would notice, and it reads as the drill having
+  // failed to advance rather than as a second question.
+  const range = { low: 60, high: 63, top: "chosen" };
+  const previous = 61;
+  // Every index in the reduced span, so this covers the note landing below the
+  // excluded one and above it.
+  const picked = [0, 0.4, 0.9].map((seed) => pickTarget(range, previous, () => seed));
+  expect(picked).toEqual([60, 62, 63]);
+  expect(picked).not.toContain(previous);
+
+  // With nothing heard yet the whole range is available, including that note.
+  expect(pickTarget(range, null, () => 0.3)).toBe(61);
+  // A previous note from OUTSIDE the range (the range was changed) excludes
+  // nothing, rather than silently dropping a note from the new one.
+  expect(pickTarget(range, 90, () => 0.99)).toBe(63);
+});
+
+test("the note to sound stays inside the range", () => {
+  for (const seed of [0, 0.25, 0.5, 0.75, 0.999999, 1]) {
+    const midi = pickTarget(DEFAULT_RANGE, null, () => seed);
+    expect(midi).toBeGreaterThanOrEqual(DEFAULT_RANGE.low);
+    expect(midi).toBeLessThanOrEqual(DEFAULT_RANGE.high);
+  }
+});
+
+test("what happened names the note either way, and names the other one when there was one", () => {
+  // The note is named in the same words and the same place whether or not it
+  // was named correctly, because that is the information. "Wrong" is not
+  // something a person can practise with; "you took a G for the G below it" is.
+  expect(roundStatement({ sounded: 66, chosen: 66 })).toBe("That was F#4.");
+  expect(roundStatement({ sounded: 66, chosen: 65 })).toBe("That was F#4. You chose F4.");
+  // The octave error specifically: the name is right and the place is not, and
+  // the statement has to distinguish those two rather than say "no".
+  expect(roundStatement({ sounded: 66, chosen: 54 })).toBe("That was F#4. You chose F#3.");
+  // Nothing is said before an answer exists.
+  expect(roundStatement({ sounded: 66, chosen: null })).toBe("");
+  expect(roundStatement(null)).toBe("");
+  // Both branches open with the identical clause - so a reader's eye lands on
+  // the same words in the same place either way.
+  expect(roundStatement({ sounded: 66, chosen: 65 })).toContain(
+    roundStatement({ sounded: 66, chosen: 66 }),
+  );
+});
+
+test("how the drill is going is two counts and nothing else", () => {
+  expect(progressStatement({ asked: 0, named: 0 })).toBe("Nothing named yet.");
+  expect(progressStatement({ asked: 1, named: 1 })).toBe("1 note, 1 named as heard.");
+  expect(progressStatement({ asked: 12, named: 9 })).toBe("12 notes, 9 named as heard.");
+  // Zero is a word rather than a nought, the same rule the practice page
+  // applies - a bare nought beside a total reads like a mark out of five.
+  expect(progressStatement({ asked: 4, named: 0 })).toBe("4 notes, none named as heard.");
+});
+
+test("nothing this exercise says is a grade", () => {
+  // Every string the module can produce, checked against practice.js's own
+  // list. The rule lives there so there is one list and one way of applying it.
+  const range = instrumentRange(instrument());
+  const said = [
+    rangeLabel(range),
+    rangeStatement(range, "Guitar (standard)"),
+    rangeSourceStatement({ low: 55, high: 76, top: "strings" }),
+    referenceStatement(instrument({ reference_pitch: 415 })),
+    roundStatement({ sounded: 66, chosen: 66 }),
+    roundStatement({ sounded: 66, chosen: 65 }),
+    progressStatement({ asked: 0, named: 0 }),
+    progressStatement({ asked: 12, named: 0 }),
+    progressStatement({ asked: 12, named: 12 }),
+    sessionNote({ asked: 12, named: 0, range, instrumentName: "Guitar (standard)" }),
+    sessionNote({ asked: 12, named: 12, range }),
+    loggedStatement(930),
+  ];
+  // Anchored: the list is proved to be able to catch something, or every
+  // assertion below passes by checking nothing.
+  expect(forbiddenWord(`this week was my ${FORBIDDEN_WORDS[0]}`)).toBe(FORBIDDEN_WORDS[0]);
+  for (const text of said) {
+    expect(text, `"${text}"`).not.toBe(undefined);
+    expect(forbiddenWord(text), `"${text}"`).toBeNull();
+    // No percentage anywhere. A count is a fact; a number out of a hundred is a
+    // mark, and a mark invites a colour.
+    expect(text, `"${text}"`).not.toMatch(/%|per cent|percent/i);
+    // and no verdict adverbs, which the shared list does not carry because the
+    // practice page has no occasion to use them
+    expect(text, `"${text}"`).not.toMatch(/\b(wrong|incorrect|correct|score|accuracy)\b/i);
+  }
+});
+
+test("the session's note says what was done and in what range", () => {
+  const range = instrumentRange(instrument());
+  expect(sessionNote({ asked: 12, named: 9, range, instrumentName: "Guitar (standard)" })).toBe(
+    "Hear a note, name it. 12 notes, 9 named as heard. E2 to D6, Guitar (standard).",
+  );
+  // No instrument, so nothing is named that was not chosen.
+  expect(sessionNote({ asked: 3, named: 3, range: DEFAULT_RANGE })).toBe(
+    "Hear a note, name it. 3 notes, 3 named as heard. C2 to C6.",
+  );
+  // A drill that was listened to and never answered is still practice, and the
+  // note says exactly that rather than reading as a broken row.
+  expect(sessionNote({ asked: 0, named: 0, range: DEFAULT_RANGE })).toBe(
+    "Hear a note, name it. Nothing named yet. C2 to C6.",
+  );
+});
+
+test("a reference pitch that is not the synthesiser's is disclosed, and one that is is not", () => {
+  // playPitch's own note says the synth is equal-tempered around A440 and takes
+  // no reference, so an instrument defined at A415 has its frequencies SHOWN at
+  // A415 and is SOUNDED at A440. A drill that quietly used such a definition
+  // would be teaching names against pitches that are not the player's own.
+  const baroque = referenceStatement(instrument({ name: "Baroque lute", reference_pitch: 415 }));
+  expect(baroque).toContain("Baroque lute");
+  expect(baroque).toContain("A415");
+  expect(baroque).toContain(`A${SYNTH_REFERENCE_HZ}`);
+  // Silent when there is nothing to disclose, which is most instruments - a
+  // disclosure printed unconditionally is one nobody reads.
+  expect(referenceStatement(instrument())).toBe("");
+  expect(referenceStatement(null)).toBe("");
+  // and a fractional one is not rounded away into looking like 440
+  expect(referenceStatement(instrument({ reference_pitch: 440.5 }))).toContain("A440.5");
+});
+
+test("what was logged is stated as a length, not as a result", () => {
+  expect(loggedStatement(930)).toBe("15m of ear training is in your practice history.");
+  expect(loggedStatement(30)).toBe("under a minute of ear training is in your practice history.");
+});


### PR DESCRIPTION
Closes #61.

A pitch sounds through the synthesiser that already exists for playback, and four
names are offered; one of them is the note that sounded. `#/ear-training`, linked
from the library sidebar and from the practice page.

One exercise, built properly. There is no drill framework, no registry and no
shared question type: the second exercise is what should motivate an abstraction,
and inventing one now would be a guess about what it needs. What is shared is
shared deliberately — the audio path is `score-render.js`'s `playPitch`, the pitch
spelling is `pitch.js`'s, and the way practice is put into words is
`practice.js`'s.

## The question is built from what was sounded

`playPitch` resolves with the MIDI note actually written into the note-on event.
That number — never the target the component picked — is what gets spelled,
offered and marked. So there is no state in which the interface is confident about
a note the synthesiser never played: **delete the audio path and there is no
question**, rather than a question about silence. The instruments editor publishes
its audition the same way, and for the same reason.

Every browser test reads the correct answer out of `data-sounded-midi`, which is
set from that resolved value, so the tests cannot pass with the audio path
stubbed — the first mutation below is exactly that, and it turns two of them red.

## Judgement calls, and why

**How the four are picked.** The issue asks for distractors "worth confusing:
near neighbours, or the same note in another octave, rather than four notes far
apart which teaches nothing." So the drill offers one of each of three kinds:

- **a semitone away** — the interval a beginner cannot hear at all, and the one an
  intermediate player mishears under pressure;
- **the same name an octave out** — the error that survives longest, because the
  note sounds right;
- **a step or a third off** — close enough to need listening, far enough that
  getting it wrong means something different from the semitone case.

Which candidate of each kind gets taken is random, so the drill is a set of
confusions rather than a pattern to learn. A range with no octave in it — the top
of a violin's — still offers four, filled nearest-first rather than shrinking the
question to three.

**Fixed range or the instrument's.** The instrument's, when there is exactly one
defined. Its lowest string to its top declared fret, with any capo counted,
because the capo decides what the instrument sounds — the same rule the
instruments editor auditions by. With *two* instruments defined, neither is
adopted: Fermata has a list of instruments and no notion of a current one, so
picking among several would be a guess, and a drill silently fitted to the wrong
instrument is worse than one that says it is using a plain four octaves (C2 to C6).
With one there is nothing to guess.

An unfretted definition declares no frets and therefore says nothing at all about
how high the instrument is played, so its range stops at its top string and the
page says why. Inventing two octaves above a violin's E string would be the drill
guessing at a technique ceiling it has no information about. A definition that
spans one note — a one-string unfretted instrument, reachable through the ordinary
editor — says so and offers no drill rather than asking an impossible question.

**Reference pitch: deliberately not applied, and said so.** The synthesiser is
equal-tempered around A440 and takes no reference — `playPitch`'s own note has
said so since the instruments editor shipped. So an instrument defined at A415 has
its frequencies *shown* at A415 and is *sounded* at A440. Rather than quietly
using such a definition and teaching names against pitches that are not the
player's, the page states the disagreement where the instrument is named. Where
the definition agrees with the synthesiser nothing is printed: a disclosure
printed unconditionally is one nobody reads.

**Replays.** Unlimited, before and after answering, and counted as nothing. The
issue asks for both directions and the point is attaching the sound to the name;
hearing a note five times is practising, not cheating. A number that only ever
rises when somebody struggles is a score under another name.

**Starting and stopping.** A Start button begins the clock and sounds the first
note; "Stop and log this practice" ends it and writes the session. A drill started
and immediately stopped with nothing ever sounded writes nothing — that is a
mis-click, and a one-second row somebody has to delete by hand is noise. Leaving
the page mid-drill still logs it, from the component's teardown, because practice
history is the one thing in Fermata that cannot be regenerated from the files on
disk.

**No metronome on this page.** The click is a general tool and could be dropped in
in two lines, which is not a reason to: naming a heard pitch has no tempo, and a
control that does nothing for the exercise is decoration to look past every time.

## Tone

A drill is the easiest place in a practice tool to start grading somebody.

- Two counts, stated: *12 notes, 9 named as heard.* **No accuracy percentage**
  anywhere — in the note, on the page, or anywhere a query could produce one —
  because a number out of a hundred is a mark rather than a fact, and it invites a
  colour. **No streak**, and nothing counts consecutive anything.
- A note you could not name is stated and nothing else happens: *"That was F#4.
  You chose F4."* Naming which note you took it for is the whole of the
  information — "wrong" is not something anybody can practise with, and a G heard
  an octave down is a different thing to work on from a G heard as an F sharp.
- The two branches open with the identical clause, render in the same place, and —
  asserted on computed style — in the same colours. There is no `--danger` in the
  component and no variant class on the statement.
- Every string the module can produce is checked against `practice.js`'s own
  `FORBIDDEN_WORDS` list, so the rule is enforced rather than written down.

## What a recorded session looks like

One ordinary `practice_sessions` row. `activity = 'ear_training'` — the vocabulary
has carried a slot for this since the practice model was written, precisely so the
first trainer would not need a table of its own:

```
activity      ear_training
score_id      NULL
mode          NULL
seconds       930                      (wall-clock time in the drill)
local_date    2026-08-22               (the browser's own day; source "recorded")
rating        NULL
tempo_bpm     NULL
note          Hear a note, name it. 12 notes, 9 named as heard. E1 to G4, Bass (four string).
```

It appears on the practice page's session list as **Ear training** with that note
beside it, in *Where the time went* under **By kind of work**, and it counts
towards a weekly goal scoped to ear training — *"1 of 1 planned days"* with the
same reached mark every other target on that page uses. No special case anywhere;
a browser test drives exactly that path.

`docs/practice-data.md` is updated to say this, and to say why a per-attempt
schema is *still* not being invented: one exercise is not enough to know whether
the unit is a position, an interval or a pitch, and the second and third —
fret-to-note, chord recognition — are what should decide it. Designing it around
this one would be the guess that section was written to avoid.

## Out of scope, on purpose

No fretboard neck component (#25), no practice constraints by string and fret
range (#26), no second or third drill (#27, #28), no achievements (#62).

## Tests

`MINIMUM_TESTS` 205 → **236**. 31 new, every one shown to fail against a mutation
of the behaviour it claims.

**18 in `tests/unit/ear-training.spec.js`.** The generator takes its randomness as
a parameter, so every pick in a test is *chosen* rather than observed, and the
interesting cases — a range with no octave in it, a range too narrow to ask a
question in at all — are ones a page would have to be built
instrument-by-instrument to reach.

**13 in `tests/browser/ear-training.spec.js`**, against the real backend, the real
build and the real soundfont, with independent evidence that an `AudioContext` was
constructed and an `.sf2` fetched.

One asserts **placement** and not only text: the statement about what the note was
renders above the four buttons, so unless its space is held open the whole
question slides down at the moment a hand is over it — and every assertion about
the wording still passes. Mutation B3 removes the reserved height and that test is
the only thing that notices. Every "this is not shown" assertion is anchored on a
selector proved to match elsewhere in the same file or the same test.

### Mutations

Each was applied on its own, the suite run, and the result reverted. All 31 tests
are covered.

**Unit (17 mutations of `web/src/lib/ear-training.js`)**

| Mutation | Went red |
| --- | --- |
| The semitone distractor is a fifth away instead of a semitone | one of each kind; the caller's randomness; a range with no octave |
| An instrument's range ignores the frets it declares | lowest string to top fret; a capo moves the range; the session's note |
| The note just heard is no longer excluded | never the note just heard |
| Every range claims to be askable | too narrow to ask in |
| The A440 disclosure is printed unconditionally | a reference that is not the synthesiser's |
| The statement grades the answer ("Correct! That was…") | names the note either way; nothing is a grade |
| The progress statement adds an accuracy percentage | two counts and nothing else; nothing is a grade; the session's note |
| Distractors are no longer confined to the range | every choice stays inside the range; a range with no octave |
| A range short of one kind offers three instead of four | every choice stays inside the range; a range with no octave |
| The same distractor of each kind every time | the caller's randomness |
| An instrument with no strings gets the default range | no strings yields no range |
| An unfretted range never explains where it stops | stops at its strings, and says why |
| The range no longer names the instrument it came from | the session's note |
| The logged statement drops what kind of work it was | stated as a length |
| The note to sound is one semitone off the range | never the note just heard; stays inside the range |
| The note that sounded is offered twice | includes it exactly once, + 4 others |

**Browser (15 mutations of `EarTraining.svelte` / `ear-training.js`)**

| Mutation | Went red |
| --- | --- |
| **The audio path is gone** — the note is spelled from what was asked for rather than what `playPitch` resolved with | a drill sounds a note and offers four built around what was heard; a synthesiser that will not load |
| Hearing a note again counts as a question | heard again … and that is not counted |
| The statement's space is no longer held open | **answering does not move the choices out from under the cursor** (only this one notices) |
| A note that was not named is coloured with `--danger` | in exactly the words and colours of the other case |
| The session is logged as something other than ear training | logs one ear-training session; shows on the practice page; leaving the page |
| Walking away from a drill throws the practice away | leaving the page mid-drill still logs it |
| One of several instruments is adopted as though it were known | with two defined neither is adopted |
| Every choice is marked correct | naming the note that sounded; in exactly the words and colours |
| The mark is drawn outside the button it belongs to (`position: fixed`) | naming the note that sounded (the containment assertion) |
| A one-note range still offers a drill | a definition that spans one note |
| The A440 disclosure is printed for every instrument | defined away from A440 |
| An instrument's range ignores its declared frets | follows one instrument and never leaves its range; defined away from A440 |
| The practice day is left to the server's UTC one | logs one ear-training session; shows on the practice page |
| A note named as heard is not counted | naming the note that sounded; heard again; logs one session; leaving the page; follows one instrument |
| The semitone distractor is a fifth away | a drill sounds a note and offers four built around what was heard |

**The two ways of removing the audio (full suite, 236 tests)**

| mutation of `score-render.js` | with the old `: key` fallback | returning `null` |
| --- | --- | --- |
| `playPitch` returns nothing — the path cannot run | 15 red | **15 red** |
| the note-on is never emitted — it runs and sounds nothing | **0 red** | **15 red** |

The same fifteen either way: ten in `ear-training.spec.js` and five in
`instruments.spec.js`, which is every test that asks for a pitch to be sounded.


## A defect in the shared audition path, found reviewing this

`playPitch` ended `return noteOn ? noteOn.noteKey : key` — falling back to the
**input** when no note-on could be found, while its comment claimed it reports
the note the synthesiser actually received. The two ways of removing the audio
were not equally visible:

| what was broken | with the fallback | returning `null` |
| --- | --- | --- |
| `playPitch` made unavailable — the path cannot run | **15** | **15** |
| the note-on never emitted — it runs and sounds nothing | **0** | **15** |

Every caller and every assertion saw the number it expected, because the function
still returned one. My own B1 mutation deleted the *call*, which is the first
mode; the second was invisible to any possible test, because the function lied.

It now returns `null`. An absent note-on means nothing was handed over and there
is no honest number to give back. **After the fix both modes are caught by the
same fifteen tests** — ten in `ear-training.spec.js` and five in
`instruments.spec.js`, which are every test that asks for a pitch to be sounded.
That is the shape to want: the audio path has one set of watchers and both ways
of breaking it trip all of them.

This matters beyond the exercise. It is the shared audition path, and it is where
the capo defect lived: the interface displayed one pitch while the synthesiser
played another and both agreed with each other while being wrong. A fallback
substituting the request for the result is that same defect one layer down,
pre-armed for every future caller. It was the only such fallback in the function —
the surrounding early returns already answer `null`, and the one other `? :` in
the neighbourhood (`pitch.js`'s `midi == null ? null : midi + capo`) already goes
the honest way.

Both call sites now say what happened rather than why: `null` means either an
unplayable pitch or a note that never reached the synthesiser, and neither caller
can distinguish them, so neither asserts a cause it did not check.

**Honest limitation:** the *absence* of that fallback is pinned by mutation
testing, not by a standing assertion, and cannot be otherwise. There is no input
for which the requested note and the note-on's key differ — which is exactly why
the fallback was invisible — so no test can reach the state that distinguishes
them without a source change. The 15 tests that now catch the second mode all
catch it *indirectly*, by the drill and the editor ceasing to work.

## The audition voice, settled without ears

The drill had inherited both its voice and its note length from the tuning check.
That is measurable, and I measured it: in the soundfont Fermata ships, **program
24 (nylon guitar) has three sample zones for the entire keyboard**, so a note is
one recording pitch-shifted a long way.

| voice | sample zones | worst stretch over C2–C6 | over a guitar's E2–D6 | over a violin's G3–E5 |
| --- | --- | --- | --- | --- |
| 24 nylon guitar | 3 | **24 semitones** (2 octaves) | 26 | 16 |
| 0 acoustic piano | 11 | **12 semitones** | 12 | 7 |

A note transposed two octaves is a thin, formant-shifted artefact, so at the ends
of the range the exercise really was testing the soundfont rather than the ear.
The drill now uses **program 0**, which also happens to be the right voice on its
own merits: a piano is what ear training is taught on, its attack is unambiguous,
and this exercise is about the *name* of a pitch rather than the timbre of an
instrument somebody may not play. The tuning check keeps the guitar — matching a
string by ear wants something like the instrument in hand, and it spans one
instrument's strings rather than four octaves, where three zones cost nothing.

The note is now held **2.5s** rather than 1.6: enough for the attack to pass and
the sustain to be heard *as* a pitch rather than as a transient, and long enough
to hum against. Both are parameters of `playPitch` now, defaulting to the tuning
check's values, so neither task inherits the other's constants.


## One flake found and fixed, which is not coverage

The mode-B run showed a 16th failure: `zz-library-missing.spec.js :: a refused
scan says so on the page`, on `expect(after.missing).toBe(2)`. That is a scan
reconciliation assertion with no connection to audio, mode A fails the identical
15 without it, and it passes 4/4 in isolation — so it is a pre-existing race, not
a watcher of this feature. **It is fixed in its own commit and counted as a flake
fixed, not as a test earned.**

The cause is a read that is not ordered against the work it reads. Clicking *I
meant to do that* starts a rescan; the test waited for the alert to disappear — a
client-side signal — then read `/api/scan/status` out of band through `request`,
overtaking the scan and seeing `missing: 0`. Now polled, with `scanning` added to
the assertions, so the read is a barrier.

This is the third instance of that pattern, after two sweeps for it, and it is in
a file written *after* the most recent one — so a point-in-time grep does not
hold. That is an argument for a mechanical guard, which is filed separately and
deliberately not built here.

## What still needs a human ear

I cannot hear this, and neither can any of the tests. Everything is asserted at
the boundary — the MIDI note handed to the synthesiser, the soundfont fetched, the
`AudioContext` constructed, the note-on read back off the `MidiFile` — which
proves the right *number* reached the synth and nothing about what came out of the
speakers. Four open questions, put as questions rather than assumptions:

- **Is 2.5 seconds right?** Chosen for stated reasons, not measured. It is a
  parameter so that whoever listens can change it without touching the tuning
  check.
- **Is a piano the voice you want**, or does an exercise inside a guitar's range
  want to sound like a guitar even at the cost of a stretched sample?
- **Is the semitone distractor too hard at the extremes**, and does the drill want
  a difficulty setting rather than always offering all three kinds?
- **Is four octaves the right default**, or would something narrower make a better
  first session?
