### PR TITLE
Document the REST API

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,12 @@ them.
   folder and are indexed immediately.
 - **Single container** — SQLite inside, two volume mounts, no external
   services.
+- **A documented REST API** — everything above is one client of `/api`, which
+  is documented, not just present: `/docs` for interactive Swagger UI,
+  `/openapi.json` for the schema itself, generated from response models kept
+  in sync with what each endpoint actually returns. Enough to script the
+  library, log practice, or build a companion app against — see
+  [the API guide](docs/api.md).
 
 ## Quick start
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -36,12 +36,23 @@ number `GET /api/version` reports is the application's own release, and there
 is no `/api/v2` alongside `/api/v1`. Until that changes, the practical
 expectations are:
 
-- **Fields are additive in the ordinary case.** A response gaining a new
-  field is not treated as a breaking change - see, for example, how the
-  transcription endpoints' Rule 8 conformance figures and provenance fields
-  (`bars_defective`, `time_signature_source`, and the rest - see
-  `TranscriptionOut` in `api_models.py`) were added to an existing response
-  rather than requiring a new endpoint.
+- **A new field reaches clients once its response model carries it, not the
+  moment a handler starts computing it.** Every response is filtered through
+  a Pydantic model (`server/fermata/api_models.py`) before it leaves the
+  server, so a field a handler adds to its own return value is invisible on
+  the wire until the matching model grows to match - see, for example, how
+  the transcription endpoints' Rule 8 conformance figures and provenance
+  fields (`bars_defective`, `time_signature_source`, and the rest - see
+  `TranscriptionOut`) had to be added to that model, not only to the
+  handler, to actually reach a reader (issues #143, #146). Growing a field
+  in the ordinary case is not a breaking change; forgetting to grow it is a
+  bug, and it is the one `server/tests/test_api_docs.py` actually guards
+  against: every request its tests make is checked against the RAW value the
+  handler returned, captured (via `fastapi.routing.run_endpoint_function`)
+  before response_model ever touched it, against what actually reached the
+  wire - and fails naming the exact route and field the moment a model falls
+  behind its handler, across every endpoint group in one mechanism rather
+  than one hand-written pin per model.
 - **A field already documented is not silently repurposed or removed.**
   Renaming or dropping a field, or changing what a value means, is called out
   in the release it ships in.

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,72 @@
+# The REST API
+
+Fermata's own web frontend is one client of a REST API under `/api`, and that
+API is not private to it. Anything that can make an HTTP request can browse
+the library, log or query practice, manage instruments, read or write
+transcriptions, and trigger a scan - which is what makes a companion app, a
+script, or a scoreboard on a second screen possible without touching this
+codebase at all.
+
+## Where the contract actually lives
+
+The API is documented by generating its OpenAPI schema rather than by hand:
+every route in `server/fermata/api.py` declares a `response_model` (a Pydantic
+model in `server/fermata/api_models.py`), a docstring, and a tag, and FastAPI
+turns that into the same schema Swagger UI and any codegen read.
+
+- **`GET /docs`** - interactive Swagger UI: every route, its parameters, its
+  request and response shapes, and a "Try it out" button that calls a real,
+  running instance.
+- **`GET /openapi.json`** - the schema itself, for generating a client or
+  feeding a tool that reads OpenAPI directly.
+
+Both are served by the same process as the API itself - there is nothing
+separate to stand up or keep in sync. `server/tests/test_api_docs.py` pins
+that the generated document validates against the OpenAPI spec, that every
+route carries a summary, a description, a tag and a response schema, and
+that FastAPI's response-model validation is genuinely switched on for this
+app rather than merely declared in a decorator - so an endpoint added without
+documenting it fails that test, with a message naming what is missing,
+rather than shipping undocumented.
+
+## What to expect between releases
+
+Fermata does not yet version this API independently of the application - the
+number `GET /api/version` reports is the application's own release, and there
+is no `/api/v2` alongside `/api/v1`. Until that changes, the practical
+expectations are:
+
+- **Fields are additive in the ordinary case.** A response gaining a new
+  field is not treated as a breaking change - see, for example, how the
+  transcription endpoints' Rule 8 conformance figures and provenance fields
+  (`bars_defective`, `time_signature_source`, and the rest - see
+  `TranscriptionOut` in `api_models.py`) were added to an existing response
+  rather than requiring a new endpoint.
+- **A field already documented is not silently repurposed or removed.**
+  Renaming or dropping a field, or changing what a value means, is called out
+  in the release it ships in.
+- **`null` is a meaningful answer, not "not implemented yet".** Several
+  fields across this API are `null` on purpose - a Rule 8 figure nothing has
+  measured, a goal's `sessions_inferred` when the goal is not countable, a
+  transcription's provenance on a hand edit - and each is documented as such
+  in `api_models.py` rather than treated as a gap to fill in later. A client
+  should not infer "this will become non-null once the feature is finished".
+- **This is a single-owner, self-hosted server**, not a multi-tenant service.
+  `owner` fields exist in several tables for a future multi-account version
+  and are always `'local'` today; nothing in the API takes or checks
+  credentials yet (see [SECURITY.md](../SECURITY.md)).
+
+The data model behind the practice endpoints specifically - what a session
+and a goal mean, what is derived versus stored, and what deliberately has no
+column - is documented in more depth in
+[docs/practice-data.md](practice-data.md); the MusicXML this API's
+transcription endpoints read and write is documented in
+[docs/musicxml-tab-profile.md](musicxml-tab-profile.md).
+
+## Who else reads this contract
+
+A planned companion server speaks the Model Context Protocol, an open
+standard, and is meant to wrap this REST API rather than reimplement its
+logic - which is the reason "generated but wrong or incomplete" is not good
+enough here: that layer's own correctness depends on this one meaning what it
+says.

--- a/server/fermata/api.py
+++ b/server/fermata/api.py
@@ -18,6 +18,38 @@ from pydantic import BaseModel, Field, StrictInt
 
 from . import instruments, practice, scanner
 from . import version as version_info
+from .api_models import (
+    ByActivityOut,
+    ByScoreOut,
+    CollectionOut,
+    CurrentGoalOut,
+    DuplicateGroupOut,
+    GoalDeleteOut,
+    GoalListOut,
+    GoalOut,
+    HealthOut,
+    InstrumentDeleteOut,
+    InstrumentOut,
+    InstrumentPresetOut,
+    LogPracticeOut,
+    PracticeHistoryOut,
+    PracticeReviewOut,
+    PracticeSessionOut,
+    PracticeSummaryOut,
+    ScanStatusOut,
+    ScanTriggerOut,
+    ScoreOut,
+    ScorePracticeOut,
+    SessionDeleteOut,
+    SessionListOut,
+    SettingsOut,
+    TagOut,
+    TranscribeResultOut,
+    TranscriptionAnalysisOut,
+    TranscriptionOut,
+    UploadOut,
+    VersionOut,
+)
 from .config import FILE_TYPES, LIBRARY_DIR
 from .db import DEFAULT_OWNER, connect, tx, write_tx
 from .glyph_rhythm import VALID_TS_DENOMINATORS
@@ -25,6 +57,18 @@ from .tabextract import analyze as analyze_pdf, extract as extract_pdf
 from .thumbs import thumb_path
 
 router = APIRouter(prefix="/api")
+
+# Every route below carries a `tags=[...]` entry grouping it in /docs, and a
+# `response_model=` pinning its shape - see api_models.py for what each model
+# documents and why it lives apart from the routes. TAG_* names are declared
+# once here so a route and /docs agree on the exact string.
+TAG_SYSTEM = "system"
+TAG_SETTINGS = "settings"
+TAG_INSTRUMENTS = "instruments"
+TAG_LIBRARY = "library"
+TAG_PRACTICE = "practice"
+TAG_TRANSCRIPTION = "transcription"
+TAG_SCAN = "scan"
 
 # SQLite's INTEGER is 64-bit, and handing the driver anything wider raises
 # OverflowError from inside the query - a 500 for what is only ever a row that
@@ -132,19 +176,22 @@ def _with_tags(conn, rows):
     return out
 
 
-@router.get("/health")
+@router.get("/health", tags=[TAG_SYSTEM], response_model=HealthOut)
 def health():
+    """Whether the process is up and answering requests at all."""
     return {"status": "ok"}
 
 
-@router.get("/version")
+@router.get("/version", tags=[TAG_SYSTEM], response_model=VersionOut)
 def get_version():
     """What build is actually running - see fermata/version.py."""
     return version_info.info()
 
 
-@router.get("/settings")
+@router.get("/settings", tags=[TAG_SETTINGS], response_model=SettingsOut)
 def get_settings():
+    """Every user preference, defaulted for anything never written - see
+    SETTINGS_DEFAULTS."""
     conn = connect()
     rows = conn.execute(
         "SELECT key, value FROM settings WHERE owner = ?", (DEFAULT_OWNER,)
@@ -169,8 +216,11 @@ def get_settings():
     return result
 
 
-@router.put("/settings")
+@router.put("/settings", tags=[TAG_SETTINGS], response_model=SettingsOut)
 def put_settings(patch: dict[str, str] = Body(...)):
+    """Write one or more preferences and return the settings as they now
+    stand. A key not already known, or a value not among its choices, fails
+    the whole call - see the module comment on SETTINGS_CHOICES."""
     # A settings store that takes arbitrary keys becomes a junk drawer - only
     # known keys are accepted, and a key with choices in SETTINGS_CHOICES must
     # be one of them.
@@ -255,8 +305,9 @@ def _normalise_instrument(body: InstrumentIn) -> dict:
         raise HTTPException(422, str(e)) from None
 
 
-@router.get("/instruments")
+@router.get("/instruments", tags=[TAG_INSTRUMENTS], response_model=list[InstrumentOut])
 def list_instruments():
+    """Every instrument the player has defined, in name order."""
     conn = connect()
     rows = conn.execute(
         "SELECT * FROM instruments WHERE owner = ? ORDER BY name COLLATE NOCASE, id",
@@ -268,13 +319,18 @@ def list_instruments():
 # Declared before /instruments/{instrument_id}: FastAPI matches in declaration
 # order, and the other way round "presets" would be tried as an int path
 # parameter and answered with a 422 about parsing rather than with the presets.
-@router.get("/instruments/presets")
+@router.get(
+    "/instruments/presets", tags=[TAG_INSTRUMENTS], response_model=list[InstrumentPresetOut]
+)
 def list_instrument_presets():
+    """Built-in tunings a player can start a definition from - see
+    instruments.PRESETS."""
     return instruments.presets()
 
 
-@router.post("/instruments")
+@router.post("/instruments", tags=[TAG_INSTRUMENTS], response_model=InstrumentOut)
 def create_instrument(body: InstrumentIn):
+    """Save a new instrument definition."""
     fields = _normalise_instrument(body)
     with write_tx() as conn:
         cur = conn.execute(
@@ -297,13 +353,14 @@ def create_instrument(body: InstrumentIn):
     return get_instrument(instrument_id)
 
 
-@router.get("/instruments/{instrument_id}")
+@router.get("/instruments/{instrument_id}", tags=[TAG_INSTRUMENTS], response_model=InstrumentOut)
 def get_instrument(instrument_id: RowId):
+    """One instrument definition."""
     conn = connect()
     return _instrument_dict(_instrument_row(conn, instrument_id))
 
 
-@router.put("/instruments/{instrument_id}")
+@router.put("/instruments/{instrument_id}", tags=[TAG_INSTRUMENTS], response_model=InstrumentOut)
 def update_instrument(instrument_id: RowId, body: InstrumentIn):
     """Replace a definition in place.
 
@@ -341,7 +398,9 @@ def update_instrument(instrument_id: RowId, body: InstrumentIn):
     return get_instrument(instrument_id)
 
 
-@router.delete("/instruments/{instrument_id}")
+@router.delete(
+    "/instruments/{instrument_id}", tags=[TAG_INSTRUMENTS], response_model=InstrumentDeleteOut
+)
 def delete_instrument(instrument_id: RowId):
     """Forget an instrument the player no longer has. Scores that referenced it
     keep their own rows - scores.instrument_id is ON DELETE SET NULL, so they
@@ -362,7 +421,7 @@ def delete_instrument(instrument_id: RowId):
     return {"deleted": instrument_id, "scores_unlinked": unlinked}
 
 
-@router.get("/scores")
+@router.get("/scores", tags=[TAG_LIBRARY], response_model=list[ScoreOut])
 def list_scores(
     search: str = "",
     collection: str = "",
@@ -371,6 +430,11 @@ def list_scores(
     favorite: bool = False,
     practiced: str = "",
 ):
+    """The library, filtered and searched. `search` matches title, composer,
+    source or series; `practiced` is 'recent' (practised in the last 14 days)
+    or 'neglected' (present on disk, and either never practised or not
+    practised in 30 days) - see the query's own comments for why those two
+    views disagree about a score whose file has gone missing."""
     if practiced and practiced not in VALID_PRACTICED:
         raise HTTPException(422, f"practiced must be one of {sorted(VALID_PRACTICED)}")
     conn = connect()
@@ -446,7 +510,7 @@ def list_scores(
     return _with_tags(conn, rows)
 
 
-@router.get("/duplicates")
+@router.get("/duplicates", tags=[TAG_LIBRARY], response_model=list[DuplicateGroupOut])
 def list_duplicates():
     """Copies of the same content that are BOTH ON DISK.
 
@@ -475,7 +539,7 @@ def list_duplicates():
     return groups
 
 
-@router.get("/collections")
+@router.get("/collections", tags=[TAG_LIBRARY], response_model=list[CollectionOut])
 def list_collections():
     """Every collection, with how many of its scores are there and how many are not.
 
@@ -504,8 +568,9 @@ def list_collections():
     return [dict(r) for r in rows]
 
 
-@router.get("/tags")
+@router.get("/tags", tags=[TAG_LIBRARY], response_model=list[TagOut])
 def list_tags():
+    """Every tag in use, and how many scores carry it."""
     conn = connect()
     rows = conn.execute(
         """SELECT t.name, COUNT(st.score_id) AS count FROM tags t
@@ -515,8 +580,9 @@ def list_tags():
     return [dict(r) for r in rows]
 
 
-@router.get("/scores/{score_id}")
+@router.get("/scores/{score_id}", tags=[TAG_LIBRARY], response_model=ScoreOut)
 def get_score(score_id: RowId):
+    """One score, with its tags, transcription flag and practice totals."""
     conn = connect()
     return _with_tags(conn, [_score_row(conn, score_id)])[0]
 
@@ -534,8 +600,11 @@ class ScorePatch(BaseModel):
     instrument_id: int | None = Field(default=None, ge=1, le=SQLITE_MAX_INTEGER)
 
 
-@router.patch("/scores/{score_id}")
+@router.patch("/scores/{score_id}", tags=[TAG_LIBRARY], response_model=ScoreOut)
 def patch_score(score_id: RowId, patch: ScorePatch):
+    """Change one or more fields on a score. `tags` replaces the whole tag
+    set when present; an explicit `instrument_id: null` clears it, which is
+    different from omitting the field entirely."""
     if patch.content_kind is not None and patch.content_kind not in VALID_KINDS:
         raise HTTPException(422, f"content_kind must be one of {sorted(VALID_KINDS)}")
     with write_tx() as conn:
@@ -757,8 +826,12 @@ def _session_row(conn, session_id: int):
     return row
 
 
-@router.post("/scores/{score_id}/practice")
+@router.post(
+    "/scores/{score_id}/practice", tags=[TAG_PRACTICE], response_model=LogPracticeOut
+)
 def log_practice(score_id: RowId, body: PracticeIn):
+    """Log a practice session against this score, and return it alongside
+    the score's recent sessions and totals."""
     with write_tx() as conn:
         _score_row(conn, score_id)
         fields = body.model_dump()
@@ -785,8 +858,11 @@ def _recent_sessions(conn, score_id: int):
     ).fetchall()
 
 
-@router.get("/scores/{score_id}/practice")
+@router.get(
+    "/scores/{score_id}/practice", tags=[TAG_PRACTICE], response_model=ScorePracticeOut
+)
 def get_practice(score_id: RowId):
+    """This score's recent sessions (up to 50) and its all-time totals."""
     conn = connect()
     _score_row(conn, score_id)
     return {
@@ -795,7 +871,7 @@ def get_practice(score_id: RowId):
     }
 
 
-@router.post("/practice/sessions")
+@router.post("/practice/sessions", tags=[TAG_PRACTICE], response_model=PracticeSessionOut)
 def log_session(body: SessionIn):
     """Log practice that is not necessarily against a piece.
 
@@ -808,8 +884,13 @@ def log_session(body: SessionIn):
         return practice.session_dict(_insert_session(conn, values))
 
 
-@router.patch("/practice/sessions/{session_id}")
+@router.patch(
+    "/practice/sessions/{session_id}", tags=[TAG_PRACTICE], response_model=PracticeSessionOut
+)
 def patch_session(session_id: RowId, patch: SessionPatch):
+    """Add or correct detail on a session already logged. An explicit null on
+    any field clears it; the whole record is re-validated, not just the
+    changed fields - see the function's own comments for why."""
     with write_tx() as conn:
         row = _session_row(conn, session_id)
         # The whole record is rebuilt and re-checked, not just the changed
@@ -845,7 +926,9 @@ def patch_session(session_id: RowId, patch: SessionPatch):
         return practice.session_dict(updated)
 
 
-@router.delete("/practice/sessions/{session_id}")
+@router.delete(
+    "/practice/sessions/{session_id}", tags=[TAG_PRACTICE], response_model=SessionDeleteOut
+)
 def delete_session(session_id: RowId):
     """Remove a session that should not be in the record.
 
@@ -863,7 +946,7 @@ def delete_session(session_id: RowId):
     return {"deleted": session_id}
 
 
-@router.get("/practice/sessions")
+@router.get("/practice/sessions", tags=[TAG_PRACTICE], response_model=SessionListOut)
 def list_sessions(
     start: str = "",
     end: str = "",
@@ -921,7 +1004,7 @@ def list_sessions(
     }
 
 
-@router.get("/practice/summary")
+@router.get("/practice/summary", tags=[TAG_PRACTICE], response_model=PracticeSummaryOut)
 def practice_summary():
     """The last seven days, for the library header.
 
@@ -958,7 +1041,7 @@ def practice_summary():
     }
 
 
-@router.get("/practice/history")
+@router.get("/practice/history", tags=[TAG_PRACTICE], response_model=PracticeHistoryOut)
 def practice_history(days: int = practice.DEFAULT_HISTORY_DAYS, today: str | None = None):
     """Where the time went over a stretch of days.
 
@@ -1056,8 +1139,11 @@ def _normalise_goal(conn, fields: dict, allow_missing_score: bool = False) -> di
         raise HTTPException(422, str(e)) from None
 
 
-@router.post("/practice/goals")
+@router.post("/practice/goals", tags=[TAG_PRACTICE], response_model=GoalOut)
 def set_goal(body: GoalIn, today: str | None = None):
+    """Set a goal for a period, replacing any goal already set for it - see
+    the function's own comments for what replacing carries over and what it
+    does not."""
     day = _today(today)
     fields = body.model_dump()
     if not fields.get("period_start"):
@@ -1113,7 +1199,7 @@ def set_goal(body: GoalIn, today: str | None = None):
 
 # Declared before the {goal_id} routes so "current" is not parsed as an id -
 # FastAPI matches in declaration order.
-@router.get("/practice/goals/current")
+@router.get("/practice/goals/current", tags=[TAG_PRACTICE], response_model=CurrentGoalOut)
 def current_goal(today: str | None = None):
     """The goal covering today, or nothing.
 
@@ -1140,8 +1226,9 @@ def current_goal(today: str | None = None):
     }
 
 
-@router.get("/practice/goals")
+@router.get("/practice/goals", tags=[TAG_PRACTICE], response_model=GoalListOut)
 def list_goals(limit: int = practice.MAX_REVIEW_WEEKS, today: str | None = None):
+    """Recent goals, most recent period first, each with its progress."""
     day = _today(today)
     if not 1 <= limit <= practice.MAX_REVIEW_WEEKS:
         raise HTTPException(422, f"limit must be between 1 and {practice.MAX_REVIEW_WEEKS}")
@@ -1154,8 +1241,11 @@ def list_goals(limit: int = practice.MAX_REVIEW_WEEKS, today: str | None = None)
     return {"goals": [practice.goal_dict(conn, r, day) for r in rows]}
 
 
-@router.patch("/practice/goals/{goal_id}")
+@router.patch("/practice/goals/{goal_id}", tags=[TAG_PRACTICE], response_model=GoalOut)
 def patch_goal(goal_id: RowId, patch: GoalPatch, today: str | None = None):
+    """Change a goal's targets, or record a reflection on how its period
+    went. `period_start` cannot be patched - see the function's own
+    comments."""
     day = _today(today)
     with write_tx() as conn:
         row = _goal_row(conn, goal_id)
@@ -1204,7 +1294,9 @@ def patch_goal(goal_id: RowId, patch: GoalPatch, today: str | None = None):
         return practice.goal_dict(conn, updated, day)
 
 
-@router.delete("/practice/goals/{goal_id}")
+@router.delete(
+    "/practice/goals/{goal_id}", tags=[TAG_PRACTICE], response_model=GoalDeleteOut
+)
 def delete_goal(goal_id: RowId):
     """Forget a goal.
 
@@ -1222,7 +1314,7 @@ def delete_goal(goal_id: RowId):
     return {"deleted": goal_id}
 
 
-@router.get("/practice/review")
+@router.get("/practice/review", tags=[TAG_PRACTICE], response_model=PracticeReviewOut)
 def practice_review(weeks: int = practice.DEFAULT_REVIEW_WEEKS, today: str | None = None):
     """Recent weeks, each stating what happened in it.
 
@@ -1268,8 +1360,15 @@ def practice_review(weeks: int = practice.DEFAULT_REVIEW_WEEKS, today: str | Non
     return {"today": day.isoformat(), "week_starts_on": starts_on, "weeks": out}
 
 
-@router.get("/scores/{score_id}/file")
+@router.get(
+    "/scores/{score_id}/file",
+    tags=[TAG_LIBRARY],
+    responses={200: {"content": {"application/pdf": {}, "application/octet-stream": {}}}},
+)
 def get_file(score_id: RowId):
+    """The score's own file - a PDF or, for anything else FILE_TYPES admits,
+    an octet stream. No response_model: this returns a FileResponse, whose
+    body is the file's bytes rather than JSON."""
     conn = connect()
     row = _score_row(conn, score_id)
     path = LIBRARY_DIR / row["path"]
@@ -1279,8 +1378,13 @@ def get_file(score_id: RowId):
     return FileResponse(path, media_type=media, filename=path.name)
 
 
-@router.get("/scores/{score_id}/thumb")
+@router.get(
+    "/scores/{score_id}/thumb",
+    tags=[TAG_LIBRARY],
+    responses={200: {"content": {"image/png": {}}}},
+)
 def get_thumb(score_id: RowId):
+    """The score's cached first-page thumbnail, if one has been generated."""
     conn = connect()
     row = _score_row(conn, score_id)
     path = thumb_path(row["hash"])
@@ -1483,8 +1587,12 @@ def _transcription_dict(row) -> dict:
     return d
 
 
-@router.get("/scores/{score_id}/transcription")
+@router.get(
+    "/scores/{score_id}/transcription", tags=[TAG_TRANSCRIPTION], response_model=TranscriptionOut
+)
 def get_transcription(score_id: RowId):
+    """The score's transcription - a hand edit if one exists, otherwise the
+    extraction - see _transcription_row."""
     conn = connect()
     _score_row(conn, score_id)
     row = _transcription_row(conn, score_id)
@@ -1493,8 +1601,14 @@ def get_transcription(score_id: RowId):
     return _transcription_dict(row)
 
 
-@router.get("/scores/{score_id}/transcription/analysis")
+@router.get(
+    "/scores/{score_id}/transcription/analysis",
+    tags=[TAG_TRANSCRIPTION],
+    response_model=TranscriptionAnalysisOut,
+)
 def get_transcription_analysis(score_id: RowId):
+    """Cheap triage of whether this score is worth extracting - see
+    tabextract.analyze."""
     conn = connect()
     row = _score_row(conn, score_id)
     if row["file_type"] != "pdf":
@@ -1532,8 +1646,16 @@ def _validate_time_signature(ts: tuple[int, int]) -> None:
             422, f"time_signature denominator must be one of {sorted(VALID_TS_DENOMINATORS)}")
 
 
-@router.post("/scores/{score_id}/transcribe")
+@router.post(
+    "/scores/{score_id}/transcribe",
+    tags=[TAG_TRANSCRIPTION],
+    response_model=TranscribeResultOut,
+)
 def transcribe(score_id: RowId, body: TranscribeIn | None = Body(default=None)):
+    """Extract tablature from this score's PDF and store it, replacing any
+    previous extraction (never a hand edit - see the function's own
+    comments). Only valid for pdf scores with a tab staff; an unreadable
+    time signature or a non-extractable pdf is a 422."""
     conn = connect()
     row = _score_row(conn, score_id)
     if row["file_type"] != "pdf":
@@ -1683,8 +1805,13 @@ def _sniff_transcription_format(content: str) -> str:
     return "musicxml" if content.lstrip().startswith("<") else "alphatex"
 
 
-@router.put("/scores/{score_id}/transcription")
+@router.put(
+    "/scores/{score_id}/transcription", tags=[TAG_TRANSCRIPTION], response_model=TranscriptionOut
+)
 def save_transcription(score_id: RowId, body: TranscriptionEditIn):
+    """Save a hand edit, replacing any hand edit already stored - never the
+    extraction. `format` is sniffed from the content when not given - see
+    _sniff_transcription_format."""
     fmt = body.format or _sniff_transcription_format(body.content)
     if fmt not in VALID_TRANSCRIPTION_FORMATS:
         raise HTTPException(
@@ -1706,7 +1833,9 @@ def save_transcription(score_id: RowId, body: TranscriptionEditIn):
     return _transcription_dict(row)
 
 
-@router.delete("/scores/{score_id}/transcription")
+@router.delete(
+    "/scores/{score_id}/transcription", tags=[TAG_TRANSCRIPTION], response_model=TranscriptionOut
+)
 def delete_transcription(score_id: RowId):
     """Discard a hand edit, reverting to the extracted transcription.
 
@@ -1728,14 +1857,17 @@ def delete_transcription(score_id: RowId):
     return _transcription_dict(row)
 
 
-@router.post("/scan")
+@router.post("/scan", tags=[TAG_SCAN], response_model=ScanTriggerOut)
 def trigger_scan():
+    """Start a library scan if one is not already running, and return the
+    status left behind by whichever pass is now current."""
     started = scanner.start_scan()
     return {"started": started, **scanner.scan_status()}
 
 
-@router.get("/scan/status")
+@router.get("/scan/status", tags=[TAG_SCAN], response_model=ScanStatusOut)
 def get_scan_status():
+    """Where the most recent (or currently running) scan stands."""
     return scanner.scan_status()
 
 
@@ -1746,7 +1878,7 @@ class ScanAcknowledgement(BaseModel):
     token: str = Field(min_length=1, max_length=128)
 
 
-@router.post("/scan/acknowledge")
+@router.post("/scan/acknowledge", tags=[TAG_SCAN], response_model=ScanTriggerOut)
 def acknowledge_scan(body: ScanAcknowledgement):
     """Say, once, that a refused reconciliation was meant.
 
@@ -1776,8 +1908,11 @@ def acknowledge_scan(body: ScanAcknowledgement):
 _SAFE_SEGMENT = re.compile(r"^[^/\\]+$")
 
 
-@router.post("/upload")
+@router.post("/upload", tags=[TAG_LIBRARY], response_model=UploadOut)
 async def upload(file: UploadFile, folder: str = "Uploads"):
+    """Save a file into the library under `folder` (created if needed) and
+    trigger a scan to pick it up. `folder` may not contain `..` or an
+    absolute path segment."""
     suffix = Path(file.filename or "").suffix.lower()
     if suffix not in FILE_TYPES:
         raise HTTPException(422, f"unsupported file type {suffix!r}")

--- a/server/fermata/api.py
+++ b/server/fermata/api.py
@@ -1363,12 +1363,20 @@ def practice_review(weeks: int = practice.DEFAULT_REVIEW_WEEKS, today: str | Non
 @router.get(
     "/scores/{score_id}/file",
     tags=[TAG_LIBRARY],
+    response_class=FileResponse,
     responses={200: {"content": {"application/pdf": {}, "application/octet-stream": {}}}},
 )
 def get_file(score_id: RowId):
     """The score's own file - a PDF or, for anything else FILE_TYPES admits,
     an octet stream. No response_model: this returns a FileResponse, whose
-    body is the file's bytes rather than JSON."""
+    body is the file's bytes rather than JSON.
+
+    `response_class=FileResponse` matters beyond documentation: without it
+    FastAPI assumes `application/json` is on offer alongside the real
+    content types declared in `responses=` above, and a codegen reading
+    /openapi.json would believe this endpoint might hand back JSON. With it,
+    only the real content types are advertised - see
+    test_binary_routes_do_not_advertise_a_json_content_type."""
     conn = connect()
     row = _score_row(conn, score_id)
     path = LIBRARY_DIR / row["path"]
@@ -1381,10 +1389,12 @@ def get_file(score_id: RowId):
 @router.get(
     "/scores/{score_id}/thumb",
     tags=[TAG_LIBRARY],
+    response_class=FileResponse,
     responses={200: {"content": {"image/png": {}}}},
 )
 def get_thumb(score_id: RowId):
-    """The score's cached first-page thumbnail, if one has been generated."""
+    """The score's cached first-page thumbnail, if one has been generated.
+    `response_class=FileResponse` - see get_file's docstring just above."""
     conn = connect()
     row = _score_row(conn, score_id)
     path = thumb_path(row["hash"])

--- a/server/fermata/api_models.py
+++ b/server/fermata/api_models.py
@@ -1,0 +1,559 @@
+"""Response shapes for the REST surface in api.py (issue #19).
+
+Every model here describes what a handler ACTUALLY returns, not an aspiration
+of what it should return - each was written by reading the handler and the
+dict-building helper it calls (`_with_tags`, `practice.session_dict`,
+`practice.goal_dict`, `_transcription_dict`, `instruments.string_details`,
+`scanner.scan_status`, ...) and writing down every key those produce, with a
+type that admits every value that key can actually hold.
+
+Two things follow from that discipline, and both are deliberate:
+
+- A field is `| None` whenever the handler can hand back `None` for it - a
+  transcription's Rule 8 figures before anything has measured them, a
+  session's tempo, a goal's `score_id`. Making it non-optional to look tidier
+  would be documentation that lies the first time a reader hits the real
+  value.
+- Where two branches of the SAME handler produce dicts with different key
+  sets - `practice.goal_progress`'s uncountable-goal branch omits
+  `sessions_inferred` and the per-day `inferred` key that the countable
+  branch's `period_facts()` always includes - the field is optional with a
+  default rather than "fixed" to always be present. This module documents
+  response shapes; it does not change what the handlers compute, and
+  response-model validation must not 500 a real, existing response.
+
+WHY THIS IS A SEPARATE MODULE and not classes sitting next to their routes in
+api.py: api.py is being edited concurrently by other work (issue #143's
+`_BAR_KEYS` tuple, and unrelated route logic), and a large mechanical set of
+response classes interleaved with route bodies would be exactly the kind of
+diff that turns a two-line change into a conflict. Every model here is
+imported by api.py and attached with `response_model=`; nothing in api.py's
+route bodies changes shape because of it.
+
+`TranscriptionOut`'s bar-figure and provenance fields are the one place this
+module has to track another module's data by hand rather than by importing
+it: they mirror api.py's `_BAR_KEYS`, `_BAR_LIST_KEYS`, `_BAR_AMOUNT_KEYS` and
+`_PROVENANCE_KEYS` tuples, which this module cannot import without a circular
+dependency (those tuples are defined in api.py, which imports this module for
+`response_model=`). tests/test_api_docs.py pins the two against each other,
+so a future change to those tuples fails a test here rather than silently
+documenting a narrower response than the one actually sent.
+"""
+
+from typing import Any
+
+from pydantic import BaseModel
+
+
+# ---------------------------------------------------------------------------
+# System
+# ---------------------------------------------------------------------------
+
+
+class HealthOut(BaseModel):
+    status: str
+
+
+class VersionOut(BaseModel):
+    version: str
+    commit: str
+    built: str
+
+
+# ---------------------------------------------------------------------------
+# Settings
+# ---------------------------------------------------------------------------
+
+
+class SettingsOut(BaseModel):
+    """The two preferences Fermata stores today - see api.SETTINGS_DEFAULTS.
+    A new setting key needs a field added here alongside SETTINGS_DEFAULTS,
+    the same way an undocumented new route needs a response model: the point
+    of this file is that the schema cannot silently fall behind what is
+    actually sent."""
+
+    staff_theme: str
+    week_starts_on: str
+
+
+# ---------------------------------------------------------------------------
+# Instruments
+# ---------------------------------------------------------------------------
+
+
+class InstrumentStringOut(BaseModel):
+    """One string's nominal tuning and what it actually sounds under the
+    instrument's capo - see instruments.string_details."""
+
+    number: int
+    pitch: str
+    midi: int
+    frequency: float
+    sounding_pitch: str
+    sounding_midi: int
+    sounding_frequency: float
+
+
+class InstrumentOut(BaseModel):
+    id: int
+    owner: str
+    kind: str
+    name: str
+    fretted: bool
+    string_count: int
+    string_pitches: list[str]
+    fret_count: int | None
+    capo: int | None
+    reference_pitch: float
+    created_at: str
+    updated_at: str
+    # Derived, not stored - see api._instrument_dict.
+    strings: list[InstrumentStringOut]
+
+
+class InstrumentPresetOut(BaseModel):
+    """A built-in tuning offered before anything is saved - see
+    instruments.presets(). Shares every field InstrumentOut has except the
+    ones that only exist once a definition is a row: id, owner, and the two
+    timestamps."""
+
+    key: str
+    name: str
+    kind: str
+    fretted: bool
+    string_count: int
+    string_pitches: list[str]
+    fret_count: int | None
+    capo: int | None
+    reference_pitch: float
+    strings: list[InstrumentStringOut]
+
+
+class InstrumentDeleteOut(BaseModel):
+    deleted: int
+    scores_unlinked: int
+
+
+# ---------------------------------------------------------------------------
+# Scores / library
+# ---------------------------------------------------------------------------
+
+
+class ScoreOut(BaseModel):
+    """A score row as api._with_tags presents it: the scores table's own
+    columns plus tags, transcription presence, and practice totals joined in
+    for every list and detail view alike."""
+
+    id: int
+    title: str
+    composer: str | None
+    collection: str | None
+    series: str | None
+    source: str | None
+    path: str
+    file_type: str
+    content_kind: str
+    pages: int | None
+    favorite: bool
+    hash: str
+    size: int
+    mtime: float
+    last_page: int
+    missing_since: str | None
+    added_at: str
+    instrument_id: int | None
+    tags: list[str]
+    has_transcription: bool
+    practice_seconds: int
+    last_practiced: str | None
+
+
+class DuplicateGroupOut(BaseModel):
+    hash: str
+    count: int
+    scores: list[ScoreOut]
+
+
+class CollectionOut(BaseModel):
+    collection: str
+    count: int
+    missing: int
+
+
+class TagOut(BaseModel):
+    name: str
+    count: int
+
+
+# ---------------------------------------------------------------------------
+# Practice: sessions
+# ---------------------------------------------------------------------------
+
+
+class PracticeSessionOut(BaseModel):
+    """One session as practice.session_dict presents it: the stored row plus
+    three derived facts - see that function's docstring for what each one
+    means and why it is derived rather than stored."""
+
+    id: int
+    owner: str
+    score_id: int | None
+    activity: str
+    mode: str | None
+    started_at: str
+    local_date: str
+    seconds: int
+    from_bar: int | None
+    to_bar: int | None
+    from_page: int | None
+    to_page: int | None
+    tempo_bpm: int | None
+    target_tempo_bpm: int | None
+    rating: int | None
+    note: str | None
+    local_date_source: str
+    reached_target: bool | None
+    score_missing: bool
+
+
+class PracticeSessionListOut(PracticeSessionOut):
+    """A session as GET /api/practice/sessions lists it - the same fields,
+    plus the piece's title joined in so a reader is not left with a bare
+    score_id (or, for a session with none, `null`)."""
+
+    score_title: str | None
+
+
+class ScorePracticeOut(BaseModel):
+    """GET /api/scores/{id}/practice: this piece's recent sessions and
+    totals - see api._practice_totals and api._recent_sessions."""
+
+    sessions: list[PracticeSessionOut]
+    session_count: int
+    practice_seconds: int
+    last_practiced: str | None
+
+
+class LogPracticeOut(ScorePracticeOut):
+    """POST /api/scores/{id}/practice: the session just logged, plus the
+    same recent-sessions-and-totals view ScorePracticeOut carries."""
+
+    session: PracticeSessionOut
+
+
+class SessionListOut(BaseModel):
+    sessions: list[PracticeSessionListOut]
+    total: int
+    truncated: bool
+
+
+class TopScoreOut(BaseModel):
+    id: int
+    title: str
+    practice_seconds: int
+
+
+class PracticeSummaryOut(BaseModel):
+    week_seconds: int
+    week_sessions: int
+    top_scores: list[TopScoreOut]
+
+
+class SessionDeleteOut(BaseModel):
+    deleted: int
+
+
+# ---------------------------------------------------------------------------
+# Practice: history / review facts
+# ---------------------------------------------------------------------------
+
+
+class DayFactOut(BaseModel):
+    """One day's totals - see practice.period_facts. Always carries
+    `inferred`: this shape is only ever produced by period_facts, which
+    always sets it (contrast GoalDayOut, below)."""
+
+    date: str
+    seconds: int
+    sessions: int
+    inferred: int
+
+
+class ByScoreOut(BaseModel):
+    score_id: int
+    title: str
+    seconds: int
+    sessions: int
+    last_practised: str | None
+
+
+class ByActivityOut(BaseModel):
+    activity: str
+    seconds: int
+    sessions: int
+
+
+class PeriodFactsOut(BaseModel):
+    """practice.period_facts()'s own return shape, exactly - no window bounds
+    and no by-score/by-activity breakdown, because period_facts never returns
+    either. Used both as the base of PracticeHistoryOut (which adds the
+    window and practice.time_spent's breakdown) and as WeekReviewOut.facts
+    (which is period_facts's return value, untouched, nested under a key)."""
+
+    days: list[DayFactOut]
+    seconds: int
+    minutes: int
+    days_practised: int
+    sessions: int
+    sessions_inferred: int
+
+
+class PracticeHistoryOut(PeriodFactsOut):
+    """GET /api/practice/history: practice.period_facts and
+    practice.time_spent over one window, with the window's own bounds."""
+
+    start: str
+    end: str
+    by_score: list[ByScoreOut]
+    by_activity: list[ByActivityOut]
+    scores_worked: int
+    by_score_truncated: bool
+
+
+# ---------------------------------------------------------------------------
+# Practice: goals
+# ---------------------------------------------------------------------------
+
+
+class GoalDayOut(BaseModel):
+    """One day inside a goal's progress. `inferred` is absent - and reads as
+    None here - on the uncountable-goal branch of practice.goal_progress,
+    which builds its own placeholder days rather than calling period_facts;
+    every other path through goal_progress sets it. See that function's
+    docstring for what `countable` means."""
+
+    date: str
+    seconds: int
+    sessions: int
+    inferred: int | None = None
+
+
+class GoalProgressOut(BaseModel):
+    """practice.goal_progress's return shape. `sessions_inferred` and every
+    per-day `inferred` are unset only on the uncountable branch - see
+    GoalDayOut and goal_progress's own docstring for `countable`, `met_days`,
+    `met_minutes` and `met`."""
+
+    days: list[GoalDayOut]
+    seconds: int
+    minutes: int
+    days_practised: int
+    sessions: int
+    sessions_inferred: int | None = None
+    status: str
+    days_left: int
+    countable: bool
+    met_days: bool | None
+    met_minutes: bool | None
+    met: bool | None
+
+
+class GoalOut(BaseModel):
+    """practice.goal_dict's return shape: a practice_goals row, the piece's
+    title if it names one, and its progress."""
+
+    id: int
+    owner: str
+    period: str
+    period_start: str
+    period_end: str
+    target_days: int | None
+    target_minutes: int | None
+    scope: str
+    score_id: int | None
+    activity: str | None
+    intent: str | None
+    reflection: str | None
+    realistic: str | None
+    created_at: str
+    updated_at: str
+    score_title: str | None
+    progress: GoalProgressOut
+
+
+class CurrentGoalOut(BaseModel):
+    goal: GoalOut | None
+    today: str
+    week_starts_on: str
+    week_start: str
+    week_end: str
+
+
+class GoalListOut(BaseModel):
+    goals: list[GoalOut]
+
+
+class GoalDeleteOut(BaseModel):
+    deleted: int
+
+
+class WeekReviewOut(BaseModel):
+    """One week of GET /api/practice/review - the week's own facts (unscoped,
+    even when a goal narrows to one piece - see practice_review's docstring),
+    its goal if one was set, and where the practice went that week."""
+
+    period: str
+    period_start: str
+    period_end: str
+    status: str
+    goal: GoalOut | None
+    facts: PeriodFactsOut
+    by_score: list[ByScoreOut]
+    by_activity: list[ByActivityOut]
+    scores_worked: int
+    by_score_truncated: bool
+
+
+class PracticeReviewOut(BaseModel):
+    today: str
+    week_starts_on: str
+    weeks: list[WeekReviewOut]
+
+
+# ---------------------------------------------------------------------------
+# Transcription
+# ---------------------------------------------------------------------------
+
+
+class TranscriptionAnalysisOut(BaseModel):
+    """GET /api/scores/{id}/transcription/analysis - tabextract.analyze()'s
+    shape, which api.get_transcription_analysis also returns by hand for a
+    non-pdf score."""
+
+    extractable: bool
+    reason: str | None
+    vector: bool
+    tab_staff_count: int
+    standard_staff_count: int
+    page_count: int
+
+
+class TranscriptionOut(BaseModel):
+    """A transcription row as api._transcription_dict presents it: the raw
+    columns, the Rule 8 conformance figures, and the meter/key/tuning
+    provenance - every one of them `| None` because "not recorded" (a hand
+    edit, or a row from before a figure was persisted) is a real, common
+    state and not a defect in this model. See _transcription_dict's own
+    module-level comment for what each group of fields means and why none of
+    it is recoverable from the warning prose alone.
+    """
+
+    id: int
+    score_id: int
+    format: str
+    content: str
+    source: str
+    # The stored blob, parsed - or the raw column text if it did not parse as
+    # JSON, or None/empty if nothing was ever stored. See _transcription_dict.
+    confidence: dict[str, Any] | str | None
+    created_at: str
+    updated_at: str
+    warnings: list[str]
+
+    # _BAR_KEYS
+    bars_overfull: int | None
+    bars_short: int | None
+    bars_defective: int | None
+    bars_measured: int | None
+    bars_padded: int | None
+    bars_unread: int | None
+    notes_no_stem: int | None
+    staves_no_stem: int | None
+    dots_unassigned: int | None
+    dots_unassigned_no_candidate: int | None
+    dots_unassigned_eliminated: int | None
+    staves_dots_unassigned: int | None
+    repeats_unread: int | None
+    endings_unread: int | None
+    endings_truncated: int | None
+    form_marks_unanchored: int | None
+    endings_incomplete: int | None
+    unison_digits_shared: int | None
+    coincident_unsplit_pairs: int | None
+    staves_coincident_unsplit: int | None
+
+    # _BAR_LIST_KEYS
+    padded_bars: list[int] | None
+    unread_bars: list[int] | None
+    spacing_bars: list[int] | None
+    degraded_bars: list[int] | None
+    repeats_unread_bars: list[int] | None
+    endings_unread_bars: list[int] | None
+    endings_truncated_bars: list[int] | None
+    form_marks_unanchored_bars: list[int] | None
+
+    # _BAR_AMOUNT_KEYS
+    inferred_rest_quarters: float | None
+
+    # _PROVENANCE_KEYS
+    time_signature: list[int] | None
+    time_signature_source: str | None
+    key_fifths: int | None
+    key_signature_source: str | None
+    tuning: list[str] | None
+    tuning_label: str | None
+    tuning_unread: list[str] | None
+
+
+class TranscribeResultOut(TranscriptionOut):
+    """POST /api/scores/{id}/transcribe: everything TranscriptionOut carries,
+    plus extraction detail that exists only on this one response - see
+    transcribe()'s closing comment for why bars/beats/notes/tempo are not
+    re-read from the stored row the way the rest of this response is."""
+
+    bars: int
+    beats: int
+    notes: int
+    tempo: int | None
+
+
+# ---------------------------------------------------------------------------
+# Scan / upload
+# ---------------------------------------------------------------------------
+
+
+class ScanStatusOut(BaseModel):
+    """scanner.scan_status()'s shape - see scanner._state for what each field
+    means, and the module comment above it for the refusal fields
+    (`refused`, `refused_reason`, `unmatched_paths`, `unmatched_count`,
+    `acknowledge_token`)."""
+
+    scanning: bool
+    total: int
+    processed: int
+    added: int
+    updated: int
+    missing: int
+    restored: int
+    unmatched_moves: int
+    refused: bool
+    refused_reason: str | None
+    unmatched_paths: list[str]
+    unmatched_count: int
+    acknowledge_token: str | None
+    errors: int
+    last_error: str | None
+    started_at: float | None
+    finished_at: float | None
+
+
+class ScanTriggerOut(ScanStatusOut):
+    """POST /api/scan and POST /api/scan/acknowledge: whether this call
+    actually started a pass, plus the status left behind by whichever pass
+    (this one, or one already running) is current."""
+
+    started: bool
+
+
+class UploadOut(BaseModel):
+    saved: str

--- a/server/fermata/api_models.py
+++ b/server/fermata/api_models.py
@@ -455,7 +455,18 @@ class TranscriptionOut(BaseModel):
     source: str
     # The stored blob, parsed - or the raw column text if it did not parse as
     # JSON, or None/empty if nothing was ever stored. See _transcription_dict.
-    confidence: dict[str, Any] | str | None
+    #
+    # `Any` and not `dict[str, Any] | str | None`: the column is a bare TEXT
+    # value nothing but transcribe() constrains in the ordinary path (always
+    # a JSON object there), but _transcription_dict's own parse only checks
+    # that json.loads succeeded, not that the result was a dict - a stored
+    # value that happens to be a JSON array, number or bool parses cleanly
+    # and is handed back as-is. That row shape is not reachable through this
+    # application today, but the helper tolerates it and this model has to
+    # tolerate whatever the helper actually hands it, or a row nothing here
+    # wrote could 500 a plain GET instead of degrading the way the helper
+    # already does.
+    confidence: Any = None
     created_at: str
     updated_at: str
     warnings: list[str]

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -26,6 +26,10 @@ dev = [
     # this is what makes running it possible rather than what triggers it.
     # See docs/musicxml-tab-profile.md#checking-a-file.
     "lxml>=5.0",
+    # Validates GET /api/openapi.json against the OpenAPI 3.1 meta-schema -
+    # see tests/test_api_docs.py. FastAPI generating SOME document is not the
+    # same claim as the document being one a client's codegen can trust.
+    "openapi-spec-validator>=0.7",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/server/tests/test_api_docs.py
+++ b/server/tests/test_api_docs.py
@@ -1,0 +1,403 @@
+"""The documented surface itself (issue #19) - not what any one endpoint
+does, which the other test modules already cover, but whether what FastAPI
+generates from api.py is actually true, complete and fetchable.
+
+Four separate claims, each with its own test group below:
+
+1. GET /openapi.json is a document that validates against the OpenAPI spec -
+   FastAPI producing SOME JSON is not the same claim as producing one a
+   client's codegen (or a planned MCP server - issue #31 - built on this
+   surface as its contract) could actually trust.
+2. Every route carries a summary, a description and at least one tag, and
+   its success response declares a schema (or, for the two file-serving
+   routes, a real content type) - see test_every_route_is_documented for
+   what "documented" is defined to mean and why an undocumented new route
+   fails this rather than passing by default. FastAPI derives a summary from
+   a function's name even with no docstring at all, so summary alone would
+   be a test that could never go red; description is what actually requires
+   someone to have written something.
+3. For a representative endpoint out of each group (system, settings,
+   instruments, library, practice, transcription, scan), the JSON that
+   actually comes back over real HTTP validates against the model
+   response_model= declares for it - proving the declared shape is the real
+   shape, not merely FastAPI's own opinion of it echoed back.
+4. FastAPI's response-model validation is switched on, not merely present in
+   the decorator - test_response_validation_actually_rejects_a_bad_response
+   proves it against a throwaway route using the exact same
+   `response_model=` idiom every route in api.py uses, so the proof is about
+   the mechanism itself rather than about any one handler happening to
+   behave.
+"""
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from openapi_spec_validator import validate as validate_openapi
+
+from fermata import api, api_models
+from fermata.main import app as full_app
+
+# Every route in api.py returns a FileResponse (binary) rather than JSON for
+# exactly these two - see the `responses=` kwarg on their decorators. They are
+# "documented" by declaring a real content type instead of a JSON schema.
+_BINARY_ROUTES = {
+    ("GET", "/api/scores/{score_id}/file"),
+    ("GET", "/api/scores/{score_id}/thumb"),
+}
+
+
+@pytest.fixture
+def client(app_env):
+    """The router alone - same pattern as test_instruments_api.py and
+    test_version_api.py's client fixtures. Schema-shape assertions use
+    `full_app` (fermata.main.app) instead, further down, because that is the
+    literal app that serves /docs and /openapi.json in production; this one
+    is for hitting live endpoints against a throwaway database."""
+    app = FastAPI()
+    app.include_router(api.router)
+    return TestClient(app)
+
+
+@pytest.fixture
+def openapi_schema():
+    return full_app.openapi()
+
+
+# ---------------------------------------------------------------------------
+# 1. The document itself validates.
+# ---------------------------------------------------------------------------
+
+
+def test_openapi_document_validates_against_the_spec(openapi_schema):
+    """FastAPI can generate JSON that LOOKS like OpenAPI while actually being
+    malformed against the spec - a response with no "content" at all under a
+    status code, a $ref FastAPI failed to resolve, and so on. This is the
+    check that a tool consuming the document (Swagger UI, a codegen, the
+    planned MCP server this documents the contract for) would not choke on
+    it. openapi_spec_validator.validate raises on the first thing wrong,
+    which pytest reports directly - there is no assertion to write."""
+    validate_openapi(openapi_schema)
+
+
+def test_openapi_json_is_actually_served(app_env, monkeypatch):
+    """Not just constructible in-process - reachable at the URL a client
+    would actually fetch."""
+    monkeypatch.setattr("fermata.main.scanner.start_scan", lambda: False)
+    monkeypatch.setattr("fermata.main.init_db", lambda: None)
+    with TestClient(full_app) as c:
+        resp = c.get("/openapi.json")
+        assert resp.status_code == 200
+        assert resp.json()["paths"]
+
+
+def test_docs_page_renders(app_env, monkeypatch):
+    """GET /docs returns 200 with an actual Swagger UI page, not merely 'not
+    404'. Checked against fetching this over a real HTTP server on an odd
+    port too - see the manual verification in the PR description; this is
+    the automated form of the same claim."""
+    monkeypatch.setattr("fermata.main.scanner.start_scan", lambda: False)
+    monkeypatch.setattr("fermata.main.init_db", lambda: None)
+    with TestClient(full_app) as c:
+        resp = c.get("/docs")
+        assert resp.status_code == 200
+        assert "text/html" in resp.headers["content-type"]
+        assert "swagger-ui" in resp.text.lower()
+        assert full_app.title in resp.text
+
+
+# ---------------------------------------------------------------------------
+# 2. Every route is documented, and an undocumented one would fail this.
+# ---------------------------------------------------------------------------
+
+
+def _operations(schema):
+    for path, methods in schema["paths"].items():
+        for method, op in methods.items():
+            if method.upper() not in ("GET", "POST", "PUT", "PATCH", "DELETE"):
+                continue  # not an operation object (e.g. "parameters")
+            yield method.upper(), path, op
+
+
+def test_every_route_is_documented(openapi_schema):
+    """The guard that keeps issue #19 solved going forward: a route added to
+    api.py with no docstring, no tag, or no response_model fails THIS test,
+    with a message naming exactly which route and which of the four is
+    missing - not a diff against some other file, and not something that
+    only a human reading /docs would ever notice."""
+    problems = []
+    for method, path, op in _operations(openapi_schema):
+        route = f"{method} {path}"
+        if not op.get("summary"):
+            problems.append(f"{route}: no summary (add response_model/tags and check the route is spelled with a docstring)")
+        if not op.get("description"):
+            problems.append(f"{route}: no docstring - add one to the handler function")
+        if not op.get("tags"):
+            problems.append(f"{route}: no tags=[...] on the route decorator")
+        responses = op.get("responses", {})
+        ok_response = responses.get("200") or responses.get("201") or next(
+            (v for k, v in responses.items() if k.startswith("2")), None
+        )
+        if ok_response is None:
+            problems.append(f"{route}: no 2xx response documented at all")
+            continue
+        content = ok_response.get("content", {})
+        if (method, path) in _BINARY_ROUTES:
+            if not content:
+                problems.append(
+                    f"{route}: binary route declared no content type - add responses={{200: "
+                    f"{{'content': {{'<mime-type>': {{}}}}}}}} to the decorator"
+                )
+        else:
+            schema_present = any("schema" in media for media in content.values())
+            if not schema_present:
+                problems.append(
+                    f"{route}: no response schema - add response_model=<Model> to the route "
+                    "decorator (see fermata/api_models.py)"
+                )
+    assert not problems, "undocumented route(s):\n" + "\n".join(problems)
+
+
+def test_every_route_has_exactly_the_expected_operation_count(openapi_schema):
+    """Pinned so a route silently added or removed from api.py is noticed
+    here rather than only by whoever next reads the endpoint inventory by
+    hand. Update this number, deliberately, the same commit that adds or
+    removes a route."""
+    count = sum(1 for _ in _operations(openapi_schema))
+    assert count == 41
+
+
+# ---------------------------------------------------------------------------
+# 3. Declared shapes match what actually comes back, across every group.
+# ---------------------------------------------------------------------------
+
+
+def test_system_and_settings_responses_match_their_models(client):
+    api_models.HealthOut.model_validate(client.get("/api/health").json())
+    api_models.VersionOut.model_validate(client.get("/api/version").json())
+    api_models.SettingsOut.model_validate(client.get("/api/settings").json())
+    api_models.SettingsOut.model_validate(
+        client.put("/api/settings", json={"staff_theme": "noir"}).json()
+    )
+
+
+def test_instrument_responses_match_their_models(client):
+    api_models.InstrumentPresetOut.model_validate(
+        client.get("/api/instruments/presets").json()[0]
+    )
+    body = {
+        "name": "Test guitar",
+        "string_count": 6,
+        "string_pitches": ["E2", "A2", "D3", "G3", "B3", "E4"],
+        "fretted": True,
+        "fret_count": 22,
+        "capo": 0,
+    }
+    created = client.post("/api/instruments", json=body)
+    instrument = api_models.InstrumentOut.model_validate(created.json())
+
+    for item in client.get("/api/instruments").json():
+        api_models.InstrumentOut.model_validate(item)
+    api_models.InstrumentOut.model_validate(
+        client.get(f"/api/instruments/{instrument.id}").json()
+    )
+    api_models.InstrumentOut.model_validate(
+        client.put(f"/api/instruments/{instrument.id}", json=body).json()
+    )
+    api_models.InstrumentDeleteOut.model_validate(
+        client.delete(f"/api/instruments/{instrument.id}").json()
+    )
+
+
+def test_library_responses_match_their_models(client, insert_score):
+    from fermata import db
+
+    conn = db.connect()
+    score_id = insert_score(conn, "Some Piece.pdf", title="Some Piece")
+    conn.execute("INSERT INTO tags(name) VALUES ('warm-up')")
+    conn.execute(
+        "INSERT INTO score_tags(score_id, tag_id) SELECT ?, id FROM tags WHERE name = 'warm-up'",
+        (score_id,),
+    )
+    conn.commit()
+
+    for item in client.get("/api/scores").json():
+        api_models.ScoreOut.model_validate(item)
+    api_models.ScoreOut.model_validate(client.get(f"/api/scores/{score_id}").json())
+    api_models.ScoreOut.model_validate(
+        client.patch(f"/api/scores/{score_id}", json={"favorite": True}).json()
+    )
+    for item in client.get("/api/collections").json():
+        api_models.CollectionOut.model_validate(item)
+    for item in client.get("/api/tags").json():
+        api_models.TagOut.model_validate(item)
+    for group in client.get("/api/duplicates").json():
+        api_models.DuplicateGroupOut.model_validate(group)
+
+
+def test_practice_responses_match_their_models(client, insert_score):
+    from fermata import db
+
+    conn = db.connect()
+    score_id = insert_score(conn, "Practice Piece.pdf", title="Practice Piece")
+    conn.commit()
+
+    logged = client.post(f"/api/scores/{score_id}/practice", json={"seconds": 600})
+    api_models.LogPracticeOut.model_validate(logged.json())
+    api_models.ScorePracticeOut.model_validate(
+        client.get(f"/api/scores/{score_id}/practice").json()
+    )
+
+    session = api_models.PracticeSessionOut.model_validate(
+        client.post("/api/practice/sessions", json={"seconds": 300, "activity": "free"}).json()
+    )
+    api_models.PracticeSessionOut.model_validate(
+        client.patch(
+            f"/api/practice/sessions/{session.id}", json={"rating": 4}
+        ).json()
+    )
+    api_models.SessionListOut.model_validate(client.get("/api/practice/sessions").json())
+    api_models.PracticeSummaryOut.model_validate(client.get("/api/practice/summary").json())
+    api_models.PracticeHistoryOut.model_validate(client.get("/api/practice/history").json())
+    api_models.SessionDeleteOut.model_validate(
+        client.delete(f"/api/practice/sessions/{session.id}").json()
+    )
+
+    goal = api_models.GoalOut.model_validate(
+        client.post("/api/practice/goals", json={"target_days": 3}).json()
+    )
+    api_models.CurrentGoalOut.model_validate(client.get("/api/practice/goals/current").json())
+    api_models.GoalListOut.model_validate(client.get("/api/practice/goals").json())
+    api_models.GoalOut.model_validate(
+        client.patch(f"/api/practice/goals/{goal.id}", json={"target_days": 5}).json()
+    )
+    api_models.PracticeReviewOut.model_validate(client.get("/api/practice/review").json())
+    api_models.GoalDeleteOut.model_validate(
+        client.delete(f"/api/practice/goals/{goal.id}").json()
+    )
+
+
+def test_a_goal_about_a_deleted_score_still_validates(client, insert_score):
+    """The one shape genuinely different from the rest: an uncountable goal's
+    progress omits `sessions_inferred` and every day's `inferred` - see
+    api_models.GoalDayOut and GoalProgressOut. This is the case that would
+    500 if those fields were modelled as required ints instead of optional
+    ones, so it is exercised on purpose rather than only in passing."""
+    from fermata import db
+
+    conn = db.connect()
+    score_id = insert_score(conn, "Deleted Piece.pdf", title="Deleted Piece")
+    conn.commit()
+    goal = client.post(
+        "/api/practice/goals", json={"scope": "score", "score_id": score_id, "target_days": 3}
+    ).json()
+    conn.execute("DELETE FROM scores WHERE id = ?", (score_id,))
+    conn.commit()
+
+    validated = api_models.GoalOut.model_validate(
+        client.get(f"/api/practice/goals").json()["goals"][0]
+    )
+    assert validated.progress.countable is False
+    assert validated.progress.sessions_inferred is None
+    assert all(day.inferred is None for day in validated.progress.days)
+    assert goal["id"] == validated.id
+
+
+def test_transcription_responses_match_their_models(client, insert_score, extractable_pdf, monkeypatch):
+    monkeypatch.setattr(api, "LIBRARY_DIR", extractable_pdf.parent)
+    from fermata import db
+
+    conn = db.connect()
+    score_id = insert_score(conn, extractable_pdf.name)
+    conn.commit()
+
+    api_models.TranscriptionAnalysisOut.model_validate(
+        client.get(f"/api/scores/{score_id}/transcription/analysis").json()
+    )
+    extracted = client.post(f"/api/scores/{score_id}/transcribe")
+    api_models.TranscribeResultOut.model_validate(extracted.json())
+    api_models.TranscriptionOut.model_validate(
+        client.get(f"/api/scores/{score_id}/transcription").json()
+    )
+    edited = client.put(
+        f"/api/scores/{score_id}/transcription", json={"content": '\\title "x"\n.\n:4 0.1 |'}
+    )
+    api_models.TranscriptionOut.model_validate(edited.json())
+    api_models.TranscriptionOut.model_validate(
+        client.delete(f"/api/scores/{score_id}/transcription").json()
+    )
+
+
+def test_transcription_model_stays_in_sync_with_api_pys_bar_key_tuples():
+    """TranscriptionOut cannot import api._BAR_KEYS et al (api.py imports
+    api_models.py for response_model=, so the reverse import would be
+    circular - see api_models.py's module docstring), so its bar-figure and
+    provenance fields are a hand-kept mirror instead. This is the guard that
+    keeps them honest: a key added to api.py's _BAR_KEYS, _BAR_LIST_KEYS,
+    _BAR_AMOUNT_KEYS or _PROVENANCE_KEYS tuples without a matching field
+    added here fails this test by name, rather than silently documenting a
+    response narrower than the one actually sent (FastAPI drops fields not
+    on the model rather than erroring, which is exactly the kind of gap
+    issue #19 exists to close)."""
+    expected = {
+        *api._BAR_KEYS,
+        *api._BAR_LIST_KEYS,
+        *api._BAR_AMOUNT_KEYS,
+        *api._PROVENANCE_KEYS,
+    }
+    # The rest of TranscriptionOut's fields: the raw row columns plus
+    # `warnings`, none of which come from the four tuples above.
+    non_mirrored = {
+        "id", "score_id", "format", "content", "source", "confidence",
+        "created_at", "updated_at", "warnings",
+    }
+    actual = set(api_models.TranscriptionOut.model_fields) - non_mirrored
+    missing = expected - actual
+    extra = actual - expected
+    assert not missing, f"api_models.TranscriptionOut is missing field(s) for: {sorted(missing)}"
+    assert not extra, f"api_models.TranscriptionOut has field(s) no longer in api.py's tuples: {sorted(extra)}"
+
+
+def test_scan_and_upload_responses_match_their_models(client, monkeypatch):
+    monkeypatch.setattr(api.scanner, "start_scan", lambda **kw: True)
+    api_models.ScanStatusOut.model_validate(client.get("/api/scan/status").json())
+    api_models.ScanTriggerOut.model_validate(client.post("/api/scan").json())
+
+
+# ---------------------------------------------------------------------------
+# 4. Response-model validation is actually switched on.
+# ---------------------------------------------------------------------------
+
+
+def test_response_validation_actually_rejects_a_bad_response():
+    """Not "the decorator has response_model=" - that a route CLAIMS a shape
+    proves nothing about whether FastAPI actually checks a real response
+    against it (response_model_exclude_unset, a custom
+    ResponseValidationError handler swallowing it, or a FastAPI version that
+    changed the default could each turn response_model= into decoration that
+    does nothing). This registers a route with the exact same
+    `@router.get(..., response_model=HealthOut)` idiom every route in api.py
+    uses, wires an endpoint that returns a body HealthOut forbids (`status`
+    must be a str; None is not one), and confirms the request fails rather
+    than quietly serving the bad body - proving the mechanism itself, not
+    any one handler, actually enforces the declared shape in this app.
+
+    See fermata-verify's mutation-testing guidance: a guard that cannot be
+    observed to fail is not verified to guard anything. This is that
+    observation, made once against the real machinery rather than assumed
+    from api.py's decorators reading correctly."""
+    from fastapi import APIRouter, FastAPI
+    from fastapi.testclient import TestClient
+
+    probe = APIRouter()
+
+    @probe.get("/probe/health", response_model=api_models.HealthOut)
+    def broken_health():
+        return {"status": None}
+
+    app = FastAPI()
+    app.include_router(probe)
+    probe_client = TestClient(app)
+
+    with pytest.raises(Exception) as exc_info:
+        probe_client.get("/probe/health")
+    assert "ResponseValidationError" in type(exc_info.value).__name__

--- a/server/tests/test_api_docs.py
+++ b/server/tests/test_api_docs.py
@@ -2,7 +2,7 @@
 does, which the other test modules already cover, but whether what FastAPI
 generates from api.py is actually true, complete and fetchable.
 
-Four separate claims, each with its own test group below:
+Five separate claims, each with its own test group below:
 
 1. GET /openapi.json is a document that validates against the OpenAPI spec -
    FastAPI producing SOME JSON is not the same claim as producing one a
@@ -10,23 +10,41 @@ Four separate claims, each with its own test group below:
    surface as its contract) could actually trust.
 2. Every route carries a summary, a description and at least one tag, and
    its success response declares a schema (or, for the two file-serving
-   routes, a real content type) - see test_every_route_is_documented for
-   what "documented" is defined to mean and why an undocumented new route
-   fails this rather than passing by default. FastAPI derives a summary from
-   a function's name even with no docstring at all, so summary alone would
-   be a test that could never go red; description is what actually requires
-   someone to have written something.
+   routes, a real content type, with no stray application/json alongside
+   it) - see test_every_route_is_documented for what "documented" is
+   defined to mean and why an undocumented new route fails this rather than
+   passing by default. FastAPI derives a summary from a function's name even
+   with no docstring at all, so summary alone would be a test that could
+   never go red; description is what actually requires someone to have
+   written something.
 3. For a representative endpoint out of each group (system, settings,
-   instruments, library, practice, transcription, scan), the JSON that
-   actually comes back over real HTTP validates against the model
-   response_model= declares for it - proving the declared shape is the real
-   shape, not merely FastAPI's own opinion of it echoed back.
+   instruments, library, practice, transcription, scan, upload), the JSON
+   that actually comes back over real HTTP validates against the model
+   response_model= declares for it.
 4. FastAPI's response-model validation is switched on, not merely present in
    the decorator - test_response_validation_actually_rejects_a_bad_response
    proves it against a throwaway route using the exact same
    `response_model=` idiom every route in api.py uses, so the proof is about
    the mechanism itself rather than about any one handler happening to
    behave.
+5. THE SYSTEMIC GUARD. Group 3's `Model.model_validate(response.json())`
+   checks are tautological on their own: a response the model just filtered
+   and serialized is model-valid by construction, so they can never catch a
+   field the model silently drops on the way to the wire - the exact bug
+   class this repo has shipped more than once when a handler grew a field
+   and its response model did not (see #143, #145, #146 for the same
+   pattern one layer down, in `_BAR_KEYS` versus what actually got written).
+   `client`, below, is wrapped so every request made through it in group 3
+   is ALSO checked against the raw value the handler itself returned, before
+   response_model ever touched it - captured via fastapi.routing's own
+   run_endpoint_function, the one seam between "what the handler computed"
+   and "what got filtered". Every key present on the raw return must reach
+   the wire at the same path, recursively, so a field dropped three levels
+   down (goal.progress.sessions_inferred, say) is named exactly where it was
+   lost. This is what actually keeps ~30 hand-mirrored models honest - not
+   the individual model_validate() calls, which stay in group 3 because they
+   check a different property (declared TYPES match reality) than this one
+   (no declared field is silently dropped).
 """
 
 import pytest
@@ -34,6 +52,7 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from openapi_spec_validator import validate as validate_openapi
 
+import fastapi.routing as fastapi_routing
 from fermata import api, api_models
 from fermata.main import app as full_app
 
@@ -46,16 +65,118 @@ _BINARY_ROUTES = {
 }
 
 
+def _assert_wire_carries_every_raw_key(raw, wire, route: str, path: str = ""):
+    """The systemic drift guard (claim 5 above). `raw` is what the handler
+    itself returned, captured before response_model touched it; `wire` is
+    the parsed JSON that actually left the server for the same request.
+    Every key present in `raw` must be reachable at the same path in
+    `wire` - recursively through nested dicts and lists of dicts, so a field
+    dropped inside a nested model (GoalOut.progress, InstrumentOut.strings,
+    ...) is named at its own path rather than only at the top.
+
+    Deliberately checks KEY PRESENCE only, never value equality - a bool
+    becoming a JSON `true`, or an int surviving a round trip, is not what
+    this is for for; response-model type-correctness is group 3's job
+    (Model.model_validate). This one question only: did every field the
+    handler computed make it to the wire, or did the model quietly drop it.
+
+    dict[str, Any] passthrough fields (TranscriptionOut.confidence) declare
+    no sub-schema, so nothing between the handler and the wire strips
+    anything inside them - recursing into them same as any other dict is
+    safe (it can only ever agree) rather than something this needs to
+    special-case around.
+    """
+    if isinstance(raw, dict):
+        assert isinstance(wire, dict), (
+            f"{route}: at '{path or '(root)'}' the raw return was a dict but the wire "
+            f"response was {type(wire).__name__} - response_model changed the shape, "
+            "not just dropped a field"
+        )
+        for key, raw_value in raw.items():
+            assert key in wire, (
+                f"{route}: field '{path}{key}' is on the handler's raw return but missing "
+                "from the wire JSON - grow its response model in api_models.py to include it"
+            )
+            _assert_wire_carries_every_raw_key(raw_value, wire[key], route, f"{path}{key}.")
+    elif isinstance(raw, (list, tuple)):
+        if not isinstance(wire, list):
+            return  # a type mismatch here is group 3's claim to catch, not this one's
+        for i, (raw_item, wire_item) in enumerate(zip(raw, wire)):
+            _assert_wire_carries_every_raw_key(raw_item, wire_item, route, f"{path}[{i}].")
+    # scalars: nothing further to check - key presence is this function's whole claim
+
+
+class _DriftGuardedClient:
+    """Wraps a TestClient so every JSON request made through it is checked
+    by _assert_wire_carries_every_raw_key - see claim 5 in the module
+    docstring. `_captured` is filled by the run_endpoint_function spy the
+    `client` fixture installs; `_call` reads off exactly the entries added
+    during its own request (there is exactly one per request in this app,
+    since no route here calls another route through Depends() - a handler
+    calling another handler function directly, as create_instrument calls
+    get_instrument, is a plain Python call and never re-enters FastAPI's
+    routing at all)."""
+
+    def __init__(self, inner: TestClient, captured: list):
+        self._inner = inner
+        self._captured = captured
+
+    def _call(self, method: str, url: str, **kwargs):
+        before = len(self._captured)
+        resp = getattr(self._inner, method)(url, **kwargs)
+        new_raws = self._captured[before:]
+        content_type = resp.headers.get("content-type", "")
+        if new_raws and content_type.startswith("application/json"):
+            _assert_wire_carries_every_raw_key(
+                new_raws[-1], resp.json(), f"{method.upper()} {url}"
+            )
+        return resp
+
+    def get(self, url, **kw):
+        return self._call("get", url, **kw)
+
+    def post(self, url, **kw):
+        return self._call("post", url, **kw)
+
+    def put(self, url, **kw):
+        return self._call("put", url, **kw)
+
+    def patch(self, url, **kw):
+        return self._call("patch", url, **kw)
+
+    def delete(self, url, **kw):
+        return self._call("delete", url, **kw)
+
+
 @pytest.fixture
-def client(app_env):
+def client(app_env, monkeypatch):
     """The router alone - same pattern as test_instruments_api.py and
     test_version_api.py's client fixtures. Schema-shape assertions use
     `full_app` (fermata.main.app) instead, further down, because that is the
     literal app that serves /docs and /openapi.json in production; this one
-    is for hitting live endpoints against a throwaway database."""
+    is for hitting live endpoints against a throwaway database.
+
+    Wrapped in _DriftGuardedClient rather than handed back as a bare
+    TestClient: every group-3 test already makes real requests here to
+    validate response shape, and reusing that same traffic for the systemic
+    drift guard (claim 5) needs no separate scenario or fixture of its own.
+    `run_endpoint_function` is FastAPI's own seam between "the handler
+    returned this" and "response_model filtered it to this" - patched at
+    the module fastapi.routing resolves it from, which is where routing.py's
+    own `await run_endpoint_function(...)` call looks it up at call time."""
     app = FastAPI()
     app.include_router(api.router)
-    return TestClient(app)
+
+    captured: list = []
+    original = fastapi_routing.run_endpoint_function
+
+    async def spy(*, dependant, values, is_coroutine):
+        result = await original(dependant=dependant, values=values, is_coroutine=is_coroutine)
+        captured.append(result)
+        return result
+
+    monkeypatch.setattr(fastapi_routing, "run_endpoint_function", spy)
+    return _DriftGuardedClient(TestClient(app), captured)
 
 
 @pytest.fixture
@@ -148,7 +269,13 @@ def test_every_route_is_documented(openapi_schema):
                     f"{{'content': {{'<mime-type>': {{}}}}}}}} to the decorator"
                 )
         else:
-            schema_present = any("schema" in media for media in content.values())
+            # `"schema" in media` is satisfied by response_model=None's own
+            # empty `{"schema": {}}` - FastAPI emits that placeholder for
+            # every JSON-content route regardless of whether a real model
+            # was ever attached, so a route with NO response_model still
+            # passed this check. `.get(...)` truthy-checked, not `in`, is
+            # what actually requires a non-empty schema object.
+            schema_present = any(media.get("schema") for media in content.values())
             if not schema_present:
                 problems.append(
                     f"{route}: no response schema - add response_model=<Model> to the route "
@@ -164,6 +291,21 @@ def test_every_route_has_exactly_the_expected_operation_count(openapi_schema):
     removes a route."""
     count = sum(1 for _ in _operations(openapi_schema))
     assert count == 41
+
+
+def test_binary_routes_do_not_advertise_a_json_content_type(openapi_schema):
+    """Without `response_class=FileResponse`, FastAPI assumes a route can
+    also answer with `application/json` (its default) alongside whatever
+    real content types `responses=` declares - so a codegen reading
+    /openapi.json would believe GET .../file or .../thumb might hand back
+    JSON, when neither ever does. Only the real content types may appear."""
+    for method, path in _BINARY_ROUTES:
+        content = openapi_schema["paths"][path][method.lower()]["responses"]["200"]["content"]
+        assert "application/json" not in content, (
+            f"{method} {path} advertises application/json - add "
+            "response_class=FileResponse to its decorator"
+        )
+        assert content, f"{method} {path} advertises no content type at all"
 
 
 # ---------------------------------------------------------------------------
@@ -277,11 +419,24 @@ def test_practice_responses_match_their_models(client, insert_score):
 
 
 def test_a_goal_about_a_deleted_score_still_validates(client, insert_score):
-    """The one shape genuinely different from the rest: an uncountable goal's
-    progress omits `sessions_inferred` and every day's `inferred` - see
-    api_models.GoalDayOut and GoalProgressOut. This is the case that would
-    500 if those fields were modelled as required ints instead of optional
-    ones, so it is exercised on purpose rather than only in passing."""
+    """The one shape genuinely different from the rest: practice.goal_progress
+    OMITS `sessions_inferred` and every day's `inferred` key entirely on its
+    uncountable branch - see api_models.GoalDayOut and GoalProgressOut's
+    docstrings. That is a fact about the RAW handler return; it is not what a
+    client actually sees. response_model= fills in each field's declared
+    default (None) for a key the handler never set, so the WIRE response
+    carries `"sessions_inferred": null` and `"inferred": null` explicitly -
+    additive relative to what main sends (an absent key becomes a present
+    null), and the one payload change this PR is actually responsible for.
+    Checked directly against the raw JSON below, deliberately, rather than
+    only through the parsed model - a model attribute reads the same
+    (`None`) whether the wire carried the key as `null` or omitted it
+    altogether, so only inspecting `response.json()` itself proves which one
+    actually happened.
+
+    Also exercises the case that would 500 if these fields were modelled as
+    required ints instead of optional ones, which is the reason this test
+    exists at all."""
     from fermata import db
 
     conn = db.connect()
@@ -293,9 +448,14 @@ def test_a_goal_about_a_deleted_score_still_validates(client, insert_score):
     conn.execute("DELETE FROM scores WHERE id = ?", (score_id,))
     conn.commit()
 
-    validated = api_models.GoalOut.model_validate(
-        client.get(f"/api/practice/goals").json()["goals"][0]
-    )
+    wire = client.get("/api/practice/goals").json()["goals"][0]
+    progress = wire["progress"]
+    assert progress["countable"] is False
+    assert "sessions_inferred" in progress and progress["sessions_inferred"] is None
+    for day in progress["days"]:
+        assert "inferred" in day and day["inferred"] is None
+
+    validated = api_models.GoalOut.model_validate(wire)
     assert validated.progress.countable is False
     assert validated.progress.sessions_inferred is None
     assert all(day.inferred is None for day in validated.progress.days)
@@ -358,9 +518,24 @@ def test_transcription_model_stays_in_sync_with_api_pys_bar_key_tuples():
 
 
 def test_scan_and_upload_responses_match_their_models(client, monkeypatch):
+    from fermata import config
+
     monkeypatch.setattr(api.scanner, "start_scan", lambda **kw: True)
     api_models.ScanStatusOut.model_validate(client.get("/api/scan/status").json())
     api_models.ScanTriggerOut.model_validate(client.post("/api/scan").json())
+
+    # UploadOut, actually exercised - app_env already made config.LIBRARY_DIR
+    # a real throwaway folder; api.py bound its own LIBRARY_DIR name at
+    # import time (`from .config import LIBRARY_DIR`), so it has to be
+    # repointed directly - see test_scanner.py's upload tests for the same
+    # pattern.
+    monkeypatch.setattr(api, "LIBRARY_DIR", config.LIBRARY_DIR)
+    uploaded = client.post(
+        "/api/upload?folder=Uploads",
+        files={"file": ("thing.pdf", b"%PDF-1.4 not a real pdf", "application/pdf")},
+    )
+    assert uploaded.status_code == 200
+    api_models.UploadOut.model_validate(uploaded.json())
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #19.

FastAPI already generates OpenAPI from `server/fermata/api.py`; the surface
wasn't documented enough for `/openapi.json` to be a contract anyone could
actually build against (bare dicts with no response shape, no summaries
beyond the auto-derived function name, no tags). This makes the generated
documentation true, complete, and pinned by a test.

**Updated after an adversarial review pass** (see "Review follow-ups" below)
- the review's own same-process raw-vs-wire diff across all 41 routes found
zero stripped fields in the models as originally submitted, but found real
gaps in how the guarding tests proved that, which are fixed here.

- Every one of the 41 routes now carries a docstring, a tag, and a
  `response_model` (39 of them) or, for the two file-serving routes that
  return binary bodies, an explicit content type via `responses=` plus
  `response_class=FileResponse` (added in the follow-up - see below).
- Response models live in `server/fermata/api_models.py`, kept apart from
  `api.py`'s route bodies on purpose - the diff on `api.py` itself is
  additive (decorator kwargs + docstrings), which matters because that file
  has other work landing on it concurrently (rebased cleanly onto #143 and
  #146; `TranscriptionOut` mirrors both's new fields).
- `server/tests/test_api_docs.py` is the guard that keeps this true going
  forward - see the module docstring for the five separate claims it pins,
  including the systemic drift guard added in the follow-up.
- `docs/api.md` points readers at `/docs` and `/openapi.json` as the source
  of truth and states what stability to expect between releases. Linked
  from the README's feature list.
- `server/pyproject.toml` gains `openapi-spec-validator` as a dev dependency
  (used by the OpenAPI-validity tests).

The whole surface is covered - no follow-up issue needed for a documentation
gap.

## Review follow-ups (this update)

1. **Dead check fixed.** `test_every_route_is_documented`'s schema check was
   `"schema" in media`, which FastAPI satisfies with its own empty
   `{"schema": {}}` placeholder even for a route with no `response_model` at
   all - the check could never go red. Fixed to `media.get("schema")`
   (truthy). Verified: added a throwaway route with a docstring and tag but
   no `response_model` -> failed naming that exact route; removed it -> all
   41 routes (including both binary ones) green again.
2. **The systemic guard.** Group 3's `Model.model_validate(response.json())`
   checks are tautological - a response the model just filtered is
   model-valid by construction, so they could never catch a model silently
   dropping a field the handler still computes (the exact pattern #143/#146
   hit one layer down in `_BAR_KEYS`). The `client` fixture in
   `test_api_docs.py` now wraps every request through
   `fastapi.routing.run_endpoint_function`, capturing each handler's raw
   return before `response_model` touches it, and asserts recursively that
   every key on that raw return reaches the wire. Verified against the
   review's own two mutations: dropping `ScoreOut.has_transcription` ->
   failed naming `GET /api/scores: field '[0].has_transcription'...`;
   adding a `SETTINGS_DEFAULTS` key without growing `SettingsOut` -> failed
   naming `GET /api/settings: field 'metronome_sound'...`. Both reverted
   after. `TranscriptionOut`'s pin against `api.py`'s `_BAR_KEYS` tuples
   stays - it checks a different property (the model's own field set vs.
   another module's tuples) than the systemic guard (no field silently
   dropped between handler and wire).
3. **`UploadOut` actually exercised.** The scan/upload test named it in a
   comment and never validated it. It now performs a real upload through
   the guarded client above.
4. **Binary routes no longer advertise `application/json`.** Without
   `response_class=FileResponse`, FastAPI assumes JSON is on offer alongside
   the real content types in `responses=`. Added to both file-serving
   routes; pinned by `test_binary_routes_do_not_advertise_a_json_content_type`.
5. **`docs/api.md` correction.** "Fields are additive" was already false
   under `response_model` filtering - a field is invisible on the wire until
   its model grows to carry it. Reworded. Also: the one observable payload
   change in this PR is that the practice-goals uncountable branch now sends
   `sessions_inferred` and `days[].inferred` as explicit `null`s where main
   omits those keys entirely (additive) -
   `test_a_goal_about_a_deleted_score_still_validates` now asserts this
   directly against the raw wire JSON, not just the parsed model (a model
   attribute reads `None` either way; only inspecting `response.json()`
   proves which one actually happened).
6. `server/pyproject.toml` mentioned above (was omitted from the original
   summary).

**Optional item taken too:** `TranscriptionOut.confidence` widened from
`dict[str, Any] | str | None` to `Any` - `_transcription_dict` tolerates a
stored blob that parses as JSON but isn't a dict (an array, a number, a
bool); not reachable through anything this application writes today, but
the model shouldn't 500 a plain GET over a row shape the helper already
degrades gracefully for.

## Verification

- Endpoint inventory (script-derived from the route decorators): 41 routes
  both before and after. Docstrings: 15/41 -> 41/41. Tags: 0/41 -> 41/41.
  `response_model`: 0/41 -> 39/41 (+2 documented via explicit content type
  and `response_class=FileResponse` for binary responses).
- `openapi-spec-validator` validates `app.openapi()` and, separately, the
  live `/openapi.json` fetched from a real `uvicorn` instance on `127.0.0.1`
  (odd port, re-verified after the follow-up changes).
- `/docs` fetched from that same live instance: `200`, Swagger UI HTML.
- Response-model validation is genuinely ON - proven two ways: (1) a
  standing test registers a throwaway route with the same `response_model=`
  idiom and a handler that violates it, confirming FastAPI raises
  `ResponseValidationError`; (2) a one-off mutation
  (`ScoreOut.title: str -> int`) hit over real HTTP confirmed
  `ResponseValidationError` from the actual production route, then reverted.
- Full suite, `FERMATA_TEST_LIBRARY` **unset** (no real sheet-music library
  reachable in this sandbox - re-derived, not assumed), `web/node_modules`
  absent: baseline (post-#143/#146, pre this PR's test file) 693 passed /
  54 skipped / 1 pre-existing unrelated failure (a meta-test about skip
  counts that fails identically in isolation on `main` too) -> after this
  PR, 710 passed / 54 skipped / same 1 pre-existing failure. +17 new tests,
  zero regressions.
- `FERMATA_TEST_LIBRARY` **set**: not independently reproducible from this
  environment - no real sheet-music library is reachable here, so the
  library-set baseline this review referenced (748/1/13) is not verified by
  this session. Flagging rather than guessing; happy to compare against a
  run from an environment that has the library mounted.

## Test plan

- [x] `py -3.13 -m pytest -rs` run before and after every round of changes,
      counts compared (library unset, as above)
- [x] `openapi-spec-validator` against both the in-process and live-fetched
      `/openapi.json`, re-checked after the follow-up changes
- [x] `/docs` fetched from a real server on an odd port (not 8080)
- [x] Deliberate response-model mismatches proven to fail: the original
      mutation test, plus the review's two mutations (`has_transcription`,
      an ungrown `SETTINGS_DEFAULTS` key) against the new systemic guard -
      all reverted after
- [x] Dead-check fix proven with a throwaway undocumented route, added then
      removed
- [x] Rebased onto latest `origin/main` (`#143`, then `#146`) before each
      push
- [ ] `FERMATA_TEST_LIBRARY`-set baseline - not verifiable from this
      environment; see Verification above
