### PR TITLE
Show which build is running (#119)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,5 +139,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      # Build args passed here so this job exercises the same path a real
+      # build would - GET /api/version reporting an actual commit and date
+      # rather than the "dev" fallback every other test run sees.
       - name: Build
-        run: docker build -t fermata:ci .
+        run: |
+          docker build \
+            --build-arg BUILD_COMMIT=$(git rev-parse --short HEAD) \
+            --build-arg BUILD_DATE=$(date -u +%Y-%m-%d) \
+            -t fermata:ci .

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,9 +13,21 @@ COPY server/ ./server/
 RUN pip install --no-cache-dir ./server
 COPY --from=web /web/dist ./static
 
+# The commit and date GET /api/version reports (see server/fermata/version.py).
+# There is no git repository in this image to ask, so these are the only
+# source of truth for either value - whoever builds the image supplies them,
+# e.g. `docker build --build-arg BUILD_COMMIT=$(git rev-parse --short HEAD)
+# --build-arg BUILD_DATE=$(date -u +%Y-%m-%d) .`. Left unset, both default to
+# "dev", which is what a plain `docker compose up --build` (no args passed)
+# still honestly reports rather than a fabricated commit.
+ARG BUILD_COMMIT=dev
+ARG BUILD_DATE=dev
+
 ENV FERMATA_LIBRARY=/data/library \
     FERMATA_CONFIG=/data/config \
-    FERMATA_WEB_DIST=/app/static
+    FERMATA_WEB_DIST=/app/static \
+    FERMATA_BUILD_COMMIT=$BUILD_COMMIT \
+    FERMATA_BUILD_DATE=$BUILD_DATE
 
 EXPOSE 8080
 HEALTHCHECK --interval=30s --timeout=5s --start-period=15s \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,15 @@
 services:
   fermata:
-    build: .
+    build:
+      context: .
+      # See the Dockerfile's own comment. Both default to "dev" when nothing
+      # sets BUILD_COMMIT / BUILD_DATE in the environment `docker compose
+      # build` runs in, e.g.:
+      #   BUILD_COMMIT=$(git rev-parse --short HEAD) BUILD_DATE=$(date -u +%Y-%m-%d) \
+      #     docker compose up --build -d
+      args:
+        BUILD_COMMIT: ${BUILD_COMMIT:-dev}
+        BUILD_DATE: ${BUILD_DATE:-dev}
     container_name: fermata
     ports:
       - "8080:8080"

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -171,6 +171,8 @@ git pull
 docker compose up --build -d
 ```
 
+Check the build tag in the sidebar (or `GET /api/version`) before assuming an upgrade didn't take or reporting a bug for a feature you expect to see — a container that is still on the old image looks exactly like a missing feature, and this is the fastest way to tell the two apart.
+
 Fermata's database applies its own schema changes automatically on startup —
 new tables and columns an upgrade needs are created the first time the new
 version starts, and a change too large for that (rebuilding a table to carry

--- a/server/fermata/api.py
+++ b/server/fermata/api.py
@@ -17,6 +17,7 @@ from fastapi.responses import FileResponse
 from pydantic import BaseModel, Field, StrictInt
 
 from . import instruments, practice, scanner
+from . import version as version_info
 from .config import FILE_TYPES, LIBRARY_DIR
 from .db import DEFAULT_OWNER, connect, tx, write_tx
 from .glyph_rhythm import VALID_TS_DENOMINATORS
@@ -134,6 +135,12 @@ def _with_tags(conn, rows):
 @router.get("/health")
 def health():
     return {"status": "ok"}
+
+
+@router.get("/version")
+def get_version():
+    """What build is actually running - see fermata/version.py."""
+    return version_info.info()
 
 
 @router.get("/settings")

--- a/server/fermata/version.py
+++ b/server/fermata/version.py
@@ -1,0 +1,61 @@
+"""What build is actually running, for GET /api/version.
+
+Surfaced because a self-hosted container updated by rebuild has no auto-update
+and no release channel, so a stale deployment is the ordinary failure mode -
+and its symptom is always the same misleading one: a feature that was merged
+looks like it does not exist, because the running image predates it. This is
+the one place that answers "what build am I on?" without guessing from
+behaviour (see issue #119).
+
+`version` is read from the installed package's own metadata rather than
+parsed a second time out of pyproject.toml by hand - one source of truth,
+read the way any installed package's version is read. The fallback below is
+for the one case that is not "installed": a bare PYTHONPATH pointed at the
+source tree, with nothing pip has ever recorded a distribution for.
+
+`commit` and `built` are never computed here and this module never shells out
+to git - there is no repository inside the built image to ask (see the
+Dockerfile). Both are supplied at image build time as Docker build args,
+landing here as environment variables. Absent - the dev server, or an image
+built without them - reads as "dev", the plain admission that nothing was
+baked in, rather than an invented commit or a crash.
+"""
+
+import os
+import tomllib
+from importlib import metadata
+from pathlib import Path
+
+PACKAGE_NAME = "fermata"
+
+# server/pyproject.toml - one level up from this file.
+_PYPROJECT = Path(__file__).resolve().parent.parent / "pyproject.toml"
+
+
+def _version_from_pyproject() -> str:
+    """The version straight out of pyproject.toml.
+
+    Only reached when metadata.version() found no installed distribution to
+    ask - reading the same file by hand rather than inventing a second number
+    that could drift from it.
+    """
+    try:
+        with _PYPROJECT.open("rb") as f:
+            return tomllib.load(f)["project"]["version"]
+    except (OSError, KeyError, tomllib.TOMLDecodeError):
+        return "unknown"
+
+
+def version() -> str:
+    try:
+        return metadata.version(PACKAGE_NAME)
+    except metadata.PackageNotFoundError:
+        return _version_from_pyproject()
+
+
+def info() -> dict:
+    return {
+        "version": version(),
+        "commit": os.environ.get("FERMATA_BUILD_COMMIT") or "dev",
+        "built": os.environ.get("FERMATA_BUILD_DATE") or "dev",
+    }

--- a/server/tests/test_version_api.py
+++ b/server/tests/test_version_api.py
@@ -1,0 +1,71 @@
+import tomllib
+from importlib import metadata
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from fermata import api, version as version_mod
+
+
+@pytest.fixture
+def client():
+    """The router alone, same pattern as test_scanner.py's client fixture -
+    this endpoint touches no database and no library, so nothing else about
+    the app is needed to reach it."""
+    app = FastAPI()
+    app.include_router(api.router)
+    return TestClient(app)
+
+
+def test_a_dev_server_reports_dev_for_commit_and_built(client, monkeypatch):
+    """The ordinary case for anyone running from source: no image ever baked
+    a commit or a date in, so the honest answer is "dev" for both - never an
+    invented value and never a 500."""
+    monkeypatch.delenv("FERMATA_BUILD_COMMIT", raising=False)
+    monkeypatch.delenv("FERMATA_BUILD_DATE", raising=False)
+    body = client.get("/api/version").json()
+    assert body["commit"] == "dev"
+    assert body["built"] == "dev"
+    assert body["version"]
+
+
+def test_a_built_image_reports_its_baked_commit_and_date(client, monkeypatch):
+    """What a built image looks like: the two build args land as environment
+    variables, and the endpoint reports exactly what was baked in - nothing
+    computed, nothing read off a git repository that is not there."""
+    monkeypatch.setenv("FERMATA_BUILD_COMMIT", "abc1234")
+    monkeypatch.setenv("FERMATA_BUILD_DATE", "2026-08-23")
+    body = client.get("/api/version").json()
+    assert body["commit"] == "abc1234"
+    assert body["built"] == "2026-08-23"
+
+
+def test_version_is_read_from_the_installed_packages_own_metadata():
+    """Not a second copy of the number - the same value importlib.metadata
+    gives any caller asking what "fermata" resolves to, which is itself read
+    from pyproject.toml at install time."""
+    assert version_mod.version() == metadata.version("fermata")
+
+
+def test_version_falls_back_to_pyproject_toml_when_nothing_is_installed(monkeypatch):
+    """A bare PYTHONPATH pointed at the source tree - nothing pip ever
+    recorded a distribution for - must not crash this endpoint. It reads the
+    same file metadata.version() would otherwise be quoting, by hand.
+
+    Compared against pyproject.toml parsed HERE, independently of
+    version.py's own parsing helper, so this cannot pass merely by agreeing
+    with itself.
+    """
+
+    def not_installed(name):
+        raise metadata.PackageNotFoundError(name)
+
+    monkeypatch.setattr(version_mod.metadata, "version", not_installed)
+
+    pyproject = Path(__file__).resolve().parents[1] / "pyproject.toml"
+    with pyproject.open("rb") as f:
+        expected = tomllib.load(f)["project"]["version"]
+
+    assert version_mod.version() == expected

--- a/web/src/lib/Library.svelte
+++ b/web/src/lib/Library.svelte
@@ -15,6 +15,18 @@
   let uploadInput;
   let showDuplicates = $state(false);
   let duplicates = $state([]);
+  // Which build is actually running (issue #119) - fetched once, quietly, so
+  // a stale deployment is diagnosable at a glance instead of by guessing from
+  // which features seem to be missing. null until it arrives, which renders
+  // as nothing rather than a placeholder worth reading twice.
+  let buildInfo = $state(null);
+  const buildLabel = $derived(
+    buildInfo
+      ? buildInfo.commit === "dev"
+        ? `v${buildInfo.version} (dev)`
+        : `v${buildInfo.version} (${buildInfo.commit}, ${buildInfo.built})`
+      : "",
+  );
 
   const KINDS = [
     ["", "All"],
@@ -47,6 +59,10 @@
   $effect(() => {
     if (!showDuplicates) return;
     api.duplicates().then((d) => (duplicates = d));
+  });
+
+  $effect(() => {
+    api.version().then((v) => (buildInfo = v));
   });
 
   $effect(() => {
@@ -224,6 +240,12 @@
       <a class="demo-link" href="#/demo">Notation/tab demo →</a>
       <a class="demo-link" href="#/settings">⚙ Settings</a>
     </div>
+
+    {#if buildLabel}
+      <!-- Quiet and always on screen - no hover, this app's primary form
+           factor is a tablet with no pointer to hover with (issue #119). -->
+      <div class="build-tag" title="Fermata build">{buildLabel}</div>
+    {/if}
   </aside>
 
   <main>
@@ -476,6 +498,15 @@
 
   .demo-link:hover {
     color: var(--brass-bright);
+  }
+
+  .build-tag {
+    text-align: center;
+    font-size: 11px;
+    color: var(--ink-dim);
+    opacity: 0.65;
+    padding-top: 10px;
+    letter-spacing: 0.02em;
   }
 
   main {

--- a/web/src/lib/api.js
+++ b/web/src/lib/api.js
@@ -182,6 +182,7 @@ export const api = {
       body: JSON.stringify(body),
     }).then(j),
   deleteInstrument: (id) => fetch(`/api/instruments/${id}`, { method: "DELETE" }).then(j),
+  version: () => fetch("/api/version").then(j),
   settings: () => fetch("/api/settings").then(j),
   putSettings: (values) =>
     fetch("/api/settings", {

--- a/web/tests/browser/version.spec.js
+++ b/web/tests/browser/version.spec.js
@@ -1,0 +1,39 @@
+// The build indicator (issue #119) - surfaced because a self-hosted
+// deployment updated by rebuild has no auto-update and no release channel, so
+// running a stale build is the ordinary failure mode. Its symptom is always
+// the same: a feature that was merged looks like it does not exist, because
+// the interface is old rather than broken. This checks the one thing that
+// makes that diagnosable without asking anyone - a quiet, always-visible line
+// in the library sidebar that names the build.
+import { expect, test } from "@playwright/test";
+
+const buildTag = (page) => page.locator(".build-tag");
+
+test("the build indicator is on screen without any interaction", async ({ page, request }) => {
+  await page.goto("/");
+  const tag = buildTag(page);
+  await expect(tag).toBeVisible();
+
+  // Compared against the endpoint's own answer, not against a hand-copied
+  // string: the test playwright's server is running under here has no build
+  // args baked in, so this is the "dev" server path - the same one a plain
+  // uvicorn run from source takes.
+  const body = await (await request.get("/api/version")).json();
+  expect(body.commit).toBe("dev");
+  expect(body.built).toBe("dev");
+  await expect(tag).toHaveText(`v${body.version} (dev)`);
+});
+
+test("the indicator needs no hover - it renders in the initial layout", async ({ page }) => {
+  // This app's primary form factor is a tablet with no pointer, so anything
+  // that only appeared on :hover would be permanently invisible there. Read
+  // straight off the accessibility tree / layout rather than via a hover
+  // interaction, which is itself the assertion: nothing here dispatches a
+  // mouseover before checking visibility.
+  await page.goto("/");
+  await expect(buildTag(page)).toBeVisible();
+  const box = await buildTag(page).boundingBox();
+  expect(box).not.toBeNull();
+  expect(box.width).toBeGreaterThan(0);
+  expect(box.height).toBeGreaterThan(0);
+});

--- a/web/tests/minimum-tests.js
+++ b/web/tests/minimum-tests.js
@@ -109,7 +109,13 @@
 //
 // Raised deliberately, and every one of the 31 was shown to fail against a
 // mutation of the behaviour it claims - see the pull request.
-export const MINIMUM_TESTS = 236;
+//
+// Plus 2 for issue #119, in tests/browser/version.spec.js: the build
+// indicator is on screen with no interaction, and its text agrees with what
+// GET /api/version actually reports rather than a hand-copied string. Both
+// were shown to fail against a mutation of the behaviour they claim - hiding
+// the indicator, and breaking the endpoint - see the pull request.
+export const MINIMUM_TESTS = 238;
 
 export default class MinimumTests {
   constructor() {


### PR DESCRIPTION
## Summary

- `GET /api/version` reports `{version, commit, built}`: `version` from the installed package's own metadata (falling back to reading `pyproject.toml` when nothing is installed - a bare `PYTHONPATH` dev run), `commit` and `built` baked into the image at build time via Docker build args and never computed from a git repository, since there isn't one inside the container. Unbaked, both read as `"dev"`.
- `Dockerfile` and `docker-compose.yml` wire `BUILD_COMMIT` / `BUILD_DATE` as build args (defaulting to `dev`); the CI image job passes real values so that path is exercised too.
- The library sidebar shows the build quietly and always on screen - e.g. `v0.1.0 (a745602, 2026-08-23)`, or `v0.1.0 (dev)` - with no hover involved, since this app's primary form factor is a tablet with no pointer.
- `docs/deployment.md` now points at the build tag as the first check before assuming an upgrade didn't take or reporting a missing feature.

Closes #119.

## Test plan

- [x] Server: `server/tests/test_version_api.py` covers the dev path, the baked path, version read from installed metadata, and the pyproject.toml fallback when nothing is installed. Full suite: 641 passed, 2 skipped (was 637 passed, 2 skipped on `main`).
- [x] Browser: `web/tests/browser/version.spec.js` asserts the indicator renders unconditionally and its text agrees with what the endpoint actually returns. `MINIMUM_TESTS` raised 236 → 238. Full suite: 238 passed.
- [x] Mutation testing: breaking `/api/version` (ignoring the baked commit) turned 1 server test red, and further breaking `version()` itself turned 2 more red; both reverts came back green. Hiding the sidebar indicator turned both new browser tests red; reverting came back green.
- [x] Verified actual endpoint output in both modes: dev server returns `{"version":"0.1.0","commit":"dev","built":"dev"}`; with `FERMATA_BUILD_COMMIT`/`FERMATA_BUILD_DATE` set (simulating a built image) it returns `{"version":"0.1.0","commit":"a745602","built":"2026-08-23"}`.