### PR TITLE
Give every emitted note a stable id, checkable against a positional map

### DIFF
--- a/docs/examples/monophonic.musicxml
+++ b/docs/examples/monophonic.musicxml
@@ -73,7 +73,7 @@
         </direction-type>
         <sound tempo="80" />
       </direction>
-      <note>
+      <note id="n1-1-0-0">
         <pitch>
           <step>E</step>
           <octave>4</octave>
@@ -88,7 +88,7 @@
           </technical>
         </notations>
       </note>
-      <note>
+      <note id="n1-1-1-0">
         <pitch>
           <step>C</step>
           <alter>1</alter>
@@ -104,7 +104,7 @@
           </technical>
         </notations>
       </note>
-      <note>
+      <note id="n1-1-2-0">
         <pitch>
           <step>A</step>
           <octave>3</octave>
@@ -119,7 +119,7 @@
           </technical>
         </notations>
       </note>
-      <note>
+      <note id="n1-1-3-0">
         <pitch>
           <step>G</step>
           <octave>4</octave>

--- a/docs/examples/navigation.musicxml
+++ b/docs/examples/navigation.musicxml
@@ -70,7 +70,7 @@
         </direction-type>
         <sound segno="segno" />
       </direction>
-      <note>
+      <note id="n1-1-0-0">
         <pitch>
           <step>E</step>
           <octave>4</octave>
@@ -85,7 +85,7 @@
           </technical>
         </notations>
       </note>
-      <note>
+      <note id="n1-1-1-0">
         <pitch>
           <step>F</step>
           <alter>1</alter>
@@ -101,7 +101,7 @@
           </technical>
         </notations>
       </note>
-      <note>
+      <note id="n1-1-2-0">
         <pitch>
           <step>G</step>
           <octave>4</octave>
@@ -116,7 +116,7 @@
           </technical>
         </notations>
       </note>
-      <note>
+      <note id="n1-1-3-0">
         <pitch>
           <step>A</step>
           <octave>4</octave>
@@ -139,7 +139,7 @@
       </direction>
     </measure>
     <measure number="2">
-      <note>
+      <note id="n2-1-0-0">
         <pitch>
           <step>B</step>
           <octave>3</octave>
@@ -154,7 +154,7 @@
           </technical>
         </notations>
       </note>
-      <note>
+      <note id="n2-1-1-0">
         <pitch>
           <step>C</step>
           <alter>1</alter>
@@ -170,7 +170,7 @@
           </technical>
         </notations>
       </note>
-      <note>
+      <note id="n2-1-2-0">
         <pitch>
           <step>D</step>
           <octave>4</octave>
@@ -185,7 +185,7 @@
           </technical>
         </notations>
       </note>
-      <note>
+      <note id="n2-1-3-0">
         <pitch>
           <step>E</step>
           <octave>4</octave>
@@ -214,7 +214,7 @@
         </direction-type>
         <sound coda="coda" />
       </direction>
-      <note>
+      <note id="n3-1-0-0">
         <pitch>
           <step>G</step>
           <octave>3</octave>
@@ -229,7 +229,7 @@
           </technical>
         </notations>
       </note>
-      <note>
+      <note id="n3-1-1-0">
         <pitch>
           <step>A</step>
           <octave>3</octave>
@@ -244,7 +244,7 @@
           </technical>
         </notations>
       </note>
-      <note>
+      <note id="n3-1-2-0">
         <pitch>
           <step>B</step>
           <alter>-1</alter>
@@ -260,7 +260,7 @@
           </technical>
         </notations>
       </note>
-      <note>
+      <note id="n3-1-3-0">
         <pitch>
           <step>C</step>
           <octave>4</octave>

--- a/docs/examples/repeat-structure.musicxml
+++ b/docs/examples/repeat-structure.musicxml
@@ -68,7 +68,7 @@
         <bar-style>heavy-light</bar-style>
         <repeat direction="forward" />
       </barline>
-      <note>
+      <note id="n1-1-0-0">
         <pitch>
           <step>E</step>
           <octave>4</octave>
@@ -83,7 +83,7 @@
           </technical>
         </notations>
       </note>
-      <note>
+      <note id="n1-1-1-0">
         <pitch>
           <step>F</step>
           <alter>1</alter>
@@ -99,7 +99,7 @@
           </technical>
         </notations>
       </note>
-      <note>
+      <note id="n1-1-2-0">
         <pitch>
           <step>G</step>
           <octave>4</octave>
@@ -114,7 +114,7 @@
           </technical>
         </notations>
       </note>
-      <note>
+      <note id="n1-1-3-0">
         <pitch>
           <step>A</step>
           <octave>4</octave>
@@ -134,7 +134,7 @@
       <barline location="left">
         <ending number="1" type="start" />
       </barline>
-      <note>
+      <note id="n2-1-0-0">
         <pitch>
           <step>B</step>
           <octave>3</octave>
@@ -149,7 +149,7 @@
           </technical>
         </notations>
       </note>
-      <note>
+      <note id="n2-1-1-0">
         <pitch>
           <step>C</step>
           <alter>1</alter>
@@ -165,7 +165,7 @@
           </technical>
         </notations>
       </note>
-      <note>
+      <note id="n2-1-2-0">
         <pitch>
           <step>D</step>
           <octave>4</octave>
@@ -180,7 +180,7 @@
           </technical>
         </notations>
       </note>
-      <note>
+      <note id="n2-1-3-0">
         <pitch>
           <step>E</step>
           <octave>4</octave>
@@ -205,7 +205,7 @@
       <barline location="left">
         <ending number="2" type="start" />
       </barline>
-      <note>
+      <note id="n3-1-0-0">
         <pitch>
           <step>G</step>
           <octave>3</octave>
@@ -220,7 +220,7 @@
           </technical>
         </notations>
       </note>
-      <note>
+      <note id="n3-1-1-0">
         <pitch>
           <step>A</step>
           <octave>3</octave>
@@ -235,7 +235,7 @@
           </technical>
         </notations>
       </note>
-      <note>
+      <note id="n3-1-2-0">
         <pitch>
           <step>B</step>
           <alter>-1</alter>
@@ -251,7 +251,7 @@
           </technical>
         </notations>
       </note>
-      <note>
+      <note id="n3-1-3-0">
         <pitch>
           <step>C</step>
           <octave>4</octave>

--- a/docs/examples/two-voice.musicxml
+++ b/docs/examples/two-voice.musicxml
@@ -64,7 +64,7 @@
           </staff-tuning>
         </staff-details>
       </attributes>
-      <note>
+      <note id="n1-1-0-0">
         <pitch>
           <step>E</step>
           <octave>4</octave>
@@ -79,7 +79,7 @@
           </technical>
         </notations>
       </note>
-      <note>
+      <note id="n1-1-1-0">
         <pitch>
           <step>D</step>
           <octave>4</octave>
@@ -94,7 +94,7 @@
           </technical>
         </notations>
       </note>
-      <note>
+      <note id="n1-1-2-0">
         <pitch>
           <step>F</step>
           <alter>1</alter>
@@ -113,7 +113,7 @@
       <backup>
         <duration>1440</duration>
       </backup>
-      <note>
+      <note id="n1-2-0-0">
         <pitch>
           <step>A</step>
           <octave>2</octave>

--- a/docs/musicxml-tab-profile.md
+++ b/docs/musicxml-tab-profile.md
@@ -700,6 +700,33 @@ reject the whole file. Nothing else in a file this profile writes begins with
 `<midi-instrument>` write `P1` / `P1-I1` — so a note id can never collide with
 one of those either.
 
+**Uniqueness precondition: one part, one staff.** The formula's uniqueness
+rests on measure, voice, onset and chord member each being unique within the
+scope the axis above it names — and that chain only reaches the whole
+document because this profile writes exactly one `<part>` and one staff (see
+[Scope](#scope)). #10's proposed second staff (tablature paired with its own
+notation staff) and #93's proposed multiple tracks each add an axis the
+formula does not currently name: a note at measure 3, voice 1, onset 0 on a
+second staff or a second track would compute the identical id string to the
+one at that position on the first. Either extension has to add a part or
+staff component to the formula before this rule's uniqueness claim would
+still hold across the whole document — it is not automatic.
+
+**The chord ordinal is emission-derived; the onset is not, and that
+asymmetry is real.** `onset` counts every beat in the *model's* voice list,
+written or not, so a beat that never gets written (a zero-duration beat, an
+inferred rest) does not shift a later beat's onset. `chord` is assigned
+during *emission*, from position in the list of chord members that survive
+[Rule 11](#fret-string-and-pitch-rules-9-13)'s pitch-representability
+filter — so a chord member Rule 11 drops shifts every later member's
+`chord` index down by one: a four-note chord whose second member is
+unrepresentable writes `chord` 0, 1, 2 on its three survivors, not 0, 2, 3,
+and a later fix that makes that pitch representable again would renumber
+the other two. Onset avoids this because the model is fixed before emission
+decides anything; chord does not, because representability is decided per
+note inside one beat, and unlike an unwritten beat, a dropped chord member
+leaves no placeholder to number around.
+
 **Why every note, rests included, rather than only the ones that sound.** The
 alternative considered was to skip rests, on the reasoning that a rest is
 never a target of anything downstream: the alternative renderer measured
@@ -716,6 +743,22 @@ an exception to the first. Writing one rule — every `<note>` element gets an
 is exactly what a rest's id looks like) and leaves nothing for a consumer to
 special-case.
 
+**What this does not cover: inferred silence has no id, and cannot.**
+Writing ids on rests closes the gap between a sounding note's position and a
+printed rest's position — it does not close the gap between either of those
+and [Rule 14](#inferred-silence-rule-14)'s `<forward>`. The schema's
+`forward` type carries no `optional-unique-id` attribute group at all, so
+inferred silence is not merely written without an id by this profile's
+choice — it has no `id` attribute to write. Measured on the library this
+profile was developed against: 5450 `<forward>` elements, none nameable.
+A consumer building a positional map over every onset a voice holds,
+silence included, therefore has partial coverage from ids alone — sounding
+notes and printed rests are addressable, inferred silence is not — and has
+to fall back to counting `<forward>` elements by position for that part of
+the map, the same way [Rule 8](#voices-rules-6-8) checking already does.
+Say this plainly because it is easy to read Rule 17 as closing the gap
+entirely once rests are included: it closes exactly one of the two gaps.
+
 **Determinism, and what it does and does not promise.** The id is computed
 from nothing but the beat's own position among the voices and measures
 `build()` was handed — never a random value, a clock, or a counter carried
@@ -728,6 +771,24 @@ measure numbers already have — an id names a *position*, not the note
 itself — and it is what "auditable against the file as emitted" means: a
 consumer checks a positional map against *this* emission's ids, not against
 ids the previous emission wrote for what looks like the same note.
+
+**Ids are emitter-owned: a document mutated outside `build()` has to
+re-derive them, not mint one.** The formula is defined over an entire
+voice's beat sequence, not over one note in isolation, so keeping it valid
+after an edit means recomputing every id in the edited voice from that
+voice's new beat sequence — never assigning a fresh, one-off id to an
+inserted note while leaving its neighbours' onset numbers as they were,
+because the neighbours after the insertion point are no longer at the
+onsets their old ids name. This is not hypothetical for this project:
+`PUT /scores/{score_id}/transcription` stores whatever content a client
+sends as the edited transcription, verbatim, with no id validation of any
+kind. A saved edit that inserts a note without renumbering what follows it
+in the same voice writes either a duplicate id — two notes now claiming the
+same onset — or, in the case that mangles the `n` prefix along the way, an
+id that is not a legal NCName; either fails validation against the MusicXML
+4.0 XSD outright (`id` is `xs:ID`, checked exactly this way under [Checking
+a file](#checking-a-file)). Renumbering the affected voice is the editor's
+responsibility, not this emitter's — this is where that contract is stated.
 
 **The invariant this rule does not disturb.** An id is one attribute on an
 element that was already being written; it adds nothing else to the

--- a/docs/musicxml-tab-profile.md
+++ b/docs/musicxml-tab-profile.md
@@ -29,6 +29,7 @@ several things this profile has to decide.
   - [Inferred silence](#inferred-silence-rule-14)
   - [Repeat structure](#repeat-structure-rule-15)
   - [Navigation marks](#navigation-marks-rule-16)
+  - [Note identifiers](#note-identifiers-rule-17)
 - [Example 1: one monophonic bar](#example-1-one-monophonic-bar)
 - [Example 2: two voices in one bar](#example-2-two-voices-in-one-bar)
 - [Checking a file](#checking-a-file)
@@ -662,6 +663,81 @@ that shape would not be more correct either. MuseScore 4.6.3 imports these
 directions as staff text on the right measures and drops the `<sound>`
 attributes, so a round trip through it keeps the marks and loses the jumps.
 
+### Note identifiers (Rule 17)
+
+**Rule 17.** Every `<note>` — rest or sounding, single note or chord member —
+carries an `id` attribute, unique within the document and stable across
+re-emission of the same content:
+
+```
+n{measure}-{voice}-{onset}-{chord}
+```
+
+`measure` is the same 1-based number the enclosing `<measure number=>` itself
+carries. `voice` is the same 1-based number the note's own `<voice>` carries.
+`onset` is the position (from 0) of this note's *beat* within its voice, and
+counts every beat the producer processed for that voice — including one that
+resolved to no writable duration and one written as `<forward>` rather than a
+`<note>` — so it never shifts because something elsewhere in the measure did
+or did not get written. `chord` is the position (from 0) of this note among
+its own beat's written notes: 0 for a rest or an unaccompanied note,
+incrementing for each further member of a chord (Rule 7).
+
+```xml
+<note id="n3-2-4-0">
+```
+
+is the note written from voice 2's fifth beat (index 4) in measure 3 — the
+first (and, since `chord` is 0, only) note at that onset.
+
+The schema's `optional-unique-id` attribute group types `id` as `xs:ID`,
+which the specification requires to be unique across the **whole** document,
+not merely among notes — and `xs:ID` is in turn constrained to `xs:NCName`,
+which cannot begin with a digit. `n` is prefixed for exactly that reason: a
+bare `3-2-4-0` is not a legal NCName, and a schema-validating parser would
+reject the whole file. Nothing else in a file this profile writes begins with
+`n` followed by a digit — `<score-part>`, `<score-instrument>` and
+`<midi-instrument>` write `P1` / `P1-I1` — so a note id can never collide with
+one of those either.
+
+**Why every note, rests included, rather than only the ones that sound.** The
+alternative considered was to skip rests, on the reasoning that a rest is
+never a target of anything downstream: the alternative renderer measured
+against this profile carries an id through to its own output for every
+*sounding* note and drops the rest of the attribute set from a rest entirely.
+That is a real property of one consumer, not a reason to special-case the
+rule here. An id exists so a positional map — MusicXML document order against
+a renderer's own bar → voice → beat → note order — can be checked rather than
+assumed, and a rest occupies a position in that order exactly as a sounding
+note does; a reader walking the file to audit its own alignment has to skip
+rests deliberately if they carry no id, which is a second rule disguised as
+an exception to the first. Writing one rule — every `<note>` element gets an
+`id` — costs nothing (the `chord`-0 case an unaccompanied note already needs
+is exactly what a rest's id looks like) and leaves nothing for a consumer to
+special-case.
+
+**Determinism, and what it does and does not promise.** The id is computed
+from nothing but the beat's own position among the voices and measures
+`build()` was handed — never a random value, a clock, or a counter carried
+between notes — so extracting the same score twice, or re-emitting the same
+beats model, produces byte-identical ids down to the ordering of chord
+members. It is NOT stable across an edit that inserts or removes a beat
+earlier in the same voice: every onset after the edit shifts, and every id
+built from that onset shifts with it. That is the same shape Rule 15's
+measure numbers already have — an id names a *position*, not the note
+itself — and it is what "auditable against the file as emitted" means: a
+consumer checks a positional map against *this* emission's ids, not against
+ids the previous emission wrote for what looks like the same note.
+
+**The invariant this rule does not disturb.** An id is one attribute on an
+element that was already being written; it adds nothing else to the
+document and moves no Rule 8 figure. Measured on the library this profile was
+developed against: adding note ids to all 293 extractable scores left
+`bars`, `bars_measured`, `bars_overfull`, `bars_short`, `bars_defective`,
+`bars_padded`, `inferred_rest_quarters`, `notes` and `beats` exactly where
+they were before the change, and every byte of every emitted file was
+unchanged apart from the `id="…"` attribute added to each `<note>`.
+
 ## Example 1: one monophonic bar
 
 One bar of 4/4 at 80 bpm in standard tuning: open first string (E4), second
@@ -746,7 +822,7 @@ validated by the test suite.
         </direction-type>
         <sound tempo="80" />
       </direction>
-      <note>
+      <note id="n1-1-0-0">
         <pitch>
           <step>E</step>
           <octave>4</octave>
@@ -761,7 +837,7 @@ validated by the test suite.
           </technical>
         </notations>
       </note>
-      <note>
+      <note id="n1-1-1-0">
         <pitch>
           <step>C</step>
           <alter>1</alter>
@@ -777,7 +853,7 @@ validated by the test suite.
           </technical>
         </notations>
       </note>
-      <note>
+      <note id="n1-1-2-0">
         <pitch>
           <step>A</step>
           <octave>3</octave>
@@ -792,7 +868,7 @@ validated by the test suite.
           </technical>
         </notations>
       </note>
-      <note>
+      <note id="n1-1-3-0">
         <pitch>
           <step>G</step>
           <octave>4</octave>
@@ -813,7 +889,8 @@ validated by the test suite.
 ```
 
 Rule 8 checks out: the measure duration is `480 × 4 × 4 ÷ 4 = 1920`, and voice
-1 holds four notes of 480 each.
+1 holds four notes of 480 each. Note ids: `n1-1-0-0` through `n1-1-3-0` — one
+measure, one voice, four onsets in order, no chords (Rule 17).
 
 The tempo direction is optional; a file with no tempo simply omits it. The
 `<metronome>` is what gets engraved and `<sound tempo=>` is what a player
@@ -848,7 +925,7 @@ meter, so only the measure is shown here.
       <!-- six <staff-tuning> elements, exactly as in Example 1 -->
     </staff-details>
   </attributes>
-  <note>
+  <note id="n1-1-0-0">
     <pitch>
       <step>E</step>
       <octave>4</octave>
@@ -863,7 +940,7 @@ meter, so only the measure is shown here.
       </technical>
     </notations>
   </note>
-  <note>
+  <note id="n1-1-1-0">
     <pitch>
       <step>D</step>
       <octave>4</octave>
@@ -878,7 +955,7 @@ meter, so only the measure is shown here.
       </technical>
     </notations>
   </note>
-  <note>
+  <note id="n1-1-2-0">
     <pitch>
       <step>F</step>
       <alter>1</alter>
@@ -897,7 +974,7 @@ meter, so only the measure is shown here.
   <backup>
     <duration>1440</duration>
   </backup>
-  <note>
+  <note id="n1-2-0-0">
     <pitch>
       <step>A</step>
       <octave>2</octave>
@@ -918,6 +995,10 @@ meter, so only the measure is shown here.
 
 The things to note:
 
+- Note ids run per-voice: voice 1's three notes are `n1-1-0-0` through
+  `n1-1-2-0`, and voice 2's one note starts its own onset count over at
+  `n1-2-0-0` — the `<backup>` between them rewinds the writing position, and
+  Rule 17's onset index rewinds with it.
 - The measure duration is `480 × 4 × 3 ÷ 4 = 1440`. Voice 1 holds three notes
   of 480; voice 2 holds one of 1440. Both sum to 1440, so Rule 8 holds.
 - The `<backup>` duration is 1440 — the whole of what voice 1 wrote — which

--- a/server/fermata/musicxml.py
+++ b/server/fermata/musicxml.py
@@ -378,15 +378,23 @@ def _sub(parent, tag, text=None, **attrib):
     return el
 
 
-def _append_note(measure, duration, type_name, dots, voice, string=None,
+def _append_note(measure, duration, type_name, dots, voice, note_id, string=None,
                  fret=None, midi=None, fifths=0, chord=False):
     """One `<note>`. The schema's sequence for a normal note is: chord?,
     (pitch|unpitched|rest), duration, tie*, instrument*, footnote?, level?,
     voice?, type?, dot*, accidental?, ..., notations* - so voice comes BEFORE
     type, and notations last. A rest is the same shape with `<rest/>` in
     place of `<pitch>` and no `<notations>`.
+
+    `note_id` is written as the note's `id` attribute (Rule 17) - the schema's
+    `optional-unique-id` attribute group types it `xs:ID`, so it has to be a
+    valid NCName and unique across the whole document. It is always supplied
+    by the caller rather than computed here: build() derives it from where
+    this note sits - measure, voice, onset, chord member - which is what makes
+    it stable across re-emission of the same content, not an accident of
+    iteration order.
     """
-    note = _sub(measure, "note")
+    note = _sub(measure, "note", id=note_id)
     if string is None:
         _sub(note, "rest")
     else:
@@ -586,6 +594,20 @@ def build(title, tempo, tuning, ts, measures, fifths=0, capo=None,
     that fires at the end of the bar (D.C., D.S., To Coda, Fine). Like a
     barline it carries no duration.
 
+    Every `<note>` this writes - rest or sounding, single or chord member -
+    carries a stable `id` (Rule 17): `n{measure}-{voice}-{onset}-{chord}`,
+    built from nothing but where the note sits. `measure` is the same 1-based
+    number the `<measure>` element itself carries; `voice` is the same
+    1-based number `<voice>` carries; `onset` is this beat's own position
+    (from 0) in ITS voice's beat list, counting every beat the producer
+    processed for that voice - including one skipped for resolving to no
+    duration and one written as `<forward>` - so an id never shifts because
+    something elsewhere in the measure did; `chord` is the position (from 0)
+    of this note among its beat's own written notes - 0 for a rest or a
+    single note, incrementing for each further chord member. Deterministic by
+    construction: nothing here reads a clock, a counter shared across calls,
+    or anything but the beats already given.
+
     `measures` is a list of (beats, measure_ts) pairs - or bare beats lists,
     for a caller with no per-measure meter to carry - where beats is a list of
     VOICES and each voice a list of (duration_code, dots, notes), notes being
@@ -647,7 +669,8 @@ def build(title, tempo, tuning, ts, measures, fifths=0, capo=None,
     in_effect = tuple(ts) if ts else None
     for index, measure_in in enumerate(measures):
         beats_in, measure_ts = _split_measure(measure_in, in_effect)
-        measure = _sub(part, "measure", number=index + 1)
+        measure_number = index + 1
+        measure = _sub(part, "measure", number=measure_number)
         opening = index == 0
         if opening or measure_ts != in_effect:
             _append_attributes(measure, measure_ts, fifths, tuning, capo, opening)
@@ -655,10 +678,10 @@ def build(title, tempo, tuning, ts, measures, fifths=0, capo=None,
         if opening and tempo:
             _append_tempo(measure, tempo)
 
-        marks = (barlines or {}).get(index + 1, {})
+        marks = (barlines or {}).get(measure_number, {})
         if "left" in marks:
             _append_barline(measure, "left", marks["left"])
-        nav = (directions or {}).get(index + 1, {})
+        nav = (directions or {}).get(measure_number, {})
         for record in nav.get("before", ()):
             _append_navigation(measure, record)
 
@@ -668,12 +691,14 @@ def build(title, tempo, tuning, ts, measures, fifths=0, capo=None,
                 backup = _sub(measure, "backup")
                 _sub(backup, "duration", written)
             written = 0
-            for duration_code, dots, notes in voice:
+            for onset_index, (duration_code, dots, notes) in enumerate(voice):
                 duration = beat_divisions(duration_code, dots)
                 if duration < _MIN_DURATION:
                     # <duration> is positive-divisions, so there is no way to
                     # write a zero-length beat. Nothing sounds for no time
-                    # either, so dropping it loses nothing.
+                    # either, so dropping it loses nothing. onset_index still
+                    # advances (it comes from enumerate(voice), not from a
+                    # counter of what got written) - see Rule 17.
                     continue
                 if not writes_a_note(duration_code, dots, notes):
                     # Everything writes_a_note rejects EXCEPT the zero-duration
@@ -703,12 +728,16 @@ def build(title, tempo, tuning, ts, measures, fifths=0, capo=None,
                     if is_representable(midi, fifths):
                         writable.append((string, fret, midi))
                 if not writable:
-                    _append_note(measure, duration, type_name, dot_count, voice_number)
+                    note_id = f"n{measure_number}-{voice_number}-{onset_index}-0"
+                    _append_note(measure, duration, type_name, dot_count, voice_number,
+                                 note_id)
                 else:
                     for position, (string, fret, midi) in enumerate(writable):
+                        note_id = (
+                            f"n{measure_number}-{voice_number}-{onset_index}-{position}")
                         _append_note(
                             measure, duration, type_name, dot_count, voice_number,
-                            string=string, fret=fret, midi=midi,
+                            note_id, string=string, fret=fret, midi=midi,
                             fifths=fifths, chord=position > 0,
                         )
                 written += duration

--- a/server/tests/test_engraved_fixtures.py
+++ b/server/tests/test_engraved_fixtures.py
@@ -2105,3 +2105,45 @@ def test_the_committed_musicxml_still_matches_its_generator():
     spec.loader.exec_module(module)
     drifted = module.write_musicxml(check_only=True)
     assert drifted == [], drifted
+
+
+# ---------------------------------------------------------------------------
+# Rule 17: note identifiers, pinned across every committed engraved fixture
+# ---------------------------------------------------------------------------
+
+_NCNAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_.-]*$")
+
+
+def test_every_engraved_fixtures_note_id_is_unique_and_a_valid_ncname():
+    """Rule 17, exercised against real extraction rather than build() called
+    directly: every `<note>` id in every score this repository can commit -
+    the full PDF pipeline, not a hand-assembled beats model - is present,
+    unique within its own document, and a legal xs:NCName.
+
+    Iterates every committed *.pdf in the engraved fixtures directory rather
+    than one name at a time, the same shape as the library-wide scan in
+    test_tabextract.py, so a new fixture is covered the day it is added
+    without anyone remembering to list it here."""
+    checked = 0
+    total_notes = 0
+    for pdf in sorted(ENGRAVED_DIR.glob("*.pdf")):
+        result = tabextract.extract(pdf)
+        if not result.extractable or not result.musicxml:
+            continue
+        root = ET.fromstring(result.musicxml)
+        ids = [n.get("id") for n in root.findall("./part/measure/note")]
+        assert ids, f"{pdf.name}: extractable but wrote no <note> ids"
+        assert all(ids), f"{pdf.name}: a <note> is missing its id"
+        for note_id in ids:
+            assert _NCNAME_RE.match(note_id), f"{pdf.name}: {note_id!r} is not a valid NCName"
+        duplicates = [i for i in set(ids) if ids.count(i) > 1]
+        assert not duplicates, f"{pdf.name}: duplicate note id(s) {duplicates}"
+        checked += 1
+        total_notes += len(ids)
+    # A floor rather than a pin on the exact fixture count, for the same
+    # reason test_library_wide_repeat_structure_leaves_conformance_untouched
+    # uses one for scores_with_structure: which fixtures extract cleanly can
+    # change as fixtures are added, but the check must not have silently
+    # stopped running against anything at all.
+    assert checked >= 20, "fewer engraved fixtures were checked than expected"
+    assert total_notes > 0

--- a/server/tests/test_musicxml.py
+++ b/server/tests/test_musicxml.py
@@ -934,6 +934,78 @@ def test_the_profile_document_quotes_the_footnote_this_emitter_writes():
         "the footnote in musicxml.py is not the one Rule 14 publishes")
 
 
+def _profile_section(text, heading, next_heading):
+    """The text of one `## heading` section, up to (not including) the next
+    top-level heading - so a fenced block can be found by which example it
+    belongs to rather than by guessing from its first line."""
+    start = text.index(heading) + len(heading)
+    end = text.index(next_heading, start)
+    return text[start:end]
+
+
+def _first_fenced_xml_block(section_text):
+    m = re.search(r"```xml\n(.*?)\n```", section_text, flags=re.S)
+    assert m, "no ```xml fenced block in this section"
+    return m.group(1)
+
+
+def _elements_equal(a, b):
+    """Structural equality - tag, attributes, direct text, and children,
+    recursively - not a string compare, because the doc's snippet and the
+    published file are indented differently (the snippet drops the levels
+    above the shown element)."""
+    if a.tag != b.tag or a.attrib != b.attrib:
+        return False
+    if (a.text or "").strip() != (b.text or "").strip():
+        return False
+    ac, bc = list(a), list(b)
+    return len(ac) == len(bc) and all(_elements_equal(x, y) for x, y in zip(ac, bc))
+
+
+def test_example_1_and_2_note_listings_match_their_published_files():
+    """Issue #150's review: writing ids on every <note> doubled the
+    hand-copied surface for Examples 1 and 2, which are the only two that
+    show a full, literal note listing - once in the doc's own fenced
+    snippet, once in docs/examples/*.musicxml. Two hand-maintained copies of
+    the same note ids are two chances for them to quietly disagree.
+
+    Examples 3 and 4 elide every <note> with "..." (see Rule 15's and Rule
+    16's own example sections) and never had a note listing to duplicate, so
+    there is nothing for this test to check there - not skipped for being
+    expensive, skipped for having no target.
+    """
+    import pathlib
+
+    root_dir = pathlib.Path(__file__).resolve().parents[2] / "docs"
+    profile = root_dir / "musicxml-tab-profile.md"
+    if not profile.is_file():
+        pytest.skip("docs/musicxml-tab-profile.md is not present in this checkout")
+    text = profile.read_text(encoding="utf-8")
+
+    example_1 = _first_fenced_xml_block(
+        _profile_section(text, "## Example 1: one monophonic bar",
+                         "## Example 2: two voices in one bar"))
+    example_2 = _first_fenced_xml_block(
+        _profile_section(text, "## Example 2: two voices in one bar",
+                         "## Example 3: repeat barline and two endings"))
+
+    published_1 = ET.parse(root_dir / "examples" / "monophonic.musicxml").getroot()
+    assert _elements_equal(ET.fromstring(example_1), published_1), (
+        "Example 1's inline snippet has drifted from monophonic.musicxml")
+
+    # Example 2's <attributes> deliberately elides the six <staff-tuning>
+    # elements behind a comment ("identical to Example 1"), so only the
+    # note-bearing children after it - the actual duplicated surface - are
+    # compared; <attributes> is not.
+    published_2_measure = ET.parse(
+        root_dir / "examples" / "two-voice.musicxml").getroot().find("./part/measure")
+    example_2_body = [c for c in ET.fromstring(example_2) if c.tag != "attributes"]
+    published_2_body = [c for c in published_2_measure if c.tag != "attributes"]
+    assert len(example_2_body) == len(published_2_body) and all(
+        _elements_equal(x, y) for x, y in zip(example_2_body, published_2_body)), (
+        "Example 2's inline note/backup listing has drifted from two-voice.musicxml")
+
+
 def test_the_published_examples_exist_and_conform():
     """docs/musicxml-tab-profile.md publishes these as reference files for
     another implementation to compare against, so they have to keep passing the

--- a/server/tests/test_musicxml.py
+++ b/server/tests/test_musicxml.py
@@ -671,6 +671,126 @@ def test_directions_are_placed_above_and_carry_no_duration():
 
 
 # ---------------------------------------------------------------------------
+# Rule 17: note identifiers
+# ---------------------------------------------------------------------------
+
+# xs:NCName: (Letter | '_') (NCNameChar)* - a prefixed digit run is not one,
+# which is exactly why every id here is prefixed with "n" (Rule 17).
+_NCNAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_.-]*$")
+
+
+def _ids(root):
+    return [n.get("id") for n in root.findall("./part/measure/note")]
+
+
+def test_every_note_carries_an_id_including_rests():
+    """Rule 17: every `<note>` gets an id, rests included - one rule rather
+    than a rule with an exception, and the reason is in the profile doc."""
+    beats = [[(4, 0, [(1, 0)]), (4, 0, []), (4, 0, [(1, 78)])]]  # note, rest,
+    # and a note with no writable pitch (Rule 11) - also written as a rest
+    root = _root(_one_bar(beats))
+    ids = _ids(root)
+    assert len(ids) == 3
+    assert all(ids), "every <note>, sounding or not, carries an id"
+
+
+def test_ids_are_valid_ncnames():
+    """`id` is `xs:ID`, which is in turn `xs:NCName` - it cannot begin with a
+    digit. The `n` prefix is the only thing standing between a bare
+    `1-1-0-0` and a document that fails schema validation outright."""
+    root = _root(_one_bar([[(4, 0, [(1, 0), (2, 2)]), (4, 0, [])]]))
+    for note_id in _ids(root):
+        assert _NCNAME_RE.match(note_id), note_id
+
+
+def test_ids_are_unique_within_a_chord_and_across_beats():
+    """A four-note chord shares one onset (Rule 7) but needs four distinct
+    ids, and consecutive beats must not collide either."""
+    beats = [[(4, 0, [(6, 0), (5, 2), (4, 2), (3, 1)])] + [(4, 0, [(1, 0)])] * 3]
+    root = _root(_one_bar(beats))
+    ids = _ids(root)
+    assert len(ids) == len(set(ids)) == 7, ids
+
+
+def test_ids_are_unique_across_voices_and_measures():
+    beats = [
+        [(4, 0, [(1, 0)]), (4, 0, [(1, 2)]), (4, 0, [(1, 3)])],
+        [(2, 1, [(5, 0)])],
+    ]
+    measures = [(beats, (3, 4))] * 3
+    root = _root(musicxml.build("T", None, DEFAULT_TUNING, (3, 4), measures))
+    ids = [n.get("id") for n in root.findall("./part/measure/note")]
+    assert len(ids) == len(set(ids)) == 12, ids
+
+
+def test_chord_members_get_distinct_ids_by_position():
+    """The `chord` component of the id is the position among a beat's own
+    written notes - 0 for the first (no `<chord/>`), incrementing for each
+    further member, and independent of `voice` or `onset`."""
+    root = _root(_one_bar([[(4, 0, [(6, 0), (5, 2), (4, 2)])]]))
+    notes = root.findall("./part/measure/note")
+    assert [n.get("id") for n in notes] == ["n1-1-0-0", "n1-1-0-1", "n1-1-0-2"]
+
+
+def test_a_dropped_beat_still_advances_the_onset_index():
+    """A beat that resolves to no duration (Rule 2's `_MIN_DURATION` guard)
+    writes nothing, but Rule 17's onset index counts it anyway - it comes
+    from enumerating the voice's own beats, not from a counter of what got
+    written - so a later note's id does not depend on an earlier beat's
+    survival."""
+    # duration_code 0 has no entry in TYPE_NAMES and resolves to 0 divisions
+    beats = [[(4, 0, [(1, 0)]), (0, 0, [(1, 1)]), (4, 0, [(1, 2)])]]
+    root = _root(_one_bar(beats))
+    ids = [n.get("id") for n in root.findall("./part/measure/note")]
+    # onset 1 (the dropped beat) never appears, but onset 2 keeps its own
+    # number rather than sliding down to fill the gap
+    assert ids == ["n1-1-0-0", "n1-1-2-0"]
+
+
+def test_a_forward_still_advances_the_onset_index_for_the_notes_after_it():
+    """Inferred silence (Rule 14) is written as `<forward>`, never a `<note>`,
+    but its onset is still counted - so the id of the note that follows it
+    names the true position in the voice's own beat list, not a compacted
+    one."""
+    beats = [[(4, 0, [(1, 0)]), (2, 0, musicxml.inferred_rest()),
+              (4, 0, [(1, 2)])]]
+    root = _root(_one_bar(beats, ts=(3, 4)))
+    ids = [n.get("id") for n in root.findall("./part/measure/note")]
+    assert ids == ["n1-1-0-0", "n1-1-2-0"]
+
+
+def test_ids_are_deterministic_across_re_emission():
+    """The whole point: the same beats model handed to build() twice, or a
+    score extracted twice, must write byte-identical ids - nothing here may
+    read a clock, a random source, or any counter not derived from position."""
+    beats = [
+        [(4, 0, [(1, 0)]), (4, 0, [(1, 2), (2, 2)]), (4, 0, [])],
+        [(2, 1, [(5, 0)])],
+    ]
+    first = _one_bar(beats, ts=(3, 4))
+    second = _one_bar(beats, ts=(3, 4))
+    assert first == second
+
+
+def test_ids_are_stable_under_an_unrelated_measure_change():
+    """An id names a position (measure, voice, onset, chord member), so a
+    change to a DIFFERENT measure must not perturb it - unlike, say, a
+    counter shared across the whole document."""
+    measure_a = [[(4, 0, [(1, 0)]), (4, 0, [(1, 2)])]]
+    other_measures = [
+        [[(4, 0, [(1, 0)])] * 4],
+        [[(4, 0, [(1, 0)])] * 4, [(4, 0, [(1, 0)])] * 4],
+    ]
+    for other in other_measures:
+        root = _root(musicxml.build(
+            "T", None, DEFAULT_TUNING, (4, 4),
+            [(measure_a, (4, 4)), (other, (4, 4))]))
+        first_measure_ids = [n.get("id") for n in
+                             root.find("./part/measure[@number='1']").findall("note")]
+        assert first_measure_ids == ["n1-1-0-0", "n1-1-1-0"]
+
+
+# ---------------------------------------------------------------------------
 # Validation against the real schema
 # ---------------------------------------------------------------------------
 

--- a/server/tests/test_tabextract.py
+++ b/server/tests/test_tabextract.py
@@ -4,6 +4,7 @@ import re
 import shutil
 import subprocess
 import tempfile
+import xml.etree.ElementTree as ET
 from pathlib import Path
 
 import fitz
@@ -3605,3 +3606,56 @@ def test_library_wide_repeat_structure_leaves_conformance_untouched(library_root
     assert totals["structure_high"] == 221
     assert totals["structure_medium"] == 72
     assert totals["structure_n/a"] == 0
+
+
+# xs:NCName: (Letter | '_') (NCNameChar)* - a bare digit run is not one,
+# which is why every id musicxml.py writes is prefixed with "n" (Rule 17).
+_NCNAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_.-]*$")
+
+
+def test_library_wide_note_ids_are_unique_and_valid_ncnames(library_root):
+    """Rule 17, library-wide (issue #150). Every `<note>` this project emits -
+    from every PDF the library this profile was developed against holds, not
+    a hand-built beats model - carries an id, every id is a legal xs:NCName,
+    and no two ids collide within their own document.
+
+    Run across the whole configured library (297 PDFs), the same shape as
+    test_library_wide_repeat_structure_leaves_conformance_untouched: one
+    fixture proves the rule holds in principle, this proves it holds at
+    the scale a real library actually reaches.
+    """
+    scores_checked = 0
+    total_note_ids = 0
+    duplicate_scores = []
+    invalid_ncname_scores = []
+    missing_id_scores = []
+    for pdf in _library_pdfs(library_root):
+        try:
+            result = tabextract.extract(pdf)
+        except Exception:
+            continue
+        if not result.extractable or not result.musicxml:
+            continue
+        root = ET.fromstring(result.musicxml)
+        ids = [n.get("id") for n in root.findall("./part/measure/note")]
+        if not ids:
+            continue
+        scores_checked += 1
+        total_note_ids += len(ids)
+        if not all(ids):
+            missing_id_scores.append(pdf.name)
+        if not all(_NCNAME_RE.match(i) for i in ids if i):
+            invalid_ncname_scores.append(pdf.name)
+        if len(set(ids)) != len(ids):
+            duplicate_scores.append(pdf.name)
+
+    assert missing_id_scores == [], f"note(s) missing an id: {missing_id_scores}"
+    assert invalid_ncname_scores == [], f"id(s) not a valid NCName: {invalid_ncname_scores}"
+    assert duplicate_scores == [], f"duplicate id(s) within a document: {duplicate_scores}"
+    # The exact figures issue #150's fix produces on this library. notes_no_stem_bar
+    # aside, note ids are written for every <note> emitted regardless of pitch,
+    # so this is strictly larger than the `notes` total (98704, sounding notes
+    # only) pinned in test_library_wide_repeat_structure_leaves_conformance_untouched
+    # above - it also counts every rest.
+    assert scores_checked == 293
+    assert total_note_ids == 100017

--- a/server/tests/test_tabextract.py
+++ b/server/tests/test_tabextract.py
@@ -3613,19 +3613,56 @@ def test_library_wide_repeat_structure_leaves_conformance_untouched(library_root
 _NCNAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_.-]*$")
 
 
+def _assert_no_offenders(scores, label, sample=6):
+    """assert-empty for a library-wide list of offending filenames, without
+    dumping the whole library at a reader when a defect is systemic. A
+    mutation that breaks uniqueness (or NCName validity) across the board -
+    see the two mutation tests this is written to survive - named ~279 (and
+    ~213) files in one AssertionError before this existed, which buried the
+    one thing worth reading (that it IS systemic) under noise nobody was
+    going to read."""
+    if not scores:
+        return
+    shown = scores[:sample]
+    remainder = len(scores) - len(shown)
+    message = f"{label}, {len(scores)} score(s): {shown}"
+    if remainder:
+        message += f" and {remainder} more"
+    raise AssertionError(message)
+
+
 def test_library_wide_note_ids_are_unique_and_valid_ncnames(library_root):
     """Rule 17, library-wide (issue #150). Every `<note>` this project emits -
     from every PDF the library this profile was developed against holds, not
     a hand-built beats model - carries an id, every id is a legal xs:NCName,
     and no two ids collide within their own document.
 
-    Run across the whole configured library (297 PDFs), the same shape as
+    Run across the whole configured library, the same shape as
     test_library_wide_repeat_structure_leaves_conformance_untouched: one
     fixture proves the rule holds in principle, this proves it holds at
     the scale a real library actually reaches.
+
+    Deliberately NOT pinned to an exact score count or an exact total id
+    count (PR #156 review): both are library-composition-dependent, and a
+    decoder change that reads one more or fewer note anywhere in the library
+    - which is any ordinary decoder improvement, not a Rule 17 regression -
+    would break an exact pin with no signal that ids are the problem. What
+    IS asserted is the identity that actually follows from Rule 17: every
+    `<note>` counted here is either a sounding note or a rest, so the total
+    must equal `result.notes` - the sounding-note count, computed from the
+    beats model BEFORE emission (see tabextract.py's own `notes_total`),
+    entirely independent of parsing the id-bearing XML this test reads -
+    plus the rests counted straight out of that same XML. If Rule 17 ever
+    stopped writing an id on some `<note>`, or wrote one on something that
+    is not a `<note>`, ids-vs-elements would still balance and this identity
+    would not catch it - that failure mode is what missing_id_scores below
+    is for. What this identity catches is scope creep or a miscount in
+    EITHER independent count feeding it. (Cross-check, not asserted: on the
+    library this was measured against, the identity holds as
+    100017 == 98704 sounding + 1313 rests.)
     """
     scores_checked = 0
-    total_note_ids = 0
+    identity_mismatches = []
     duplicate_scores = []
     invalid_ncname_scores = []
     missing_id_scores = []
@@ -3637,11 +3674,14 @@ def test_library_wide_note_ids_are_unique_and_valid_ncnames(library_root):
         if not result.extractable or not result.musicxml:
             continue
         root = ET.fromstring(result.musicxml)
-        ids = [n.get("id") for n in root.findall("./part/measure/note")]
-        if not ids:
+        notes = root.findall("./part/measure/note")
+        if not notes:
             continue
         scores_checked += 1
-        total_note_ids += len(ids)
+        ids = [n.get("id") for n in notes]
+        sounding = sum(1 for n in notes if n.find("rest") is None)
+        if sounding != result.notes:
+            identity_mismatches.append((pdf.name, sounding, result.notes))
         if not all(ids):
             missing_id_scores.append(pdf.name)
         if not all(_NCNAME_RE.match(i) for i in ids if i):
@@ -3649,13 +3689,14 @@ def test_library_wide_note_ids_are_unique_and_valid_ncnames(library_root):
         if len(set(ids)) != len(ids):
             duplicate_scores.append(pdf.name)
 
-    assert missing_id_scores == [], f"note(s) missing an id: {missing_id_scores}"
-    assert invalid_ncname_scores == [], f"id(s) not a valid NCName: {invalid_ncname_scores}"
-    assert duplicate_scores == [], f"duplicate id(s) within a document: {duplicate_scores}"
-    # The exact figures issue #150's fix produces on this library. notes_no_stem_bar
-    # aside, note ids are written for every <note> emitted regardless of pitch,
-    # so this is strictly larger than the `notes` total (98704, sounding notes
-    # only) pinned in test_library_wide_repeat_structure_leaves_conformance_untouched
-    # above - it also counts every rest.
-    assert scores_checked == 293
-    assert total_note_ids == 100017
+    _assert_no_offenders(missing_id_scores, "note(s) missing an id")
+    _assert_no_offenders(invalid_ncname_scores, "id(s) not a valid NCName")
+    _assert_no_offenders(duplicate_scores, "duplicate id(s) within a document")
+    assert identity_mismatches == [], (
+        f"XML sounding-note count disagrees with result.notes (score, xml_sounding, "
+        f"result.notes): {identity_mismatches[:10]}"
+        + (f" and {len(identity_mismatches) - 10} more" if len(identity_mismatches) > 10 else ""))
+    # A floor rather than a pin (see docstring): which PDFs in the maintainer's
+    # library extract cleanly can change, but the check must not have silently
+    # stopped running against anything close to the whole library.
+    assert scores_checked >= 250, f"only {scores_checked} scores were checked"


### PR DESCRIPTION
## Summary

Every `<note>` the MusicXML emitter writes now carries a stable, deterministic
`id` attribute — `n{measure}-{voice}-{onset}-{chord}` — derived only from
where the note sits (Rule 17 of `docs/musicxml-tab-profile.md`). Rests are
included, not skipped, so a consumer walking document order never has to
special-case them; the reasoning is written into the profile.

- `server/fermata/musicxml.py`: `_append_note` takes a required `note_id`;
  `build()` computes it from `(measure_number, voice_number, onset_index,
  chord_position)`, where `onset_index` is the beat's own position in its
  voice's beat list (counting skipped and `<forward>`-written beats, so it
  never shifts because something elsewhere in the measure did or did not
  get written).
- `docs/musicxml-tab-profile.md`: Rule 17, plus regenerated
  `docs/examples/*.musicxml` and their inline snippets so the published
  examples actually carry ids. Rule 17 also states: ids are emitter-owned
  (a document edited outside `build()` — e.g. via `PUT
  /scores/{id}/transcription`, which stores client content verbatim with no
  id validation — has to re-derive the affected voice's ids, not mint one);
  the uniqueness proof holds only for a single part/staff, which #10's
  two-staff proposal and #93's multi-track proposal would each need to
  extend; the chord ordinal is emission-derived (shifts if Rule 11 drops a
  chord member) while onset is model-derived, and that asymmetry is stated
  plainly; and `<forward>` (Rule 14 inferred silence) has no `id` attribute
  at all — the schema's `forward` type carries no `optional-unique-id` group
  — so a positional map built from ids has no reach into inferred silence.
- Tests: unit coverage for uniqueness, NCName validity, determinism, and
  onset stability under an unrelated edit (`server/tests/test_musicxml.py`);
  a fixture-level pin across every committed engraved PDF
  (`test_engraved_fixtures.py`); a library-gated pin across the full 297-PDF
  library (`test_tabextract.py`); a drift check pinning the doc's inline
  Example 1/2 note listings against the published example files.

## Review round 2 (addressed on this branch)

- The library-gated test no longer pins an exact score count or an exact
  total id count — both are library-composition-dependent and would break
  on any ordinary decoder change with no signal ids were the problem. It now
  asserts the identity that actually follows from Rule 17 (per score, the
  XML count of sounding `<note>` elements equals `result.notes`, computed
  independently from the beats model before emission), keeps
  zero-duplicates / zero-invalid-NCName as hard assertions, and floors the
  score count (`>= 250`) instead of pinning it. `100017` (measured as
  `98704` sounding + `1313` rests) is now a documented cross-check in the
  comment, not an assertion.
- Offender lists (duplicate ids, invalid NCNames, missing ids) are truncated
  to a handful of names plus a count on failure, instead of dumping every
  matching filename (was ~279 / ~213 names in one `AssertionError`).
- Added the inline-snippet-vs-published-file drift test described above.

## Verification (297-PDF library, `git archive a2c1111` as baseline)

- **Every note carries a unique id.** Library-gated test: `scores_checked
  >= 250` (293 measured), the sounding-count identity holds for every
  score, zero duplicates, zero invalid NCNames, zero missing ids.
- **Determinism.** The whole library extracted twice with this branch:
  every file's MusicXML sha256 identical across the two runs (0 mismatches
  / 297 files).
- **Byte-identical apart from `id="…"`.** Every file's MusicXML, with all
  `id` attributes stripped, hashes identically against the `a2c1111`
  baseline (0 mismatches / 297 files). Conformance aggregates re-derived on
  both sides and equal: `bars` 10632, `bars_defective` 5332, `notes` 98704,
  `beats` 82780, plus `bars_measured`, `bars_unread`, `bars_overfull`,
  `bars_short`, `bars_padded`, `inferred_rest_quarters` — all unchanged.
- **XSD validation and alphaTab.** `test_validates_against_xsd` and
  `test_the_published_examples_validate_against_xsd` (MusicXML 4.0 schema)
  pass; the alphaTab-backed playback tests that load emitted MusicXML
  (`_load_musicxml_with_alphatab`, including the onset/backup and
  repeat-playback tests) pass unchanged, confirming alphaTab does not choke
  on the new attribute.
- **Mutation testing, re-run against the reworked assertions.** Dropping
  the voice component from the id made the uniqueness tests fail (unit,
  engraved-fixture, and library-gated — the last with a truncated,
  readable message naming 6 of 279 affected scores). Making an id start
  with a digit made the NCName tests fail the same way (6 of 213). Both
  reverted cleanly (`git checkout --`, commit-backed) back to green.
- Full suite: 856 passed, 0 failed, 0 skipped, with `FERMATA_TEST_LIBRARY`,
  `FERMATA_MUSICXML_XSD`, and `web/node_modules` all set/present.

## Test plan

- [x] `pytest -rs` full suite, all three env vars set: 856 passed / 0 failed / 0 skipped
- [x] Library-wide note-id identity/uniqueness/NCName check (floored at >= 250, not pinned)
- [x] Engraved-fixture-level note-id pin
- [x] Doc inline-snippet-vs-published-file drift check (Examples 1 and 2)
- [x] Mutation testing (voice-drop collision, digit-leading NCName), re-run against the reworked assertions — red, then reverted to green
- [x] Full-library determinism (two passes, identical hashes)
- [x] Full-library byte-identical-modulo-id diff against `a2c1111` baseline
- [x] XSD validation and alphaTab load checks

Closes #150