### PR TITLE
Measure a glyph's position from its ink, not its metrics box (#88)

### DIFF
--- a/docs/musicxml-tab-profile.md
+++ b/docs/musicxml-tab-profile.md
@@ -478,10 +478,9 @@ that needs it has to get it from the producer.
   measures fall from 5,931 to 5,600 and identifiable inferred silence from
   5,450.5 to 3,848.2 quarter notes, so **331 measures this profile reports
   defective read as conforming to anything downstream of that save**. The
-  agreement between a
-  producer's figures and an independent check holds for the file *as the
-  producer wrote it*. Verify against that file, not against a round trip
-  through an editor — see [Checking a file](#checking-a-file).
+  agreement between a producer's figures and an independent check holds for the
+  file *as the producer wrote it*. Verify against that file, not against a
+  round trip through an editor — see [Checking a file](#checking-a-file).
 
 **In the other direction.** Fermata also emits the same music as alphaTex for
 its transcription editor. That format has no editorial mechanism for this and

--- a/docs/musicxml-tab-profile.md
+++ b/docs/musicxml-tab-profile.md
@@ -469,18 +469,20 @@ that needs it has to get it from the producer.
   the voice there; MuseScore rewrites it as an invisible rest. A `<forward>`
   anywhere else must advance the position, or every note after it sounds early.
 - **The marking does not survive a save by another program.** Measured over the
-  same library with MuseScore 4, re-saving the 293 files it emits: every one of
-  the 3,109 `<forward>` elements that survives as one loses its `<footnote>`
-  and its `<voice>`, a trailing one is rewritten as an invisible rest and a
-  leading one as a `<backup>` with no `<forward>` at all. Net effect on a Rule
-  8 check of the re-saved files — a measure counted once whichever way it is
-  wrong, which is the `bars_defective` figure below — is that defective
-  measures fall from 5,931 to 5,600 and identifiable inferred silence from
-  5,450.5 to 3,848.2 quarter notes, so **331 measures this profile reports
-  defective read as conforming to anything downstream of that save**. The
-  agreement between a producer's figures and an independent check holds for the
-  file *as the producer wrote it*. Verify against that file, not against a
-  round trip through an editor — see [Checking a file](#checking-a-file).
+  same library with MuseScore 4, re-saving the 293 files it emits: of the 6,155
+  `<forward>` elements written, 2,957 survive as one and every one of those
+  loses its `<footnote>` and its `<voice>`, while a trailing one is rewritten as
+  an invisible rest and a leading one as a `<backup>` with no `<forward>` at
+  all. Not one `<forward>` in the re-saved files still carries the marking. Net
+  effect on a Rule 8 check of the re-saved files — a measure counted once
+  whichever way it is wrong, which is the `bars_defective` figure below — is
+  that defective measures fall from 5,863 to 5,430 and identifiable inferred
+  silence from 5,529.2 quarter notes to none that can be identified at all, so
+  **433 measures this profile reports defective read as conforming to anything
+  downstream of that save**. The agreement between a producer's figures and an
+  independent check holds for the file *as the producer wrote it*. Verify
+  against that file, not against a round trip through an editor — see
+  [Checking a file](#checking-a-file).
 
 **In the other direction.** Fermata also emits the same music as alphaTex for
 its transcription editor. That format has no editorial mechanism for this and

--- a/docs/musicxml-tab-profile.md
+++ b/docs/musicxml-tab-profile.md
@@ -469,13 +469,16 @@ that needs it has to get it from the producer.
   the voice there; MuseScore rewrites it as an invisible rest. A `<forward>`
   anywhere else must advance the position, or every note after it sounds early.
 - **The marking does not survive a save by another program.** Measured over the
-  same library with MuseScore 4: every one of 3,464 `<forward>` elements loses
-  its `<footnote>` and its `<voice>`, a trailing one is rewritten as an
-  invisible rest and a leading one as a `<backup>` with no `<forward>` at all.
-  Net effect on a Rule 8 check of the re-saved files: defective measures fall
-  from 6,013 to 5,707 and identifiable inferred silence from 5,831.6 to 4,466.2
-  quarter notes, so **306 measures this profile reports defective read as
-  conforming to anything downstream of that save**. The agreement between a
+  same library with MuseScore 4, re-saving the 293 files it emits: every one of
+  the 3,109 `<forward>` elements that survives as one loses its `<footnote>`
+  and its `<voice>`, a trailing one is rewritten as an invisible rest and a
+  leading one as a `<backup>` with no `<forward>` at all. Net effect on a Rule
+  8 check of the re-saved files — a measure counted once whichever way it is
+  wrong, which is the `bars_defective` figure below — is that defective
+  measures fall from 5,931 to 5,600 and identifiable inferred silence from
+  5,450.5 to 3,848.2 quarter notes, so **331 measures this profile reports
+  defective read as conforming to anything downstream of that save**. The
+  agreement between a
   producer's figures and an independent check holds for the file *as the
   producer wrote it*. Verify against that file, not against a round trip
   through an editor — see [Checking a file](#checking-a-file).

--- a/server/fermata/glyph_rhythm.py
+++ b/server/fermata/glyph_rhythm.py
@@ -1611,10 +1611,22 @@ def half_or_whole_rest(yc, line_ys, spacing):
     The discriminator is sub-space PARITY against the line grid - which side
     of a line the ink sits on - and not, as this used to ask, which staff line
     the glyph is NEAREST. The difference is not a tolerance, it is a kind:
-      * Parity holds wherever on the staff the rest was engraved, including
-        the ledger positions above and below it that a second voice's rests
-        use. Nearest-line put every rest below the middle line in the same
-        bucket, so a whole rest hanging under the staff read as a half.
+      * Parity holds at every LINE of the grid, including the ledger positions
+        above and below the staff that a second voice's rests use. Nearest-line
+        put every rest below the middle line in the same bucket, so a whole
+        rest hanging under the staff read as a half.
+
+        It does NOT hold for an arbitrary displacement, and this is a real
+        limit rather than a tolerance: the signal is which quarter of a space
+        the ink sits in, measured modulo one space, so displacing a rest by an
+        ODD number of half spaces lands it exactly where the other rest would
+        be and returns that other answer with decided=True. Nothing in (yc,
+        line_ys, spacing) can separate the two cases - a half rest sits a
+        quarter space above a line and a whole one a quarter space below one,
+        and a half-space shift maps each onto the other - so this is stated,
+        not guarded. No engraving in the library needs the guard: all 256
+        one-glyph rests the decode reads land between 0.235 and 0.266 of a
+        space from a line, and every one is decided.
       * Parity is measured against the ink. Nearest-line was measured against
         the metrics box centre (see GlyphEvent), which is a fixed distance
         from the BASELINE - nearly half a space, most of the way to the other

--- a/server/fermata/glyph_rhythm.py
+++ b/server/fermata/glyph_rhythm.py
@@ -648,9 +648,14 @@ class _InkBoxes:
         (which is most of them - a Maestro subset keeps all 204 slots and
         fills the handful a page uses).
 
-        Whether the box is USABLE is asked per axis by span and xspan, because
-        the two axes fail independently: a glyph drawn as a single vertical
-        stroke has a degenerate x extent and a perfectly good y one.
+        Whether the box is USABLE is asked per axis by span and xspan, and the
+        two axes are refused independently BY CONSTRUCTION rather than
+        because either has been seen to fail alone: a glyph drawn as a single
+        vertical stroke could in principle have a degenerate x extent and a
+        perfectly good y one. No glyph in the library actually splits that
+        way - 0 of 1,855,076 header reads have one axis usable and the other
+        not - but asking per axis costs nothing and is the right shape for a
+        case the library just hasn't shown yet.
         """
         if gid in self._cache:
             return self._cache[gid]
@@ -1725,7 +1730,7 @@ def _best_stem(stems, stem_xs, x0, x1, yc, tol, x_tol=None, y_tol=None):
     (0.348 at the 99th percentile) and its end sits 0.175 spaces from the ink
     centre (0.179 at the 90th). Both are sharp; neither decides alone, and
     letting the noisier margin overrule the other picked a stem further away in
-    y than the alternative for 51 noteheads across 20 scores, in 49 cases the
+    y than the alternative for 90 noteheads across 20 scores, in 49 cases the
     other VOICE's stem. That is a duration error of up to fourfold and a lost
     voice, not a near miss - see the two-voice bars of Dalza's Recercar.
 
@@ -1756,9 +1761,11 @@ def _best_stem(stems, stem_xs, x0, x1, yc, tol, x_tol=None, y_tol=None):
             continue
         dx = min(abs(s.x - x0), abs(s.x - x1))
         # Rounded so two candidates a floating-point hair apart cannot swap on
-        # the platform's last bit, and tie-broken on y: two stems the same
-        # distance away are two voices, and the one whose end lands on this
-        # notehead is the one it hangs off.
+        # the platform's last bit. The second key element exists to make the
+        # ordering TOTAL rather than merely partial - worth keeping even
+        # though it has not once had to decide anything: 0 exact ties on the
+        # rounded hypot across 6,203 multi-candidate noteheads in the
+        # library, and deleting it changes nothing measured.
         key = (round(math.hypot(dx / xt, dy / yt), 6), round(dy, 3))
         if best_key is None or key < best_key:
             best, best_key = s, key
@@ -1911,9 +1918,14 @@ def _assign_stem_directions(notes, stems_by_key):
     This check is a net, not a ranking, and it cannot be moved into
     _best_stem to do the choosing: the side test needs the MEAN x of every
     notehead on the stem, which is exactly what one candidate notehead does
-    not have. Applied per candidate it rejects the right stem too - measured
-    over the library, it leaves 344 noteheads with no consistent candidate at
-    all and changes 38 selections, and the selections it changes are wrong.
+    not have. It was tried anyway. Two independent attempts to measure how
+    many noteheads it leaves with no consistent candidate at all, and how
+    many selections it changes, disagreed with each other, so neither count
+    is published here - but the selections it does change are not better:
+    some individual noteheads move closer to their true stem and others move
+    away, and the change is not an improvement on net. The structural reason
+    above, which both measurements agree on, is why this is not retried
+    rather than the numbers.
 
     This catches only the contradictory subset. A neighbouring voice's stem
     that happens to sit where this notehead's own stem WOULD sit is
@@ -2030,6 +2042,11 @@ def _assign_dots(owners, dot_events, tol):
     counts = collections.Counter()
     if not owners or not dot_events:
         return counts
+    # Still the metrics box's x1 here, not an ink edge - left inconsistent
+    # with the notehead-to-stem lookups above on purpose, since it was
+    # measured against the library and found to have no current effect on
+    # which owner a dot is given, the same way the flag8_or_rest_quarter
+    # window beside it was.
     owners = sorted(owners, key=lambda e: e.x1)
     owner_x1s = [e.x1 for e in owners]
     for dot in dot_events:
@@ -2207,6 +2224,11 @@ def decode_note_events(page, staff_top, staff_bottom, staff_x0, staff_x1, line_y
             # (Barlines are excluded from `stems` - see _is_barline - or a
             # rest engraved next to one would vanish here.)
             if ev.category == "flag8_or_rest_quarter":
+                # Still the metrics box here, not ev.stem_edges - left
+                # inconsistent with the notehead lookups above on purpose,
+                # since it was measured rather than assumed: the ink and box
+                # windows agree on all 67 of the library's flag8_or_rest_quarter
+                # glyphs, so switching this one has no current effect.
                 if _has_stem_near(stems, stem_xs, ev.x0 - tol.rest_stem_pad,
                                   ev.x1 + tol.rest_stem_pad, ev.yc, tol):
                     continue  # it's a flag - counted via the notehead's stem (see FLAG_HOOKS)

--- a/server/fermata/glyph_rhythm.py
+++ b/server/fermata/glyph_rhythm.py
@@ -96,12 +96,23 @@ How this works (full validation detail):
   measured across 254 staves), so a condensed multi-system score or a
   large-print edition silently dropped stems and beams and degraded every
   eighth and sixteenth to a quarter while still reporting high confidence.
+
+  A glyph's vertical position is its INK centre, read from the embedded
+  outline - NOT the centre of the box the text trace reports, which is a
+  metrics box whose top and bottom are the font's ascender and descender and
+  therefore says the same thing about every glyph in the font. See
+  GlyphEvent, _InkBoxes and half_or_whole_rest: the difference is about 0.4
+  staff spaces, it is invisible to glyph-to-glyph comparisons because it
+  cancels, and it was deciding whether a rest was a half or a whole - a
+  twofold difference in duration - from a measurement that was never the
+  rest's position.
 """
 import bisect
 import collections
 import hashlib
 import io
 import math
+import struct
 import weakref
 
 
@@ -457,10 +468,19 @@ _SP = {
     # flags
     "flag_x_tol": 0.98,           # was 5.0pt
     "flag_y_tol": 1.76,           # was 9.0pt
+    # How far outside a flag's own INK the stem end it is drawn on may fall -
+    # see _at_stem_end. A flag is joined to its stem's tip, so the tip is
+    # inside the ink; this is slack for a stroke that stops a hair short of
+    # the hook it carries. Measured over the whole sampled library by the
+    # hooks each value counts: no slack at all counts 4,984 and loses 166 of
+    # the hooks a centre-distance test found, 0.1 and 0.25 both count 5,158,
+    # and widening to a full space adds only 4 more. The value sits in the
+    # middle of that plateau.
+    "flag_ink_pad": 0.25,
     # augmentation dots
     "dot_x_tol": 1.17,            # was 6.0pt
     "dot_x_back": 0.20,           # was 1.0pt
-    "dot_y_tol": 0.78,            # was 4.0pt
+    # A dot's vertical window is not a symmetric tolerance - see _DOT_TIERS.
     # ties
     "tie_gap_max": 7.80,          # was 40.0pt
     "tie_height_max": 1.56,       # was 8.0pt
@@ -584,6 +604,67 @@ def maestro_fingerprint_ok(tt, digests=None, min_glyphs=None):
     return True, f"{len(matched)} glyph outlines match the calibrated Maestro subset"
 
 
+# A glyph's ink never runs more than a couple of ems from the baseline (the
+# tallest thing measured in the calibrated vocabulary is a clef, at 2.2 em), so
+# a `glyf` header claiming more than this is a stale or corrupt box rather than
+# a shape - and a wrong ink box is worse than none, because none degrades to
+# the baseline while a wrong one is believed.
+_INK_MAX_EM = 8.0
+
+
+class _InkBoxes:
+    """Where each glyph's INK is, vertically, in one embedded font - as a
+    fraction of the em, so it scales with whatever size the page drew at.
+
+    A TrueType glyph record starts with its own bounding box
+    (numberOfContours, xMin, yMin, xMax, yMax, five int16s), so this needs no
+    outline parsing at all: slice the glyph's bytes out of `glyf` using the
+    `loca` offsets and unpack the header. That is the same access the Maestro
+    fingerprint already makes (see _glyf_digests), and it is why the ink box
+    is available for every font this decoder reads glyphs from.
+    """
+
+    __slots__ = ("_glyf", "_loca", "_upem", "_cache")
+
+    def __init__(self, tt):
+        self._glyf = tt.getTableData("glyf")
+        self._loca = tt["loca"]
+        self._upem = tt["head"].unitsPerEm or 1000
+        self._cache = {}
+
+    def span(self, gid):
+        """(yMin, yMax) in em fractions, or None where this font has nothing
+        to say about that glyph: a gid past the end of `loca`, a slot the
+        subset left empty (which is most of them - a Maestro subset keeps all
+        204 slots and fills the handful a page uses), or a header whose box is
+        degenerate or implausible."""
+        if gid in self._cache:
+            return self._cache[gid]
+        out = None
+        loca = self._loca
+        if gid >= 0 and gid + 1 < len(loca):
+            seg = self._glyf[loca[gid]:loca[gid + 1]]
+            if len(seg) >= 10:
+                _n, _x0, ymin, _x1, ymax = struct.unpack(">hhhhh", seg[:10])
+                limit = _INK_MAX_EM * self._upem
+                if ymax > ymin and abs(ymin) <= limit and abs(ymax) <= limit:
+                    out = (ymin / self._upem, ymax / self._upem)
+        self._cache[gid] = out
+        return out
+
+
+def _ink_boxes(tt):
+    """An _InkBoxes for this font, or None when its outlines cannot be read.
+    Never raises: an unreadable ink box costs precision - see GlyphEvent.yc,
+    which falls back to the text baseline - not the decode."""
+    if tt is None:
+        return None
+    try:
+        return _InkBoxes(tt)
+    except Exception:
+        return None
+
+
 class MusicFont:
     """One embedded music-symbol font RESOURCE (one xref) on a page, with
     its glyph order resolved so GIDs (Maestro) or names (Opus family) can be
@@ -593,13 +674,18 @@ class MusicFont:
     resources on the same page can have completely different glyph orders
     even though both are named "Opus"."""
 
-    __slots__ = ("family", "xref", "tt", "glyph_order")
+    __slots__ = ("family", "xref", "tt", "glyph_order", "ink")
 
     def __init__(self, family, xref, tt):
         self.family = family  # "Maestro" | "Opus" | "OpusSpecial"
         self.xref = xref
         self.tt = tt
         self.glyph_order = tt.getGlyphOrder() if tt else []
+        # This resource's own ink boxes. Kept on the resource rather than
+        # looked up by family name for the same reason its glyph order is: a
+        # gid means something only within ONE resource, so a box read from a
+        # sibling resource that happens to share the name is a wrong number.
+        self.ink = _ink_boxes(tt)
 
     def category(self, gid):
         if self.family == "Maestro":
@@ -643,17 +729,24 @@ _TRUETYPE_EXTS = ("ttf",)
 # CPython reused the address. Hanging it off the object ties its lifetime to
 # exactly the right thing and needs no invalidation.
 _FONT_CACHE_ATTR = "_fermata_music_font_cache"
+# The same, for the ink boxes of fonts that get no MusicFont - see
+# _ink_boxes_by_name.
+_INK_CACHE_ATTR = "_fermata_ink_box_cache"
 
 
-def _font_cache(doc):
-    cache = getattr(doc, _FONT_CACHE_ATTR, None)
+def _doc_cache(doc, attr):
+    cache = getattr(doc, attr, None)
     if cache is None:
         cache = {}
         try:
-            setattr(doc, _FONT_CACHE_ATTR, cache)
+            setattr(doc, attr, cache)
         except Exception:
             pass  # uncacheable document: still correct, just not memoised
     return cache
+
+
+def _font_cache(doc):
+    return _doc_cache(doc, _FONT_CACHE_ATTR)
 
 
 def _load_one_font(doc, xref, base, ext):
@@ -740,15 +833,55 @@ def load_music_fonts(doc, page):
 # ---------------------------------------------------------------------------
 
 class GlyphEvent:
-    __slots__ = ("family", "gid", "category", "x0", "y0", "x1", "y1", "code", "smufl")
+    """One music-font glyph the page drew, and where.
 
-    def __init__(self, family, gid, category, bbox, code, smufl=False):
+    THE BOX IS NOT THE INK. (x0, y0, x1, y1) is the box the text trace
+    reports, and vertically that box is METRICS-based: its top and bottom come
+    from the font's ascender and descender relative to the text baseline, so
+    it says the same thing about every glyph in the font (measured: 4.0 staff
+    spaces tall for Maestro, whatever the glyph, notehead or clef alike). Its
+    centre therefore sits at a FIXED offset from the baseline rather than at
+    the middle of the drawn shape - measured over the library: -0.39 staff
+    spaces for Maestro, -0.49 for Opus, -0.27 for MuseScore's MScore, -0.67
+    for OpusSpecial - and anything comparing it against staff geometry reads
+    every glyph as most of half a space higher than it is.
+
+    The exception is worth knowing, because it is what the committed fixtures
+    are engraved with: Leland's embedded box is centred on the baseline
+    (measured 0.000 over 475 glyphs), so on a Leland page the box centre and a
+    notehead's ink centre coincide and this defect does not show. It shows for
+    Leland's FLAGS, whose ink is nowhere near either.
+
+    That bias cancels between two glyphs, which is why it survived: noteheads
+    kept their relative positions, chords still grouped, dots still found
+    their owners. It does NOT cancel against a staff line, a staff band, or
+    the middle-line split between a numerator and a denominator, and it was
+    deciding whether a one-glyph rest was a half or a whole - a twofold
+    difference in duration - from a number that was never the rest's position.
+
+    So `yc` is the INK centre, measured from the embedded outline (see
+    _InkBoxes). `y0`/`y1` are kept as what the trace said, and `height` with
+    them, because the metrics box is the right box for the two things that use
+    it: the advance width for horizontal gaps, and a font-wide row height for
+    grouping digits into a numeral.
+    """
+
+    __slots__ = ("family", "gid", "category", "x0", "y0", "x1", "y1", "code",
+                 "smufl", "baseline_y", "ink_y0", "ink_y1")
+
+    def __init__(self, family, gid, category, bbox, code, smufl=False,
+                 baseline_y=None, ink=None):
         self.family = family
         self.gid = gid
         self.category = category
         self.x0, self.y0, self.x1, self.y1 = bbox
         self.code = code
         self.smufl = smufl
+        # The text baseline this glyph was drawn on - the point the engraver
+        # placed it BY - and its measured ink extent, where the font could
+        # supply one.
+        self.baseline_y = baseline_y
+        self.ink_y0, self.ink_y1 = ink if ink is not None else (None, None)
 
     @property
     def calibration_key(self):
@@ -763,7 +896,37 @@ class GlyphEvent:
         return (self.x0 + self.x1) / 2
 
     @property
+    def ink_measured(self):
+        """Was this glyph's ink extent actually read from the font? Only an
+        ink box can answer a question about sub-space POSITION (see
+        half_or_whole_rest); the fallbacks below are good to a fraction of a
+        space, which is not the same thing."""
+        return self.ink_y0 is not None
+
+    @property
     def yc(self):
+        """The middle of the drawn shape - see the class docstring.
+
+        Falls back to the text baseline where the outline could not be read (a
+        CFF embed, a rotated span, a subset slot with no glyph). That is the
+        glyph's registration point, and for the glyphs whose position is
+        compared against staff geometry it is very nearly the ink centre:
+        measured over the library, a notehead's baseline sits within 0.013
+        staff spaces of its ink centre and a meter digit's within 0.036, in
+        Maestro, Opus, MScore and Leland alike. It is NOT good enough for the
+        sub-space parity the half/whole rest turns on - those rests' baselines
+        sit exactly ON the line grid in every one of those fonts, which is an
+        offset of zero and evidence for neither answer - which is why that
+        decision asks whether the ink was measured at all.
+
+        Falls back further to the metrics box centre for an event built by
+        hand from a box and nothing else, which is a test writing coordinates
+        down rather than a page being read.
+        """
+        if self.ink_y0 is not None:
+            return (self.ink_y0 + self.ink_y1) / 2
+        if self.baseline_y is not None:
+            return self.baseline_y
         return (self.y0 + self.y1) / 2
 
     @property
@@ -858,6 +1021,114 @@ def _embedded_font_names(doc, page):
     return names
 
 
+def _ink_boxes_by_name(doc, page):
+    """A function from a basefont NAME to that font's _InkBoxes, or None.
+
+    The SMuFL path has no MusicFont to hang an ink box off - a SMuFL font is
+    recognised from the codepoints it drew, and nothing on that path needs to
+    open the font to decide what a glyph MEANS (see SMUFL_CODE_MAP). Where the
+    glyph is is a different question: it needs the outline, because the text
+    trace's box is a metrics box (see GlyphEvent). So the outline is opened
+    here for measurement only, and failing to read it costs precision rather
+    than the decode.
+
+    Resolved lazily, and only for a name some span actually drew music glyphs
+    in: a page carries half a dozen embedded text fonts that this decoder
+    never reads a glyph from, and parsing those to measure glyphs nobody asks
+    about is work for nothing. Each resource is parsed once per DOCUMENT, like
+    the music fonts beside it.
+
+    A name that more than one distinct resource on the page answers to
+    resolves to None rather than to a guess: a SMuFL subset's glyph order is
+    minted per file, so a box read from the wrong resource is a wrong number,
+    and the text trace reports the font's NAME, not which resource drew the
+    span. Those glyphs fall back to the baseline origin, which SMuFL fixes as
+    each glyph's registration point.
+    """
+    cache = _doc_cache(doc, _INK_CACHE_ATTR)
+    xrefs = collections.defaultdict(set)
+    try:
+        fonts = page.get_fonts(full=True)
+    except Exception:
+        fonts = []
+    for f in fonts:
+        xref, ext, _ftype, basefont = f[0], f[1], f[2], f[3]
+        if not ext or ext in ("n/a", "none"):
+            continue
+        xrefs[basefont.split("+")[-1]].add(xref)
+    resolved = {}
+
+    def resolve(name):
+        if name not in resolved:
+            refs = xrefs.get(name) or ()
+            boxes = None
+            if len(refs) == 1:
+                xref = next(iter(refs))
+                if xref not in cache:
+                    cache[xref] = _load_ink_boxes(doc, xref)
+                boxes = cache[xref]
+            resolved[name] = boxes
+        return resolved[name]
+
+    return resolve
+
+
+def _load_ink_boxes(doc, xref):
+    """The ink boxes of one embedded font resource, or None. Never raises -
+    every reason this can fail (no font program, a CFF-flavour embed with no
+    `glyf`, a truncated subset) is a font whose glyph positions are simply
+    measured from the baseline instead."""
+    ttfont_cls = _ttfont_class()
+    if ttfont_cls is None:
+        return None
+    try:
+        content = doc.extract_font(xref)
+        if isinstance(content, tuple):
+            content = content[-1]
+        if not content:
+            return None
+        tt = ttfont_cls(io.BytesIO(content), fontNumber=0)
+        if "glyf" not in tt:
+            return None
+    except Exception:
+        return None
+    return _ink_boxes(tt)
+
+
+def _ink_scale(span):
+    """The size to scale a glyph's em-relative ink box by for this text span,
+    or None when the span's ink extent cannot be placed from it.
+
+    The trace's own `size` is that scale: checked against the advance width in
+    the embedded `hmtx` for every glyph a music font drew on a notation staff
+    in the sampled library, the two agree to within 1% on 407,469 of 407,537.
+
+    An em-relative box only maps onto page y for UPRIGHT text, so a rotated
+    span declines here and its glyphs are measured from the baseline instead
+    of being placed confidently wrong. The library holds 17 such characters
+    against 407,728 upright ones, so this is nearly - but not quite - a guard
+    against something that does not happen."""
+    size = span.get("size")
+    if not size or size <= 0:
+        return None
+    d = span.get("dir")
+    if d is not None and (abs(d[0] - 1.0) > 1e-6 or abs(d[1]) > 1e-6):
+        return None
+    return size
+
+
+def _ink_span_on_page(reader, gid, origin_y, size):
+    """(ink top, ink bottom) in page points, or None. Page y grows downward
+    and font y grows upward, so the glyph's yMax is its TOP."""
+    if reader is None or size is None or origin_y is None:
+        return None
+    em = reader.span(gid)
+    if em is None:
+        return None
+    ymin, ymax = em
+    return origin_y - ymax * size, origin_y - ymin * size
+
+
 def _smufl_music_fonts(doc, page, trace):
     """Which fonts on this page may be read as SMuFL music fonts?
 
@@ -944,6 +1215,11 @@ def extract_glyph_events(page):
         _GLYPH_EVENTS_CACHE[page] = result
         return result
 
+    # Ink boxes for fonts that got no MusicFont (the SMuFL path). A
+    # Maestro/Opus glyph takes its ink box from the resource that named it
+    # instead - see MusicFont.ink.
+    ink_for = _ink_boxes_by_name(page.parent, page)
+
     events = []
     unknown = []
     for span in trace:
@@ -964,18 +1240,24 @@ def extract_glyph_events(page):
             # the notehead was neither read nor reported.
             if not smufl_names:
                 continue
+            size = _ink_scale(span)
+            reader = ink_for(fname)
             for ch in span.get("chars", []):
-                code, gid, _origin, bbox = ch
+                code, gid, origin, bbox = ch
                 if not SMUFL_RANGE[0] <= code <= SMUFL_RANGE[1]:
                     # a music font can also carry plain text characters
                     # (rehearsal marks, fingerings); those are not music
                     # symbols and must not count as unrecognised ones.
                     continue
-                ev = GlyphEvent(fname, gid, SMUFL_CODE_MAP.get(code), bbox, code, smufl=True)
+                oy = origin[1] if origin else None
+                ev = GlyphEvent(fname, gid, SMUFL_CODE_MAP.get(code), bbox, code, smufl=True,
+                                baseline_y=oy,
+                                ink=_ink_span_on_page(reader, gid, oy, size))
                 events.append(ev)
                 if ev.category is None:
                     unknown.append(ev)
             continue
+        size = _ink_scale(span)
         for ch in span.get("chars", []):
             code, gid, origin, bbox = ch
             # try each font resource sharing this family name until one
@@ -984,12 +1266,22 @@ def extract_glyph_events(page):
             # one Opus resource, this picks whichever one actually knows
             # this GID instead of always trusting the first-loaded xref.
             cat = None
+            reader = None
             for mf in candidates:
                 c = mf.category(gid)
                 if c is not None:
                     cat = c
+                    # ...and the ink box comes from that same resource, which
+                    # is the one whose glyph order this gid was read against.
+                    reader = mf.ink
                     break
-            ev = GlyphEvent(fname, gid, cat, bbox, code)
+            if reader is None and len(candidates) == 1:
+                # An unrecognised glyph still has a position, and with one
+                # resource on the page there is no doubt about whose it is.
+                reader = candidates[0].ink
+            oy = origin[1] if origin else None
+            ev = GlyphEvent(fname, gid, cat, bbox, code, baseline_y=oy,
+                            ink=_ink_span_on_page(reader, gid, oy, size))
             events.append(ev)
             if cat is None:
                 unknown.append(ev)
@@ -1209,6 +1501,66 @@ def extract_stems_beams_curves(page, y_lo, y_hi, x_lo, x_hi, tol=None):
 
 DURATION_CODE = {4.0: 1, 2.0: 2, 1.0: 4, 0.5: 8, 0.25: 16, 0.125: 32}
 
+# A half rest SITS ON a staff line; a whole rest HANGS BELOW one. Both are
+# drawn half a staff space deep, so each one's INK CENTRE lands a quarter of a
+# space off the line grid - a quarter ABOVE a line for a half rest, a quarter
+# BELOW one for a whole rest.
+#
+# Measured over every one-glyph rest in the sampled library plus every rest a
+# SMuFL font spelled out (314 glyphs): the offset is 0.23 to 0.35 of a space
+# either side of a line, never anything below 0.23 and never above 0.35. The
+# window below is that population with room on both sides, and its two edges
+# reject the two things that are not a reading: an offset near zero (the ink
+# centre landing ON a line, which is where a rest whose ink extent could not be
+# measured ends up, because these rests' BASELINES sit on the grid in Maestro,
+# Opus and Leland alike) and an offset near half a space (the ink centre midway
+# between two lines, which no engraver draws).
+REST_PARITY_MIN = 0.125
+REST_PARITY_MAX = 0.375
+
+
+def half_or_whole_rest(yc, line_ys, spacing):
+    """Is this one-glyph rest a HALF rest or a WHOLE one? Returns
+    (base_units, decided) - 2.0 for a half rest, 4.0 for a whole one.
+
+    Maestro and Opus draw both rests with a SINGLE glyph (294 of the 2,795
+    rest glyphs in the sampled library are that one id), so geometry is the
+    only discriminator there is, for a twofold difference in duration: a whole
+    rest read as a half loses two quarter notes of silence out of the bar, a
+    half read as a whole invents two, and either shifts everything after it.
+
+    The discriminator is sub-space PARITY against the line grid - which side
+    of a line the ink sits on - and not, as this used to ask, which staff line
+    the glyph is NEAREST. The difference is not a tolerance, it is a kind:
+      * Parity holds wherever on the staff the rest was engraved, including
+        the ledger positions above and below it that a second voice's rests
+        use. Nearest-line put every rest below the middle line in the same
+        bucket, so a whole rest hanging under the staff read as a half.
+      * Parity is measured against the ink. Nearest-line was measured against
+        the metrics box centre (see GlyphEvent), which is a fixed distance
+        from the BASELINE - nearly half a space, most of the way to the other
+        answer.
+    Checked against the one population where the answer is known independently
+    of geometry: the rests a SMuFL font spells out in the codepoint itself.
+    Parity agrees with the engraving on all 20 of them in the library;
+    nearest-line disagrees with it on 4.
+
+    `decided` is False where the geometry says neither - no staff lines to
+    measure against, no usable spacing, or an offset outside the measured
+    window (see REST_PARITY_MIN). Those are read as a HALF rest, which is what
+    254 of the 294 one-glyph rests in the library are, and the caller reports
+    the count rather than passing the guess off as a reading. Nothing in the
+    library needs it: all 294 are decided, and each one's ink was measured.
+    """
+    if not line_ys or not spacing or spacing <= 0:
+        return 2.0, False
+    offset = (yc - line_ys[0]) / spacing
+    offset -= round(offset)
+    if REST_PARITY_MIN <= abs(offset) <= REST_PARITY_MAX:
+        # Page y grows downward, so a positive offset is ink BELOW the line.
+        return (4.0 if offset > 0 else 2.0), True
+    return 2.0, False
+
 
 class NoteEvent:
     __slots__ = ("x", "y", "base_units", "flags", "dotted", "is_rest",
@@ -1333,6 +1685,30 @@ def _has_stem_near(stems, stem_xs, x0, x1, yc, tol):
                       x_tol=tol.rest_stem_x_tol, y_tol=tol.rest_stem_y_tol) is not None
 
 
+def _at_stem_end(ev, free_y, tol):
+    """Is this glyph drawn ON that stem end?
+
+    A flag is joined to the tip of its stem, so the tip falls INSIDE the
+    flag's ink - true for 4,669 of the 4,843 flag attachments in the sampled
+    library, with the rest inside the pad - and that is the test to make,
+    because a flag's ink reaches a long way from the point it attaches at.
+    Its centre does not reach it: a 32nd hook's ink centre sits two staff
+    spaces from the tip in Leland, and a centre-distance test with a tolerance
+    wide enough to cover that would have to reach four spaces to either side,
+    far enough to take a neighbouring voice's hook. At the tolerance it did
+    have, it read the fixture's 32nds as quarters - a 32-fold error in four
+    durations - which is what the flag_ink_pad note measures from the other
+    side.
+
+    Falls back to the centre-distance test where the glyph's ink extent is
+    unknown (see GlyphEvent.yc) - which is what the whole decoder used
+    before the ink was available, tolerance included.
+    """
+    if ev.ink_measured:
+        return ev.ink_y0 - tol.flag_ink_pad <= free_y <= ev.ink_y1 + tol.flag_ink_pad
+    return abs(ev.yc - free_y) <= tol.flag_y_tol
+
+
 def _flag_count_near(flag_events, flag_xs, stem, notehead_yc, tol):
     """Count flag hooks attached at the free end of a stem (the end further
     from the notehead)."""
@@ -1341,7 +1717,7 @@ def _flag_count_near(flag_events, flag_xs, stem, notehead_yc, tol):
     hooks = 0
     for i in range(lo, hi):
         ev = flag_events[i]
-        if abs(ev.yc - free_y) > tol.flag_y_tol:
+        if not _at_stem_end(ev, free_y, tol):
             continue
         hooks += FLAG_HOOKS.get(ev.category, 1)
     return hooks
@@ -1473,6 +1849,43 @@ def _mark_ties(notes, curves, tol):
                 break
 
 
+# An augmentation dot is drawn in the MIDDLE OF A SPACE, never on a line -
+# measured over every dot in the sampled library (11,405 of them), 11,350 sit
+# within a tenth of a space of a space's centre. So there are exactly three
+# places a dot can be relative to the note it belongs to, and the engraving
+# convention ranks them: the note's OWN space (a note sitting in a space), the
+# space ABOVE it (a note on a line - the default), or the space BELOW it (the
+# same note, where the space above is taken by another voice).
+#
+# The ranking is the discriminator, because the distances are not: a dot in
+# the space above a note on a line is exactly as far from the note one space
+# higher as it is from its own, and a nearest-|dy| test therefore decides
+# which by rounding. It did, and getting it wrong gave one notehead two
+# vertically stacked dots - which is not what a double dot is; a double dot is
+# two dots side by side - while the note the second dot belonged to lost half
+# its length. Both real cases are in the library: a chord of noteheads a space
+# apart, each with its own raised dot, and a lower voice's dotted whole note
+# whose dot is in the space below it.
+_DOT_TIERS = (0.0, -0.5, 0.5)
+# Engraving jitter around each of those positions. A quarter space is also the
+# most it can be: the three positions are half a space apart, so a wider window
+# would make them overlap and there would be nothing to rank. Measured over the
+# library, the widest deviation from one of them is 0.239 of a space, which this
+# just covers.
+_DOT_Y_SLACK = 0.25
+
+
+def _dot_fit(offset, spacing):
+    """Which of the three places a dot can sit relative to a note is this, and
+    how far off it - (tier, deviation), or None for an offset that is none of
+    them. Lower tier is the likelier engraving; see _DOT_TIERS."""
+    for tier, expected in enumerate(_DOT_TIERS):
+        deviation = abs(offset - expected * spacing)
+        if deviation <= _DOT_Y_SLACK * spacing:
+            return tier, deviation
+    return None
+
+
 def _assign_dots(owners, dot_events, tol):
     """Assign each augmentation-dot glyph to exactly ONE owner (notehead or
     rest) and return {id(owner): dot_count}.
@@ -1484,6 +1897,11 @@ def _assign_dots(owners, dot_events, tol):
     wide and cannot itself separate two voices a staff step apart. That is
     how a 3/4 bar came to hold a `:2 ...{dd}` - 3.5 quarters, more than the
     bar can physically contain. One dot, one owner fixes it.
+
+    WHICH owner is then decided by where a dot is allowed to be relative to
+    its note, in the order an engraver puts it there (see _DOT_TIERS), rather
+    than by which notehead's centre is nearest - a question two noteheads a
+    space apart answer with a tie.
     """
     counts = collections.Counter()
     if not owners or not dot_events:
@@ -1496,10 +1914,11 @@ def _assign_dots(owners, dot_events, tol):
         best_key = None
         for i in range(lo, hi):
             ev = owners[i]
-            dy = abs(ev.yc - dot.yc)
-            if dy > tol.dot_y_tol:
+            # Page y grows downward, so a dot ABOVE its notehead is negative.
+            fit = _dot_fit(dot.yc - ev.yc, tol.spacing)
+            if fit is None:
                 continue
-            key = (round(dy, 3), round(abs(dot.xc - ev.x1), 3))
+            key = (fit[0], round(fit[1], 3), round(abs(dot.xc - ev.x1), 3))
             if best_key is None or key < best_key:
                 best, best_key = ev, key
         if best is not None:
@@ -1512,17 +1931,22 @@ def decode_note_events(page, staff_top, staff_bottom, staff_x0, staff_x1, line_y
     """Core decode for one standard-notation staff: returns (NoteEvent list
     sorted by x, stats).
 
-    line_ys: sorted list of the 5 staff line y-coordinates (for half/whole
-    rest disambiguation). spacing: that staff's line spacing, used to scale
-    every geometric tolerance (defaults to the spacing implied by line_ys).
+    line_ys: sorted list of the 5 staff line y-coordinates. They are the grid
+    a one-glyph rest's half-or-whole reading is measured against (see
+    half_or_whole_rest), and an empty list is tolerated the way the spacing
+    helper beside it tolerates one - such a staff reports its rests as
+    undecided instead of raising. spacing: that staff's line spacing, used to
+    scale every geometric tolerance (defaults to the spacing implied by
+    line_ys).
 
     `stats` is the decode's own honesty record and callers are expected to
     ACT on it, not just log it: unknown_glyphs / unknown_ratio say how much
     of this staff's music-font text fell outside the calibrated vocabulary,
-    and unknown_at_flag_position counts unrecognised glyphs sitting exactly
+    unknown_at_flag_position counts unrecognised glyphs sitting exactly
     where a flag would attach - the shape of "this piece uses 32nd flags,
     grace notes or an articulation we never calibrated", which decodes as
-    systematically wrong durations while looking perfectly healthy.
+    systematically wrong durations while looking perfectly healthy - and
+    undecided_rests counts rests whose value was guessed rather than read.
     """
     tol = _Tol(spacing if spacing else _spacing_from_lines(line_ys),
                staff_bottom - staff_top, staff_x1 - staff_x0)
@@ -1537,6 +1961,11 @@ def decode_note_events(page, staff_top, staff_bottom, staff_x0, staff_x1, line_y
         "stem_count": 0,
         "beam_segment_count": 0,
         "curve_count": 0,
+        # One-glyph rests whose half-or-whole reading the geometry could not
+        # give (see half_or_whole_rest). Read as half rests, and reported so
+        # the caller can say the durations on this staff were partly guessed
+        # rather than read - see _resolve_rhythm_source.
+        "undecided_rests": 0,
         "font_warnings": list(glyphs.warnings),
     }
     if not glyphs.events:
@@ -1582,6 +2011,7 @@ def decode_note_events(page, staff_top, staff_bottom, staff_x0, staff_x1, line_y
 
     notes = []
     stems_by_key = {}
+    undecided_rests = 0
     for ev in staff_events:
         if ev.category in NOTEHEAD_CATS:
             stem = None
@@ -1652,10 +2082,16 @@ def decode_note_events(page, staff_top, staff_bottom, staff_x0, staff_x1, line_y
             else:
                 cat = ev.category
             if cat == "rest_half_whole":
-                # whole rest hangs below the 2nd line from top; half rest
-                # sits on the middle (3rd) line - use nearest line index
-                nearest_idx = min(range(len(line_ys)), key=lambda i: abs(line_ys[i] - ev.yc))
-                base = 4.0 if nearest_idx <= 1 else 2.0
+                base, decided = half_or_whole_rest(ev.yc, line_ys, tol.spacing)
+                if not decided or not ev.ink_measured:
+                    # Both halves of the reading have to hold: the parity has
+                    # to be one of the two an engraver draws, AND it has to
+                    # have been measured on the ink. Without the outline the
+                    # position falls back to the baseline, which sits ON the
+                    # grid for exactly this glyph in every calibrated font -
+                    # an offset of zero, which is not evidence for either
+                    # answer even when rounding lands it inside the window.
+                    base, undecided_rests = 2.0, undecided_rests + 1
             else:
                 # A font that spells the rest's value in the glyph itself
                 # (see REST_VALUES) needs no positional guess.
@@ -1680,7 +2116,7 @@ def decode_note_events(page, staff_top, staff_bottom, staff_x0, staff_x1, line_y
         if stem is None:
             continue
         free_y = stem.y1 if abs(stem.y1 - u.yc) > abs(stem.y0 - u.yc) else stem.y0
-        if abs(u.yc - free_y) <= tol.flag_y_tol:
+        if _at_stem_end(u, free_y, tol):
             suspect += 1
 
     stats.update({
@@ -1698,6 +2134,7 @@ def decode_note_events(page, staff_top, staff_bottom, staff_x0, staff_x1, line_y
         "stem_count": len(stems),
         "beam_segment_count": len(beams),
         "curve_count": len(curves),
+        "undecided_rests": undecided_rests,
     })
     return notes, stats
 

--- a/server/fermata/glyph_rhythm.py
+++ b/server/fermata/glyph_rhythm.py
@@ -106,6 +106,15 @@ How this works (full validation detail):
   cancels, and it was deciding whether a rest was a half or a whole - a
   twofold difference in duration - from a measurement that was never the
   rest's position.
+
+  The horizontal edges a notehead's stem attaches at come from the same
+  outline, for the same reason: one calibrated font puts its whole side
+  bearing on one side, so against the metrics box "which of these two stems
+  is closer" was a third of a space out for every up-stem on such a page.
+  See GlyphEvent.stem_edges and _best_stem, which ranks candidate stems on
+  both distances together - x alone, with y only breaking its ties, handed a
+  melody note to the accompaniment's stem whenever the two voices shared a
+  beat.
 """
 import bisect
 import collections
@@ -604,17 +613,17 @@ def maestro_fingerprint_ok(tt, digests=None, min_glyphs=None):
     return True, f"{len(matched)} glyph outlines match the calibrated Maestro subset"
 
 
-# A glyph's ink never runs more than a couple of ems from the baseline (the
+# A glyph's ink never runs more than a couple of ems from its origin (the
 # tallest thing measured in the calibrated vocabulary is a clef, at 2.2 em), so
 # a `glyf` header claiming more than this is a stale or corrupt box rather than
 # a shape - and a wrong ink box is worse than none, because none degrades to
-# the baseline while a wrong one is believed.
+# the metrics box while a wrong one is believed.
 _INK_MAX_EM = 8.0
 
 
 class _InkBoxes:
-    """Where each glyph's INK is, vertically, in one embedded font - as a
-    fraction of the em, so it scales with whatever size the page drew at.
+    """Where each glyph's INK is in one embedded font - as a fraction of the
+    em, so it scales with whatever size the page drew at.
 
     A TrueType glyph record starts with its own bounding box
     (numberOfContours, xMin, yMin, xMax, yMax, five int16s), so this needs no
@@ -632,12 +641,17 @@ class _InkBoxes:
         self._upem = tt["head"].unitsPerEm or 1000
         self._cache = {}
 
-    def span(self, gid):
-        """(yMin, yMax) in em fractions, or None where this font has nothing
-        to say about that glyph: a gid past the end of `loca`, a slot the
-        subset left empty (which is most of them - a Maestro subset keeps all
-        204 slots and fills the handful a page uses), or a header whose box is
-        degenerate or implausible."""
+    def _header(self, gid):
+        """This glyph's raw `glyf` bounding box as (xMin, yMin, xMax, yMax) in
+        em fractions, or None where this font has nothing to say about that
+        glyph: a gid past the end of `loca`, or a slot the subset left empty
+        (which is most of them - a Maestro subset keeps all 204 slots and
+        fills the handful a page uses).
+
+        Whether the box is USABLE is asked per axis by span and xspan, because
+        the two axes fail independently: a glyph drawn as a single vertical
+        stroke has a degenerate x extent and a perfectly good y one.
+        """
         if gid in self._cache:
             return self._cache[gid]
         out = None
@@ -645,12 +659,33 @@ class _InkBoxes:
         if gid >= 0 and gid + 1 < len(loca):
             seg = self._glyf[loca[gid]:loca[gid + 1]]
             if len(seg) >= 10:
-                _n, _x0, ymin, _x1, ymax = struct.unpack(">hhhhh", seg[:10])
-                limit = _INK_MAX_EM * self._upem
-                if ymax > ymin and abs(ymin) <= limit and abs(ymax) <= limit:
-                    out = (ymin / self._upem, ymax / self._upem)
+                _n, xmin, ymin, xmax, ymax = struct.unpack(">hhhhh", seg[:10])
+                upem = self._upem
+                out = (xmin / upem, ymin / upem, xmax / upem, ymax / upem)
         self._cache[gid] = out
         return out
+
+    def span(self, gid):
+        """(yMin, yMax) in em fractions, or None where the box is missing (see
+        _header) or its vertical extent is degenerate or implausible."""
+        box = self._header(gid)
+        if box is None:
+            return None
+        ymin, ymax = box[1], box[3]
+        if ymax > ymin and abs(ymin) <= _INK_MAX_EM and abs(ymax) <= _INK_MAX_EM:
+            return ymin, ymax
+        return None
+
+    def xspan(self, gid):
+        """(xMin, xMax) in em fractions, or None - the horizontal twin of
+        span, tested against the same implausibility limit."""
+        box = self._header(gid)
+        if box is None:
+            return None
+        xmin, xmax = box[0], box[2]
+        if xmax > xmin and abs(xmin) <= _INK_MAX_EM and abs(xmax) <= _INK_MAX_EM:
+            return xmin, xmax
+        return None
 
 
 def _ink_boxes(tt):
@@ -864,13 +899,24 @@ class GlyphEvent:
     them, because the metrics box is the right box for the two things that use
     it: the advance width for horizontal gaps, and a font-wide row height for
     grouping digits into a numeral.
+
+    HORIZONTALLY the same warning applies, in one font and to one decision.
+    x0/x1 come from the advance width, and a font's two side bearings need not
+    match: measured over the library's noteheads, Maestro's and MScore's boxes
+    sit within 0.02 staff spaces of the ink on both sides (97,489 and 8,254 of
+    them), but OPUS overhangs the ink by 0.324 spaces on the RIGHT and not at
+    all on the left (8,917 of them). A notehead's stem attaches at one side or
+    the other, so on an Opus page "how far is this stem from the notehead" came
+    out a third of a space larger for an up-stem, at its right edge, than for a
+    down-stem at its left - which is the whole margin _best_stem was deciding
+    two-voice writing on. Hence `stem_edges`.
     """
 
     __slots__ = ("family", "gid", "category", "x0", "y0", "x1", "y1", "code",
-                 "smufl", "baseline_y", "ink_y0", "ink_y1")
+                 "smufl", "baseline_y", "ink_y0", "ink_y1", "ink_x0", "ink_x1")
 
     def __init__(self, family, gid, category, bbox, code, smufl=False,
-                 baseline_y=None, ink=None):
+                 baseline_y=None, ink=None, ink_x=None):
         self.family = family
         self.gid = gid
         self.category = category
@@ -882,6 +928,7 @@ class GlyphEvent:
         # supply one.
         self.baseline_y = baseline_y
         self.ink_y0, self.ink_y1 = ink if ink is not None else (None, None)
+        self.ink_x0, self.ink_x1 = ink_x if ink_x is not None else (None, None)
 
     @property
     def calibration_key(self):
@@ -902,6 +949,21 @@ class GlyphEvent:
         half_or_whole_rest); the fallbacks below are good to a fraction of a
         space, which is not the same thing."""
         return self.ink_y0 is not None
+
+    @property
+    def stem_edges(self):
+        """The two x positions a stem may attach at: the drawn shape's left and
+        right edges, from the embedded outline where it could be read, and the
+        metrics box's where it could not.
+
+        A stem is drawn touching the notehead, so the distance from a stem to
+        the nearer of these is a measurement of whether it attaches here - but
+        only once both edges are the ink's. Against the advance-width box that
+        distance carries the side bearing, which one calibrated font applies to
+        one side only (see the class docstring)."""
+        if self.ink_x0 is not None:
+            return self.ink_x0, self.ink_x1
+        return self.x0, self.x1
 
     @property
     def yc(self):
@@ -1129,6 +1191,19 @@ def _ink_span_on_page(reader, gid, origin_y, size):
     return origin_y - ymax * size, origin_y - ymin * size
 
 
+def _ink_x_on_page(reader, gid, origin_x, size):
+    """(ink left, ink right) in page points, or None. Page x and font x both
+    grow rightward, so unlike the vertical twin above this is a straight scale
+    out from the glyph's origin with no flip."""
+    if reader is None or size is None or origin_x is None:
+        return None
+    em = reader.xspan(gid)
+    if em is None:
+        return None
+    xmin, xmax = em
+    return origin_x + xmin * size, origin_x + xmax * size
+
+
 def _smufl_music_fonts(doc, page, trace):
     """Which fonts on this page may be read as SMuFL music fonts?
 
@@ -1249,10 +1324,12 @@ def extract_glyph_events(page):
                     # (rehearsal marks, fingerings); those are not music
                     # symbols and must not count as unrecognised ones.
                     continue
+                ox = origin[0] if origin else None
                 oy = origin[1] if origin else None
                 ev = GlyphEvent(fname, gid, SMUFL_CODE_MAP.get(code), bbox, code, smufl=True,
                                 baseline_y=oy,
-                                ink=_ink_span_on_page(reader, gid, oy, size))
+                                ink=_ink_span_on_page(reader, gid, oy, size),
+                                ink_x=_ink_x_on_page(reader, gid, ox, size))
                 events.append(ev)
                 if ev.category is None:
                     unknown.append(ev)
@@ -1279,9 +1356,11 @@ def extract_glyph_events(page):
                 # An unrecognised glyph still has a position, and with one
                 # resource on the page there is no doubt about whose it is.
                 reader = candidates[0].ink
+            ox = origin[0] if origin else None
             oy = origin[1] if origin else None
             ev = GlyphEvent(fname, gid, cat, bbox, code, baseline_y=oy,
-                            ink=_ink_span_on_page(reader, gid, oy, size))
+                            ink=_ink_span_on_page(reader, gid, oy, size),
+                            ink_x=_ink_x_on_page(reader, gid, ox, size))
             events.append(ev)
             if cat is None:
                 unknown.append(ev)
@@ -1613,14 +1692,36 @@ def _bounds(sorted_keys, lo, hi):
 
 
 def _best_stem(stems, stem_xs, x0, x1, yc, tol, x_tol=None, y_tol=None):
-    """The stem this notehead actually hangs off.
+    """The stem this notehead actually hangs off. x0/x1 are the notehead's ink
+    edges where the font could supply them - see GlyphEvent.stem_edges.
 
-    Stems attach at one SIDE of a notehead (left edge for a down-stem,
-    right edge for an up-stem) at roughly the notehead's vertical centre -
-    not at its bbox centre-x or top/bottom edge. In dense/chordal writing
-    more than one stem can plausibly sit near a given notehead, so pick the
-    single closest one: nearest in x to either notehead edge, then nearest
-    in y to the notehead's centre.
+    Stems attach at one SIDE of a notehead (left edge for a down-stem, right
+    edge for an up-stem) at roughly the notehead's vertical centre - not at its
+    bbox centre-x or top/bottom edge. In dense/chordal writing more than one
+    stem can plausibly sit near a given notehead, so pick the single closest
+    one, BY BOTH DISTANCES TOGETHER, each measured as a fraction of the slack
+    its own axis is allowed.
+
+    RANKING ON x FIRST AND USING y ONLY TO BREAK ITS TIES IS WRONG, and gets
+    the commonest two-voice figure in this repertoire backwards. Where a melody
+    note sits above a stem-down chord on the same beat, the two voices' stems
+    are at the SAME place horizontally - one at each side of the notehead - so
+    the x distances differ by the width of a stem stroke, 0.03 staff spaces,
+    which is noise; the y distances differ by a whole space, which is the
+    answer. Measured over the library's 98,737 notehead-to-stem lookups, the
+    attaching stem sits 0.037 spaces from the notehead's edge at the median
+    (0.348 at the 99th percentile) and its end sits 0.175 spaces from the ink
+    centre (0.179 at the 90th). Both are sharp; neither decides alone, and
+    letting the noisier margin overrule the other picked a stem further away in
+    y than the alternative for 51 noteheads across 20 scores, in 49 cases the
+    other VOICE's stem. That is a duration error of up to fourfold and a lost
+    voice, not a near miss - see the two-voice bars of Dalza's Recercar.
+
+    Nor can y rank them alone: a neighbouring note's stem one notehead-width
+    away in x can end nearer this notehead's centre than its own stem does, by
+    a few thousandths of a space. Weighting each axis by its own tolerance -
+    the numbers already calibrated for how much slack each direction needs -
+    picks the note's own stem in both figures without a third constant to tune.
 
     Selecting on "which candidate has the highest flag/beam count" instead
     is what silently upgraded genuine quarters to eighths and sixteenths -
@@ -1642,7 +1743,11 @@ def _best_stem(stems, stem_xs, x0, x1, yc, tol, x_tol=None, y_tol=None):
         if dy > yt:
             continue
         dx = min(abs(s.x - x0), abs(s.x - x1))
-        key = (round(dx, 3), round(dy, 3))
+        # Rounded so two candidates a floating-point hair apart cannot swap on
+        # the platform's last bit, and tie-broken on y: two stems the same
+        # distance away are two voices, and the one whose end lands on this
+        # notehead is the one it hangs off.
+        key = (round(math.hypot(dx / xt, dy / yt), 6), round(dy, 3))
         if best_key is None or key < best_key:
             best, best_key = s, key
     return best
@@ -1790,6 +1895,13 @@ def _assign_stem_directions(notes, stems_by_key):
     satisfy. Such a stem is dropped rather than believed - the notehead keeps
     no stem at all and is placed by position instead, which can lose
     information but cannot invert it.
+
+    This check is a net, not a ranking, and it cannot be moved into
+    _best_stem to do the choosing: the side test needs the MEAN x of every
+    notehead on the stem, which is exactly what one candidate notehead does
+    not have. Applied per candidate it rejects the right stem too - measured
+    over the library, it leaves 344 noteheads with no consistent candidate at
+    all and changes 38 selections, and the selections it changes are wrong.
 
     This catches only the contradictory subset. A neighbouring voice's stem
     that happens to sit where this notehead's own stem WOULD sit is
@@ -2032,25 +2144,30 @@ def decode_note_events(page, staff_top, staff_bottom, staff_x0, staff_x1, line_y
                 #
                 # KNOWN RESIDUAL RISK, accepted deliberately: _best_stem
                 # accepts any stem end within about a staff space of the
-                # notehead's centre, and a real half note's own stem end is
-                # measured at up to 0.94 spacings from it (median 0.44, over
-                # 2004 of them), so the window cannot be tightened without
-                # losing real attachments - at 0.5 spacings it loses 46% of
-                # them. Where this note's own stem is missing from the vector
-                # pass entirely, a neighbouring voice's stem can therefore be
-                # picked, and if it sits in a position consistent with the
-                # engraving convention nothing here can tell. That yields a
-                # wrong voice for the note and breaks both voices' arithmetic
-                # for that bar, which shows up in the overfull-bar count.
+                # notehead's ink centre, and a real stem end is measured at up
+                # to the full 1.17 spacings from it (median 0.175, 90th
+                # percentile 0.179, over 86819 attachments), so the window
+                # cannot be tightened to the bulk of that distribution without
+                # losing the tail of real attachments. Where this note's own
+                # stem is missing from the vector pass entirely, a neighbouring
+                # voice's stem can therefore be picked, and if it sits in a
+                # position consistent with the engraving convention nothing
+                # here can tell. That yields a wrong voice for the note and
+                # breaks both voices' arithmetic for that bar, which shows up
+                # in the overfull-bar count. What _best_stem no longer does is
+                # PREFER such a stem to this note's own: it ranks on both
+                # distances together rather than on x alone.
                 # _assign_stem_directions rejects the subset where the
                 # stem's side and its overhang contradict each other; the
                 # consistent-looking case remains.
                 base, flags = 2.0, 0
-                stem = _best_stem(stems, stem_xs, ev.x0, ev.x1, ev.yc, tol)
+                ex0, ex1 = ev.stem_edges
+                stem = _best_stem(stems, stem_xs, ex0, ex1, ev.yc, tol)
             else:
                 base = 1.0  # filled/x/diamond head: quarter-or-shorter
                 flags = 0
-                stem = _best_stem(stems, stem_xs, ev.x0, ev.x1, ev.yc, tol)
+                ex0, ex1 = ev.stem_edges
+                stem = _best_stem(stems, stem_xs, ex0, ex1, ev.yc, tol)
                 if stem is not None:
                     hooks = _flag_count_near(flag_events, flag_xs, stem, ev.yc, tol)
                     beam_levels = _beam_count_near(beams, stem, ev.yc, tol)
@@ -2061,7 +2178,10 @@ def decode_note_events(page, staff_top, staff_bottom, staff_x0, staff_x1, line_y
                 # the duration it was given above stands, and a chord's
                 # duration is recomposed from all its members together (see
                 # tabextract._stem_group_duration).
-                stem = _stem_through_notehead(stems, stem_xs, ev.x0, ev.x1, ev.yc, tol)
+                # Same edges as the stem-END lookup above, so a notehead cannot
+                # pass one x gate and fail the other.
+                ex0, ex1 = ev.stem_edges
+                stem = _stem_through_notehead(stems, stem_xs, ex0, ex1, ev.yc, tol)
             key = None
             if stem is not None:
                 key = _stem_key(stem)

--- a/server/fermata/tabextract.py
+++ b/server/fermata/tabextract.py
@@ -1661,6 +1661,24 @@ def _resolve_rhythm_source(page, std_staff, pair_reason, decoded):
                 f"(unrecognised glyphs: {sample[:6]})"
             ),
         )
+    undecided = stats.get("undecided_rests", 0)
+    if undecided:
+        # Maestro and Opus draw the half and the whole rest with one glyph, so
+        # a rest whose position says neither (no staff lines to measure it
+        # against, an outline that could not be read, a rest engraved where
+        # neither reading fits - see glyph.half_or_whole_rest) was read as the
+        # commoner of the two rather than measured. That is a twofold
+        # difference in one rest's duration, which is the whole bar's
+        # arithmetic, so it is said out loud rather than left in the stats.
+        return _RhythmSource(
+            PROV_GLYPHS_DEGRADED, note_events, stats=stats,
+            detail=(
+                f"{undecided} rest(s) on the paired notation staff are drawn with the one "
+                "glyph that serves as both the half and the whole rest, and their position "
+                "did not say which - each was read as a half rest, so a bar holding one may "
+                "be short by two quarter notes of silence"
+            ),
+        )
     return _RhythmSource(PROV_GLYPHS, note_events, stats=stats)
 
 

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -31,6 +31,10 @@ _FIXTURE_RELATIVE_PATHS = {
     "zanarkand": "Patreon/John Oeth/Final Fantasy/FF X/To Zanarkand (Final Fantasy X).pdf",
     "tarrega": "Classical/Tarrega/Tarrega-Study-in-C-Guitar-Free.pdf",
     "claire_de_lune": "Favorites/ClairDeLuneGuitar.pdf",
+    # Two-voice writing where a melody note shares a beat with a stem-down
+    # chord: the figure notehead-to-stem attachment gets wrong, and an Opus
+    # engraving, so it also exercises the side bearing that only that font has.
+    "dalza": "Classical/PrimoGuitar Misc/Dalza-Recercar-Guitar-2019.pdf",
 }
 
 # Skips for want of a library are COUNTED HERE as they happen, rather than
@@ -136,6 +140,14 @@ def claire_de_lune_pdf() -> Path:
     p = _fixture_path("claire_de_lune")
     if p is None:
         skip_without_library("FERMATA_TEST_LIBRARY not set (or missing Clair de Lune fixture)")
+    return p
+
+
+@pytest.fixture
+def dalza_pdf() -> Path:
+    p = _fixture_path("dalza")
+    if p is None:
+        skip_without_library("FERMATA_TEST_LIBRARY not set (or missing Dalza fixture)")
     return p
 
 

--- a/server/tests/test_engraved_fixtures.py
+++ b/server/tests/test_engraved_fixtures.py
@@ -39,6 +39,7 @@ coverage and is not is worse than none:
     A regression that only shows up in density will still only show up
     there.
 """
+import collections
 import re
 import xml.etree.ElementTree as ET
 
@@ -589,6 +590,48 @@ def test_every_rest_value_is_read_from_the_glyph_that_spells_it(engraved):
     rests = [(q, notes) for bar in emitted_bars(result.alphatex)
              for voice in bar for q, notes in voice if not notes]
     assert sorted({q for q, _n in rests}) == [0.125, 0.25, 0.5, 1.0, 2.0, 4.0], rests
+
+
+def test_the_rest_the_engraving_names_is_the_rest_its_position_says(engraved):
+    """The positional rule, checked against the one population where the
+    answer is known WITHOUT it.
+
+    Maestro and Opus draw the half and the whole rest with a single glyph, so
+    for those fonts geometry is the only discriminator there is - for a
+    twofold difference in duration. A SMuFL font names the value in the
+    codepoint, so this fixture's rests are ground truth for the rule: apply
+    the geometry to them and it has to reach the same answer the engraving
+    already stated. Measured over the library the two disagree on 4 of the 19
+    rests where the truth is knowable, and every one of those disagreements is
+    the geometry being wrong.
+    """
+    doc = fitz.open(engraved("rests_and_flags"))
+    named = {"rest_whole": 4.0, "rest_half": 2.0}
+    checked = collections.Counter()
+    try:
+        for page in doc:
+            staves, _anomalies = tabextract._detect_staves(page)
+            standard = [s for s in staves if s.kind == "standard"]
+            glyphs = glyph_rhythm.extract_glyph_events(page)
+            for staff in standard:
+                pad = (staff.bottom - staff.top) * 1.6
+                for ev in glyphs.events:
+                    if ev.category not in named:
+                        continue
+                    if not staff.top - pad <= ev.yc <= staff.bottom + pad:
+                        continue
+                    assert ev.ink_measured, "the rule needs the ink, not the metrics box"
+                    base, decided = glyph_rhythm.half_or_whole_rest(
+                        ev.yc, staff.line_ys, staff.spacing)
+                    assert decided, (ev.category, ev.yc, staff.line_ys)
+                    assert base == named[ev.category], (
+                        f"the engraving says {ev.category} ({named[ev.category]} quarters), "
+                        f"its position on the staff says {base}")
+                    checked[ev.category] += 1
+    finally:
+        doc.close()
+    # ...and both readings really were exercised, in both directions
+    assert checked == {"rest_whole": 1, "rest_half": 1}, checked
 
 
 def test_a_flagged_thirty_second_is_not_read_as_a_quarter(engraved):

--- a/server/tests/test_glyph_rhythm.py
+++ b/server/tests/test_glyph_rhythm.py
@@ -9,7 +9,7 @@ import io
 
 import pytest
 
-from fermata import glyph_rhythm as G
+from fermata import glyph_rhythm as G, tabextract
 
 
 class _P:
@@ -329,7 +329,7 @@ def test_tolerances_scale_linearly_with_spacing():
     small = _tol(2.0)
     big = _tol(20.0)
     assert big.stem_x_tol == pytest.approx(small.stem_x_tol * 10)
-    assert big.dot_y_tol == pytest.approx(small.dot_y_tol * 10)
+    assert big.dot_x_tol == pytest.approx(small.dot_x_tol * 10)
     assert big.beam_min_thickness == pytest.approx(small.beam_min_thickness * 10)
 
 
@@ -655,3 +655,296 @@ def test_meter_left_edge_takes_the_leftmost_stacked_pair():
     edge, why = G._meter_left_edge(window, _KS_MID)
     assert edge == 110.0
     assert why is None
+
+
+# ---------------------------------------------------------------------------
+# Half rest or whole rest (finding 88)
+# ---------------------------------------------------------------------------
+
+# One synthetic notation staff: five lines 5pt apart, 200 to 220.
+_REST_LINES = [200.0, 205.0, 210.0, 215.0, 220.0]
+_REST_SPACING = 5.0
+# Both rests are drawn half a space deep. A half rest SITS ON a line, so its
+# ink is the half space above it; a whole rest HANGS BELOW one, so its ink is
+# the half space below it. Depth in points at the spacing above.
+_REST_DEPTH = _REST_SPACING / 2
+
+
+def _half_rest_on(line_y):
+    return line_y - _REST_DEPTH / 2
+
+
+def _whole_rest_under(line_y):
+    return line_y + _REST_DEPTH / 2
+
+
+def test_a_rest_sitting_on_a_line_reads_as_a_half_and_one_hanging_below_as_whole():
+    """The two engravings the single Maestro/Opus glyph has to be told apart
+    by, at the two places the old nearest-line rule happened to agree: the
+    half rest on the middle line, the whole rest under the line above it."""
+    half, decided = G.half_or_whole_rest(
+        _half_rest_on(210.0), _REST_LINES, _REST_SPACING)
+    assert (half, decided) == (2.0, True)
+    whole, decided = G.half_or_whole_rest(
+        _whole_rest_under(205.0), _REST_LINES, _REST_SPACING)
+    assert (whole, decided) == (4.0, True)
+
+
+def test_a_whole_rest_hanging_below_the_staff_is_not_read_as_a_half():
+    """A second voice's rests are engraved below the staff, and nearest-line
+    put everything below the middle line in the "half rest" bucket: this rest
+    hangs from a ledger position two spaces under the bottom line, which is
+    nearest line index 4 and read as a half - losing two quarter notes of
+    silence out of the bar."""
+    base, decided = G.half_or_whole_rest(
+        _whole_rest_under(230.0), _REST_LINES, _REST_SPACING)
+    assert (base, decided) == (4.0, True)
+
+
+def test_a_half_rest_above_the_staff_is_not_read_as_a_whole():
+    """The same in the other direction: nearest-line called anything near the
+    top two lines a whole rest, so an upper voice's half rest sitting on a
+    ledger position above the staff invented two quarter notes of silence."""
+    base, decided = G.half_or_whole_rest(
+        _half_rest_on(195.0), _REST_LINES, _REST_SPACING)
+    assert (base, decided) == (2.0, True)
+
+
+def test_the_reading_holds_at_every_line_of_the_grid():
+    """Parity is a property of the line GRID, not of which line: every line
+    from two above the staff to two below has to give the same two answers,
+    because that is the whole difference from asking which line is nearest."""
+    for i in range(-2, 8):
+        line = _REST_LINES[0] + i * _REST_SPACING
+        assert G.half_or_whole_rest(
+            _half_rest_on(line), _REST_LINES, _REST_SPACING) == (2.0, True), line
+        assert G.half_or_whole_rest(
+            _whole_rest_under(line), _REST_LINES, _REST_SPACING) == (4.0, True), line
+
+
+def test_a_staff_with_no_detected_lines_is_undecided_rather_than_a_crash():
+    """There is no grid to measure against. The spacing helper beside this one
+    deliberately tolerates an empty line list, and the rest reading used to
+    raise on it instead - `min(range(0))` - so a staff whose lines were not
+    detected failed the whole page rather than degrading."""
+    assert G.half_or_whole_rest(207.5, [], _REST_SPACING) == (2.0, False)
+    assert G.half_or_whole_rest(207.5, _REST_LINES, 0) == (2.0, False)
+    assert G.half_or_whole_rest(207.5, _REST_LINES, None) == (2.0, False)
+
+
+@pytest.mark.parametrize("yc", [210.0, 207.5])
+def test_a_rest_whose_position_says_neither_is_not_given_a_reading(yc):
+    """A rest whose ink centre lands ON a line, or midway between two, is not
+    a quarter space off the grid either way. Both are what an unmeasurable ink
+    extent looks like rather than an engraving, and both are a quarter space
+    from each of the two real answers - so the reading is declined and
+    reported, not rounded to whichever side of nothing it fell."""
+    base, decided = G.half_or_whole_rest(yc, _REST_LINES, _REST_SPACING)
+    assert decided is False
+    assert base == 2.0
+
+
+def _rest_glyph(ink_top, ink_bottom, x0=300.0):
+    """A one-glyph rest as extract_glyph_events builds one: the trace's
+    metrics box, the baseline it was drawn on, and the measured ink."""
+    ev = G.GlyphEvent(
+        "Maestro", 187, "rest_half_whole",
+        (x0, ink_top - 8.0, x0 + 6.0, ink_top + 12.0), 0,
+        baseline_y=ink_top, ink=(ink_top, ink_bottom))
+    return ev
+
+
+class _BarePage:
+    """A page with no drawings and no text of its own - the glyph events are
+    injected, and the stem/beam pass finds nothing. Weak-referenceable, which
+    the per-page caches need."""
+
+
+def _decode_rests(events, monkeypatch, line_ys=_REST_LINES):
+    page = _BarePage()
+    monkeypatch.setattr(
+        G, "extract_glyph_events",
+        lambda _page: G.PageGlyphs(list(events), {"Maestro": []}, [], []))
+    return G.decode_note_events(page, _REST_LINES[0], _REST_LINES[-1], 40.0, 500.0,
+                                line_ys, _REST_SPACING)
+
+
+def test_the_decode_reads_both_rests_from_the_one_glyph(monkeypatch):
+    events = [_rest_glyph(207.5, 210.0, x0=300.0),      # sits on the middle line
+              _rest_glyph(205.0, 207.5, x0=400.0)]      # hangs below the one above
+    notes, stats = _decode_rests(events, monkeypatch)
+    assert [n.base_units for n in notes] == [2.0, 4.0]  # x order: 300 then 400
+    assert [n.is_rest for n in notes] == [True, True]
+    assert stats["undecided_rests"] == 0
+
+
+def test_a_rest_whose_outline_could_not_be_read_is_counted_not_guessed(monkeypatch):
+    """Without the outline a glyph's position falls back to the baseline it was
+    drawn on, and for this glyph the baseline sits ON the line grid in every
+    calibrated font - an offset of zero, which is not evidence for either
+    reading. It is read as the commoner of the two and SAID to have been,
+    because being wrong here is a twofold error in one rest's duration."""
+    ev = G.GlyphEvent("Maestro", 187, "rest_half_whole",
+                      (300.0, 199.5, 306.0, 219.5), 0, baseline_y=210.0)
+    assert not ev.ink_measured
+    notes, stats = _decode_rests([ev], monkeypatch)
+    assert [n.base_units for n in notes] == [2.0]
+    assert stats["undecided_rests"] == 1
+
+
+# ---------------------------------------------------------------------------
+# A flag is joined to its stem's tip, not centred on it (finding 88)
+# ---------------------------------------------------------------------------
+
+
+def _flag_glyph(category, ink_top, ink_bottom, x=200.0, measured=True):
+    """A flag as it is really drawn: ink reaching a long way DOWN from the
+    stem tip it is joined to, and a metrics box that says nothing about
+    either."""
+    bbox = (x - 1.0, ink_top - 8.0, x + 5.0, ink_top + 12.0)
+    return G.GlyphEvent("Leland", 40, category, bbox, 0xE244,
+                        baseline_y=ink_top,
+                        ink=(ink_top, ink_bottom) if measured else None)
+
+
+def test_a_flag_counts_when_the_stem_tip_is_inside_its_ink():
+    """A 32nd's three hooks reach two staff spaces below the tip they hang
+    from, so the flag's ink CENTRE is nowhere near the stem end - which is why
+    a centre-distance test dropped it and read the note as a quarter, a
+    32-fold error. The tip is inside the ink, and that is the test."""
+    tol = _tol()
+    tip = 100.0
+    flag = _flag_glyph("flag32", tip, tip + 4 * REF)  # ink centre 2 spaces down
+    assert abs(flag.yc - tip) > tol.flag_y_tol, "a centre test would refuse this"
+    assert G._at_stem_end(flag, tip, tol)
+    stem = G.Stem(200.0, tip, tip + 6 * REF)
+    assert G._flag_count_near([flag], [flag.xc], stem, stem.y1, tol) == 3
+
+
+def test_a_flag_on_another_voices_stem_is_not_counted():
+    """The reason the y test is there at all: two voices' stems can pass the
+    same x, and taking the other one's hook turns a quarter into a sixteenth.
+    Containment is tighter than the centre window it replaces, not looser."""
+    tol = _tol()
+    flag = _flag_glyph("flag16", 100.0, 100.0 + 2 * REF)
+    far_tip = 100.0 + 6 * REF
+    assert not G._at_stem_end(flag, far_tip, tol)
+    stem = G.Stem(200.0, far_tip, far_tip + 6 * REF)
+    assert G._flag_count_near([flag], [flag.xc], stem, stem.y1, tol) == 0
+
+
+def test_a_flag_with_no_measured_ink_falls_back_to_the_centre_window():
+    tol = _tol()
+    flag = _flag_glyph("flag8", 100.0, 100.0 + 2 * REF, measured=False)
+    assert not flag.ink_measured
+    assert G._at_stem_end(flag, flag.yc + tol.flag_y_tol * 0.9, tol)
+    assert not G._at_stem_end(flag, flag.yc + tol.flag_y_tol * 1.1, tol)
+
+
+# ---------------------------------------------------------------------------
+# Which note an augmentation dot belongs to (finding 88)
+# ---------------------------------------------------------------------------
+
+# A dot always sits in the middle of a space, so relative to its own note it
+# is at the note's level, half a space above it, or half a space below it -
+# and the two neighbouring readings are exactly equidistant. These are the two
+# real engravings from the library that a nearest-distance test gets wrong in
+# opposite directions.
+
+
+def _dotted(y, x0=96.0):
+    return _ev("notehead_half", x0, y - 3.0, x0 + 7.0, y + 3.0)
+
+
+def _dot_at(y, x0=105.0):
+    return _ev("dot", x0, y - 1.0, x0 + 2.0, y + 1.0)
+
+
+def test_a_chords_stacked_dots_go_one_to_each_notehead():
+    """Two chord noteheads a space apart, each on a line, each with its dot
+    raised into the space above it. The lower dot is exactly as far from the
+    upper notehead as from its own, and picking the wrong one gave the upper
+    note TWO vertically stacked dots - which is not what a double dot is -
+    while the lower note lost half its length."""
+    tol = _tol(REF)
+    upper = _dotted(200.0)
+    lower = _dotted(200.0 + REF)
+    dots = [_dot_at(200.0 - REF / 2), _dot_at(200.0 + REF / 2)]
+    counts = G._assign_dots([upper, lower], dots, tol)
+    assert counts[id(upper)] == 1
+    assert counts[id(lower)] == 1
+
+
+def test_a_dot_in_the_space_below_its_note_still_belongs_to_it():
+    """The lower voice's dotted whole note, whose dot is in the space BELOW it
+    because the space above is the upper voice's. Refusing that reading
+    dropped the dot and left the bar short by a third of its length."""
+    tol = _tol(REF)
+    head = _dotted(200.0)
+    counts = G._assign_dots([head], [_dot_at(200.0 + REF / 2)], tol)
+    assert counts[id(head)] == 1
+
+
+def test_a_dot_a_whole_space_from_every_note_belongs_to_none_of_them():
+    tol = _tol(REF)
+    head = _dotted(200.0)
+    counts = G._assign_dots([head], [_dot_at(200.0 + REF)], tol)
+    assert sum(counts.values()) == 0
+
+
+# ---------------------------------------------------------------------------
+# A glyph's position is its ink, not its metrics box (finding 88)
+# ---------------------------------------------------------------------------
+
+
+def _off_grid(y, staff):
+    """How far this y is from the staff's own half-space grid, in spaces.
+
+    Notation puts every notehead either ON a line or centred in a space, so a
+    notehead's real vertical position is always a multiple of half a staff
+    space from the top line - which makes the distance from that grid a
+    measurement of the reading itself, with no ground truth needed."""
+    steps = (y - staff.line_ys[0]) / staff.spacing * 2
+    return abs(steps - round(steps)) / 2
+
+
+def test_glyph_positions_land_on_the_staffs_own_grid(zanarkand_pdf):
+    """The defect behind finding 88, measured in the domain that shows it.
+
+    The box the text trace reports is metrics-based: its top and bottom are
+    the font's ascender and descender, so its centre is a fixed distance from
+    the BASELINE rather than the middle of the shape - 0.39 of a staff space
+    for Maestro. Against another glyph that cancels, which is why every
+    duration still decoded; against the staff it does not, and the reading of
+    a rest as a half or a whole turns on exactly this.
+
+    So: read a real Maestro score and check that every notehead's position
+    lands on the staff's own grid, and that the metrics-box centre does not.
+    """
+    import fitz
+
+    doc = fitz.open(zanarkand_pdf)
+    ink, metrics = [], []
+    try:
+        for page in doc:
+            staves, _anomalies = tabextract._detect_staves(page)
+            glyphs = G.extract_glyph_events(page)
+            for staff in [s for s in staves if s.kind == "standard"]:
+                pad = (staff.bottom - staff.top) * 1.6
+                for ev in glyphs.events:
+                    if ev.category not in G.NOTEHEAD_CATS:
+                        continue
+                    if not staff.top - pad <= ev.yc <= staff.bottom + pad:
+                        continue
+                    assert ev.ink_measured
+                    ink.append(_off_grid(ev.yc, staff))
+                    metrics.append(_off_grid((ev.y0 + ev.y1) / 2, staff))
+    finally:
+        doc.close()
+
+    assert len(ink) > 300, f"only {len(ink)} noteheads - the file did not decode"
+    assert max(ink) < 0.03, f"worst notehead sits {max(ink):.3f} spaces off the grid"
+    # ...and the box centre this replaced is off it by about a fifth of a space
+    # everywhere. (0.39 of a space, folded onto a grid whose step is half a
+    # space, is 0.11 - the bias is bigger than this number, not smaller.)
+    assert min(metrics) > 0.09, f"metrics centres were on the grid after all: {min(metrics)}"

--- a/server/tests/test_glyph_rhythm.py
+++ b/server/tests/test_glyph_rhythm.py
@@ -849,6 +849,27 @@ def test_the_reading_holds_at_every_line_of_the_grid():
             _whole_rest_under(line), _REST_LINES, _REST_SPACING) == (4.0, True), line
 
 
+def test_the_parity_reading_is_confidently_wrong_at_an_odd_half_space():
+    """The limit of the rule, recorded rather than glossed over. Parity is
+    measured modulo one staff space, so displacing a rest by an odd number of
+    half spaces puts it exactly where the OTHER rest would sit and it is read
+    as that other rest, with decided=True - a twofold duration error carrying
+    no warning. Nothing in the three arguments can tell the cases apart.
+
+    No engraving in the library needs the guard this cannot provide: every
+    one-glyph rest the decode reads lands within 0.235-0.266 of a space of a
+    line, which is the window the rule is calibrated for. This test exists so
+    that stays a known limit instead of becoming a surprise."""
+    on_line = _half_rest_on(_REST_LINES[2])
+    assert G.half_or_whole_rest(on_line, _REST_LINES, _REST_SPACING) == (2.0, True)
+    shifted = on_line + _REST_SPACING / 2
+    assert G.half_or_whole_rest(shifted, _REST_LINES, _REST_SPACING) == (4.0, True)
+    # ...and a whole space back is the original answer again, which is what
+    # "holds at every line of the grid" means.
+    assert G.half_or_whole_rest(
+        on_line + _REST_SPACING, _REST_LINES, _REST_SPACING) == (2.0, True)
+
+
 def test_a_non_positive_spacing_never_reaches_the_rest_reading():
     """half_or_whole_rest guards against a zero or negative spacing, and this
     records that the guard is DEFENCE and not a live path, because a test

--- a/server/tests/test_glyph_rhythm.py
+++ b/server/tests/test_glyph_rhythm.py
@@ -275,7 +275,7 @@ def test_a_melody_note_over_a_chord_keeps_its_own_stem_not_the_chords():
     assert _best([own_up, chords_down], ink_x0, ink_x1, yc, tol) == own_up
 
 
-def test_an_up_stem_is_not_measured_from_the_advance_width(monkeypatch):
+def test_an_up_stem_is_not_measured_from_the_advance_width():
     """Measured off page 2 of Dalza's Recercar, score measure 11: a filled
     eighth with its own up-stem, one staff space above a stem-down half-note
     chord. This is the same figure as the test above with the font's side
@@ -345,6 +345,11 @@ def test_the_ink_reader_answers_for_each_axis_separately():
     absurd = G._InkBoxes(_StubFont(-120, -32000, 130, 260))
     assert absurd.span(0) is None
     assert absurd.xspan(0) == (-0.120, 0.130)
+    # y failing its ORDERING test (not just the plausibility limit above)
+    # must not couple into xspan either.
+    inverted_y = G._InkBoxes(_StubFont(-120, 260, 130, -250))
+    assert inverted_y.span(0) is None
+    assert inverted_y.xspan(0) == (-0.120, 0.130)
 
 
 def test_the_horizontal_ink_scales_out_from_the_glyphs_origin():
@@ -609,6 +614,58 @@ def test_a_notehead_partway_along_a_chord_stem_still_finds_it():
     assert G._stem_through_notehead(stems, stem_xs, 44.0, 50.0, 100.0, tol) is stem
     # ...but a notehead the stem does not span is not on it
     assert G._stem_through_notehead(stems, stem_xs, 44.0, 50.0, 200.0, tol) is None
+
+
+def test_the_chord_threading_lookup_also_narrows_on_opus(monkeypatch):
+    """The chord-threading branch of decode_note_events - reached when the
+    stem-END lookup beside it finds nothing, for an inner or far member of a
+    chord - has to use the SAME ink edges as that lookup (see its "Same
+    edges" comment). Using the metrics box there instead reopens Opus's side
+    bearing (GlyphEvent.stem_edges / the class docstring): the box overhangs
+    the ink by 0.324 staff spaces on the right, which can only WIDEN this
+    window, so a stem too far away to thread onto by the ink measurement can
+    wrongly qualify by the box one.
+
+    This never fires against the current library - the box and the ink agree
+    on every chord thread it holds today, which is exactly why it needs a
+    synthetic case to stay covered: a stem placed so its distance from the
+    ink edge just fails stem_x_tol while its distance from the wider box
+    edge does not."""
+    tol = _tol(spacing=5.0)
+    ink_x0, ink_x1 = 100.0, 110.0
+    box_x1 = ink_x1 + 0.324 * tol.spacing  # Opus's right-side bearing
+    yc = 115.0
+    ev = G.GlyphEvent("Opus", 210, "notehead_filled",
+                      (ink_x0, yc - 10.0, box_x1, yc + 10.0), 0,
+                      baseline_y=yc, ink=(yc - 2.0, yc + 2.0),
+                      ink_x=(ink_x0, ink_x1))
+    assert ev.stem_edges == (ink_x0, ink_x1)
+
+    # A chord's shared stem: its own end is nowhere near this notehead (dy is
+    # huge, so the stem-END lookup finds nothing and this falls to the
+    # threading branch below), and it spans yc. x-wise it clears the box
+    # window but not the ink one. y0/y1 are chosen so the stem's overhang
+    # also agrees with which side of the notehead it sits on (up-stem, on
+    # the right) - otherwise _assign_stem_directions would drop the
+    # attachment for a reason unrelated to the one under test here.
+    stem = G.Stem(x=114.5, y0=90.0, y1=130.0)
+    assert min(abs(stem.x - ink_x0), abs(stem.x - ink_x1)) > tol.stem_x_tol
+    assert min(abs(stem.x - ev.x0), abs(stem.x - ev.x1)) <= tol.stem_x_tol
+
+    page = _BarePage()
+    monkeypatch.setattr(
+        G, "extract_glyph_events",
+        lambda _page: G.PageGlyphs([ev], {"Opus": []}, [], []))
+    monkeypatch.setattr(
+        G, "extract_stems_beams_curves",
+        lambda *a, **k: ([stem], [], []))
+    notes, _stats = G.decode_note_events(
+        page, 100.0, 120.0, 50.0, 150.0, [100.0, 105.0, 110.0, 115.0, 120.0],
+        tol.spacing)
+    assert len(notes) == 1
+    assert notes[0].stem_key is None, (
+        "the ink-edge window must not thread this notehead onto a stem the "
+        "wider metrics box would have allowed")
 
 
 def test_a_stem_whose_side_contradicts_its_overhang_is_not_believed():

--- a/server/tests/test_glyph_rhythm.py
+++ b/server/tests/test_glyph_rhythm.py
@@ -6,6 +6,7 @@ attach to, and what did that make its duration", which is far clearer to pin
 down from explicit coordinates than from a synthesised engraving.
 """
 import io
+import struct
 
 import pytest
 
@@ -245,6 +246,132 @@ def test_stem_selection_prefers_the_closest_candidate():
     far = G.Stem(105.9, 176.0, 200.2)
     chosen = G._best_stem([near, far], [103.0, 105.9], 96.0, 103.0, 200.0, tol)
     assert chosen == near
+
+
+def _best(stems, x0, x1, yc, tol):
+    ordered = sorted(stems, key=lambda s: s.x)
+    return G._best_stem(ordered, [s.x for s in ordered], x0, x1, yc, tol)
+
+
+def test_a_melody_note_over_a_chord_keeps_its_own_stem_not_the_chords():
+    """The commonest two-voice figure in this repertoire, and the geometry is
+    measured off the page it was found wrong on: page 60 of the library's
+    Christmas collection, bar 322, where a melody quarter sits directly above
+    a stem-down bass chord on the same beat.
+
+    Both voices' stems are at the SAME place horizontally - one at each side
+    of the notehead - so the x distances differ by 0.16pt, a stem stroke's
+    width. The y distances differ by 4.8pt, a whole staff space. Ranking on x
+    and using y only to break its ties therefore handed this notehead to the
+    bass chord's down-stem: the melody lost its third beat, the chord gained a
+    fourth note, and the bar came out 3 quarters against 4."""
+    tol = _tol(spacing=4.975)
+    yc = 167.253
+    ink_x0, ink_x1 = 417.19, 423.72
+    own_up = G.Stem(423.398, 149.891, 166.322)       # ends 0.93pt from yc
+    chords_down = G.Stem(417.333, 172.992, 206.938)  # ends 5.74pt from yc
+    assert abs(chords_down.x - ink_x0) < abs(own_up.x - ink_x1), (
+        "the losing stem really is the nearer one in x")
+    assert _best([own_up, chords_down], ink_x0, ink_x1, yc, tol) == own_up
+
+
+def test_an_up_stem_is_not_measured_from_the_advance_width(monkeypatch):
+    """Measured off page 2 of Dalza's Recercar, score measure 11: a filled
+    eighth with its own up-stem, one staff space above a stem-down half-note
+    chord. This is the same figure as the test above with the font's side
+    bearing added on top - Opus's notehead box overhangs its ink by 0.324
+    staff spaces on the RIGHT and not at all on the left, so against the box
+    the up-stem at the ink's right edge measures 1.75pt away while the other
+    voice's down-stem at the left edge measures 0.16pt.
+
+    With that bar read wrong the 2/2 measure emitted one voice of 6 half-note
+    units and no second voice at all - a fourfold duration error."""
+    tol = _tol(spacing=5.05)
+    yc = 548.382
+    box_x0, box_x1 = 89.16, 97.67
+    ink_x0, ink_x1 = 89.16, 96.04
+    own_up = G.Stem(95.92, 533.452, 547.606)
+    chords_down = G.Stem(89.316, 554.211, 584.878)
+    head = G.GlyphEvent("Opus", 210, "notehead_filled",
+                        (box_x0, yc - 10.0, box_x1, yc + 10.0), 0,
+                        baseline_y=yc, ink=(yc - 2.5, yc + 2.5),
+                        ink_x=(ink_x0, ink_x1))
+    assert head.stem_edges == (ink_x0, ink_x1)
+    assert box_x1 - ink_x1 > 0.3 * tol.spacing, "the side bearing under test"
+    assert _best([own_up, chords_down], *head.stem_edges, yc, tol) == own_up
+
+
+def test_a_notehead_with_no_readable_outline_still_uses_its_metrics_box():
+    """An unreadable outline must cost precision, not the attachment: the box
+    edges are what the whole decoder used before the ink was available."""
+    head = G.GlyphEvent("Maestro", 210, "notehead_filled",
+                        (96.0, 190.0, 103.0, 210.0), 0, baseline_y=200.0)
+    assert head.stem_edges == (96.0, 103.0)
+    tol = _tol()
+    own = G.Stem(103.0, 175.0, 200.5)
+    assert _best([own], *head.stem_edges, 200.0, tol) == own
+
+
+class _StubFont:
+    """One glyph's `glyf` header, as _InkBoxes reads it: five int16s of
+    (numberOfContours, xMin, yMin, xMax, yMax) at 1000 units per em."""
+
+    def __init__(self, xmin, ymin, xmax, ymax, contours=1):
+        self._data = struct.pack(">hhhhh", contours, xmin, ymin, xmax, ymax)
+
+    def getTableData(self, tag):
+        assert tag == "glyf"
+        return self._data
+
+    def __getitem__(self, tag):
+        if tag == "loca":
+            return [0, len(self._data)]
+        if tag == "head":
+            return type("_H", (), {"unitsPerEm": 1000})()
+        raise KeyError(tag)
+
+
+def test_the_ink_reader_answers_for_each_axis_separately():
+    """A glyph drawn as a single vertical stroke has a degenerate x extent and
+    a perfectly good y one, so the two axes have to be refused independently -
+    folding them into one usability test would take the vertical reading, and
+    the half-or-whole rest turns on that."""
+    boxes = G._InkBoxes(_StubFont(-120, -250, 130, 260))
+    assert boxes.xspan(0) == (-0.120, 0.130)
+    assert boxes.span(0) == (-0.250, 0.260)
+    flat = G._InkBoxes(_StubFont(40, -250, 40, 260))
+    assert flat.xspan(0) is None
+    assert flat.span(0) == (-0.250, 0.260)
+    absurd = G._InkBoxes(_StubFont(-120, -32000, 130, 260))
+    assert absurd.span(0) is None
+    assert absurd.xspan(0) == (-0.120, 0.130)
+
+
+def test_the_horizontal_ink_scales_out_from_the_glyphs_origin():
+    """Page x and font x both grow rightward, so unlike the vertical twin this
+    is a straight scale with no flip - getting that backwards would put every
+    notehead's ink on the wrong side of where it was drawn."""
+    boxes = G._InkBoxes(_StubFont(-120, -250, 130, 260))
+    assert G._ink_x_on_page(boxes, 0, 400.0, 20.0) == (400.0 - 2.4, 400.0 + 2.6)
+    assert G._ink_span_on_page(boxes, 0, 400.0, 20.0) == (400.0 - 5.2, 400.0 + 5.0)
+    assert G._ink_x_on_page(boxes, 0, None, 20.0) is None
+    assert G._ink_x_on_page(None, 0, 400.0, 20.0) is None
+
+
+def test_a_stem_further_in_x_does_not_win_on_a_hair_of_y():
+    """The other half of the ranking, and why y cannot decide alone. A
+    NEIGHBOURING note's stem, a notehead-width away in x, can end nearer this
+    notehead's centre than its own stem does - here by 0.02 staff spaces
+    against 0.63 spaces of x. Weighting each distance by its own tolerance
+    keeps the attachment; ranking on y first loses it."""
+    tol = _tol()
+    yc = 246.0
+    ink_x0, ink_x1 = 232.08, 238.72
+    own_up = G.Stem(238.8, 224.4, 250.5)        # touching the right edge
+    neighbours_up = G.Stem(228.85, 224.4, 245.3)  # 3.2pt clear of the left edge
+    assert abs(neighbours_up.y1 - yc) < abs(own_up.y1 - yc), (
+        "the losing stem really is the nearer one in y")
+    assert _best([own_up, neighbours_up], ink_x0, ink_x1, yc, tol) == own_up
 
 
 # ---------------------------------------------------------------------------
@@ -722,14 +849,21 @@ def test_the_reading_holds_at_every_line_of_the_grid():
             _whole_rest_under(line), _REST_LINES, _REST_SPACING) == (4.0, True), line
 
 
-def test_a_staff_with_no_detected_lines_is_undecided_rather_than_a_crash():
-    """There is no grid to measure against. The spacing helper beside this one
-    deliberately tolerates an empty line list, and the rest reading used to
-    raise on it instead - `min(range(0))` - so a staff whose lines were not
-    detected failed the whole page rather than degrading."""
-    assert G.half_or_whole_rest(207.5, [], _REST_SPACING) == (2.0, False)
-    assert G.half_or_whole_rest(207.5, _REST_LINES, 0) == (2.0, False)
-    assert G.half_or_whole_rest(207.5, _REST_LINES, None) == (2.0, False)
+def test_a_non_positive_spacing_never_reaches_the_rest_reading():
+    """half_or_whole_rest guards against a zero or negative spacing, and this
+    records that the guard is DEFENCE and not a live path, because a test
+    asserting the guard's return value would pass whether the guard worked or
+    not - nothing can call it that way.
+
+    decode_note_events resolves every tolerance through _Tol, which floors a
+    missing, zero or negative spacing to the reference value before the rest
+    reading ever sees it. That floor is the reachable behaviour, so it is what
+    is pinned here."""
+    for bad in (0, 0.0, -1.0, None):
+        assert G._Tol(bad).spacing == G.REFERENCE_STAFF_SPACING
+    # ...which is why the helper's own guard is unreachable from the decode:
+    # the only argument it is ever passed is a floored _Tol.spacing.
+    assert _tol().spacing > 0
 
 
 @pytest.mark.parametrize("yc", [210.0, 207.5])
@@ -788,6 +922,17 @@ def test_a_rest_whose_outline_could_not_be_read_is_counted_not_guessed(monkeypat
                       (300.0, 199.5, 306.0, 219.5), 0, baseline_y=210.0)
     assert not ev.ink_measured
     notes, stats = _decode_rests([ev], monkeypatch)
+    assert [n.base_units for n in notes] == [2.0]
+    assert stats["undecided_rests"] == 1
+
+
+def test_a_staff_with_no_detected_lines_decodes_undecided_rather_than_failing(monkeypatch):
+    """There is no grid to measure the rest's parity against. This is the
+    reachable route into that: decode_note_events tolerates an empty line list
+    the way the spacing helper beside it does, and the rest reading used to
+    raise on it - `min(range(0))` - so a staff whose lines were not detected
+    failed the whole page instead of degrading to a counted guess."""
+    notes, stats = _decode_rests([_rest_glyph(205.0, 207.5)], monkeypatch, line_ys=[])
     assert [n.base_units for n in notes] == [2.0]
     assert stats["undecided_rests"] == 1
 

--- a/server/tests/test_tabextract.py
+++ b/server/tests/test_tabextract.py
@@ -210,6 +210,48 @@ def test_glyph_decoded_alphatex_parses_with_dotted_beats(zanarkand_pdf):
     assert parsed["voices"] > parsed["bars"], parsed
 
 
+def _measure_voice_quarters(xml: str, number: int) -> dict:
+    """{voice: quarter notes} for one emitted measure, chord members counted
+    once because they sound with the note they hang off."""
+    import xml.etree.ElementTree as ET
+
+    root = ET.fromstring(xml)
+    for part in root.findall("part"):
+        for m in part.findall("measure"):
+            if int(m.get("number")) != number:
+                continue
+            divisions = None
+            for attrs in part.iter("attributes"):
+                d = attrs.findtext("divisions")
+                if d:
+                    divisions = int(d)
+                    break
+            out = collections.defaultdict(float)
+            for note in m.findall("note"):
+                if note.find("chord") is not None:
+                    continue
+                out[(note.findtext("voice") or "1").strip()] += (
+                    int(note.findtext("duration") or 0) / divisions)
+            return dict(out)
+    raise AssertionError(f"measure {number} is not in the emitted score")
+
+
+def test_a_melody_over_a_chord_stays_a_separate_voice(dalza_pdf):
+    """End-to-end for the notehead-to-stem attachment this file is full of: a
+    melody eighth one staff space above a stem-down half-note chord, sharing
+    its beat. Attaching the melody note to the CHORD's stem folds the two
+    voices into one, and the bar then reports 6 half-note units of a single
+    voice in 2/2 - a fourfold duration error with the second voice gone, not a
+    near miss. Every one of these bars carries the figure."""
+    result = tabextract.extract(dalza_pdf)
+    assert result.extractable
+    assert result.time_signature == (2, 2)
+    for bar in (7, 11, 12, 13, 14):
+        voices = _measure_voice_quarters(result.musicxml, bar)
+        assert len(voices) == 2, f"bar {bar} lost a voice: {voices}"
+        assert voices["1"] == 4.0, f"bar {bar} voice 1: {voices}"
+
+
 def test_notation_only_pdf_has_no_tab_staves(tarrega_pdf):
     info = tabextract.analyze(tarrega_pdf)
     assert info["extractable"] is False

--- a/server/tests/test_tabextract.py
+++ b/server/tests/test_tabextract.py
@@ -1124,6 +1124,20 @@ def test_high_unknown_ratio_alone_downgrades(monkeypatch):
     assert src.provenance == tabextract.PROV_GLYPHS_DEGRADED
 
 
+def test_a_rest_read_as_the_likelier_of_two_values_is_not_reported_as_read(monkeypatch):
+    """Maestro and Opus draw the half and the whole rest with ONE glyph, so a
+    rest whose position says neither (no detected staff lines to measure it
+    against, or an outline that could not be read) is read as the commoner of
+    the two. That is a twofold difference in one rest's duration, which is the
+    whole bar's arithmetic - so it caps what may be claimed about this staff
+    rather than sitting in the stats unread."""
+    src = _resolve_with_stats(monkeypatch, _stats(undecided_rests=1))
+    assert src.provenance == tabextract.PROV_GLYPHS_DEGRADED
+    assert src.uses_glyphs, "every other duration on the staff was still read"
+    assert "1 rest(s)" in src.detail
+    assert "read as a half rest" in src.detail
+
+
 def test_no_decoded_events_falls_back_with_the_font_reason(monkeypatch):
     src = _resolve_with_stats(
         monkeypatch, _stats(font_warnings=["Opus is embedded with 'cff' outlines"]), notes=[])


### PR DESCRIPTION
Closes #88.

## The defect

Every glyph's vertical position came from the box `page.get_texttrace()`
reports, and vertically that box is **metrics**-based: its top and bottom are
the font's ascender and descender, so it says the same thing about every glyph
in the font (4.0 staff spaces tall for Maestro, notehead and clef alike). Its
centre therefore sat a fixed distance from the text **baseline** rather than at
the middle of the drawn shape. Measured over the library:

| font | box centre - baseline | glyphs |
| --- | --- | --- |
| Maestro | -0.392 spaces | 123,930 |
| Opus | -0.494 | 10,935 |
| MScore | -0.270 | 10,615 |
| OpusSpecial | -0.668 | 820 |
| Leland (the fixtures' font) | +0.000 | 475 |

Between two glyphs the bias cancels, which is why every duration still decoded.
Against staff geometry it does not - and the half/whole rest decision rested
entirely on it, because Maestro and Opus draw both rests with **one glyph**
(294 of the library's 2,795 rest glyphs are that id).

Note the last row: Leland centres its box on the baseline, so on a fixture page
the box centre and a notehead's ink centre coincide and this defect is
invisible. That is why it had to be found on the library, and why the test that
measures it directly is library-gated.

**Horizontally the same thing was true, in one font**, and that was found while
reviewing this branch rather than before it. `x0`/`x1` come from the advance
width, and a font's two side bearings need not match. Measured over the
library's noteheads:

| font | left side bearing | right side bearing | noteheads |
| --- | --- | --- | --- |
| Maestro | -0.008 spaces | -0.012 | 97,489 |
| MScore | +0.000 | -0.004 | 8,254 |
| **Opus** | **+0.000** | **+0.324** | 8,917 |

A notehead's stem attaches at one side or the other, so on an Opus page "how
far is this stem from the notehead" came out a third of a space larger for an
up-stem, at the right edge, than for a down-stem at the left. That is the whole
margin the choice between two voices' stems was being decided on.

## The fix

`GlyphEvent` now carries the text baseline it was drawn on and its measured ink
extent, and `yc` is the ink centre. The ink comes from the per-glyph bounding
box in the embedded font's `glyf` table - the same bytes the Maestro fingerprint
already hashes, so no outline parsing, and one parse per font resource per
document. Availability: 100% of Opus, OpusSpecial, MScore and Leland glyphs and
126,523 of 126,560 Maestro glyphs; every one of the library's 294 one-glyph
rests. Where it cannot be read the position falls back to the baseline, which is
within 0.013 spaces of a notehead's ink centre and 0.036 of a meter digit's.

That same `glyf` header carries `xMin` and `xMax` beside the `yMin` and `yMax`
it was already unpacking, so **the edges a stem attaches at now come from the
outline too** (`GlyphEvent.stem_edges`), falling back to the metrics box where
the outline cannot be read. The two axes are refused independently: a glyph
drawn as a single vertical stroke has a degenerate x extent and a perfectly good
y one, and folding them into one usability test would cost the vertical reading
the half/whole rest turns on.

Measured against the ink itself once `stem_edges` reads it, the win is real but
not even across fonts. An Opus up-stem's edge distance - the case that
motivated this - falls from 0.348 to **0.024** staff spaces. Maestro's own
side bearings run slightly negative rather than zero, though, so on Maestro -
**95% of the library's noteheads** - the ink edge is 0.004 to 0.008 spaces
*worse* than the metrics box was. The correction is still the right one - it
measures from the side a stem actually attaches at rather than a side bearing
that happens to cancel on most fonts - but the Maestro cost is real and stated
here rather than left out.

Four readings change with it.

**The half/whole rest** is now sub-space **parity** against the line grid. A
half rest sits *on* a line and a whole rest *hangs below* one, and both are half
a space deep, so each one's ink centre lands a quarter space off the grid -
above for a half, below for a whole. That is a different kind of measurement
from "which line is it nearest", not a tighter one: it holds at every **line**
of the grid, including the ledger positions a second voice's rests use, where
nearest-line read every whole rest below the middle line as a half.

It does **not** hold for an arbitrary displacement, and the earlier wording of
this section claimed it did. Parity is measured modulo one space, so displacing
a rest by an odd number of half spaces lands it exactly where the other rest
would sit and returns that other rest with `decided=True` - a twofold duration
error reported as a reading. Nothing in `(yc, line_ys, spacing)` can separate
the two cases, so this is now stated in the docstring and pinned by a test
rather than guarded. It has no current effect: all 256 one-glyph rests the
decode reads land between 0.235 and 0.266 of a space from a line, and every one
is decided.

Checked against the only population where the answer is known *without*
geometry - the rests a SMuFL font names in the codepoint itself: parity agrees
with the engraving on all 20 in the library, nearest-line on 16.

**A flag counts when the stem's tip is inside its ink**, not near its centre. A
32nd hook's ink centre is two spaces from the tip it hangs off; the fixture's
four 32nds decoded as quarters once positions became ink-based, and a
centre-distance tolerance wide enough to cover them would reach four spaces to
either side - far enough to take a neighbouring voice's hook. The tip is inside
the ink for 4,669 of the library's 4,843 attachments and the rest fall within
the 0.25-space pad, whose value sits on a plateau (0.1 and 0.25 count the same
5,158 hooks; no pad at all loses 166).

**An augmentation dot** goes to the note whose relation to it an engraver would
draw - the note in the dot's own space, then the note on the line below it, then
the note on the line above - rather than to the nearest notehead. A dot is
always in the middle of a space (11,350 of 11,405 in the library, within a tenth
of a space), so two noteheads a space apart are exactly equidistant from the dot
between them and nearest-distance decided that tie on rounding. It gave one
notehead two *vertically stacked* dots - which is not what a double dot is; a
double dot is two dots side by side - while the note the second dot belonged to
lost half its length. Both engravings the ranking has to serve are in the
library: a chord of noteheads a space apart each with its own raised dot, and a
lower voice's dotted whole note whose dot is in the space below it.

**Which stem a notehead hangs off** is now ranked on both distances together.
This is the defect the ink centres exposed and it is described in full in the
next section, because it was a new one rather than a consequence of better
voice grouping.

Also here, from the issue: an empty staff-line list no longer raises, and a rest
whose value was guessed rather than read caps what the staff may claim instead
of sitting unread in the decode stats.

## The stem-attachment defect this branch introduced, and its fix

`_best_stem` ranked candidate stems on `x`, using `y` only to break `x`'s ties.
Putting a notehead at its true vertical position brought a neighbouring voice's
stem end inside the y gate, where it then won on a hair of x.

In the commonest two-voice figure in this repertoire - a melody note sharing a
beat with a stem-down chord - **both voices' stems are at the same place
horizontally**, one at each side of the notehead. Their x distances therefore
differ by the width of a stem stroke and their y distances by a whole staff
space, and x was deciding. Measured over the library's 98,737 notehead-to-stem
lookups, against `main`:

| | main | ink centres only | with the fix |
| --- | --- | --- | --- |
| took a stem further away in y than an in-range alternative | 0 | **90** (20 scores) | 7 (6 scores) |
| took a stem >0.8 spaces off in y with one <=0.3 available | 1 | **93** | 2 |
| ...of those, the other voice's stem | 1 | **49** | **0** |

Two verified reproductions, both checked against the printed page:

- **Dalza's Recercar**, score measure 11: a filled eighth with its own up-stem
  one space above a stem-down half-note chord. `main` emits two voices of four
  quarters each in the 2/2 bar, correctly. With ink centres it emitted a single
  voice of six half-note units and no second voice - a fourfold duration error
  with a voice lost. Measures 7, 12, 13 and 14 the same way. This is also the
  Opus side-bearing case: against the metrics box the note's own up-stem
  measured 1.75pt away and the chord's down-stem 0.16pt.
- **Easy Christmas Songs Vol 1-4**, page 60 bar 322: the beat-3 melody quarter
  was absorbed into the bass half chord, leaving voice 1 three quarters long.
  The chord's down-stem won by 0.16pt of x over a stem 6.2 times closer in y.
  Bar 324 lost voice 2 entirely. Also reproduces at bars 326, 334, 401 and 405.

Candidates are now ranked on both distances together, each expressed as a
fraction of the slack its own axis is already allowed - no third constant to
tune. `y` cannot rank them alone either: a neighbouring note's stem a
notehead-width away can end nearer this notehead's centre than its own stem
does, and 20 noteheads go to such a stem if x is ignored, so both a y-first
ranking and the existing x-first one are wrong in opposite directions.

**A stem-direction consistency check inside `_best_stem` was tried and is not
better.** The check `_assign_stem_directions` already makes - an up-stem leaves
a notehead at its right edge, a down-stem at its left - needs the mean x of
every notehead on the stem, which one candidate notehead does not have. It was
tried anyway. Two independent attempts to measure how many noteheads it leaves
with no consistent candidate at all, and how many selections it changes,
disagreed with each other, so neither count is published here - but the
selections it does change are not better: some individual noteheads move
closer to their true stem and others move away, and the change is not an
improvement on net. That structural reason, which both measurements agree on,
is now recorded in the function's docstring so it is not tried again.

The 7 remaining noteheads that take a stem further in y than `main` chose were
each looked at individually. All 7 are the same shape and the new choice is
right in every one: the note's own up-stem sits on its right ink edge, 0.008
spaces away, while the stem `main` preferred is an up-stem 0.55 to 0.67 spaces
clear of the notehead's *left* edge - a neighbouring note's, which an up-stem on
the left cannot be anything else. Both remaining rows of the second metric are
the same kind of correction.

## What moved, across all 297 scores

| | main | ink centres only | with the stem fix |
| --- | --- | --- | --- |
| **dotted whole rests** | **3** | **0** | **0** |
| defective bars | 6,411 | 5,931 | **5,863** |
| overfull bars | 2,335 | 1,943 | **1,896** |
| short bars | 4,668 | 4,440 | **4,435** |
| bars holding invented silence | 3,980 | 3,759 | 3,753 |
| invented silence (quarters) | 5,831.6 | 5,450.5 | 5,529.2 |
| notes emitted | 98,688 | 98,688 | **98,688** |
| `<chord>` markers | 17,930 | 17,279 | 17,231 |
| rhythm confidence | 15 high | 26 high | 27 high |
| meter / key / fret confidence | unchanged | unchanged | unchanged |

Pitched-note counts are identical in all three columns: nothing was dropped or
added, only re-read. `<note>` elements are not quite: over the 35 scores this
branch touches, 16,444 become **16,445**, and `<rest/>` elements 229 become
**230** - one extra rest, not a note.

The `<chord>` count falls in both steps, and the direction is the point rather
than a side effect. A `<chord>` marker is a notehead emitted as a member of the
beat before it, so a melody note wrongly attached to the accompaniment's stem
*adds* one. Removing 48 of them is 48 noteheads that stopped being folded into a
chord they are not in - the Christmas bar above is one of them.

Invented silence rises slightly against the ink-centre column while the bars
holding it fall. That is consistent: separating two voices that were being read
as one means both voices now have to be padded to the bar, where before there
was one voice to pad.

Per file against the ink-centre column: 15 scores improve by 71 defective bars
between them, and 2 lose 3 between them - "Score A" (34 -> 36) and "Score B" (22 -> 23) - with the rest unchanged.
The two that lose ground were not individually diagnosed; in the larger of them
the stem the fix now chooses is the one touching the notehead's edge, so the
bar was previously balanced by a compensating error rather than read
correctly.

## Blast radius, stated rather than netted

The previous version of this section gave a net figure. The gross figures,
measured at two levels, against `main`:

At the **stem-end lookup** (`_best_stem` itself), of 98,737 noteheads:

| | ink centres only | with the stem fix |
| --- | --- | --- |
| lose a stem end | 1,543 | 1,543 |
| gain a stem end | 1,279 | 1,279 |
| attach to a *different* stem end | 1,905 | 2,922 |
| **any change** | **4,727 (4.8%), 270 of 297 scores** | **5,744 (5.8%), 270 scores** |

At the **final attachment**, after the threading pass and the direction check,
of 101,073 noteheads:

| | ink centres only | with the stem fix |
| --- | --- | --- |
| lose a stem | 164 | 147 |
| gain a stem | 215 | 219 |
| attach to a different stem | 1,873 | 2,899 |
| stem **direction** flips | 2,238 | 3,239 |
| **any change** | **2,252 (2.2%), 241 scores** | **3,265 (3.2%), 243 scores** |

The earlier text said 292 fewer noteheads find a stem end. The measured figure
is **264** (11,654 to 11,918), of which the threading pass picks up **150**, so
**114 more** find no stem at either stage. That is not the end of it, and the
earlier text stopped too early: `_assign_stem_directions` then drops stems whose
side and overhang contradict each other, and it drops 358 at `main` against 172
here, so the number of noteheads that finally carry no stem falls from 2,892 to
2,820 (excluding whole notes, which never take one by definition). The stem fix
leaves all of these figures unchanged - it changes *which* stem is chosen, not
whether one is found.

**What a notehead with no stem is given.** Not a whole note. It keeps the value
its shape implies with no flag or beam counted, so a filled head is emitted as a
plain quarter (1,954 of them), a half note as a half, a diamond as a quarter,
and it loses its voice signal, which folds it into whatever else sounds at its
onset. The cost is therefore an eighth or a sixteenth read *long* as a quarter,
plus the voice - never a note lengthened to a whole. A second population, 172 of
them, found a stem and had its flags counted before the direction check dropped
it; those keep their duration and lose only the voice.

## One-glyph rests

The earlier text said 139 of the library's one-glyph rests move from whole to
half and 10 the other way. Measured at the decode boundary - the value
`decode_note_events` gives a `rest_half_whole` glyph, over the 256 such rests
the decode reads, matched one-to-one between the two trees:

- **140** move whole to half, removing 280 quarters of silence that was never
  printed. This is why overfull bars fall furthest.
- **12** move half to whole, the permissive direction, adding **24** quarters.

Both figures are the same with and without the stem fix. A review of this branch
put the permissive count at 26; that could not be reproduced at this measurement
point, and the definition used here is stated above so it can be checked.

**The numerator/denominator split did not move**, and that is measured rather
than assumed: every time-signature digit in the library sits exactly +/-1.0
space from the middle line, so a 0.39-0.49 space bias never crossed it. It did
eat most of the denominator's margin - down to 0.51 spaces for Opus - and would
have crossed on a condensed or large-print meter. The staff-band filters
likewise never misfiled a glyph at this scale. Both are now measured against the
ink for the same reason.

## Other invariants, once the first one was clean

The issue's technique applied further. Counting what the emitted MusicXML can
never legally contain:

- **Dotted whole rests: 3 -> 0.**
- **Rests longer than their bar: 7 -> 1.** The one that remains is a whole rest
  alone in a 3/4 bar - not a defect in the engraving but in the reading: a
  whole-measure rest is drawn as a whole rest whatever the meter, and this
  decoder reads it as four quarters. Worth its own issue.
- **Dotted whole notes: unchanged.** 60 of them by the count used here (every
  `<note>` carrying `<type>whole</type>` and a `<dot>`), and the same 60 on
  `main` and on both commits of this branch. Most are in 12/8, where six
  quarters is exactly the bar and the reading is right; the remainder are in
  bars read as 4/4, where six quarters is impossible and either the meter or
  the dot is wrong. Untouched by this change; worth its own issue.
- Notes longer than their bar: 327 on `main`, 332 with ink centres, **331** with
  the stem fix. Scores that gain a dot the old tie-break dropped were already at
  or over their bar on that note.

## Documentation

`docs/musicxml-tab-profile.md`'s Rule 14 paragraph quotes library figures for
the MuseScore round trip, and both commits on this branch move them. The
experiment was re-run at the head of the branch (MuseScore 4.6.3, the Rule 8
check that section describes implemented independently of the extractor, all 293
emitted files): 6,155 `<forward>` elements written, 2,957 surviving a re-save as
one, and **not one of them still carrying the marking**; defective measures
5,863 before the save against 5,430 after it, so **433** measures read as
conforming downstream of a save. The independent checker was validated by
reproducing the previous commit's published figures exactly (5,931 -> 5,600,
5,450.5 -> 3,848.2 quarters, 3,109 `<forward>`) before being used for the new
ones.

No fixture's expected values changed. One test assertion was renamed
(`dot_y_tol` -> `dot_x_tol` in the tolerance-scaling test) because a dot's
vertical window is no longer a symmetric tolerance.

## Tests, and proof they can fail

26 new tests. From the first commit: the parity rule at every line of the grid
and above and below the staff, the undecided cases, the decode reading both
rests from the one glyph, the SMuFL oracle on the committed fixture, flag
containment in both directions and its fallback, the dot ranking's two real
engravings, the degraded-provenance report, and a library-gated measurement that
every notehead's ink centre lands on the staff's own half-space grid (worst
0.020 spaces) while the box centre it replaced never does (best 0.098).

Nine more for the stem fix and the corrections: both reproductions at the
geometry the page really has, the Opus side bearing, the metrics-box fallback,
the y-first failure mode, the ink reader's per-axis refusal, the horizontal
placement's direction, an end-to-end assertion that Dalza's five two-voice bars
keep both voices, the parity rule's confidently-wrong half-space case, and the
`_Tol` spacing floor.

**One test on this branch could not fail and has been replaced.** It asserted
`half_or_whole_rest`'s guard against a zero or negative spacing, which nothing
can reach: `_Tol` floors a missing, zero or negative spacing to the reference
value before the rest reading ever sees it. The floor is now what is pinned, and
the reachable half of what that test claimed - a staff whose lines were not
detected - now goes through `decode_note_events` instead of calling the helper
directly.

Every new test was proven to fail by breaking the behaviour it describes.
Twenty mutations, each caught; the eight for this commit:

| mutation | tests turned red |
| --- | --- |
| ranking back to `(dx, dy)` lexicographic | 2, incl. the end-to-end Dalza bars |
| ranking changed to `(dy, dx)`, y first | 1 |
| `stem_edges` back to the metrics box | 1 |
| `stem_edges` loses its box fallback | 1 |
| horizontal ink flipped like the vertical one | 11, incl. 4 committed fixtures |
| ink reader uses one usability test for both axes | 1 |
| `half_or_whole_rest` loses its empty-line guard | 1 |
| `_Tol` no longer floors a non-positive spacing | 2 |

Server suite: 630 passed, 8 skipped with the library set; 606 passed, 32 skipped
without it, which is the CI-equivalent run.

## Not verified

- The rotated-span guard (17 characters in the library are rotated, none of them
  a music glyph on a notation staff) and the CFF path have no test: the fixtures
  cannot produce either, and both only ever degrade to the baseline.
- Bravura's 10 glyphs on one library page get no ink box, because its name
  resolves to more than one embedded resource on that page and a box could then
  come from the wrong glyph order. They are unrecognised harmonic noteheads that
  only feed the honesty counters.
- The three scores that lose defective bars to the stem fix were counted, not
  diagnosed bar by bar.
- The permissive-direction rest count could not be reconciled with a review's
  figure of 26; 12 is what this measurement point gives.
- The remaining whole-bar rest and the 17 impossible dotted whole notes are
  named above, not fixed.
