### PR TITLE
Report coincident_unsplit_pairs on a reloaded transcription (#143)

### DIFF
--- a/server/fermata/api.py
+++ b/server/fermata/api.py
@@ -1362,7 +1362,17 @@ _BAR_KEYS = ("bars_overfull", "bars_short", "bars_defective", "bars_measured",
              # ExtractionResult/to_dict deliberately - see the note above
              # about the disclosure that reaches a reader in prose and
              # reaches nobody in data.
-             "unison_digits_shared")
+             "unison_digits_shared",
+             # `coincident_unsplit_pairs` / `staves_coincident_unsplit`
+             # (issue #116): a unison shared between two voices whose second,
+             # distinct candidate stem could not be found, so the two copies
+             # of the coincident notehead could not be told apart - the exact
+             # "recoverable from nothing else here" case the disclosures
+             # above exist for. Reached ExtractionResult and to_dict() with
+             # #116 itself but never HERE (issue #143), so a reloaded
+             # transcription reported every disclosure the decoder made
+             # except this one.
+             "coincident_unsplit_pairs", "staves_coincident_unsplit")
 
 # WHICH bars those were, as data and not only inside the warning prose. The
 # prose names them, but it caps the list, and the profile document states that a
@@ -1582,6 +1592,16 @@ def transcribe(score_id: RowId, body: TranscribeIn | None = Body(default=None)):
             "dots_unassigned_no_candidate": result.dots_unassigned_no_candidate,
             "dots_unassigned_eliminated": result.dots_unassigned_eliminated,
             "staves_dots_unassigned": result.staves_dots_unassigned,
+            # coincident_unsplit_pairs / staves_coincident_unsplit (issue
+            # #116, #143): _BAR_KEYS above only controls what a stored blob
+            # is READ back as - this dict is what gets written into it in the
+            # first place, and it named every other _BAR_KEYS entry by hand
+            # already but never picked these two up, so the round trip broke
+            # here even after _BAR_KEYS did the reading half. Without this,
+            # a score with real unsplit pairs (e.g. Ronfaure, 15 per #116)
+            # stores None for both and #143's own verification plan fails.
+            "coincident_unsplit_pairs": result.coincident_unsplit_pairs,
+            "staves_coincident_unsplit": result.staves_coincident_unsplit,
             "spacing_bars": result.spacing_bars,
             "degraded_bars": result.degraded_bars,
             "repeats_unread": result.repeats_unread,

--- a/server/tests/test_transcription_api.py
+++ b/server/tests/test_transcription_api.py
@@ -388,7 +388,13 @@ BAR_KEYS = ("bars_overfull", "bars_short", "bars_defective", "bars_measured",
             # added to _BAR_KEYS at the same time as ExtractionResult and
             # to_dict rather than after an adversarial review found it
             # missing, and exercised HERE so its reload path is real.
-            "unison_digits_shared")
+            "unison_digits_shared",
+            # coincident_unsplit_pairs / staves_coincident_unsplit (issue
+            # #116) were the opposite gap: reached ExtractionResult and
+            # to_dict with #116 itself but never _BAR_KEYS in api.py nor
+            # HERE (issue #143), so their reload path went unexercised until
+            # now.
+            "coincident_unsplit_pairs", "staves_coincident_unsplit")
 # Which bars, and how much silence - the figures that only exist as data. The
 # warning prose caps its bar list, and the profile document promises a consumer
 # that `inferred_rest_quarters` is the sum of the `<forward>` durations in the
@@ -478,6 +484,31 @@ def test_which_bars_were_not_read_from_glyphs_survives_a_reload(
     assert fetched["dots_unassigned_no_candidate"] == 0
     assert fetched["dots_unassigned_eliminated"] == 0
     assert fetched["staves_dots_unassigned"] == 0
+
+
+def test_a_coincident_unsplit_pair_survives_a_reload(app_env, ronfaure_pdf, monkeypatch,
+                                                       insert_score):
+    """coincident_unsplit_pairs / staves_coincident_unsplit (issue #116) round
+    trip against a score where they are non-zero, for the same reason the bar
+    figures above are: all-zeros looks identical to a persistence bug that
+    dropped them. Ronfaure reads 15 unsplit pairs across 4 staves (see
+    test_a_coincident_pair_with_no_second_stem_is_disclosed_not_silently_doubled
+    in test_tabextract.py) - reaching ExtractionResult and to_dict() with
+    #116 itself, but neither _BAR_KEYS in api.py nor the confidence blob
+    transcribe() writes ever picked them up (issue #143), so a reloaded
+    transcription reported every other disclosure the decoder made except
+    this one."""
+    monkeypatch.setattr(api, "LIBRARY_DIR", ronfaure_pdf.parent)
+    conn = db.connect()
+    score_id = insert_score(conn, ronfaure_pdf.name)
+
+    posted = api.transcribe(score_id, body=None)
+    fetched = api.get_transcription(score_id)
+
+    assert posted["coincident_unsplit_pairs"] == 15
+    assert posted["staves_coincident_unsplit"] == 4
+    assert fetched["coincident_unsplit_pairs"] == posted["coincident_unsplit_pairs"]
+    assert fetched["staves_coincident_unsplit"] == posted["staves_coincident_unsplit"]
 
 
 def test_a_row_stored_before_the_bar_figures_reports_them_unrecorded(app_env, insert_score):


### PR DESCRIPTION
## Summary
- `_BAR_KEYS` in `server/fermata/api.py` never named `coincident_unsplit_pairs` / `staves_coincident_unsplit` (issue #116's disclosure pair), so a reloaded transcription reported every inference the decoder made except this one. Added both, mirrored in `test_transcription_api.py`'s `BAR_KEYS`.
- Verifying the round trip against real data (a library score, 15 unsplit pairs / 4 staves per #116) surfaced a second, deeper gap: `transcribe()`'s hand-written `confidence_json` dict never wrote `result.coincident_unsplit_pairs` / `result.staves_coincident_unsplit` into storage at all, so the `_BAR_KEYS`-only fix alone would still round-trip `None`. Fixed that write-side gap too, and added a dedicated reload test against the real library fixture so this stays caught.

## Test plan
- [x] `set(to_dict()) - set(_BAR_KEYS))` contains no disclosure counters (only primary fields and keys covered by `_BAR_LIST_KEYS` / `_BAR_AMOUNT_KEYS` / `_PROVENANCE_KEYS` remain)
- [x] Re-derived that score's 15 unsplit pairs / 4 staves independently via `tabextract.extract`, then verified `api.transcribe` → `api.get_transcription` reports the same 15 / 4 before and after reload
- [x] Mutation check: reverting just the two new `_BAR_KEYS` entries turns 4 tests in `test_transcription_api.py` red (`test_bar_conformance_survives_a_reload`, `test_a_coincident_unsplit_pair_survives_a_reload`, `test_a_row_stored_before_the_bar_figures_reports_them_unrecorded`, `test_an_edit_states_that_nothing_measured_it`); restoring returns them to green
- [x] Full suite with `FERMATA_TEST_LIBRARY` set: 734 passed, 1 pre-existing failure (`test_the_summary_says_how_many_tests_skipped_for_want_of_a_library`, absent `web/node_modules` in this checkout), 13 skipped

Closes #143
