### PR TITLE
Say when a duration was floored, and which bars were not read (#115, #117)

### DIFF
--- a/docs/musicxml-tab-profile.md
+++ b/docs/musicxml-tab-profile.md
@@ -841,6 +841,32 @@ into the reported confidence instead. That confidence also states any known
 defect below the threshold at which it changes label, so an unqualified
 high-confidence string means no measure was in question rather than not many.
 
+**How each measure's durations were obtained** is reported alongside them.
+`rhythm_provenance` counts staff systems by source: `glyphs` means flags,
+beams, dots and rest shapes were decoded; `spacing` means durations were
+inferred from the horizontal gaps between noteheads, which is only as good as
+the engraver's spacing being proportional and is wrong wherever a system was
+justified to the margin or spaced by hand; `glyphs-degraded` means the staff
+was read from its engraving with something on it left unread. `spacing_bars`
+and `degraded_bars` are the measure numbers those systems produced. The counts
+say how much of a transcription is in question, and only the lists say which of
+it — which is the form of the fact a reader comparing against the PDF can use.
+
+`notes_no_stem` is how many filled noteheads were read with no stem attached,
+across `staves_no_stem` notation staves. A note's flags and beams hang off its
+stem, so for those notes there was nothing to count and each was emitted at the
+longest duration its notehead alone allows — a quarter. That is a floor rather
+than a reading, and because it is the longest of the candidate values such a
+note always plays long and always pushes its measure towards Rule 8's overfull
+side; it has also lost the stem direction that assigns it to a voice. A staff
+carrying any of them is reported as `glyphs-degraded` rather than `glyphs`.
+
+Every one of these figures is also stated in the warning prose, in the same
+numbers. That is deliberate duplication rather than redundancy: a consumer
+written before a field existed does not read it, and the warnings are a list of
+strings that gets displayed as it is, so a count added without its sentence is
+a measurement nobody is ever told.
+
 **How the meter and key were obtained** is reported the same way, and for the
 same reason: `time_signature` with `time_signature_source`, and `key_fifths`
 with `key_signature_source`. A source of `glyph-decoded` or `auto-detected`

--- a/server/fermata/api.py
+++ b/server/fermata/api.py
@@ -1314,8 +1314,14 @@ def _transcription_row(conn, score_id: int):
 # holding silence that was deduced from the meter rather than read from the
 # page, or holding nothing that was read at all, is not the reading the other
 # figures make it look like, and neither is recoverable from them.
+#
+# `notes_no_stem` / `staves_no_stem` belong with them too. A filled notehead
+# whose stem the decoder never found has no flag or beam to count, so it was
+# emitted at the longest duration its notehead alone allows - a floor, not a
+# reading, and one that always errs long. That is the same kind of fact as a
+# padded bar and is recoverable from nothing else here.
 _BAR_KEYS = ("bars_overfull", "bars_short", "bars_defective", "bars_measured",
-             "bars_padded", "bars_unread")
+             "bars_padded", "bars_unread", "notes_no_stem", "staves_no_stem")
 
 # WHICH bars those were, as data and not only inside the warning prose. The
 # prose names them, but it caps the list, and the profile document states that a
@@ -1323,7 +1329,13 @@ _BAR_KEYS = ("bars_overfull", "bars_short", "bars_defective", "bars_measured",
 # `inferred_rest_quarters` - a claim the application has to actually make good
 # on. `padded_bars` / `unread_bars` are lists of bar numbers;
 # `inferred_rest_quarters` is a quarter-note count and can be fractional.
-_BAR_LIST_KEYS = ("padded_bars", "unread_bars")
+#
+# `spacing_bars` / `degraded_bars` are the same kind of list for the same
+# reason: which bars' durations came from the gaps between noteheads rather
+# than the noteheads, and which came off a staff something on it could not be
+# read. The staff counts in `rhythm_provenance` say how much; only these say
+# which, and a bar number is what a reader can carry back to the PDF.
+_BAR_LIST_KEYS = ("padded_bars", "unread_bars", "spacing_bars", "degraded_bars")
 _BAR_AMOUNT_KEYS = ("inferred_rest_quarters",)
 
 
@@ -1515,6 +1527,10 @@ def transcribe(score_id: RowId, body: TranscribeIn | None = Body(default=None)):
             "padded_bars": result.padded_bars,
             "unread_bars": result.unread_bars,
             "inferred_rest_quarters": result.inferred_rest_quarters,
+            "notes_no_stem": result.notes_no_stem,
+            "staves_no_stem": result.staves_no_stem,
+            "spacing_bars": result.spacing_bars,
+            "degraded_bars": result.degraded_bars,
             "time_signature": list(result.time_signature) if result.time_signature else None,
             "time_signature_source": result.time_signature_source,
             "key_fifths": result.key_fifths,

--- a/server/fermata/api.py
+++ b/server/fermata/api.py
@@ -1333,8 +1333,10 @@ _BAR_KEYS = ("bars_overfull", "bars_short", "bars_defective", "bars_measured",
 # `spacing_bars` / `degraded_bars` are the same kind of list for the same
 # reason: which bars' durations came from the gaps between noteheads rather
 # than the noteheads, and which came off a staff something on it could not be
-# read. The staff counts in `rhythm_provenance` say how much; only these say
-# which, and a bar number is what a reader can carry back to the PDF.
+# read. `rhythm_provenance` on the extraction result says how many staves
+# resolved each way, but that field is not one this module stores or exposes
+# - only these bar-number lists carry the fact out to a consumer, and a bar
+# number is what a reader can carry back to the PDF.
 _BAR_LIST_KEYS = ("padded_bars", "unread_bars", "spacing_bars", "degraded_bars")
 _BAR_AMOUNT_KEYS = ("inferred_rest_quarters",)
 

--- a/server/fermata/glyph_rhythm.py
+++ b/server/fermata/glyph_rhythm.py
@@ -178,6 +178,13 @@ MAESTRO_GID_MAP = {
     # table's own "rendered and eyeballed" standard. A signature that would
     # need digit0 correctly falls through to "not detected" (see
     # decode_time_signature) rather than silently emitting a wrong value.
+    #
+    # gid 174 (notehead_diamond, harmonics) is bucketed with notehead_filled
+    # as of #115: `duration_needs_stem` is True for it, so an unfound stem
+    # floors it at a quarter the same way a filled head does. Quarter-vs-half
+    # is unpinned for a diamond - unlike notehead_half it carries no shape
+    # that says which, so a diamond engraved as a half is read as a quarter
+    # whenever its stem is not found, not just left undecided.
 }
 
 # Fingerprint for the calibrated Maestro subset: GID -> sha256 of that

--- a/server/fermata/glyph_rhythm.py
+++ b/server/fermata/glyph_rhythm.py
@@ -2087,7 +2087,10 @@ def decode_note_events(page, staff_top, staff_bottom, staff_x0, staff_x1, line_y
     where a flag would attach - the shape of "this piece uses 32nd flags,
     grace notes or an articulation we never calibrated", which decodes as
     systematically wrong durations while looking perfectly healthy - and
-    undecided_rests counts rests whose value was guessed rather than read.
+    undecided_rests counts rests whose value was guessed rather than read,
+    and no_stem_noteheads counts filled noteheads that came out of the decode
+    with no stem at all, whose duration is therefore a floor rather than a
+    reading.
     """
     tol = _Tol(spacing if spacing else _spacing_from_lines(line_ys),
                staff_bottom - staff_top, staff_x1 - staff_x0)
@@ -2107,6 +2110,24 @@ def decode_note_events(page, staff_top, staff_bottom, staff_x0, staff_x1, line_y
         # the caller can say the durations on this staff were partly guessed
         # rather than read - see _resolve_rhythm_source.
         "undecided_rests": 0,
+        # Filled (or x / diamond) noteheads that reached the end of the decode
+        # with NO stem - neither a stem end near the head nor a stem passing
+        # through it. Such a head can be a quarter, an eighth, a sixteenth or
+        # shorter, and the flag or beam that would say which attaches to the
+        # stem that was not found, so nothing here can count one: the head is
+        # emitted at its unflagged floor value. The floor is the longest of
+        # the possible readings, so one of these reads LONG, never short, and
+        # takes its bar's arithmetic with it. Counted for the same reason
+        # undecided_rests is - so the caller can say the durations on this
+        # staff were partly floored rather than read (see
+        # tabextract._resolve_rhythm_source).
+        #
+        # A half or whole notehead is deliberately NOT counted here even
+        # though its stem can be missing just as easily: neither shape can
+        # carry a flag or a beam in any notation, so its value is fully
+        # determined by the head and a missing stem costs only the voice
+        # signal, not the duration.
+        "no_stem_noteheads": 0,
         "font_warnings": list(glyphs.warnings),
     }
     if not glyphs.events:
@@ -2153,9 +2174,13 @@ def decode_note_events(page, staff_top, staff_bottom, staff_x0, staff_x1, line_y
     notes = []
     stems_by_key = {}
     undecided_rests = 0
+    no_stem_noteheads = 0
     for ev in staff_events:
         if ev.category in NOTEHEAD_CATS:
             stem = None
+            # Whether this head's DURATION depends on finding its stem. Set
+            # only for the quarter-or-shorter shapes; see no_stem_noteheads.
+            duration_needs_stem = False
             if ev.category == "notehead_whole":
                 # whole notes never take a stem, flag or beam by definition -
                 # don't even look for one (a nearby unrelated stem in a dense
@@ -2195,6 +2220,7 @@ def decode_note_events(page, staff_top, staff_bottom, staff_x0, staff_x1, line_y
             else:
                 base = 1.0  # filled/x/diamond head: quarter-or-shorter
                 flags = 0
+                duration_needs_stem = True
                 ex0, ex1 = ev.stem_edges
                 stem = _best_stem(stems, stem_xs, ex0, ex1, ev.yc, tol)
                 if stem is not None:
@@ -2211,6 +2237,11 @@ def decode_note_events(page, staff_top, staff_bottom, staff_x0, staff_x1, line_y
                 # pass one x gate and fail the other.
                 ex0, ex1 = ev.stem_edges
                 stem = _stem_through_notehead(stems, stem_xs, ex0, ex1, ev.yc, tol)
+                if stem is None and duration_needs_stem:
+                    # Both stem lookups came up empty on a head whose value
+                    # only its stem could have settled. `flags` is still 0 and
+                    # will stay 0, so this head goes out at its floor.
+                    no_stem_noteheads += 1
             key = None
             if stem is not None:
                 key = _stem_key(stem)
@@ -2289,6 +2320,7 @@ def decode_note_events(page, staff_top, staff_bottom, staff_x0, staff_x1, line_y
         "beam_segment_count": len(beams),
         "curve_count": len(curves),
         "undecided_rests": undecided_rests,
+        "no_stem_noteheads": no_stem_noteheads,
     })
     return notes, stats
 

--- a/server/fermata/tabextract.py
+++ b/server/fermata/tabextract.py
@@ -1725,9 +1725,9 @@ def _resolve_rhythm_source(page, std_staff, pair_reason, decoded):
         # Reported however few there are, and NOT ratio-gated, for the same
         # reason an unrecognised notehead above is not: how dense the staff
         # around it happens to be is not evidence about this note. Measured
-        # over the library that degrades 493 of 2749 notation staves, which
-        # is the honest size of the problem rather than a threshold chosen to
-        # keep the count down.
+        # over the library that degrades 493 of the 2657 notation staves that
+        # supplied glyph durations at all, which is the honest size of the
+        # problem rather than a threshold chosen to keep the count down.
         return _RhythmSource(
             PROV_GLYPHS_DEGRADED, note_events, stats=stats,
             detail=(
@@ -2010,8 +2010,8 @@ def _rhythm_report(counts, details, conformance=None, unread_bars=(),
             warnings.append(
                 f"{degraded} staff system(s) were read from the engraved notation but not "
                 "everything on them could be read - a music-font glyph this decoder has not "
-                "been calibrated for, a notehead with no stem to count flags on, or a rest "
-                "whose printed position did not say which value it was - so treat their "
+                "been calibrated for, a notehead with no stem this decoder could find, or a "
+                "rest whose printed position did not say which value it was - so treat their "
                 f"durations as medium confidence.{where}"
             )
         warnings.append(_TUPLET_WARNING)
@@ -2040,13 +2040,21 @@ def _rhythm_report(counts, details, conformance=None, unread_bars=(),
     # said. A count of degraded staves cannot be turned back into it: one
     # stemless notehead on a staff and forty of them read identically there.
     if no_stem_notes:
+        # This count is honest for the GATE - the stem was not found, so both
+        # the duration and the voice are a guess either way - but not for a
+        # claim about what got emitted. A stemless head is folded into any
+        # host stem within onset tolerance by the absorb pass in
+        # `_stem_groups`, and most of them ARE attached that way: of the
+        # heads this counts, most inherit a duration from that host rather
+        # than going out at the plain-quarter floor. Only say what is true of
+        # every one of them.
         warnings.append(
             f"{no_stem_notes} notehead(s) across {no_stem_staves} staff system(s) were read with "
-            "no stem attached to them. A note's flags and beams hang off its stem, so for those "
-            "notes there was nothing to count: each was emitted as a plain quarter, the LONGEST "
-            "duration its notehead on its own allows. Any of them the score wrote as an eighth "
-            "or shorter therefore plays long and overfills its bar, and each also lost the stem "
-            "direction that says which of a bar's voices it belongs to"
+            "no stem this decoder could find. A note's flags and beams hang off its stem, so for "
+            "those notes both the duration and which of a bar's voices they belong to rest on a "
+            "guess rather than a reading: where such a head could not be attached to a "
+            "neighbouring stem, it was emitted at the plain quarter, the LONGEST duration its "
+            "notehead on its own allows"
         )
 
     # Bars that don't add up outrank how the durations were obtained: a
@@ -2126,10 +2134,16 @@ def _rhythm_report(counts, details, conformance=None, unread_bars=(),
             f"({defective}) or hold nothing that was read from the score ({len(unread_bars)})"
         )
     if bars and unreliable / bars >= 0.25:
-        confidence = (
-            "low overall - individual durations were read from the score's own engraving, but "
-            + reason
-        )
+        # Compose onto whatever `confidence` already says, the same way the
+        # branch below does - not replace it. Replacing it here with a fresh
+        # "durations were read from the score's own engraving" reasserted the
+        # exact claim a degraded or spacing-derived score had just finished
+        # disclosing as NOT fully true, which is the headline flatly
+        # contradicting the sentence right below it. The threshold still
+        # decides the LABEL (this is the one place "low overall" gets said),
+        # but the clause after it stays whatever the disclosure above earned.
+        _, _, rest = confidence.partition(" - ")
+        confidence = f"low overall - {rest}; {reason}" if rest else f"low overall; {reason}"
     elif bars and unreliable:
         # Below the threshold is not the same as clean, and a binary gate threw
         # away everything the counts above just established: sixteen of the

--- a/server/fermata/tabextract.py
+++ b/server/fermata/tabextract.py
@@ -51,6 +51,15 @@ ExtractionResult.warnings, .confidence and .rhythm_provenance rather than
 papered over; callers can also offer a manual time-signature override (see
 extract()'s time_signature argument) for when auto-detection comes up empty.
 
+Every one of those gaps is stated TWICE, and both halves are required. The
+count is a field on ExtractionResult, so the data stays queryable; the same
+fact is also written into .warnings as a sentence, because that is the only
+one of the two anything downstream reads on its own - a list of strings gets
+looped over and displayed, a new field gets ignored by every consumer written
+before it existed. A count added without its sentence is a measurement nobody
+is ever told; see .bars_padded / "bar(s) contain silence" for the shape both
+halves take.
+
 VOICES: classical and fingerstyle guitar is polyphonic - a melody sounding
 OVER an independent bass line - so a bar's notes are not one sequence. Each
 notehead is grouped with the others on ITS OWN STEM (a chord is one beat),
@@ -227,6 +236,26 @@ class ExtractionResult:
     # constants). Reported so a caller can see the mix directly instead of
     # having to parse it back out of the confidence string.
     rhythm_provenance: dict = field(default_factory=dict)
+    # WHICH bars the staves behind those counts produced. A count of staves
+    # says how much of a score's rhythm was not read from its glyphs; only
+    # these say which music that was, and a bar number is the one coordinate a
+    # reader can carry back to the PDF - same reason `padded_bars` exists
+    # beside `bars_padded`. `spacing_bars` are bars whose durations came from
+    # the horizontal gaps between noteheads rather than from the noteheads;
+    # `degraded_bars` are bars read from the engraving with something on their
+    # staff left unread. Both are stated in the warning prose as well, because
+    # a field on its own reaches nobody.
+    spacing_bars: list[int] = field(default_factory=list)
+    degraded_bars: list[int] = field(default_factory=list)
+    # Filled noteheads that came out of the decode with no stem, and how many
+    # notation staves carried at least one. Such a head can be a quarter or
+    # anything shorter, and the flag or beam that would say which attaches to
+    # the stem that was not found, so it is emitted at its unflagged floor - a
+    # duration that is a guess, and one that always errs LONG. Counted here for
+    # the same reason `bars_padded` is: it is the size of what was invented,
+    # and it cannot be recovered from any other figure on this result.
+    notes_no_stem: int = 0
+    staves_no_stem: int = 0
 
     def to_dict(self) -> dict:
         return {
@@ -261,6 +290,10 @@ class ExtractionResult:
             "confidence": self.confidence,
             "warnings": self.warnings,
             "rhythm_provenance": self.rhythm_provenance,
+            "spacing_bars": list(self.spacing_bars),
+            "degraded_bars": list(self.degraded_bars),
+            "notes_no_stem": self.notes_no_stem,
+            "staves_no_stem": self.staves_no_stem,
         }
 
 
@@ -1679,6 +1712,32 @@ def _resolve_rhythm_source(page, std_staff, pair_reason, decoded):
                 "be short by two quarter notes of silence"
             ),
         )
+    no_stem = stats.get("no_stem_noteheads", 0)
+    if no_stem:
+        # A filled notehead with no stem cannot have its flags or beams
+        # counted, because both attach to the stem that was not found, so it
+        # goes out at its unflagged floor: a quarter where the page may say
+        # an eighth, a sixteenth or shorter. The floor is the LONGEST of the
+        # candidate readings, so this always reads long and always takes the
+        # bar's arithmetic with it, and the note has lost its voice signal
+        # besides (see glyph.decode_note_events, no_stem_noteheads).
+        #
+        # Reported however few there are, and NOT ratio-gated, for the same
+        # reason an unrecognised notehead above is not: how dense the staff
+        # around it happens to be is not evidence about this note. Measured
+        # over the library that degrades 493 of 2749 notation staves, which
+        # is the honest size of the problem rather than a threshold chosen to
+        # keep the count down.
+        return _RhythmSource(
+            PROV_GLYPHS_DEGRADED, note_events, stats=stats,
+            detail=(
+                f"{no_stem} notehead(s) on the paired notation staff have no stem this "
+                "decoder could find, so no flag or beam could be counted for them - each "
+                "was given the longest duration its notehead alone allows (a quarter) "
+                "rather than a read one, and reads long wherever the score wrote it "
+                "shorter"
+            ),
+        )
     return _RhythmSource(PROV_GLYPHS, note_events, stats=stats)
 
 
@@ -1876,7 +1935,8 @@ def _overfull_bars(measures) -> tuple[int, int]:
     return bars.overfull, bars.counted
 
 
-def _rhythm_report(counts, details, conformance=None, unread_bars=()):
+def _rhythm_report(counts, details, conformance=None, unread_bars=(),
+                   prov_bars=None, no_stem_notes=0, no_stem_staves=0):
     """Derive the document's rhythm warnings and confidence string from the
     collected per-staff provenances - the single place that decides both, so
     they cannot drift out of step with each other or with the measure loop.
@@ -1886,8 +1946,22 @@ def _rhythm_report(counts, details, conformance=None, unread_bars=()):
     `conformance` is a _BarConformance, or None where no bars were measured.
     `unread_bars` is the numbers of bars nothing was read from at all - see the
     warning below for why they are reported here rather than as Rule 8 defects.
+
+    `prov_bars` maps a PROV_* value to the numbers of the bars the staves that
+    resolved to it produced. A count of staves says HOW MUCH of a score's
+    rhythm was not read from its glyphs; only the bar numbers say WHICH music
+    that was, which is what lets somebody check those bars against the PDF -
+    the same reason the padded-bars warning names its bars rather than only
+    counting them. Empty, or absent, means no bar numbers were collected and
+    the prose says nothing it cannot support.
+
+    `no_stem_notes` / `no_stem_staves` are how many filled noteheads across
+    how many notation staves came out of the decode with no stem, and so with
+    their duration floored at a quarter rather than read - see
+    glyph.decode_note_events.
     """
     conformance = conformance or _BarConformance(0, 0, 0, 0)
+    prov_bars = prov_bars or {}
     overfull, short = conformance.overfull, conformance.short
     defective, bars = conformance.defective, conformance.counted
     padded, padded_bars = conformance.padded, conformance.padded_bars
@@ -1895,6 +1969,8 @@ def _rhythm_report(counts, details, conformance=None, unread_bars=()):
     glyphs = counts.get(PROV_GLYPHS, 0)
     degraded = counts.get(PROV_GLYPHS_DEGRADED, 0)
     spacing = counts.get(PROV_SPACING, 0)
+    spacing_bars = sorted(prov_bars.get(PROV_SPACING) or ())
+    degraded_bars = sorted(prov_bars.get(PROV_GLYPHS_DEGRADED) or ())
     warnings = []
 
     if not glyphs and not degraded:
@@ -1905,17 +1981,38 @@ def _rhythm_report(counts, details, conformance=None, unread_bars=()):
         confidence = "low - inferred from note spacing only, no dotted notes or ties modeled"
     else:
         if spacing:
+            # WHICH bars those systems produced, not just how many systems
+            # there were. "treat those sections as low confidence" was
+            # unanswerable without them: a reader was told that some fraction
+            # of the score's durations came out of the gaps between noteheads
+            # rather than the noteheads themselves, and given no way to find
+            # out which fraction. Spacing-derived rhythm is only as good as
+            # the engraver's spacing being proportional, which a justified or
+            # hand-adjusted system is not, so these are the bars to check
+            # first.
+            where = (f" The bars they produced are: {_bar_list(spacing_bars)}."
+                     if spacing_bars else "")
             warnings.append(
                 f"durations were read from the engraved notation for {glyphs + degraded} staff "
                 f"system(s); {spacing} staff system(s) could not be read that way and use a "
                 "rougher estimate from note spacing instead - treat those sections as low "
-                "confidence"
+                f"confidence.{where}"
             )
         if degraded:
+            # Named the same way, and for the same reason. A degraded staff was
+            # read from the engraving, but something on it was not: an
+            # uncalibrated glyph, a rest whose value its position did not
+            # settle, or a notehead whose stem was never found. The
+            # per-staff reason is appended below as "rhythm source: ..."; this
+            # says how much of the score it applies to and where.
+            where = (f" The bars they produced are: {_bar_list(degraded_bars)}."
+                     if degraded_bars else "")
             warnings.append(
-                f"{degraded} staff system(s) were read from the engraved notation but contain "
-                "music-font glyphs this decoder has not been calibrated for - treat their "
-                "durations as medium confidence"
+                f"{degraded} staff system(s) were read from the engraved notation but not "
+                "everything on them could be read - a music-font glyph this decoder has not "
+                "been calibrated for, a notehead with no stem to count flags on, or a rest "
+                "whose printed position did not say which value it was - so treat their "
+                f"durations as medium confidence.{where}"
             )
         warnings.append(_TUPLET_WARNING)
         warnings.append(_TIE_WARNING)
@@ -1926,14 +2023,31 @@ def _rhythm_report(counts, details, conformance=None, unread_bars=()):
             )
         elif degraded:
             confidence = (
-                "medium - decoded from the score's engraving, but some music-font glyphs used by "
-                "this score are outside the decoder's calibrated vocabulary"
+                "medium - decoded from the score's engraving, but not all of it was read: some "
+                "staves carry a music-font glyph outside the decoder's calibrated vocabulary, a "
+                "notehead whose stem it could not find, or a rest whose printed position did not "
+                "say which value it was"
             )
         else:
             confidence = (
                 "high - decoded directly from the notehead/stem/flag/beam/dot glyphs in the score's "
                 "own engraving"
             )
+
+    # Noteheads whose duration is a FLOOR rather than a reading. Stated as its
+    # own sentence, with its own count, because the provenance sentence above
+    # counts staves and this is the only place the number of affected NOTES is
+    # said. A count of degraded staves cannot be turned back into it: one
+    # stemless notehead on a staff and forty of them read identically there.
+    if no_stem_notes:
+        warnings.append(
+            f"{no_stem_notes} notehead(s) across {no_stem_staves} staff system(s) were read with "
+            "no stem attached to them. A note's flags and beams hang off its stem, so for those "
+            "notes there was nothing to count: each was emitted as a plain quarter, the LONGEST "
+            "duration its notehead on its own allows. Any of them the score wrote as an eighth "
+            "or shorter therefore plays long and overfills its bar, and each also lost the stem "
+            "direction that says which of a bar's voices it belongs to"
+        )
 
     # Bars that don't add up outrank how the durations were obtained: a
     # confident reading of every notehead still produces a wrong bar when its
@@ -2463,6 +2577,19 @@ def _extract(doc, pdf_path, time_signature: tuple[int, int] | None) -> Extractio
     # (see _rhythm_report) rather than from a branch here.
     prov_counts = collections.Counter()
     prov_details = collections.defaultdict(list)
+    # WHICH bars each provenance produced, keyed by PROV_* value. A count of
+    # staves says how much of a score's rhythm was not read from its glyphs;
+    # only these say which music that was, and a bar number is the one
+    # coordinate a reader can carry back to the PDF. See _rhythm_report.
+    prov_bars = collections.defaultdict(list)
+    # Filled noteheads that came out of the decode with no stem, and how many
+    # notation staves carried at least one. Summed over the DECODES rather than
+    # over the tab staves so a notation staff read by two tab staves is not
+    # counted twice - the memo in `decoded` is per page, so the same set of
+    # noteheads is only ever visited once here.
+    no_stem_notes = 0
+    no_stem_staves = 0
+    no_stem_seen = set()
     unmatched_columns_glyph = 0
     unmatched_glyph_notes_total = 0
     # How many bars were transcribed as concurrent voices. How much of the
@@ -2521,6 +2648,19 @@ def _extract(doc, pdf_path, time_signature: tuple[int, int] | None) -> Extractio
             for fw in source.stats.get("font_warnings") or []:
                 if fw not in font_warnings_seen:
                     font_warnings_seen.append(fw)
+            if source.uses_glyphs:
+                # Counted per NOTATION staff, and only where its decode is
+                # what the durations were actually taken from: a staff that
+                # fell all the way back to spacing threw its decode away, so
+                # its stemless noteheads never reached the transcription and
+                # reporting them would overstate what is wrong with it.
+                seen_key = (page_idx, id(std_staff))
+                if seen_key not in no_stem_seen:
+                    no_stem_seen.add(seen_key)
+                    staff_no_stem = source.stats.get("no_stem_noteheads", 0)
+                    if staff_no_stem:
+                        no_stem_notes += staff_no_stem
+                        no_stem_staves += 1
 
             # The meter in effect for this staff: from the notation staff it
             # reads, or from its own position when it reads none.
@@ -2544,6 +2684,10 @@ def _extract(doc, pdf_path, time_signature: tuple[int, int] | None) -> Extractio
                 for col in columns:
                     col["xc"] = col["x"] + avg_digit_w / 2
 
+            # Where this staff's bars start in the document's numbering. Every
+            # iteration of the loop below appends exactly one measure, in both
+            # branches, so the staff owns the whole run from here to the end.
+            staff_first_bar = len(all_measures) + 1
             for i, m_cols in enumerate(measures_for_staff):
                 m_lo, m_hi = bounds[i], bounds[i + 1]
                 if source.uses_glyphs:
@@ -2595,12 +2739,18 @@ def _extract(doc, pdf_path, time_signature: tuple[int, int] | None) -> Extractio
                 durations_q = _infer_measure_rhythm(m_cols, measure_quarter_len, m_hi)
                 beats = [(_snap_duration(dq), 0, col["notes"]) for col, dq in zip(m_cols, durations_q)]
                 all_measures.append((beats, staff_ts))
+            prov_bars[source.provenance].extend(
+                range(staff_first_bar, len(all_measures) + 1))
 
     # Rhythm warnings and confidence: derived once, from what the staves
     # actually resolved to.
     conformance = _bar_conformance(all_measures)
+    spacing_bars = sorted(prov_bars.get(PROV_SPACING, ()))
+    degraded_bars = sorted(prov_bars.get(PROV_GLYPHS_DEGRADED, ()))
     rhythm_warnings, rhythm_confidence = _rhythm_report(
-        prov_counts, prov_details, conformance, tuple(unread_bars)
+        prov_counts, prov_details, conformance, tuple(unread_bars),
+        prov_bars=prov_bars, no_stem_notes=no_stem_notes,
+        no_stem_staves=no_stem_staves,
     )
     warnings.extend(rhythm_warnings)
     # Font-level problems that weren't already the reason a staff degraded
@@ -2752,4 +2902,8 @@ def _extract(doc, pdf_path, time_signature: tuple[int, int] | None) -> Extractio
         confidence=confidence,
         warnings=warnings,
         rhythm_provenance=dict(prov_counts),
+        spacing_bars=spacing_bars,
+        degraded_bars=degraded_bars,
+        notes_no_stem=no_stem_notes,
+        staves_no_stem=no_stem_staves,
     )

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -35,6 +35,14 @@ _FIXTURE_RELATIVE_PATHS = {
     # chord: the figure notehead-to-stem attachment gets wrong, and an Opus
     # engraving, so it also exercises the side bearing that only that font has.
     "dalza": "Classical/PrimoGuitar Misc/Dalza-Recercar-Guitar-2019.pdf",
+    # Filled noteheads whose stems the vector pass never sees, on every one of
+    # its notation staves. Nothing engraved in this repository reproduces that
+    # - MuseScore draws every stem as a clean vector line, so all twelve
+    # committed fixtures report zero - and it is the state that floors a
+    # notehead's duration at a quarter, so the counter for it needs a real
+    # score to be exercised on at all.
+    "hymn_of_the_fayth": (
+        "Patreon/John Oeth/Final Fantasy/FF X/Hymn of the Fayth (Final Fantasy X).pdf"),
 }
 
 # Skips for want of a library are COUNTED HERE as they happen, rather than
@@ -148,6 +156,15 @@ def dalza_pdf() -> Path:
     p = _fixture_path("dalza")
     if p is None:
         skip_without_library("FERMATA_TEST_LIBRARY not set (or missing Dalza fixture)")
+    return p
+
+
+@pytest.fixture
+def hymn_of_the_fayth_pdf() -> Path:
+    p = _fixture_path("hymn_of_the_fayth")
+    if p is None:
+        skip_without_library(
+            "FERMATA_TEST_LIBRARY not set (or missing 'Hymn of the Fayth' fixture)")
     return p
 
 

--- a/server/tests/test_engraved_fixtures.py
+++ b/server/tests/test_engraved_fixtures.py
@@ -36,11 +36,11 @@ coverage and is not is worse than none:
     the real examples live only in the maintainer's library.
   * A filled notehead whose stem the vector pass cannot see. This engraver
     draws every stem as a clean vector line, so all twelve fixtures here
-    report zero of them, while 493 of the library's 2749 notation staves
-    carry at least one. The counter and the disclosure for that state
-    (see #115) are exercised against a real score in
-    test_tabextract.py and against explicit geometry in
-    test_glyph_rhythm.py; nothing here can reach it.
+    report zero of them, while 493 of the 2657 notation staves in the
+    library that supplied glyph durations at all carry at least one. The
+    counter and the disclosure for that state (see #115) are exercised
+    against a real score in test_tabextract.py and against explicit
+    geometry in test_glyph_rhythm.py; nothing here can reach it.
   * Scale. The library's reference score is 50 bars of real two-voice
     fingerstyle writing; the fixture with two voices is eight contrived bars.
     A regression that only shows up in density will still only show up

--- a/server/tests/test_engraved_fixtures.py
+++ b/server/tests/test_engraved_fixtures.py
@@ -34,6 +34,13 @@ coverage and is not is worse than none:
     geometry is covered by a synthetic page built here instead - see
     test_abutting_furniture_below_a_staff_is_not_welded_into_a_line - and
     the real examples live only in the maintainer's library.
+  * A filled notehead whose stem the vector pass cannot see. This engraver
+    draws every stem as a clean vector line, so all twelve fixtures here
+    report zero of them, while 493 of the library's 2749 notation staves
+    carry at least one. The counter and the disclosure for that state
+    (see #115) are exercised against a real score in
+    test_tabextract.py and against explicit geometry in
+    test_glyph_rhythm.py; nothing here can reach it.
   * Scale. The library's reference score is 50 bars of real two-voice
     fingerstyle writing; the fixture with two voices is eight contrived bars.
     A regression that only shows up in density will still only show up
@@ -872,6 +879,28 @@ def test_tablature_alone_falls_back_to_spacing_and_says_which(engraved):
     assert any("own system" in w for w in result.warnings)
     assert any("inferred from horizontal spacing" in w for w in result.warnings)
     assert result.time_signature_source.startswith("not detected")
+    # WHICH bars those are, as data - one entry per emitted bar, so a consumer
+    # can mark them without parsing the prose. The staff count in
+    # rhythm_provenance says how much of the score came from spacing; only this
+    # says which of it, and the two have to agree.
+    assert result.spacing_bars == list(range(1, 13))
+    assert result.degraded_bars == []
+
+
+def test_a_degraded_system_names_the_bars_it_produced(engraved):
+    """The same thing for a staff that WAS read from the engraving with
+    something on it left unread. Four bars of this fixture come off the staff
+    carrying two uncalibrated harmonics, and until these were collected a
+    reader was told that some fraction of the score was in question with no way
+    to find out which fraction."""
+    result = tabextract.extract(engraved("harmonics_dense"))
+    assert result.rhythm_provenance == {tabextract.PROV_GLYPHS_DEGRADED: 1,
+                                        tabextract.PROV_GLYPHS: 1}
+    assert result.degraded_bars == [1, 2, 3, 4]
+    assert result.spacing_bars == []
+    named = next(w for w in result.warnings
+                 if "1 staff system(s) were read from the engraved" in w)
+    assert "The bars they produced are: 1, 2, 3, 4." in named
 
 
 def test_a_final_system_too_short_to_detect_loses_its_bars(engraved):

--- a/server/tests/test_glyph_rhythm.py
+++ b/server/tests/test_glyph_rhythm.py
@@ -1016,6 +1016,57 @@ def test_a_staff_with_no_detected_lines_decodes_undecided_rather_than_failing(mo
 
 
 # ---------------------------------------------------------------------------
+# A notehead with no stem has its duration floored, and says so (#115)
+# ---------------------------------------------------------------------------
+
+
+def _head_glyph(category, yc=207.5, x0=300.0):
+    """A notehead as extract_glyph_events builds one, with its outline read."""
+    return G.GlyphEvent("Maestro", 207, category,
+                        (x0, yc - 4.0, x0 + 7.0, yc + 4.0), 0,
+                        baseline_y=yc, ink=(yc - 2.5, yc + 2.5))
+
+
+def test_a_filled_notehead_with_no_stem_is_counted_not_just_floored(monkeypatch):
+    """A filled notehead can be a quarter or anything shorter, and the flag or
+    beam that says which hangs off its stem. With no stem there is nothing to
+    count, so it goes out at the LONGEST of the candidate readings - which
+    means it reads long and overfills its bar. Emitting that is sometimes
+    unavoidable; not counting it is what let a score be built on floored
+    durations and still report its rhythm as read from the glyphs."""
+    notes, stats = _decode_rests([_head_glyph("notehead_filled")], monkeypatch)
+    assert [n.base_units for n in notes] == [1.0]
+    assert [n.flags for n in notes] == [0], "no stem, so no flag could be counted"
+    assert notes[0].stem_key is None
+    assert stats["no_stem_noteheads"] == 1
+
+
+def test_a_stemless_notehead_that_cannot_carry_a_flag_is_not_counted(monkeypatch):
+    """A half or whole notehead's value is settled by the head alone - neither
+    shape takes a flag or a beam in any notation - so a missing stem costs the
+    voice signal and nothing about the duration. Counting those here would
+    inflate the figure with notes whose durations were read correctly, and the
+    figure is only worth stating if it means what it says."""
+    notes, stats = _decode_rests(
+        [_head_glyph("notehead_half", x0=300.0),
+         _head_glyph("notehead_whole", x0=400.0)], monkeypatch)
+    assert [n.base_units for n in notes] == [2.0, 4.0]
+    assert all(n.stem_key is None for n in notes), "no stems on this page at all"
+    assert stats["no_stem_noteheads"] == 0
+
+
+def test_the_stemless_count_is_zero_when_every_head_found_its_stem(zanarkand_pdf):
+    """The counter has to be able to report nothing, or it says nothing. This
+    score's noteheads all attach, so a counter wired to fire on every filled
+    head - or on the wrong branch - shows up here rather than in the aggregate."""
+    result = tabextract.extract(str(zanarkand_pdf))
+    assert result.notes_no_stem == 0
+    assert result.staves_no_stem == 0
+    assert result.rhythm_provenance == {tabextract.PROV_GLYPHS: 10}
+    assert not any("no stem attached" in w for w in result.warnings)
+
+
+# ---------------------------------------------------------------------------
 # A flag is joined to its stem's tip, not centred on it (finding 88)
 # ---------------------------------------------------------------------------
 

--- a/server/tests/test_glyph_rhythm.py
+++ b/server/tests/test_glyph_rhythm.py
@@ -1063,7 +1063,7 @@ def test_the_stemless_count_is_zero_when_every_head_found_its_stem(zanarkand_pdf
     assert result.notes_no_stem == 0
     assert result.staves_no_stem == 0
     assert result.rhythm_provenance == {tabextract.PROV_GLYPHS: 10}
-    assert not any("no stem attached" in w for w in result.warnings)
+    assert not any("no stem this decoder could find" in w for w in result.warnings)
 
 
 # ---------------------------------------------------------------------------

--- a/server/tests/test_tabextract.py
+++ b/server/tests/test_tabextract.py
@@ -1200,6 +1200,22 @@ def test_a_staff_whose_heads_all_found_a_stem_is_still_fully_read(monkeypatch):
     assert src.provenance == tabextract.PROV_GLYPHS
 
 
+def test_the_no_stem_gate_sits_at_the_end_of_the_resolution_ladder(monkeypatch):
+    """`no_stem_noteheads` is checked LAST, after every unknown-vocabulary
+    branch, and that ordering is deliberate rather than incidental: a staff
+    whose glyphs are mostly unrecognised has nothing this decoder can trust at
+    all, so it must fall back to the spacing heuristic outright rather than
+    being reported as `glyphs-degraded` - which still claims the glyphs
+    themselves were read - just because it also happens to carry a few
+    stemless noteheads. Pinned here so a reordering that moved the no-stem
+    check ahead of the ratio fallback would be caught by a single assertion
+    rather than only by a drop in some library-wide count nobody is watching."""
+    src = _resolve_with_stats(monkeypatch, _stats(
+        unknown_glyphs=36, unknown_ratio=0.9, band_glyphs=40, no_stem_noteheads=3))
+    assert src.provenance == tabextract.PROV_SPACING
+    assert not src.uses_glyphs
+
+
 def test_no_decoded_events_falls_back_with_the_font_reason(monkeypatch):
     src = _resolve_with_stats(
         monkeypatch, _stats(font_warnings=["Opus is embedded with 'cff' outlines"]), notes=[])
@@ -1467,9 +1483,17 @@ def test_floored_durations_are_counted_and_disclosed_on_a_real_score(hymn_of_the
     # have been read from the glyphs.
     assert result.rhythm_provenance == {tabextract.PROV_GLYPHS_DEGRADED: 4}
     assert not result.confidence["rhythm"].startswith("high")
+    # The headline itself must not contradict the disclosure: every staff on
+    # this file is floored and the defective-bar ratio crosses the gate, so
+    # the confidence string used to be REPLACED with "durations were read
+    # from the score's own engraving" - the exact claim this file's own
+    # warnings withdraw. Composing onto the existing disclosure instead means
+    # the stem caveat has to survive into the final headline.
+    assert "stem" in result.confidence["rhythm"], result.confidence["rhythm"]
     # ...and it is SAID, not just counted. The interface loops over the warning
     # strings; a field on its own reaches nobody.
-    said = [w for w in result.warnings if "no stem attached" in w]
+    said = [w for w in result.warnings if "no stem this decoder could find" in w
+            and "notehead(s) across" in w]
     assert len(said) == 1, result.warnings
     assert "73 notehead(s) across 4 staff system(s)" in said[0]
     # The per-staff reasons are surfaced too, and they name the mechanism
@@ -1533,7 +1557,7 @@ def test_floored_note_durations_are_said_out_loud_with_their_count():
     warnings, _c = tabextract._rhythm_report(
         counts, {}, tabextract._BarConformance(0, 0, 0, 20),
         no_stem_notes=37, no_stem_staves=4)
-    said = [w for w in warnings if "no stem attached" in w]
+    said = [w for w in warnings if "notehead(s) across" in w and "no stem this decoder" in w]
     assert len(said) == 1, warnings
     assert "37 notehead(s) across 4 staff system(s)" in said[0]
     assert "plain quarter" in said[0]
@@ -1541,7 +1565,7 @@ def test_floored_note_durations_are_said_out_loud_with_their_count():
     # Nothing is said when every notehead found its stem.
     quiet, _c = tabextract._rhythm_report(
         counts, {}, tabextract._BarConformance(0, 0, 0, 20))
-    assert not any("no stem attached" in w for w in quiet)
+    assert not any("notehead(s) across" in w and "no stem this decoder" in w for w in quiet)
 
 
 def test_a_quarter_note_count_is_exact_not_rounded():

--- a/server/tests/test_tabextract.py
+++ b/server/tests/test_tabextract.py
@@ -1180,6 +1180,26 @@ def test_a_rest_read_as_the_likelier_of_two_values_is_not_reported_as_read(monke
     assert "read as a half rest" in src.detail
 
 
+def test_a_notehead_whose_duration_was_floored_is_not_reported_as_read(monkeypatch):
+    """A filled notehead with no stem has no flag or beam to count, so it is
+    emitted at the longest value its head alone allows. That is a guess, and
+    one that always errs long, so it caps what may be claimed about the staff
+    the same way an unreadable rest does - rather than sitting in the stats
+    while the staff reports its rhythm as read from the glyphs."""
+    src = _resolve_with_stats(monkeypatch, _stats(no_stem_noteheads=3))
+    assert src.provenance == tabextract.PROV_GLYPHS_DEGRADED
+    assert src.uses_glyphs, "every notehead that did find its stem was still read"
+    assert "3 notehead(s)" in src.detail
+    assert "no stem" in src.detail
+
+
+def test_a_staff_whose_heads_all_found_a_stem_is_still_fully_read(monkeypatch):
+    """The gate must not fire on zero, or every staff in the library degrades
+    and the distinction it exists to draw is gone."""
+    src = _resolve_with_stats(monkeypatch, _stats(no_stem_noteheads=0))
+    assert src.provenance == tabextract.PROV_GLYPHS
+
+
 def test_no_decoded_events_falls_back_with_the_font_reason(monkeypatch):
     src = _resolve_with_stats(
         monkeypatch, _stats(font_warnings=["Opus is embedded with 'cff' outlines"]), notes=[])
@@ -1424,6 +1444,104 @@ def test_the_padded_bars_are_named_not_just_counted():
     quiet, _c = tabextract._rhythm_report(
         counts, {}, tabextract._BarConformance(0, 0, 0, 20))
     assert not any("deduced from the time signature" in w for w in quiet)
+
+
+def test_floored_durations_are_counted_and_disclosed_on_a_real_score(hymn_of_the_fayth_pdf):
+    """The end-to-end half of #115, and the reason it needs a real score.
+
+    Every notation staff in this file carries filled noteheads whose stems the
+    vector pass never sees, so their durations are floored at a quarter. That
+    state does not arise in anything engraved in this repository - MuseScore
+    draws every stem as a clean vector line and all twelve committed fixtures
+    report zero - so a test built only on those would have exercised a branch
+    no real input reaches, which is the mistake #108 shipped and had to have
+    removed.
+
+    The numbers are exact on purpose. A counter that fires on the wrong branch,
+    or one wired to the notehead count rather than to the stemless ones, still
+    produces a non-zero figure and a plausible-looking sentence."""
+    result = tabextract.extract(str(hymn_of_the_fayth_pdf))
+    assert result.notes_no_stem == 73
+    assert result.staves_no_stem == 4
+    # Every staff on the file is degraded by it, so nothing here can claim to
+    # have been read from the glyphs.
+    assert result.rhythm_provenance == {tabextract.PROV_GLYPHS_DEGRADED: 4}
+    assert not result.confidence["rhythm"].startswith("high")
+    # ...and it is SAID, not just counted. The interface loops over the warning
+    # strings; a field on its own reaches nobody.
+    said = [w for w in result.warnings if "no stem attached" in w]
+    assert len(said) == 1, result.warnings
+    assert "73 notehead(s) across 4 staff system(s)" in said[0]
+    # The per-staff reasons are surfaced too, and they name the mechanism
+    # rather than the symptom.
+    assert any("no stem this decoder could find" in w for w in result.warnings)
+
+
+def test_spacing_derived_rhythm_names_the_bars_it_produced():
+    """A count of staff systems says how much of a score's rhythm came out of
+    the gaps between noteheads instead of the noteheads. It does not say WHICH
+    music that was, so "treat those sections as low confidence" was an
+    instruction a reader had no way to follow - the padded-bars message names
+    its bars for exactly this reason, and this is the same fact about the same
+    score."""
+    counts = collections.Counter({tabextract.PROV_GLYPHS: 3, tabextract.PROV_SPACING: 2})
+    warnings, confidence = tabextract._rhythm_report(
+        counts, {}, tabextract._BarConformance(0, 0, 0, 12),
+        prov_bars={tabextract.PROV_SPACING: [5, 6, 7, 11]})
+    said = [w for w in warnings if "rougher estimate from note spacing" in w]
+    assert len(said) == 1, warnings
+    assert "2 staff system(s) could not be read that way" in said[0]
+    assert "The bars they produced are: 5, 6, 7, 11." in said[0]
+    # ...and a score with any spacing-derived staff cannot present as read.
+    assert not confidence.startswith("high")
+
+
+def test_a_degraded_staff_names_its_bars_and_does_not_claim_one_cause():
+    """A degraded staff was read from the engraving with something on it left
+    unread, and the cause is no longer only an uncalibrated glyph - a notehead
+    with no stem lands here too. Naming one cause in the summary sentence
+    described the wrong problem for most of the staves it covered."""
+    counts = collections.Counter({tabextract.PROV_GLYPHS: 1,
+                                  tabextract.PROV_GLYPHS_DEGRADED: 2})
+    warnings, confidence = tabextract._rhythm_report(
+        counts, {}, tabextract._BarConformance(0, 0, 0, 8),
+        prov_bars={tabextract.PROV_GLYPHS_DEGRADED: [3, 4]})
+    said = [w for w in warnings if "2 staff system(s) were read from the engraved" in w]
+    assert len(said) == 1, warnings
+    assert "no stem" in said[0]
+    assert "not been calibrated" in said[0]
+    assert "The bars they produced are: 3, 4." in said[0]
+    assert confidence.startswith("medium")
+
+
+def test_bar_numbers_are_not_invented_when_none_were_collected():
+    """Absent bar numbers must produce no sentence about bar numbers, rather
+    than an empty list that reads as "no bars were affected"."""
+    counts = collections.Counter({tabextract.PROV_GLYPHS: 3, tabextract.PROV_SPACING: 2})
+    warnings, _c = tabextract._rhythm_report(counts, {})
+    said = next(w for w in warnings if "rougher estimate from note spacing" in w)
+    assert "The bars they produced" not in said
+
+
+def test_floored_note_durations_are_said_out_loud_with_their_count():
+    """The interface consumes warnings as strings and loops over them, so prose
+    reaches a reader on its own; a count field does not. This count therefore
+    has to exist as a SENTENCE, and it has to be the number of notes - the
+    staff counts beside it cannot be turned back into it, because one stemless
+    notehead on a staff and forty of them read identically there."""
+    counts = collections.Counter({tabextract.PROV_GLYPHS_DEGRADED: 4})
+    warnings, _c = tabextract._rhythm_report(
+        counts, {}, tabextract._BarConformance(0, 0, 0, 20),
+        no_stem_notes=37, no_stem_staves=4)
+    said = [w for w in warnings if "no stem attached" in w]
+    assert len(said) == 1, warnings
+    assert "37 notehead(s) across 4 staff system(s)" in said[0]
+    assert "plain quarter" in said[0]
+
+    # Nothing is said when every notehead found its stem.
+    quiet, _c = tabextract._rhythm_report(
+        counts, {}, tabextract._BarConformance(0, 0, 0, 20))
+    assert not any("no stem attached" in w for w in quiet)
 
 
 def test_a_quarter_note_count_is_exact_not_rounded():

--- a/server/tests/test_transcription_api.py
+++ b/server/tests/test_transcription_api.py
@@ -368,12 +368,17 @@ def test_edit_format_is_read_off_the_content(content, expected):
 
 
 BAR_KEYS = ("bars_overfull", "bars_short", "bars_defective", "bars_measured",
-            "bars_padded", "bars_unread")
+            "bars_padded", "bars_unread", "notes_no_stem", "staves_no_stem")
 # Which bars, and how much silence - the figures that only exist as data. The
 # warning prose caps its bar list, and the profile document promises a consumer
 # that `inferred_rest_quarters` is the sum of the `<forward>` durations in the
 # file, so the application has to actually offer the number.
-BAR_DETAIL_KEYS = ("padded_bars", "unread_bars", "inferred_rest_quarters")
+#
+# `spacing_bars` / `degraded_bars` are here for the same reason: the staff
+# counts in the confidence string say how much of a score's rhythm was not read
+# from its glyphs, and only these say which of it.
+BAR_DETAIL_KEYS = ("padded_bars", "unread_bars", "inferred_rest_quarters",
+                   "spacing_bars", "degraded_bars")
 
 
 def test_bar_conformance_survives_a_reload(app_env, engraved, monkeypatch, insert_score):
@@ -419,6 +424,34 @@ def test_bar_conformance_survives_a_reload(app_env, engraved, monkeypatch, inser
     assert fetched["bars_defective"] <= fetched["bars_measured"]
     assert max(fetched["bars_overfull"], fetched["bars_short"]) <= fetched["bars_defective"]
     assert fetched["warnings"] == posted["warnings"]
+
+
+def test_which_bars_were_not_read_from_glyphs_survives_a_reload(
+        app_env, engraved, monkeypatch, insert_score):
+    """`bars_padded`'s round trip is asserted against a score where the figures
+    are non-zero, on purpose - all-zeros would have looked identical to a
+    persistence bug that dropped everything. The same has to hold for which
+    bars' durations came out of the gaps between noteheads rather than the
+    noteheads themselves, so this runs against a tab-only edition, where all
+    twelve bars did.
+
+    A staff count alone cannot answer "which of this is in question", and the
+    confidence string is where the staff counts live - so if these lists do not
+    survive the reload, every visit to the score after the extracting one is
+    back to being unable to say."""
+    pdf = engraved("tab_only")
+    monkeypatch.setattr(api, "LIBRARY_DIR", pdf.parent)
+    conn = db.connect()
+    score_id = insert_score(conn, pdf.name)
+
+    posted = api.transcribe(score_id, body=None)
+    fetched = api.get_transcription(score_id)
+
+    assert posted["spacing_bars"] == list(range(1, 13))
+    assert fetched["spacing_bars"] == posted["spacing_bars"]
+    assert fetched["degraded_bars"] == []
+    assert fetched["notes_no_stem"] == 0, "no notation staff here to read a stem off"
+    assert fetched["staves_no_stem"] == 0
 
 
 def test_a_row_stored_before_the_bar_figures_reports_them_unrecorded(app_env, insert_score):

--- a/server/tests/test_transcription_api.py
+++ b/server/tests/test_transcription_api.py
@@ -576,3 +576,33 @@ def test_the_api_transcribes_a_real_engraved_score(
     fetched = api.get_transcription(score_id)
     assert fetched["content"] == posted["content"]
     assert fetched["warnings"] == posted["warnings"]
+
+
+def test_floored_note_durations_survive_the_api_round_trip(
+    app_env, hymn_of_the_fayth_pdf, monkeypatch, insert_score
+):
+    """`test_which_bars_were_not_read_from_glyphs_survives_a_reload` above only
+    ever checks `notes_no_stem` / `staves_no_stem` against zero, on a fixture
+    with no notation staff to read a stem off at all. A persistence bug that
+    unconditionally wrote 0 into that column would pass every test in this
+    file and still be silently discarding the #115 disclosure on reload.
+
+    That state - a genuinely non-zero floored-duration count - does not arise
+    in anything engraved in this repository (see test_engraved_fixtures.py's
+    "what these cannot reach" list), so this runs against the same real
+    library score the extractor-level test does."""
+    pdf = hymn_of_the_fayth_pdf
+    monkeypatch.setattr(api, "LIBRARY_DIR", pdf.parent)
+    conn = db.connect()
+    score_id = insert_score(conn, pdf.name)
+
+    posted = api.transcribe(score_id, body=None)
+    assert posted["notes_no_stem"] == 73
+    assert posted["staves_no_stem"] == 4
+
+    fetched = api.get_transcription(score_id)
+    assert fetched["notes_no_stem"] == posted["notes_no_stem"]
+    assert fetched["staves_no_stem"] == posted["staves_no_stem"]
+    assert fetched["notes_no_stem"] > 0, "the whole point: this must not be the zero case"
+    assert fetched["warnings"] == posted["warnings"]
+    assert any("no stem this decoder could find" in w for w in fetched["warnings"])

--- a/web/scripts/check-warning-patterns.mjs
+++ b/web/scripts/check-warning-patterns.mjs
@@ -56,6 +56,29 @@ const UNREAD_BARS_SENTENCE =
   "time signature and so pass every arithmetic check, but nothing in them was read: " +
   "they are not evidence that the score was transcribed, and a bar that is genuinely " +
   "silent in the source cannot be told from one whose contents were missed";
+// Score-specific sentences #115/#117 added or reworded. Each starts with a
+// digit the way the bar-arithmetic sentences above do (or, for the spacing
+// sentence, names bars the same way they do), so each is its own regression
+// fixture against the same failure mode: a rewording that made one of these
+// start matching BAR_RE would fold it into the headline bar count and
+// silently drop it from the per-score list.
+const FLOORED_NOTE_DURATIONS_SENTENCE =
+  "73 notehead(s) across 4 staff system(s) were read with no stem this decoder could " +
+  "find. A note's flags and beams hang off its stem, so for those notes both the " +
+  "duration and which of a bar's voices they belong to rest on a guess rather than a " +
+  "reading: where such a head could not be attached to a neighbouring stem, it was " +
+  "emitted at the plain quarter, the LONGEST duration its notehead on its own allows";
+const SPACING_STAVES_SENTENCE =
+  "durations were read from the engraved notation for 3 staff system(s); 2 staff " +
+  "system(s) could not be read that way and use a rougher estimate from note spacing " +
+  "instead - treat those sections as low confidence. The bars they produced are: " +
+  "5, 6, 7, 11.";
+const DEGRADED_STAVES_SENTENCE =
+  "2 staff system(s) were read from the engraved notation but not everything on them " +
+  "could be read - a music-font glyph this decoder has not been calibrated for, a " +
+  "notehead with no stem this decoder could find, or a rest whose printed position " +
+  "did not say which value it was - so treat their durations as medium confidence. " +
+  "The bars they produced are: 3, 4.";
 
 const problems = [];
 
@@ -83,6 +106,25 @@ if (BAR_RE.test(UNREAD_BARS_SENTENCE)) {
       "folded into the headline bar count and dropped from the per-score list",
   );
 }
+// Same failure mode again for the three sentences #115/#117 added or
+// reworded: none of them is bar-arithmetic prose, so none of them may ever
+// start matching BAR_RE, on pain of being folded into the headline bar count
+// and silently dropped from the per-score list.
+for (const [name, sentence] of [
+  ["floored-note-durations", FLOORED_NOTE_DURATIONS_SENTENCE],
+  ["spacing-derived-staves", SPACING_STAVES_SENTENCE],
+  ["degraded-staves", DEGRADED_STAVES_SENTENCE],
+]) {
+  if (BAR_RE.test(sentence)) {
+    problems.push(
+      `BAR_RE now matches _rhythm_report's ${name} sentence - it would be folded into ` +
+        "the headline bar count and dropped from the per-score list",
+    );
+  }
+  if (STANDING_LIMITS.some((lim) => lim.test.test(sentence))) {
+    problems.push(`_rhythm_report's ${name} sentence reads as a standing limit`);
+  }
+}
 for (const [name, sentence] of [
   ["inferred-silence", PADDED_BARS_SENTENCE],
   ["bars-read-as-nothing", UNREAD_BARS_SENTENCE],
@@ -93,8 +135,13 @@ for (const [name, sentence] of [
   if (!/The bars are: \d+/.test(sentence)) {
     problems.push(`_rhythm_report's ${name} sentence no longer names the bars`);
   }
-  if (STANDING_LIMITS.some((lim) => lim.test.test(sentence))) {
-    problems.push(`_rhythm_report's ${name} sentence reads as a standing limit`);
+}
+for (const [name, sentence] of [
+  ["spacing-derived-staves", SPACING_STAVES_SENTENCE],
+  ["degraded-staves", DEGRADED_STAVES_SENTENCE],
+]) {
+  if (!/The bars they produced are: \d+/.test(sentence)) {
+    problems.push(`_rhythm_report's ${name} sentence no longer names the bars it produced`);
   }
 }
 

--- a/web/src/lib/ScoreCompare.svelte
+++ b/web/src/lib/ScoreCompare.svelte
@@ -392,8 +392,9 @@
       // `res` carries the format the server read off the content, which is
       // what the viewer dispatches on - so let it win over the loaded row's.
       // `res` STATES warnings ([]) and every bar figure (null) - the bars_*
-      // counts plus padded_bars, unread_bars and inferred_rest_quarters - on
-      // every response rather than omitting them for an edit, which has no
+      // counts plus padded_bars, unread_bars, spacing_bars, degraded_bars,
+      // inferred_rest_quarters, notes_no_stem and staves_no_stem - on every
+      // response rather than omitting them for an edit, which has no
       // confidence to report - an absent key would be silently kept by this
       // spread, which is exactly how a saved edit once went on reporting the
       // bar counts and warnings from the content it had just replaced. An

--- a/web/tests/browser/fixtures/transcription-warnings.js
+++ b/web/tests/browser/fixtures/transcription-warnings.js
@@ -100,7 +100,7 @@ export const TWO_VOICE_WARNINGS = [
 export const TWO_VOICE_CONFIDENCE = {
   frets: "high - read directly from vector text spans positioned against detected tab staff lines",
   rhythm:
-    "low overall - individual durations were read from the score's own engraving, but 9 of 12 bar(s) do not add up to their time signature",
+    "low overall - decoded directly from the notehead/stem/flag/beam/dot glyphs in the score's own engraving; 9 of 12 bar(s) do not add up to their time signature",
   time_signature: "high - read directly from the time-signature digit glyphs printed on the score",
 };
 


### PR DESCRIPTION
Closes #115. Addresses #117, with a correction to its premise below.

The server half of the recurring defect: the measurement gets built, and the half that tells the user gets left. Both additions here exist as a structured field **and** as warning prose, because the interface loops over `warnings` as a list of strings and displays them, while a new field is read by nothing written before it existed.

## #115 — nothing counted the guessed note durations

A filled (or x / diamond) notehead that reaches the end of `decode_note_events` with no stem — neither a stem end near it nor a stem passing through it — has no flag or beam to count, because both attach to the stem. It is emitted at the longest value its notehead alone allows: a plain quarter. That is the *floor* of the candidate readings, so such a note always plays long and always pushes its bar towards the overfull side, and it has lost the stem direction that assigns it to a voice as well.

- `decode_note_events` now reports `no_stem_noteheads`.
- A staff carrying any of them resolves to `glyphs-degraded` rather than `glyphs`, with a per-staff reason, fed exactly the way `undecided_rests` is. **Not** ratio-gated, for the same reason `unknown_noteheads` is not: how dense the staff around a note happens to be is not evidence about that note.
- `ExtractionResult.notes_no_stem` / `.staves_no_stem`, persisted into the confidence blob and surfaced on both POST and GET.
- A document-level sentence naming the number of **notes**, which is the only place that number is said — the staff counts beside it cannot be turned back into it, since one stemless notehead on a staff and forty read identically there.

Half and whole noteheads are deliberately excluded: neither shape can carry a flag or beam in any notation, so a missing stem costs the voice signal and nothing about the duration.

**The number does not reproduce.** Measured over the 297 library PDFs (293 extractable):

| definition | count |
|---|---|
| filled/x/diamond heads leaving the decode with no stem — what this PR counts | **2,227** |
| ...of those, reaching a stem group in an emitted bar | 2,132 |
| ...of those, in a group whose flags came out 0, i.e. actually emitted at the floor | 1,805 |
| `notehead_filled` only, stemless after `_assign_stem_directions` | 2,153 |
| filled/x/diamond, stemless after `_assign_stem_directions` | 2,353 |

Nothing lands on 1,954. The last row is above the counter because `_assign_stem_directions` strips `stem_key` from a further ~126 heads *after* their flags were already read — those lose their voice, not their duration, so counting them would inflate the figure.

Distribution: 493 of 2,749 decoded notation staves, in 182 of 293 scores. Among affected staves the ratio of stemless-to-total heads is 7.3% at the median and 20.6% at the 90th percentile, so these are not one-off strays.

**Reachability.** Nothing engraved in this repository reaches this state — MuseScore draws every stem as a clean vector line, and all twelve committed fixtures report zero. The end-to-end test therefore runs against a real library score (`Hymn of the Fayth`: 73 noteheads, 4 staves, all 4 degraded) rather than against a branch no real input can enter, which is the mistake #108 shipped and had removed. That limit is written into `test_engraved_fixtures.py`'s "what these cannot reach" list rather than left implicit.

## #117 — spacing-derived rhythm

**The premise is wrong, and this is the correction.** `rhythm_provenance` over the library is exactly as filed — `glyphs 2656 / glyphs-degraded 3 / spacing 125` — but prose for it already existed and already reached the user. `_rhythm_report` has emitted *"durations were read from the engraved notation for N staff system(s); M staff system(s) could not be read that way and use a rougher estimate from note spacing instead"* since before this branch, and all 5 library scores holding a spacing staff already finish at `low overall`, not `high` - none of them presents as read. `glyphs-degraded` had its own sentence too.

What was actually missing is **where**. "Treat those sections as low confidence" was an instruction a reader had no way to follow: the message counted staff systems and named no music, unlike the padded-bars message it was supposed to match. So:

- `spacing_bars` and `degraded_bars`, collected per staff from the document's own bar numbering, carried on `ExtractionResult`, persisted, and surfaced on GET.
- Both sentences now name their bars through the existing `_bar_list` cap.
- The degraded summary sentence no longer names an uncalibrated glyph as *the* cause — with this PR that is the minority cause — and states the three instead.

One correction to a claim in the issue: `rhythm_provenance` is **not** in the stored confidence blob. It is on the extract response only, so it dies on the first reload. The new lists are stored, so they survive.

**`glyphs-degraded` keeps its own disclosure.** It is not `spacing` — the glyphs were decoded — and it is not `glyphs` — something on the staff was not read. Folding it either way would make one of those two claims false, and it stops being a rounding question after this PR anyway: it goes from 3 staves to 495.

## Effect on the reported label

Measured over 293 extractable library scores, before → after:

```
high    27 -> 19
medium   0 ->  8
low    266 -> 266
```

Eight scores move from `high` to `medium`, all eight for stemless noteheads. Nothing moves out of `low`: 174 of the 182 affected scores were already `low` on bar arithmetic. Provenance goes `glyphs 2656/deg 3/spacing 125` → `glyphs 2164/deg 495/spacing 125`.

## The two inert counters

`undecided_rests` and `unknown_at_flag_position` are both still 0 across all 2,749 decoded staves. Neither is dead code and neither is measuring the wrong thing — they are **genuinely rare, and rare for a stated reason**. `undecided_rests` only fires where a font spells the half and whole rest with one glyph *and* the geometry declines the parity, which needs an unreadable outline or an undetected staff-line grid; `unknown_at_flag_position` needs a glyph outside the calibrated vocabulary sitting exactly at a stem's free end, and the library's unknown-glyph ratio is 0.0 at the 99th percentile. They are tripwires for input this library does not contain, which is a fair thing for them to be — but it does mean that before this PR the confidence label rested on bar arithmetic alone, exactly as #114 records. `no_stem_noteheads` is the first counter that fires on real data.

## Should the new counter feed the confidence gate?

Not in this PR, and #114's thresholds are untouched. It already caps the label through provenance (8 scores `high` → `medium`). Feeding it into the 0.25 defective-bar ratio would be the wrong shape: that gate is a *proportion of bars*, and this is a count of *notes*, so it would need its own threshold rather than joining that one. Worth noting for #114 that the two overlap heavily — a floored duration reads long, which is precisely what overfills a bar, so a large part of what the bar-arithmetic gate already catches is this defect seen downstream. A separate note-level threshold would mostly re-condemn scores that gate has already condemned; the 8 scores that changed label here are the ones it would newly reach, and provenance reaches them already.

## Tests

12 new tests; suite goes 637 → 649 passed, 2 skipped (the two `FERMATA_MUSICXML_XSD` ones, unchanged). Without a library: 622 passed, 29 skipped — 27 library skips, up from 25, the two new ones being the real-score tests above. `npm ci` was run in `web/` so the six alphaTab round-trip tests actually ran.

Every change was proved to be load-bearing by reverting it and confirming red:

| mutation | red |
|---|---|
| counter never increments | 2 failed |
| counter stops excluding half/whole heads | 5 failed |
| provenance gate never fires | 2 failed |
| the count exists but nothing says it | 2 failed |
| spacing sentence stops naming its bars | 1 failed |
| degraded sentence stops naming its bars | 2 failed |
| degraded sentence reverts to naming one cause | 1 failed |
| bar numbers never collected | 3 failed |
| new figures not persisted | 1 failed |

Committed before measuring, since a harness that reverts with `git checkout --` discards uncommitted work and then measures the old code.

## Review findings addressed

Both blockers and every smaller item from review were fixed in place:

- **Blocker 1** (`tabextract.py`, the ≥0.25 defective-bar branch): it REPLACED `confidence` with a fresh "durations were read from the score's own engraving," discarding whatever degraded-stem or spacing disclosure the score had already earned — true on 174 of 182 affected scores. It now composes onto the existing `confidence` (stripping only the old label, the way the sibling branch just below it already did), so the stem/spacing caveat survives into the headline. Proved red against the prior code on the `Hymn of the Fayth` fixture (every staff floored, ratio over the gate) before fixing it.
- **Blocker 2** (the floored-note-durations sentence): it attached an emission-stage claim ("plays long and overfills its bar") to the decode-stage count of 2,227, true of only 1,528 of them. The count still gates on 2,227; the sentence now claims only what holds for every one of them — duration and voice rest on a guess, and where such a head could not be attached to a neighbouring stem it was emitted at the plain quarter.
- The two summary sentences reading "no stem attached to them" / "no stem to count flags on" now read "no stem this decoder could find," matching the per-staff wording — these are Finale/Sibelius engravings; the stems exist, this decoder just didn't find them.
- The uncommitted denominator ("493 of 2,749 notation staves") is now "493 of the 2,657 notation staves that supplied glyph durations at all" — the same population the numerator was measured against — fixed identically in `test_engraved_fixtures.py`.
- PR body corrected: p90 stemless ratio is 20.6% (7.3% is the median, not the p90); 293 extractable scores, not 292; the "any spacing staff already reported mixed" claim replaced with what the review measured — all 5 such scores finish at `low overall`.
- Three cheap tests added: a unit assertion pinning the no-stem gate at the end of `_resolve_rhythm_source`'s ladder (a staff mostly out of vocabulary AND carrying stemless heads must resolve to spacing, not glyphs-degraded); the real-score API round trip extended to assert a non-zero `notes_no_stem` survives `transcribe` → `get_transcription`; `check-warning-patterns.mjs` fixtures for the three score-specific sentences this PR adds or reworded, so none of them can start matching `BAR_RE` and vanish from the per-score list.
- Stale comments fixed: `api.py`'s `_BAR_LIST_KEYS` comment no longer cites `rhythm_provenance` as something this module exposes; `ScoreCompare.svelte`'s save-edit comment now lists all four new keys (`spacing_bars`, `degraded_bars`, `notes_no_stem`, `staves_no_stem`); the Maestro GID table now notes that gid 174 (diamond) is bucketed with `notehead_filled` as `duration_needs_stem`, with quarter-vs-half unpinned for it.

Suite now: 651 passed, 2 skipped (with `FERMATA_TEST_LIBRARY` set and `npm ci` run in `web/`). The three new tests were each proved load-bearing the same way as the rest of this PR:

| mutation | red |
|---|---|
| the no-stem gate moved ahead of the spacing fallback in the ladder | 1 failed |
| the API layer writes 0 into `notes_no_stem` unconditionally | 1 failed |
| a fixture sentence reworded to match `BAR_RE` | `check-warning-patterns.mjs` fails |

Committed before each mutation and reverted with `git checkout --` afterwards, then re-confirmed green.

## Not touched

`web/` — the interface half is #103, in flight separately. It needs no change to pick these up: `ScoreCompare.svelte` renders the whole `warnings` list and filters only the two standing limits, so the new sentences already reach the reader, and `node scripts/check-warning-patterns.mjs` still passes against the reworded degraded message.

