### PR TITLE
Give a compound meter's bar a sound of its own, and name subdivisions honestly (#121)

### DIFF
--- a/web/src/lib/Metronome.svelte
+++ b/web/src/lib/Metronome.svelte
@@ -254,6 +254,13 @@
     return { numerator: Number(m[1]), denominator: Number(m[2]) };
   }
 
+  // The subdivision picker's own options, by the CURRENT meter's click unit -
+  // see SUBDIVISION_LABELS in metronome-engine.js for why "Eighths" cannot be
+  // a fixed list. Falls back to the x/4 rung for a meter string that does not
+  // yet parse (mid-edit, or unset), the same default metronomePattern itself
+  // uses for a malformed denominator.
+  const subdivisionLabels = $derived(SUBDIVISION_LABELS(meterParts(meter)?.denominator ?? 4));
+
   // Pushes every setting at `c`, in the order the engine needs them: enabled
   // LAST, because setEnabled is the call that can start the click running and
   // it must not do that against stale values for the instant before the rest
@@ -674,7 +681,7 @@
           onchange={(ev) => chooseSubdivision(ev.target.value)}
           title="How finely each beat is clicked"
         >
-          {#each SUBDIVISION_LABELS as [value, label]}
+          {#each subdivisionLabels as [value, label]}
             <option {value}>{label}</option>
           {/each}
         </select>

--- a/web/src/lib/metronome-engine.js
+++ b/web/src/lib/metronome-engine.js
@@ -45,6 +45,7 @@ import {
   MAX_METRONOME_BPM,
   MIN_METRONOME_BPM,
   clampBpm,
+  clickLevel,
   clickPhaseInBar,
   metronomePattern,
   rawClickRate,
@@ -54,14 +55,34 @@ import {
 export const METRONOME_LOOKAHEAD_MS = 25;
 export const METRONOME_SCHEDULE_AHEAD_S = 0.12;
 export const METRONOME_CLICK_SECONDS = 0.05;
-// Accent is both higher-pitched and louder than a plain subdivision tick -
-// pitch alone survives a quiet room or a cheap speaker better than volume
-// alone does, so the two are stacked rather than picking one. Gains are
-// sized so the two can never clip even in the pathological case of one
-// click's tail overlapping the next one's attack: 0.6 + 0.35 = 0.95, under
-// unity with headroom to spare. MAX_METRONOME_BPM keeps that overlap from
-// ever actually happening in practice - see its own comment in metronome.js.
+// Three sounds, not two: the downbeat (the first click of the bar), the beat
+// (the start of a group inside the bar - a compound meter's dotted-quarter
+// pulse), and the plain tick everything else gets. In a simple meter the
+// beat tier never fires (clickLevel never answers "beat" there - see its own
+// comment), so a simple meter is exactly the two sounds it always was.
+//
+// The downbeat is both higher-pitched and louder than the other two - pitch
+// alone survives a quiet room or a cheap speaker better than volume alone
+// does, so the two are stacked rather than picking one. The beat tier is
+// distinguished by PITCH ALONE, at the tick's own gain: giving it a gain
+// between the two would put the worst adjacent pair (downbeat immediately
+// followed by beat) at 0.6 + 0.48 = 1.08, over the headroom the comment below
+// establishes, where pitch survives a bad speaker better than volume does
+// anyway. And it has to sit below METRONOME_ACCENT_HZ by enough that a
+// listener - and a test - can call it "clearly the lower one": both browser
+// suites' own ACCENT_HZ_THRESHOLD is 1200, so anything at or above that reads
+// as the downbeat, which is why the beat tier is well under it rather than
+// merely different from it.
+//
+// Gains are sized so the loudest two can never clip even in the pathological
+// case of one click's tail overlapping the next one's attack: 0.6 + 0.35 =
+// 0.95, under unity with headroom to spare. MAX_METRONOME_BPM keeps that
+// overlap from ever actually happening in practice - see its own comment in
+// metronome.js. Revisiting the beat tier's gain (if pitch alone turns out too
+// subtle in a real room) means re-deriving this arithmetic, not editing
+// around it.
 export const METRONOME_ACCENT_HZ = 1500;
+export const METRONOME_BEAT_HZ = 1180;
 export const METRONOME_TICK_HZ = 950;
 export const METRONOME_ACCENT_GAIN = 0.6;
 export const METRONOME_TICK_GAIN = 0.35;
@@ -84,13 +105,15 @@ export const MAX_SUBDIVISION = 4;
  * proportion moves (a tempo change written mid-piece, or the meter itself
  * changing - which changes the rate even when the tempo does not).
  *
- * `onClick(accent, numerator, denominator, phase)` fires once per click ONLY
+ * `onClick(level, numerator, denominator, phase)` fires once per click ONLY
  * from inside the real scheduling call that creates its oscillator - not
  * merely alongside it - so deleting that function's body silences this too;
  * nothing downstream of it can report a click that scheduleClick never
- * actually attempted. `phase` is the bar-relative slot the click landed in -
- * exposed separately from `accent` so a caller can tell the phase is really
- * being derived from a playhead each time, not merely incrementing.
+ * actually attempted. `level` is `"downbeat" | "beat" | "tick"` - see
+ * clickLevel in metronome.js for what decides it - and `phase` is the
+ * bar-relative slot the click landed in, exposed separately from `level` so a
+ * caller can tell the phase is really being derived from a playhead each
+ * time, not merely incrementing.
  *
  * `ready` gates onTempo. It defaults to true, because a metronome standing on
  * its own always has a real number to report from the instant it exists. A
@@ -161,11 +184,11 @@ export function createMetronomeEngine({ onTempo = () => {}, onClick = () => {}, 
 
   /**
    * Everything one click needs, resolved together from one reading of the
-   * context - the meter, the rate, the slot in the bar, and whether that slot
-   * is accented. Resolved together rather than by four separate lookups on
-   * purpose: the rate depends on the meter's unit and the accent depends on
-   * the same pattern the phase is taken modulo, so two readings of a context
-   * that moves under them can disagree.
+   * context - the meter, the rate, the slot in the bar, and which of the
+   * three sounds that slot gets. Resolved together rather than by four
+   * separate lookups on purpose: the rate depends on the meter's unit and the
+   * level depends on the same pattern the phase is taken modulo, so two
+   * readings of a context that moves under them can disagree.
    */
   function resolve(live) {
     const bar = live?.bar ?? null;
@@ -173,7 +196,6 @@ export function createMetronomeEngine({ onTempo = () => {}, onClick = () => {}, 
     const denominator = bar?.denominator ?? meterDenominator;
     const pattern = metronomePattern(numerator, denominator);
     const clicksPerBar = pattern.clicksPerBar * subdivision;
-    const accentEvery = pattern.accentEvery * subdivision;
     // Subdivision is folded into effectiveClickRate's INPUTS rather than
     // multiplied onto its output, so MAX_METRONOME_BPM still lands on the
     // rate actually scheduled. Multiplying afterwards would let a
@@ -218,7 +240,11 @@ export function createMetronomeEngine({ onTempo = () => {}, onClick = () => {}, 
       clicksPerBar,
       phase,
       limit,
-      accent: accentEnabled && phase % accentEvery === 0,
+      // setAccent(false) has to flatten BOTH upper tiers, not just the
+      // downbeat - "turning the accent off makes every real click identical"
+      // is the property this is for, and it would go on being false for the
+      // beat tier if that check lived inside clickLevel instead of here.
+      level: accentEnabled ? clickLevel(phase, clicksPerBar, pattern.accentEvery, subdivision) : "tick",
       // Rounded ONCE, here, and used unrounded nowhere else: both the
       // scheduler and the readout consume exactly this number. A display that
       // rounds separately from what the scheduler consumes is exactly the
@@ -251,14 +277,17 @@ export function createMetronomeEngine({ onTempo = () => {}, onClick = () => {}, 
   // click that gets reported without a real audio node behind it is exactly
   // the failure this project has shipped before: a test - or a player - that
   // trusts a value the interface merely intended to produce.
-  function scheduleClick(time, accent, numerator, denominator, phase) {
+  function scheduleClick(time, level, numerator, denominator, phase) {
     const ctx = audioCtx;
     const osc = ctx.createOscillator();
     const gain = ctx.createGain();
-    osc.frequency.value = accent ? METRONOME_ACCENT_HZ : METRONOME_TICK_HZ;
+    osc.frequency.value =
+      level === "downbeat" ? METRONOME_ACCENT_HZ : level === "beat" ? METRONOME_BEAT_HZ : METRONOME_TICK_HZ;
     osc.connect(gain);
     gain.connect(ctx.destination);
-    const peak = accent ? METRONOME_ACCENT_GAIN : METRONOME_TICK_GAIN;
+    // The beat tier is distinguished by pitch alone, at the tick's own gain -
+    // see the headroom comment above METRONOME_BEAT_HZ.
+    const peak = level === "downbeat" ? METRONOME_ACCENT_GAIN : METRONOME_TICK_GAIN;
     // A short percussive envelope, not a sustained tone: near-instant attack
     // so the click reads as a transient a note can be placed against, then an
     // exponential decay - linear ramps to silence read as a cut-off, not a
@@ -274,7 +303,7 @@ export function createMetronomeEngine({ onTempo = () => {}, onClick = () => {}, 
     // way of this function actually running - createOscillator, the gain
     // envelope and this call all have to happen first - so deleting
     // scheduleClick's body still silences onClick exactly as intended.
-    onClick(accent, numerator, denominator, phase);
+    onClick(level, numerator, denominator, phase);
     osc.start(time);
     osc.stop(time + METRONOME_CLICK_SECONDS + 0.02);
     pendingOscillators.push(osc);
@@ -311,7 +340,7 @@ export function createMetronomeEngine({ onTempo = () => {}, onClick = () => {}, 
       // playhead fresh again - so the cost is an occasional single click's
       // accent placed a slot off near a boundary, not a drift that persists.
       const click = resolve(context());
-      scheduleClick(nextClickTime, click.accent, click.numerator, click.denominator, click.phase);
+      scheduleClick(nextClickTime, click.level, click.numerator, click.denominator, click.phase);
       freeRunPhase += 1;
       nextClickTime += secondsPerClick(click.rate);
     }
@@ -439,11 +468,23 @@ export function createMetronomeEngine({ onTempo = () => {}, onClick = () => {}, 
       report();
     },
     /** How many clicks each notated click is split into - 1 for the plain
-     * beat, 2 for eighths against a quarter-note beat, and so on. */
+     * beat, 2 for eighths against a quarter-note beat, and so on.
+     *
+     * Realigns freeRunPhase to the downbeat when no pulse source is
+     * installed - i.e. when the phase above is a counter rather than
+     * something derived fresh from a playhead. Without this, a change made
+     * mid-run leaves the very next click at whatever offset the OLD
+     * clicksPerBar happened to have counted up to, rather than on the
+     * downbeat: the interval is still right, so nothing drifts, but the first
+     * click after the change is not where a player just told it to be. A
+     * caller WITH a pulse source has nothing to realign - the phase is
+     * recomputed from the playhead on every click regardless of what this
+     * setting just did. */
     setSubdivision(next) {
       const v = Math.round(Number(next));
       if (!Number.isInteger(v) || v < 1 || v > MAX_SUBDIVISION) return;
       subdivision = v;
+      if (!pulseSource) freeRunPhase = 0;
       report();
     },
     /** Whether the first click of each bar is accented at all. Off makes every
@@ -452,12 +493,14 @@ export function createMetronomeEngine({ onTempo = () => {}, onClick = () => {}, 
     setAccent(v) {
       accentEnabled = !!v;
     },
-    /** The meter to click when no pulse source supplies one. */
+    /** The meter to click when no pulse source supplies one. See
+     * setSubdivision above for why this also realigns freeRunPhase. */
     setMeter(numerator, denominator) {
       const n = Math.round(Number(numerator));
       const d = Math.round(Number(denominator));
       if (Number.isInteger(n) && n > 0) meterNumerator = n;
       if (Number.isInteger(d) && d > 0) meterDenominator = d;
+      if (!pulseSource) freeRunPhase = 0;
       report();
     },
     /** The quarter-note tempo a proportion is taken of. */
@@ -543,13 +586,51 @@ export const PROPORTION_PRESETS = [15, 25, 35, 50, 60, 70, 80, 90, 100, 110, 125
  * slow-practice crawl to a fast one. */
 export const BPM_PRESETS = [40, 50, 60, 72, 84, 96, 108, 120, 132, 144, 160, 176, 200];
 
-/** Subdivisions offered in the interface, by name. */
-export const SUBDIVISION_LABELS = [
-  [1, "Beat"],
-  [2, "Eighths"],
-  [3, "Triplets"],
-  [4, "Sixteenths"],
-];
+// The note each subdivision setting actually clicks, by the meter's OWN
+// click unit (metronomePattern's `unit` - the denominator, an eighth for
+// .../8) - not a fixed absolute-note ladder. `subdivision` multiplies that
+// unit, so what ×2 clicks in 6/8 (an eighth-note meter: sixteenths) is not
+// what it clicks in 4/4 (a quarter-note meter: eighths), and a label that
+// does not move with the meter names the wrong note. "Beat" is gone
+// entirely: it was only ever true in x/4, and in x/8 it named the
+// subdivision rather than the beat - the specific defect this table exists
+// to fix. ×3 is a triplet of the next rung down (×1), the same relationship
+// a dotted note's triplet always has to the plainer value beside it.
+const SUBDIVISION_TABLE = {
+  2: [
+    [1, "Halves"],
+    [2, "Quarters"],
+    [3, "Quarter triplets"],
+    [4, "Eighths"],
+  ],
+  4: [
+    [1, "Quarters"],
+    [2, "Eighths"],
+    [3, "Eighth triplets"],
+    [4, "Sixteenths"],
+  ],
+  8: [
+    [1, "Eighths"],
+    [2, "Sixteenths"],
+    [3, "Sixteenth triplets"],
+    [4, "Thirty-seconds"],
+  ],
+  16: [
+    [1, "Sixteenths"],
+    [2, "Thirty-seconds"],
+    [3, "32nd triplets"],
+    [4, "Sixty-fourths"],
+  ],
+};
+
+/** Subdivisions offered in the interface, by name - a function of the
+ * meter's own click unit (the denominator), not a fixed list: see
+ * SUBDIVISION_TABLE above for why "Eighths" cannot mean the same interval in
+ * every meter. An unlisted unit falls back to the x/4 rung, the same default
+ * metronomePattern itself uses for a malformed denominator. */
+export function SUBDIVISION_LABELS(unit) {
+  return SUBDIVISION_TABLE[unit] ?? SUBDIVISION_TABLE[4];
+}
 
 /** Time signatures offered as a pre-fill when there is no piece to read one
  * from. Not a limit on what is possible - metronomePattern handles any meter

--- a/web/src/lib/metronome.js
+++ b/web/src/lib/metronome.js
@@ -141,6 +141,41 @@ export function metronomePattern(numerator, denominator) {
   };
 }
 
+/**
+ * Which of three sounds a click at `phase` gets: `"downbeat"` (the first
+ * click of the bar), `"beat"` (the start of a group inside the bar - the
+ * dotted-quarter pulse in a compound meter), or `"tick"` (everything else).
+ *
+ * `accentEvery` here is `metronomePattern`'s own, UN-multiplied by
+ * subdivision - this is the one place that multiplication happens, so a
+ * caller (metronome-engine.js's `resolve()`) hands over the pattern's raw
+ * grouping and the subdivision separately rather than pre-combining them.
+ *
+ * In a simple meter `accentEvery === clicksPerBar`, so the only phase
+ * satisfying the beat test is phase 0 - already claimed by the downbeat
+ * check above it - and this always answers `"tick"` for everything else.
+ * That is what keeps a simple meter down to two sounds: the beat tier exists
+ * only where a bar actually contains more than one group, which is
+ * precisely a compound meter's reason for having accentEvery lower than
+ * clicksPerBar in the first place.
+ *
+ * `clicksPerBar` is used only to validate `phase` against - a degenerate or
+ * out-of-range bar answers `"tick"` rather than propagating a bad modulus,
+ * the same defensive stance clickPhaseInBar takes for the same inputs.
+ */
+export function clickLevel(phase, clicksPerBar, accentEvery, subdivision) {
+  const cpb = Number(clicksPerBar);
+  const p = Number(phase);
+  if (!Number.isFinite(p) || !(cpb > 0)) return "tick";
+  const normalized = ((p % cpb) + cpb) % cpb;
+  if (normalized === 0) return "downbeat";
+  const ae = Number(accentEvery);
+  const sub = Number.isInteger(Number(subdivision)) && Number(subdivision) >= 1 ? Number(subdivision) : 1;
+  const beatEvery = Number.isFinite(ae) && ae > 0 ? ae * sub : 0;
+  if (beatEvery > 0 && normalized % beatEvery === 0) return "beat";
+  return "tick";
+}
+
 /** Seconds between one click and the next, at a click RATE already in clicks
  * per minute (see effectiveClickRate) - there is no meter or mode left to
  * convert here, which is deliberate: the rate handed in is already the

--- a/web/src/lib/score-render.js
+++ b/web/src/lib/score-render.js
@@ -1105,6 +1105,7 @@ export function createScoreView(host, opts = {}) {
   if (host) {
     delete host.dataset.metronomeClicks;
     delete host.dataset.metronomeAccent;
+    delete host.dataset.metronomeLevel;
     delete host.dataset.metronomeNumerator;
     delete host.dataset.metronomeDenominator;
     delete host.dataset.metronomePhase;
@@ -1114,10 +1115,16 @@ export function createScoreView(host, opts = {}) {
   // Reflects each scheduled click onto the host, the same way publish() below
   // reflects layout and theme - so a test can assert on a click that actually
   // happened rather than on a value this module only intended to produce.
-  function publishMetronomeClick(accent, numerator, denominator, phase) {
+  // `level` is "downbeat" | "beat" | "tick" (see clickLevel in metronome.js);
+  // `metronomeAccent` stays a plain boolean rather than being removed, so
+  // nothing already reading it as "was this click accented at all" changes
+  // meaning - it is just now `level !== "tick"` instead of the old two-level
+  // flag.
+  function publishMetronomeClick(level, numerator, denominator, phase) {
     if (!host) return;
     host.dataset.metronomeClicks = String((Number(host.dataset.metronomeClicks) || 0) + 1);
-    host.dataset.metronomeAccent = String(accent);
+    host.dataset.metronomeLevel = level;
+    host.dataset.metronomeAccent = String(level !== "tick");
     host.dataset.metronomeNumerator = String(numerator);
     host.dataset.metronomeDenominator = String(denominator);
     host.dataset.metronomePhase = String(phase);

--- a/web/tests/browser/metronome-everywhere.spec.js
+++ b/web/tests/browser/metronome-everywhere.spec.js
@@ -48,10 +48,19 @@ const baseNote = (page) => page.locator(".metronome-base");
 const limitNote = (page) => page.locator(".metronome-limit");
 const playButton = (page) => page.locator(".player button.primary");
 
-// Halfway between METRONOME_TICK_HZ (950) and METRONOME_ACCENT_HZ (1500) in
-// metronome-engine.js - a threshold rather than an exact match, so this suite
-// is coupled only to "clearly the higher one".
+// ABOVE METRONOME_BEAT_HZ (1180) in metronome-engine.js - a threshold rather
+// than an exact match, so this suite is coupled only to "clearly the highest
+// of the three".
 const ACCENT_HZ_THRESHOLD = 1200;
+// Halfway between METRONOME_TICK_HZ (950) and METRONOME_BEAT_HZ (1180) -
+// "clearly the middle one, not the plain tick".
+const BEAT_HZ_THRESHOLD = 1065;
+
+/** The three-level name for a real oscillator frequency, read off the same
+ * two thresholds every test in this file uses. */
+function levelOf(frequency) {
+  return frequency > ACCENT_HZ_THRESHOLD ? "downbeat" : frequency > BEAT_HZ_THRESHOLD ? "beat" : "tick";
+}
 
 test.beforeEach(async ({ page }) => {
   await page.addInitScript(() => {
@@ -232,6 +241,111 @@ test("turning the accent off makes every real click identical, and turning it ba
     restored.some((s) => s.frequency > ACCENT_HZ_THRESHOLD),
     `frequencies: ${restored.map((s) => s.frequency).join(",")}`,
   ).toBe(true);
+});
+
+// -------------------------------------------- issue #121: a bar with no bar
+
+test("in 6/8 the bar is audible, not only the grouping - a third, distinct click marks where it starts", async ({
+  page,
+}) => {
+  await page.goto("/#/metronome");
+  await meterSelect(page).selectOption("6/8");
+  await bpmInput(page).fill("240");
+  await bpmInput(page).press("Tab");
+  await subdivisionSelect(page).selectOption("1");
+  await startButton(page).click();
+
+  // Two bars and one click over, so the third downbeat proves the pattern
+  // repeats rather than being a fluke of where the run happened to start -
+  // the standalone page always starts fresh at phase 0 (start() resets
+  // freeRunPhase), so this sequence is deterministic from the very first
+  // click.
+  const starts = await oscillatorStarts(page, 13);
+  const levels = starts.map((s) => levelOf(s.frequency));
+  expect(levels, `frequencies: ${starts.map((s) => s.frequency).join(",")}`).toEqual([
+    "downbeat", "tick", "tick", "beat", "tick", "tick",
+    "downbeat", "tick", "tick", "beat", "tick", "tick",
+    "downbeat",
+  ]);
+
+  // Stated directly on the real frequencies too, in the exact shape the
+  // issue's own report used: the downbeat (index 0) is higher than the beat
+  // (index 3), which is itself higher than a plain tick (index 1). Red today
+  // at the first inequality alone - phase 0 and phase 3 were byte-identical,
+  // both 1500 Hz.
+  expect(starts[0].frequency).toBeGreaterThan(starts[3].frequency);
+  expect(starts[3].frequency).toBeGreaterThan(starts[1].frequency);
+});
+
+test("compound meters of different lengths do not sound the same - 6/8 and 9/8 are not the same click stream wearing different labels", async ({
+  page,
+}) => {
+  await page.goto("/#/metronome");
+  await meterSelect(page).selectOption("6/8");
+  await bpmInput(page).fill("300");
+  await bpmInput(page).press("Tab");
+  await subdivisionSelect(page).selectOption("1");
+  await startButton(page).click();
+  const sixEight = (await oscillatorStarts(page, 25)).map((s) => levelOf(s.frequency));
+
+  await startButton(page).click(); // stop
+  await page.evaluate(() => window.__resetOscillatorStarts());
+  await meterSelect(page).selectOption("9/8");
+  await startButton(page).click(); // a fresh start - phase resets to the downbeat
+
+  const nineEight = (await oscillatorStarts(page, 25)).map((s) => levelOf(s.frequency));
+
+  // Red today for a reason no threshold constant can dodge: both meters
+  // produce the literal same level string - "downbeat, tick, tick, beat,
+  // tick, tick, ..." repeating - because there was nothing but the grouping
+  // to click, and the grouping repeats identically in every compound meter
+  // regardless of how many groups the bar actually holds. This is the
+  // sharpest of the three tests here: it cannot be satisfied by anything
+  // short of the bar itself becoming audible.
+  expect(nineEight, `6/8: ${sixEight.join(",")} / 9/8: ${nineEight.join(",")}`).not.toEqual(sixEight);
+});
+
+test("the subdivision option that names the eighth really clicks the eighth, not the sixteenth underneath it", async ({
+  page,
+}) => {
+  await page.goto("/#/metronome");
+  await meterSelect(page).selectOption("6/8");
+
+  // Read the picker's own option labels rather than assuming which numeric
+  // value carries "Eighths" - written against the OBSERVABLE (the label, and
+  // the rate it produces), not the mechanism, so this passes whichever way
+  // the label defect gets fixed: relabelling the rungs to match what they
+  // always clicked, or remapping the factors so "Eighths" becomes the
+  // meter's own ×1 in 6/8.
+  const options = await subdivisionSelect(page)
+    .locator("option")
+    .evaluateAll((opts) => opts.map((o) => ({ value: o.value, label: o.textContent })));
+  const eighths = options.find((o) => o.label === "Eighths");
+  expect(eighths, `options: ${JSON.stringify(options)}`).toBeTruthy();
+  await subdivisionSelect(page).selectOption(eighths.value);
+
+  await bpmInput(page).fill("100");
+  await bpmInput(page).press("Tab");
+  await startButton(page).click();
+
+  // Paired with the count below, so a relabel that leaves the audio
+  // untouched (the option renamed but still clicking sixteenths) cannot pass
+  // this: 6/8 read as eighths at box 100 has to measure ~100 clicks a
+  // minute, not the 200 the mislabelled "Eighths" used to produce.
+  const rate = await measuredRate(page, 6);
+  expect(rate, `measured ${rate}`).toBeGreaterThan(97);
+  expect(rate, `measured ${rate}`).toBeLessThan(103);
+
+  // And the count between downbeats has to be six - a bar of 6/8 clicked on
+  // the eighth, not twelve (sixteenths, what "Eighths" used to actually
+  // click) or eighteen (sixteenth triplets).
+  const starts = await oscillatorStarts(page, 13);
+  const downbeats = [];
+  starts.forEach((s, i) => {
+    if (levelOf(s.frequency) === "downbeat") downbeats.push(i);
+  });
+  expect(downbeats.length, `frequencies: ${starts.map((s) => s.frequency).join(",")}`).toBeGreaterThanOrEqual(2);
+  expect(downbeats[1] - downbeats[0], `downbeats at: ${downbeats.join(",")}`).toBe(6);
 });
 
 test("standing on its own, the metronome arrives at what it was last left at - the only context it has", async ({

--- a/web/tests/browser/metronome.spec.js
+++ b/web/tests/browser/metronome.spec.js
@@ -44,11 +44,15 @@ const bpmInput = (page) => page.locator("input.metronome-bpm");
 const speedSelect = (page) => page.locator('select[title="Playback speed"]');
 const loopButton = (page) => page.locator('button:has-text("Loop")');
 const countInButton = (page) => page.locator('button:has-text("Count-in")');
-// Roughly halfway between METRONOME_TICK_HZ (950) and METRONOME_ACCENT_HZ
-// (1500) in score-render.js - a threshold rather than an exact match so this
-// suite is not coupled to the precise constants, only to "clearly the higher
-// one".
+// ABOVE METRONOME_BEAT_HZ (1180) in metronome-engine.js - a threshold rather
+// than an exact match so this suite is not coupled to the precise constants,
+// only to "clearly the highest of the three". Below this is the downbeat's
+// own tier; at or below it is the beat tier or the plain tick, told apart by
+// BEAT_HZ_THRESHOLD next.
 const ACCENT_HZ_THRESHOLD = 1200;
+// Halfway between METRONOME_TICK_HZ (950) and METRONOME_BEAT_HZ (1180) -
+// "clearly the middle one, not the plain tick".
+const BEAT_HZ_THRESHOLD = 1065;
 
 test.beforeEach(async ({ page }) => {
   await page.addInitScript((accentThreshold) => {
@@ -224,7 +228,7 @@ test("the live tempo shown is the actual click RATE - clicks per minute, matchin
   }
 });
 
-test("6/8 accents every third eighth, exactly where the real phase says it should - verified against the real oscillator frequency, not just the dataset flag reported alongside it", async ({
+test("6/8 sounds three distinct levels, exactly where the real phase says it should - verified against the real oscillator frequency, not just the dataset flag reported alongside it", async ({
   page,
 }) => {
   // Deliberately does not assume which phase slot the run happens to start
@@ -252,11 +256,18 @@ test("6/8 accents every third eighth, exactly where the real phase says it shoul
     expect(phases[i], `phases: ${phases.join(", ")}`).toBe((phases[i - 1] + 1) % 6);
   }
 
-  // The real oscillator frequency, not the dataset accent flag alongside
-  // it, has to agree with what the real phase says should be accented -
-  // every third slot (0, 3) starting from the downbeat.
-  const accents = starts.map((s) => s.frequency > ACCENT_HZ_THRESHOLD);
-  expect(accents).toEqual(phases.map((p) => p % 3 === 0));
+  // The real oscillator frequency, not the dataset accent flag alongside it,
+  // has to agree with what the real phase says the sound should be: the
+  // downbeat only at phase 0 (issue #121 - a bare "every third slot" accent
+  // left 6/8, 9/8 and 12/8 sounding identical, because phase 3 got the exact
+  // same click as phase 0), the beat tier at the other dotted-quarter pulse
+  // (phase 3), and a plain tick at the four phases that are neither.
+  const levels = starts.map((s) =>
+    s.frequency > ACCENT_HZ_THRESHOLD ? "downbeat" : s.frequency > BEAT_HZ_THRESHOLD ? "beat" : "tick",
+  );
+  expect(levels, `phases: ${phases.join(", ")}, frequencies: ${starts.map((s) => s.frequency).join(", ")}`).toEqual(
+    phases.map((p) => (p === 0 ? "downbeat" : p === 3 ? "beat" : "tick")),
+  );
 });
 
 test("fixed-BPM mode clicks the typed rate itself, in every meter - not a quarter-note tempo converted onto the meter's unit", async ({

--- a/web/tests/minimum-tests.js
+++ b/web/tests/minimum-tests.js
@@ -109,7 +109,33 @@
 //
 // Raised deliberately, and every one of the 31 was shown to fail against a
 // mutation of the behaviour it claims - see the pull request.
-export const MINIMUM_TESTS = 236;
+//
+// Plus 11 for issue #121 - a compound meter's bar had no sound of its own,
+// and the subdivision labels named the wrong note.
+//
+// 3 in tests/browser/metronome-everywhere.spec.js, all driven through the
+// standalone page's own controls: 6/8 sounding three distinct levels rather
+// than the two that made every dotted-quarter pulse identical; 6/8 and 9/8
+// no longer producing byte-identical click streams (the sharpest of the
+// three - satisfiable only by the bar itself becoming audible); and the
+// subdivision option that names the eighth actually clicking six times a bar
+// in 6/8, paired with a rate assertion so a relabel that leaves the audio
+// untouched cannot pass it.
+//
+// 6 in tests/unit/metronome.spec.js, for clickLevel: the three sounds it
+// gives 6/8, a simple meter never reaching the beat tier, subdivision
+// scaling the beat's spacing along with the downbeat's, phase normalised
+// into range the same way clickPhaseInBar's own input is, and two guarding
+// a degenerate bar and a non-integer subdivision from corrupting either.
+//
+// 2 in tests/unit/metronome-engine.spec.js: changing the subdivision, and
+// separately the meter, while the click is running puts the very next click
+// back on the downbeat rather than at whatever offset the free-running
+// counter had reached.
+//
+// Raised deliberately, and every one of the 11 was shown to fail against a
+// mutation of the behaviour it claims - see the pull request.
+export const MINIMUM_TESTS = 247;
 
 export default class MinimumTests {
   constructor() {

--- a/web/tests/unit/metronome-engine.spec.js
+++ b/web/tests/unit/metronome-engine.spec.js
@@ -10,6 +10,16 @@
 // it at the Web Audio boundary. Nothing here should ever be read as evidence
 // that a click happened; currentRate() is the number the scheduler consumes,
 // and these tests only check that it is the right number.
+//
+// The phase-realignment tests at the bottom are the one deliberate exception:
+// proving freeRunPhase actually gets reset needs it to have moved off zero
+// first, and it only ever moves inside tick()'s real scheduling loop - there
+// is no seam that advances it any other way, on purpose, since a counter
+// divorced from real scheduling is the exact bug metronome-engine.js's own
+// header warns against. So those two tests install a minimal Web Audio stand-
+// in on `window` (a fake AudioContext whose clock is real wall-clock time, and
+// oscillators that do nothing) and wait on the real scheduler's own onClick
+// calls - still no browser, no page, and no real sound, but real timers.
 import { expect, test } from "@playwright/test";
 
 import { MAX_METRONOME_BPM, MIN_METRONOME_BPM } from "../../src/lib/metronome.js";
@@ -379,5 +389,126 @@ test("the ceiling is reachable from ordinary meters at ordinary presets, not onl
     e.setBaseTempo(tempo);
     e.setMeter(meter[0], meter[1]);
     expect(e.currentLimit(), `100% of ${tempo} in ${meter[0]}/${meter[1]}`).toBeNull();
+  }
+});
+
+// ------------------------------------- reaching for a setting while running
+//
+// Issue #121's third finding: freeRunPhase (the counter used only when no
+// pulse source is installed) was never realigned when clicksPerBar changed
+// mid-run, so the first click after a meter or subdivision change landed at
+// an arbitrary offset rather than on the downbeat - the interval stayed
+// correct, so nothing drifted, but the very next click was not where a
+// player had just told it to be.
+//
+// See the file header for why these two need a fake AudioContext where the
+// rest of this file needs none.
+
+/** A minimal Web Audio stand-in: real wall-clock time as the audio clock, and
+ * oscillators/gains that do nothing. Installed on `window` (which does not
+ * otherwise exist in this Node-run file) only for the lifetime of one test. */
+function installFakeAudio() {
+  const startedAt = Date.now();
+  class FakeAudioParam {
+    setValueAtTime() {}
+    linearRampToValueAtTime() {}
+    exponentialRampToValueAtTime() {}
+  }
+  class FakeGainNode {
+    constructor() {
+      this.gain = new FakeAudioParam();
+    }
+    connect() {}
+  }
+  class FakeOscillatorNode {
+    constructor(ctx) {
+      this.context = ctx;
+      this.frequency = { value: 0 };
+    }
+    connect() {}
+    start() {}
+    stop() {}
+  }
+  class FakeAudioContext {
+    get currentTime() {
+      return (Date.now() - startedAt) / 1000;
+    }
+    createOscillator() {
+      return new FakeOscillatorNode(this);
+    }
+    createGain() {
+      return new FakeGainNode();
+    }
+    resume() {
+      return Promise.resolve();
+    }
+    close() {
+      return Promise.resolve();
+    }
+  }
+  global.window = { AudioContext: FakeAudioContext };
+  return () => {
+    delete global.window;
+  };
+}
+
+/** Polls (there is no fake-timer seam here, only real wall-clock time - see
+ * installFakeAudio) until at least `n` real onClick calls have landed. */
+async function waitForClicks(calls, n, timeoutMs = 4000) {
+  const deadline = Date.now() + timeoutMs;
+  while (calls.length < n) {
+    if (Date.now() > deadline) {
+      throw new Error(`timed out waiting for ${n} clicks, got ${calls.length}: ${JSON.stringify(calls)}`);
+    }
+    await new Promise((r) => setTimeout(r, 5));
+  }
+}
+
+test("changing the subdivision mid-run puts the very next click on the downbeat, not wherever the free-running counter had reached", async () => {
+  const uninstall = installFakeAudio();
+  try {
+    const calls = [];
+    const e = createMetronomeEngine({ onClick: (level, numerator, denominator, phase) => calls.push({ level, phase }) });
+    e.setMode("bpm");
+    e.setBpm(MAX_METRONOME_BPM); // the fastest the click can run, so the wait below stays short
+    e.setMeter(4, 4);
+    e.setEnabled(true);
+
+    await waitForClicks(calls, 2);
+    // Sanity: the counter genuinely has moved off the downbeat by the second
+    // click - a reset that happened to already show phase 0 here would prove
+    // nothing about the change made below.
+    expect(calls[1].phase, JSON.stringify(calls)).not.toBe(0);
+
+    e.setSubdivision(2);
+    await waitForClicks(calls, 3);
+    expect(calls[2].phase, JSON.stringify(calls)).toBe(0);
+
+    e.setEnabled(false);
+  } finally {
+    uninstall();
+  }
+});
+
+test("changing the meter mid-run puts the very next click on the downbeat the same way", async () => {
+  const uninstall = installFakeAudio();
+  try {
+    const calls = [];
+    const e = createMetronomeEngine({ onClick: (level, numerator, denominator, phase) => calls.push({ level, phase }) });
+    e.setMode("bpm");
+    e.setBpm(MAX_METRONOME_BPM);
+    e.setMeter(4, 4);
+    e.setEnabled(true);
+
+    await waitForClicks(calls, 2);
+    expect(calls[1].phase, JSON.stringify(calls)).not.toBe(0);
+
+    e.setMeter(6, 8);
+    await waitForClicks(calls, 3);
+    expect(calls[2].phase, JSON.stringify(calls)).toBe(0);
+
+    e.setEnabled(false);
+  } finally {
+    uninstall();
   }
 });

--- a/web/tests/unit/metronome.spec.js
+++ b/web/tests/unit/metronome.spec.js
@@ -10,6 +10,7 @@ import {
   MIN_METRONOME_BPM,
   barAtTick,
   clampBpm,
+  clickLevel,
   clickPhaseInBar,
   effectiveClickRate,
   metronomePattern,
@@ -155,7 +156,14 @@ test("simple meters click one per beat, only the downbeat accented", () => {
   }
 });
 
-test("compound meters click the eighth-note subdivision, accented in threes", () => {
+test("compound meters click the eighth-note subdivision, grouped in threes - accentEvery marks where each GROUP starts, not on its own how loud a click sounds", () => {
+  // accentEvery === 3 says where the dotted-quarter pulses fall (1, 4, 7,
+  // ...); it does not say the bar has only two sounds in it. Issue #121: a
+  // metronome built on accentEvery alone as a bare on/off accent leaves 6/8,
+  // 9/8 and 12/8 clicking byte-identical streams, because every one of those
+  // pulses got the same sound regardless of which pulse STARTS the bar. See
+  // clickLevel below for the function that actually decides the sound -
+  // downbeat only at phase 0, this grouping everywhere else it recurs.
   for (const [num, den] of [
     [6, 8],
     [9, 8],
@@ -224,15 +232,28 @@ test("only denominators 8 and 16 are ever treated as compound, across every nume
   }
 });
 
-test("an accented click recurs every accentEvery ticks, across more than one bar", () => {
-  // What a scheduler actually uses accentEvery for: is click index i accented?
+test("a group start recurs every accentEvery ticks, across more than one bar - but only the FIRST one each bar is the downbeat", () => {
+  // What a scheduler actually uses accentEvery for: is click index i the
+  // start of a group? That is a weaker claim than "is it accented" - group
+  // starts 3 and 9 below are not the bar's own downbeat, and clickLevel (see
+  // metronome.spec.js's own tests) is what tells the two apart by sound.
   const p = metronomePattern(6, 8);
-  const accented = (i) => i % p.accentEvery === 0;
-  const overTwoBars = Array.from({ length: p.clicksPerBar * 2 }, (_, i) => accented(i));
+  const groupStart = (i) => i % p.accentEvery === 0;
+  const overTwoBars = Array.from({ length: p.clicksPerBar * 2 }, (_, i) => groupStart(i));
   expect(overTwoBars).toEqual([
-    true, false, false, true, false, false, // bar 1: 1, 4
-    true, false, false, true, false, false, // bar 2: 1, 4 again
+    true, false, false, true, false, false, // bar 1: group starts at 1, 4 - only 1 is the downbeat
+    true, false, false, true, false, false, // bar 2: 1, 4 again - only 1 is the downbeat
   ]);
+  // The distinction stated as sound, using clickLevel directly: index 0 (bar
+  // 1's downbeat) and index 6 (bar 2's downbeat) are "downbeat"; index 3 and
+  // 9 - group starts that are NOT the downbeat - are only "beat".
+  const levels = Array.from({ length: p.clicksPerBar * 2 }, (_, i) =>
+    clickLevel(i, p.clicksPerBar, p.accentEvery, 1),
+  );
+  expect(levels[0]).toBe("downbeat");
+  expect(levels[3]).toBe("beat");
+  expect(levels[6]).toBe("downbeat");
+  expect(levels[9]).toBe("beat");
 });
 
 test("a malformed time signature falls back to 4/4 rather than producing nonsense clicks", () => {
@@ -240,6 +261,71 @@ test("a malformed time signature falls back to 4/4 rather than producing nonsens
   expect(metronomePattern(4, 0)).toEqual({ clicksPerBar: 4, accentEvery: 4, unit: 4 });
   expect(metronomePattern(Number.NaN, 4)).toEqual({ clicksPerBar: 4, accentEvery: 4, unit: 4 });
   expect(metronomePattern(4.5, 4)).toEqual({ clicksPerBar: 4, accentEvery: 4, unit: 4 });
+});
+
+// -------------------------------------------------------------- click level
+//
+// Issue #121: with only two sounds (accent and tick), a bare metronome in
+// compound meter had nothing to mark where the BAR starts, as opposed to
+// where each dotted-quarter group inside it starts - 6/8, 9/8 and 12/8
+// clicked byte-identical streams. clickLevel is the third sound's decision,
+// factored out of metronome-engine.js's resolve() into one named, tested
+// place: "downbeat" | "beat" | "tick", from phase and the pattern alone, no
+// audio and no browser required.
+
+test("6/8 gets all three sounds - downbeat at the bar, beat at the other dotted-quarter pulse, tick at the two plain eighths between them", () => {
+  // metronomePattern(6, 8) is { clicksPerBar: 6, accentEvery: 3, unit: 8 }.
+  const levels = Array.from({ length: 12 }, (_, i) => clickLevel(i, 6, 3, 1));
+  expect(levels).toEqual([
+    "downbeat", "tick", "tick", "beat", "tick", "tick",
+    "downbeat", "tick", "tick", "beat", "tick", "tick",
+  ]);
+});
+
+test("a simple meter never reaches the beat tier - accentEvery equals clicksPerBar, so nothing but phase 0 can ever satisfy either test", () => {
+  // metronomePattern(4, 4) is { clicksPerBar: 4, accentEvery: 4, unit: 4 }.
+  // This is the whole reason 4/4 stays two sounds: clickLevel(i, 4, 4, ...)
+  // for i = 1, 2, 3 fails BOTH the downbeat test (i !== 0) and the beat test
+  // (i is not a multiple of accentEvery, which here is the same number as
+  // clicksPerBar) - there is no phase left over for a third sound to occupy.
+  const levels = Array.from({ length: 8 }, (_, i) => clickLevel(i, 4, 4, 1));
+  expect(levels).toEqual(["downbeat", "tick", "tick", "tick", "downbeat", "tick", "tick", "tick"]);
+});
+
+test("subdivision multiplies the beat's spacing along with the downbeat's - splitting 6/8 into sixteenths still marks the same two dotted-quarter pulses, just with twice as many ticks between them", () => {
+  // 6/8 at subdivision 2: clicksPerBar becomes 12 (metronome-engine.js's
+  // resolve() does that multiplication), but accentEvery is handed to
+  // clickLevel UN-multiplied (metronomePattern's raw 3) with subdivision
+  // passed alongside it - phase % (accentEvery * subdivision) is clickLevel's
+  // own job, not something a caller pre-computes.
+  const levels = Array.from({ length: 12 }, (_, i) => clickLevel(i, 12, 3, 2));
+  expect(levels).toEqual([
+    "downbeat", "tick", "tick", "tick", "tick", "tick",
+    "beat", "tick", "tick", "tick", "tick", "tick",
+  ]);
+});
+
+test("phase is normalised into range before either test runs, the same defensive stance clickPhaseInBar takes on its own input", () => {
+  expect(clickLevel(6, 6, 3, 1)).toBe("downbeat"); // wraps to 0
+  expect(clickLevel(-3, 6, 3, 1)).toBe("beat"); // wraps to 3
+  expect(clickLevel(-6, 6, 3, 1)).toBe("downbeat"); // wraps to 0
+});
+
+test("clickLevel guards a degenerate bar or a bad accentEvery rather than propagating NaN into a modulus", () => {
+  expect(clickLevel(0, 0, 3, 1)).toBe("tick");
+  expect(clickLevel(3, -6, 3, 1)).toBe("tick");
+  expect(clickLevel(Number.NaN, 6, 3, 1)).toBe("tick");
+  // No usable accentEvery still answers correctly for phase 0 (still the
+  // downbeat, tested first) and never claims "beat" for anything else.
+  expect(clickLevel(0, 6, Number.NaN, 1)).toBe("downbeat");
+  expect(clickLevel(3, 6, Number.NaN, 1)).toBe("tick");
+  expect(clickLevel(3, 6, 0, 1)).toBe("tick");
+});
+
+test("a subdivision that is not a positive integer is treated as 1 rather than corrupting the beat spacing", () => {
+  for (const bad of [0, -1, Number.NaN, undefined, null, "two"]) {
+    expect(clickLevel(3, 6, 3, bad), `subdivision ${String(bad)}`).toBe("beat");
+  }
 });
 
 // -------------------------------------------------------------- click timing


### PR DESCRIPTION
## Summary

Fixes #121. The investigation comment on the issue found two real defects behind the "accents on 6 instead of 8ths" report:

- **No audible bar in compound meter.** Only two sound levels existed (accent and tick), and in 6/8 `accentEvery` is 3 - so every dotted-quarter pulse got the identical accent. 6/8, 9/8 and 12/8 produced byte-identical click streams; nothing marked where the bar itself starts.
- **Subdivision labels named the wrong note.** `subdivision` multiplies the meter's own click unit, which in compound meter is already the eighth - so "Eighths" in 6/8 actually clicked sixteenths (measured: 200 clicks/min at box 100, not 100).

Plus a bonus finding: `freeRunPhase` was never realigned when the meter or subdivision changed mid-run, leaving the accent at an arbitrary offset until the next full bar caught it up.

## Changes

- **A third pitch tier** (`clickLevel`, new in `metronome.js`) for the bar's own downbeat versus a group start inside it - `"downbeat" | "beat" | "tick"`. The middle tier sits at ~1180 Hz, at the tick's own gain (0.35), so the 0.6 + 0.35 = 0.95 headroom invariant holds and it stays below both browser suites' `ACCENT_HZ_THRESHOLD` (1200). In a simple meter `accentEvery === clicksPerBar`, so the middle tier never fires and 4/4 is bit-for-bit unchanged. `setAccent(false)` flattens both upper tiers. `onClick`/`publishMetronomeClick` now carry a `level`, with `metronomeAccent` preserved as `level !== "tick"` so nothing reading it changes meaning.
- **Meter-aware subdivision labels.** `SUBDIVISION_LABELS` in `metronome-engine.js` is now a function of the meter's own click unit rather than a fixed list, consumed as a `$derived` in `Metronome.svelte`. "Beat" is gone - it was only ever true in x/4.
- **Phase realignment.** `setSubdivision`/`setMeter` reset `freeRunPhase` when no pulse source is installed, so a change made mid-run lands the next click back on the downbeat.

## Tests

All new/restated tests were run red against unmodified `main` and green against this fix, then re-broken one at a time by reverting each piece of the fix in isolation:

| Mutation | Result |
|---|---|
| (none - unmodified main) | 4 assertions red (3 new browser tests + 1 restated) |
| Fix applied | All 247 tests green |
| Remove the third tier | 7 failed (both new browser meter tests, the restated viewer test, and 5 new `clickLevel` unit tests) |
| Make subdivision labels static again | 1 failed (the label-honesty test) |
| Drop the `freeRunPhase` reset | 2 failed (both new phase-realignment unit tests) |

`MINIMUM_TESTS` raised from 236 to 247 (11 added: 3 browser in `metronome-everywhere.spec.js`, 6 unit for `clickLevel` in `metronome.spec.js`, 2 unit for phase realignment in `metronome-engine.spec.js`). Two existing unit tests that encoded the old two-level behaviour as intended were restated to the three-level truth rather than deleted, and one existing browser test (6/8's accent-frequency assertion in `metronome.spec.js`) was updated the same way.

The existing 4/4 assertions in both browser suites (including the two counting `frequency > 1200` accents) pass unchanged, which is the evidence that 4/4 output is bit-for-bit the same as before.

## Test plan

- [x] `npm run build` (no compiler warnings)
- [x] `npm run test:browser` - 247/247 passed
- [x] New assertions confirmed red against unmodified `main`, green against this branch
- [x] Each of the three fix components mutated away in isolation and confirmed to turn its designed test(s) red
