### PR TITLE
Prime the audition player, so a note is actually voiced (#120)

### DIFF
--- a/web/src/lib/score-render.js
+++ b/web/src/lib/score-render.js
@@ -562,16 +562,44 @@ function auditionPlayer() {
   }
   auditionApi = api;
 
-  // Waits on the soundfont rather than on playerReady, which is the renderer's
-  // "ready to play THIS SCORE" and needs a midi file generated from one. There
-  // is no score here and never will be, so it would never fire; a loaded
-  // soundfont is the whole of what a one-shot note needs.
+  // "playerReady would never fire without a midi" was true, and was exactly
+  // the trap: a loaded soundfont is not a playable instrument. alphaTab turns
+  // a parsed soundfont into voiceable presets in exactly one place -
+  // AlphaSynth._checkReadyForPlayback() - and that only runs once a midi has
+  // ALSO been loaded, because it is the midi that says which programs are
+  // worth building presets for. playOneTimeMidiFile never loads one, so with
+  // nothing waited on but soundFontLoaded this used to resolve into a player
+  // with a soundfont and an empty preset table - every note-on finding
+  // nothing to voice, and the synthesiser rendering digital silence for
+  // exactly as long as the note was meant to last, while every event on the
+  // way through kept reporting success.
+  //
+  // So a midi is loaded here, once, naming every melodic program (0-127) on
+  // the audition channel - there is no score to draw it from, but a midi
+  // naming every program is all _checkReadyForPlayback needs to build the
+  // full preset table - and THEN playerReady is the thing waited on. It is
+  // now the honest signal: it fires only once presets actually exist to
+  // voice a note with. Measured once, on load: 12 ms for all 128 programs.
   //
   // Failure comes from the synth's own soundFontLoadFailed where there is one,
   // rather than from api.error: that fires for anything at all, and a render
-  // complaint has no business disabling playback.
+  // complaint has no business disabling playback. Both guards, and the
+  // timeout below, cover the primer load too: a soundfont that loads but
+  // yields nothing voiceable now fails loudly instead of resolving into
+  // silence.
   const ready = new Promise((resolve, reject) => {
-    api.soundFontLoaded.on(() => resolve(api.player));
+    api.soundFontLoaded.on(() => {
+      const primer = new alphaTab.midi.MidiFile();
+      primer.division = TICKS_PER_QUARTER;
+      for (let program = 0; program <= MAX_MIDI; program++) {
+        primer.addEvent(
+          new alphaTab.midi.ProgramChangeEvent(0, 0, AUDITION_CHANNEL, program),
+        );
+      }
+      primer.addEvent(new alphaTab.midi.EndOfTrackEvent(0, 1));
+      api.player.loadMidiFile(primer);
+    });
+    api.playerReady.on(() => resolve(api.player));
     const failed = api.player?.soundFontLoadFailed;
     if (failed) {
       failed.on((e) => reject(toError(e, "the synthesiser's soundfont could not be loaded")));
@@ -610,12 +638,19 @@ function toError(e, fallback) {
 /**
  * Sound one pitch on its own, as a MIDI note number.
  *
- * Resolves with THE MIDI NOTE ACTUALLY SOUNDED - the number written into the
- * note-on event - or **null if no note was handed over at all**. Returning the
- * note rather than a success flag is deliberate: it lets a caller display and
+ * Resolves with THE MIDI NOTE HANDED TO THE SYNTHESISER - the number written
+ * into the note-on event - or **null if no note was handed over at all**.
+ * That is a claim about this boundary, not about the speaker: it is the
+ * number this function gave the synthesiser to play, not a promise that a
+ * sample carrying it ever reached the audio graph. Whether the synthesiser
+ * had anything voiceable to play it with is exactly the gap the audition
+ * player used to fall into silently (see auditionPlayer's own comment) and
+ * is what the audio-peak checks in the browser suites test for - audibility
+ * is their job, not this docstring's to promise. Returning the note rather
+ * than a success flag is deliberate even so: it lets a caller display and
  * publish what crossed this boundary instead of restating what it asked for,
- * which is the only way an interface can be observed to have played the right
- * pitch rather than merely to have intended one.
+ * which is the only way an interface can be observed to have handed off the
+ * right pitch rather than merely to have intended one.
  *
  * THE NULL IS THE WHOLE OF THAT GUARANTEE, and it was once not kept. This used
  * to end `return noteOn ? noteOn.noteKey : key` - falling back to the INPUT when

--- a/web/tests/browser/ear-training.spec.js
+++ b/web/tests/browser/ear-training.spec.js
@@ -93,6 +93,52 @@ test.beforeEach(async ({ page, request }) => {
     }
   });
 
+  // Independent evidence that a sample actually left the synthesiser, not
+  // just that a note-on was handed to it. A soundfont with no voiceable
+  // presets accepts a note-on, runs to completion and reports success while
+  // rendering nothing but zeros - see the root-cause notes on issue #120 -
+  // so `data-sounded-count` moving is not proof anything was heard. This taps
+  // whatever node alphaTab connects to the audio destination (an
+  // AudioWorkletNode normally, a ScriptProcessorNode on the fallback path)
+  // with an AnalyserNode and tracks the largest sample magnitude seen on it.
+  // `--mute-audio` (this suite's own launch option) silences the OUTPUT
+  // DEVICE, not the graph, so this reads real amplitude either way.
+  await page.addInitScript(() => {
+    window.__audioPeak = 0;
+    const tap = (node, ctx) => {
+      const analyser = ctx.createAnalyser();
+      analyser.fftSize = 2048;
+      node.connect(analyser);
+      const frame = new Float32Array(analyser.fftSize);
+      setInterval(() => {
+        analyser.getFloatTimeDomainData(frame);
+        for (const sample of frame) {
+          window.__audioPeak = Math.max(window.__audioPeak, Math.abs(sample));
+        }
+      }, 25);
+    };
+    const Worklet = window.AudioWorkletNode;
+    if (Worklet) {
+      window.AudioWorkletNode = class extends Worklet {
+        constructor(ctx, name, options) {
+          super(ctx, name, options);
+          tap(this, ctx);
+        }
+      };
+    }
+    // The fallback path when AudioWorklet is unavailable - same synth, same
+    // graph, a different node type doing the connecting.
+    for (const proto of [window.AudioContext?.prototype, window.OfflineAudioContext?.prototype]) {
+      if (!proto?.createScriptProcessor) continue;
+      const original = proto.createScriptProcessor;
+      proto.createScriptProcessor = function (...args) {
+        const node = original.apply(this, args);
+        tap(node, this);
+        return node;
+      };
+    }
+  });
+
   await page.goto("/#/ear-training");
   await expect(drill(page)).toBeVisible();
 });
@@ -631,4 +677,61 @@ test("a synthesiser that will not load says so rather than leaving a silent dril
   await expect(drill(page)).toHaveAttribute("data-sounded-count", "1", { timeout: 30_000 });
   await expect(choices(page)).toHaveCount(4);
   await expect(notices(page)).toHaveCount(0);
+});
+
+test("a sounded note is actually audible - not a note-on handed to a synth with nothing to voice it", async ({
+  page,
+}) => {
+  // The defect issue #120 is about: a soundfont with no voiceable presets
+  // takes a note-on, runs the sequencer to completion and reports success at
+  // every step, while the synthesiser renders nothing but zeros. Every other
+  // test in this file reads its answer off data-sounded-midi/-count, which
+  // is set from what playPitch resolved with - correct even in the silent
+  // case, because the number written into the note-on event is genuinely
+  // what was handed over. Only the audio-peak tap installed in beforeEach can
+  // tell the two apart: it lives downstream, on the node the synthesiser's
+  // samples actually flow through, and only a real sample can move it above
+  // zero.
+  await startDrill(page);
+  await expect
+    .poll(() => page.evaluate(() => window.__audioPeak), {
+      message: "expected a non-zero sample to have reached the audio graph",
+      timeout: 10_000,
+    })
+    .toBeGreaterThan(0.01);
+});
+
+test("the tab stays responsive through a sounding - a heartbeat kept ticking, before and after", async ({
+  page,
+}) => {
+  // From the freeze report on issue #120: the freeze itself never reproduced,
+  // and the positive evidence against it was a 50 ms heartbeat interval that
+  // kept advancing across a sounding, with evaluation answering in
+  // single-digit milliseconds throughout. This is that check, standing.
+  //
+  // Asserted FIRST and unconditionally: a backgrounded tab has its timers
+  // throttled to around 1 Hz by the browser itself, nothing this application
+  // does. Without ruling that out first, a heartbeat that genuinely advanced
+  // - just far slower than a healthy foreground tab - could read as a false
+  // failure of a page that was never frozen at all.
+  await expect
+    .poll(() => page.evaluate(() => document.visibilityState))
+    .toBe("visible");
+
+  await page.evaluate(() => {
+    window.__heartbeats = 0;
+    window.__heartbeatTimer = setInterval(() => {
+      window.__heartbeats += 1;
+    }, 50);
+  });
+
+  const before = await page.evaluate(() => window.__heartbeats);
+  await startDrill(page);
+  // Once more, across a SECOND sounding - "before and after a sounding" is
+  // what the investigation measured, not only before the first one.
+  await page.locator(".hear-again").click();
+  await expect(drill(page)).toHaveAttribute("data-sounded-count", "2", { timeout: 30_000 });
+  const after = await page.evaluate(() => window.__heartbeats);
+
+  expect(after, `heartbeats stalled: ${before} before, ${after} after`).toBeGreaterThan(before);
 });

--- a/web/tests/browser/instruments.spec.js
+++ b/web/tests/browser/instruments.spec.js
@@ -85,6 +85,54 @@ test.beforeEach(async ({ page, request }) => {
     }
   });
 
+  // Independent evidence that a sample actually left the synthesiser, not
+  // just that a note-on was handed to it. The string audition runs through
+  // the exact same shared audition path ear-training.spec.js's own copy of
+  // this tap guards - see the root-cause notes on issue #120 - so it is
+  // blind to the same defect in exactly the same way: a soundfont with no
+  // voiceable presets accepts a note-on, runs to completion and reports
+  // success while rendering nothing but zeros. This taps whatever node
+  // alphaTab connects to the audio destination (an AudioWorkletNode
+  // normally, a ScriptProcessorNode on the fallback path) with an
+  // AnalyserNode and tracks the largest sample magnitude seen on it.
+  // `--mute-audio` (this suite's own launch option) silences the OUTPUT
+  // DEVICE, not the graph, so this reads real amplitude either way.
+  await page.addInitScript(() => {
+    window.__audioPeak = 0;
+    const tap = (node, ctx) => {
+      const analyser = ctx.createAnalyser();
+      analyser.fftSize = 2048;
+      node.connect(analyser);
+      const frame = new Float32Array(analyser.fftSize);
+      setInterval(() => {
+        analyser.getFloatTimeDomainData(frame);
+        for (const sample of frame) {
+          window.__audioPeak = Math.max(window.__audioPeak, Math.abs(sample));
+        }
+      }, 25);
+    };
+    const Worklet = window.AudioWorkletNode;
+    if (Worklet) {
+      window.AudioWorkletNode = class extends Worklet {
+        constructor(ctx, name, options) {
+          super(ctx, name, options);
+          tap(this, ctx);
+        }
+      };
+    }
+    // The fallback path when AudioWorklet is unavailable - same synth, same
+    // graph, a different node type doing the connecting.
+    for (const proto of [window.AudioContext?.prototype, window.OfflineAudioContext?.prototype]) {
+      if (!proto?.createScriptProcessor) continue;
+      const original = proto.createScriptProcessor;
+      proto.createScriptProcessor = function (...args) {
+        const node = original.apply(this, args);
+        tap(node, this);
+        return node;
+      };
+    }
+  });
+
   await page.goto("/#/settings");
   await expect(section(page)).toBeVisible();
 });
@@ -159,6 +207,29 @@ test("clicking a string reaches the synthesiser", async ({ page }) => {
 
   expect(soundfontRequests.length).toBeGreaterThan(0);
   expect(await page.evaluate(() => window.__audioContexts)).toBeGreaterThan(0);
+});
+
+test("a string audition is actually audible - not a note-on handed to a synth with nothing to voice it", async ({
+  page,
+}) => {
+  // With no fret to aim at, a heard pitch IS the interface for an unfretted
+  // instrument - not a convenience - which is exactly why this suite cannot
+  // settle for data-audition-midi/-count. Both are set from what playPitch
+  // resolved with, and that number is correct even when nothing sounded: it
+  // is the note handed to the synthesiser, not a report that a sample of it
+  // ever reached the audio graph. See the root-cause notes on issue #120 -
+  // the string audition runs through the exact same shared audition path
+  // ear-training's drill does, and was silent by the same mechanism since it
+  // was written. Only the audio-peak tap installed in beforeEach can tell a
+  // real sample apart from a soundfont with nothing voiceable to play it.
+  await choosePreset(page, "guitar-standard");
+  await editorRows(page).first().locator("button.play").click();
+  await expect
+    .poll(() => page.evaluate(() => window.__audioPeak), {
+      message: "expected a non-zero sample to have reached the audio graph",
+      timeout: 10_000,
+    })
+    .toBeGreaterThan(0.01);
 });
 
 test("a definition saves and survives a reload", async ({ page, request }) => {

--- a/web/tests/minimum-tests.js
+++ b/web/tests/minimum-tests.js
@@ -186,7 +186,29 @@
 //
 // Raised deliberately, and every one of the 11 was shown to fail against a
 // mutation of the behaviour it claims - see the pull request.
-export const MINIMUM_TESTS = 262;
+//
+// Plus 3 for issue #120 - the shared audition path had never produced a
+// sample: a loaded soundfont is not a playable instrument, and the audition
+// player waited on soundFontLoaded instead of a readiness that meant
+// anything, so every note-on found an empty preset table and the
+// synthesiser rendered digital silence while reporting success at every
+// step.
+//
+// 2 audio-peak checks - one in tests/browser/ear-training.spec.js, one in
+// tests/browser/instruments.spec.js, because the string audition runs
+// through the exact same path and was silent by the same mechanism - each
+// tapping the node alphaTab connects to the audio destination with an
+// AnalyserNode and asserting a real sample crossed it, which is the one
+// thing data-sounded-midi/-count and data-audition-midi/-count cannot show:
+// both are set from the note HANDED to the synthesiser, correct even when
+// nothing came out the other end. Measured red (peak 0.000) against
+// unmodified main and green (peak >0.01, actually ~0.387) with the fix.
+//
+// 1 heartbeat watchdog in tests/browser/ear-training.spec.js, standing
+// evidence against the freeze this issue also reported, which never
+// reproduced: a heartbeat interval kept advancing across a sounding in the
+// investigation, and this keeps that fact checked rather than assumed.
+export const MINIMUM_TESTS = 265;
 
 export default class MinimumTests {
   constructor() {


### PR DESCRIPTION
## Summary

Fixes #120. The shared audition path (`playPitch` in `web/src/lib/score-render.js`) has never produced a sample. `auditionPlayer()` resolved as soon as `soundFontLoaded` fired - but a loaded soundfont is not a playable instrument. alphaTab only turns a parsed soundfont into voiceable presets in `AlphaSynth._checkReadyForPlayback()`, which only runs once a midi has *also* been loaded, and the audition path deliberately never loads one (`playOneTimeMidiFile` never calls `loadMidiFile`). Every note-on found an empty preset table, and the synthesiser rendered digital silence for the note's full duration while every event on the way through kept reporting success - because reading back the note-on off the `MidiFile` this code built itself is correct even in the silent case. Ear training and the instruments editor's string audition have been silent by this mechanism since they shipped.

- `auditionPlayer()` now loads a primer midi naming all 128 melodic programs on `soundFontLoaded`, then resolves on `playerReady` instead - the signal that only fires once presets actually exist to voice a note with. Measured once, on load: 12 ms. The existing `soundFontLoadFailed` / `api.error` / 45s timeout guards cover the primer load too.
- Rewrote the stale comment explaining why `playerReady` was avoided - it was avoided for the right reason (it never fired without a midi) and that was exactly the trap.
- Corrected `playPitch`'s docstring: it resolves with the note *handed to* the synthesiser, not "actually sounded" - audibility is the new tests' job, not this function's promise.

## Regression tests

Added an audio-peak tap to both `tests/browser/ear-training.spec.js` and `tests/browser/instruments.spec.js` (the string audition runs through the same path): an `addInitScript` wraps `AudioWorkletNode` (and the `createScriptProcessor` fallback) with an `AnalyserNode`, tracking the largest sample magnitude seen. After a note sounds, the test polls `window.__audioPeak` for a value above 0.01. `--mute-audio` (this suite's own launch option) silences the output device, not the graph, so this reads real amplitude in CI same as locally.

Measured:
- Against unmodified `main` (`b72103c`): **peak 0.000** in both spec files - red.
- With the fix: **peak ≈0.437 (ear training) / ≈0.307 (instruments)** - green, both comfortably above the 0.01 threshold and consistent with the ~0.387 measured during the investigation.

Also added a heartbeat watchdog in `ear-training.spec.js`, standing evidence against the freeze this issue also reported (which never reproduced): a 50 ms interval is asserted to keep advancing across a sounding. It asserts `document.visibilityState === "visible"` first, since a backgrounded tab throttles timers to ~1 Hz and would otherwise fail this check falsely on an otherwise healthy page.

### Mutation testing (after committing the fix)
- Reverted the primer-load change → both audio-peak tests failed (red), confirming they actually catch the regression.
- Disconnected the analyser tap from the graph while the real fix was still in place → the audio-peak test failed rather than silently passing, confirming it cannot return green on a missing/broken tap.

## Test counts

`MINIMUM_TESTS` raised from 262 to 265 (3 tests added: one audio-peak check in each spec file, plus the heartbeat watchdog). Full suite: **265 passed**, 0 failed, matching the new floor exactly.

## Test plan
- [x] `npm run build` (web/dist rebuilt)
- [x] `npm run test:browser` - 265/265 passing
- [x] Audio-peak tests measured red against unmodified `main`, green with the fix
- [x] Mutation: reverted primer load → tests red
- [x] Mutation: broke the peak tap with the fix in place → test still red (proves it isn't a tautology)