### PR TITLE
Read the system printed beside the last one, and count any still lost

### DIFF
--- a/docs/musicxml-tab-profile.md
+++ b/docs/musicxml-tab-profile.md
@@ -639,7 +639,7 @@ last full system on the same horizontal band, and staff detection lost that
 whole system, so its coda sign was read off the page and had no bar to name
 because this transcription held none of that system's bars. Reading the
 system is what fixed it — see **A system that was not read** below — and it
-took `nav_marks_unresolved` from 87 bars to 8 at the same time. The 8 that
+took `nav_marks_unresolved` from 87 bars to 7 at the same time. The 7 that
 remain are scores that genuinely name a target their page does not draw.
 
 ### A system that was not read

--- a/docs/musicxml-tab-profile.md
+++ b/docs/musicxml-tab-profile.md
@@ -29,6 +29,7 @@ several things this profile has to decide.
   - [Inferred silence](#inferred-silence-rule-14)
   - [Repeat structure](#repeat-structure-rule-15)
   - [Navigation marks](#navigation-marks-rule-16)
+    - [A system that was not read](#a-system-that-was-not-read)
   - [Note identifiers](#note-identifiers-rule-17)
 - [Example 1: one monophonic bar](#example-1-one-monophonic-bar)
 - [Example 2: two voices in one bar](#example-2-two-voices-in-one-bar)
@@ -628,9 +629,45 @@ staff whose bars it would otherwise be clamped onto — is reported in
 bar. Both feed the `structure` confidence key.
 
 This is not a rare branch. In the library this profile was developed against,
-**86 of 297 scores print "D.S.", and 43 marks over the library are read off
-the page and anchored to no bar.** Of those 86, two draw no segno for the
+**86 of 297 scores print "D.S."** Of those 86, two draw no segno for the
 D.S. to name and get their words and no `dalsegno`; the other 84 do draw one.
+
+**`nav_marks_unanchored` is now 0 over that library, and it used to be 43.**
+Those 43 were almost entirely one defect, and not a defect in reading marks:
+these arrangements print the coda as a short system to the *right* of the
+last full system on the same horizontal band, and staff detection lost that
+whole system, so its coda sign was read off the page and had no bar to name
+because this transcription held none of that system's bars. Reading the
+system is what fixed it — see **A system that was not read** below — and it
+took `nav_marks_unresolved` from 87 bars to 8 at the same time. The 8 that
+remain are scores that genuinely name a target their page does not draw.
+
+### A system that was not read
+
+Every figure above describes music that reached the transcription and says
+how well it was read. `systems_unread` says how much never reached it: a
+staff-sized group of staff lines was found on a page, could not be read as a
+staff, and so contributed no bars at all. `systems_unread_pages` says which
+pages — **pages, not bars, and for the same reason `nav_marks_unanchored`
+has no bar list: a system that was never read has no bar numbers, because
+bar numbers are assigned by a grid its bars never entered.**
+
+It has to be counted, and counted separately, because of an asymmetry that
+makes silence here worse than error. The bars that vanish with a system are
+as likely as any others to be the ones that did not add up — so losing a
+system can move `bars_defective` *down*. A conformance figure that improves
+when music disappears is worse than no figure, and `systems_unread` is the
+number that stops it being read that way: **`bars`, `notes` and every Rule 8
+count describe only the systems that were read, and this is what says so.**
+
+A score with a lost system also reports `structure` confidence as `low`,
+outranking every other structure term. The repeat and navigation marks that
+were read may be perfectly complete and still describe a form built out of
+bars the file does not contain.
+
+In the library this profile was developed against, `systems_unread` is **2**,
+on 2 files. Before the side-by-side systems above were read it was **41**,
+across 22 files.
 
 **A correction, stated plainly, because an earlier version of this rule said
 the opposite.** This document previously claimed that *no score in the

--- a/server/fermata/api.py
+++ b/server/fermata/api.py
@@ -1491,7 +1491,17 @@ _BAR_KEYS = ("bars_overfull", "bars_short", "bars_defective", "bars_measured",
              # phase 2, Rule 16), here for the same reason the repeat/volta
              # keys above are: a caller with only the API must not have to
              # infer the caveat from a file that looks complete.
-             "nav_marks_unanchored", "nav_marks_unresolved")
+             "nav_marks_unanchored", "nav_marks_unresolved",
+             # `systems_unread` (issue #152): a SYSTEM whose bars were never
+             # read - the only disclosure here about music that is ABSENT
+             # from the transcription rather than imperfect in it. It has to
+             # survive a reload for the same reason the rest do, and more
+             # sharply: every other figure in this blob describes the
+             # systems that WERE read, so a reader without this one is
+             # holding a set of numbers that silently excludes a page's
+             # worth of music. Losing a system can even move
+             # `bars_defective` down.
+             "systems_unread")
 
 # WHICH bars those were, as data and not only inside the warning prose. The
 # prose names them, but it caps the list, and the profile document states that a
@@ -1518,7 +1528,14 @@ _BAR_LIST_KEYS = ("padded_bars", "unread_bars", "spacing_bars", "degraded_bars",
                    # target the score does not draw. `nav_marks_unanchored`
                    # has no list of its own on purpose: a mark with no bar
                    # to name has no bar number to report.
-                   "nav_marks_unresolved_bars")
+                   "nav_marks_unresolved_bars",
+                   # WHICH PAGES a lost system was on (issue #152). This is a
+                   # page list where its neighbours are bar lists, and that is
+                   # forced by the defect: a system that was never read has no
+                   # bar numbers, because bar numbers come from the grid its
+                   # bars never entered. A page is the coordinate that does
+                   # exist, and the one a reader can turn to.
+                   "systems_unread_pages")
 _BAR_AMOUNT_KEYS = ("inferred_rest_quarters",)
 
 
@@ -1765,6 +1782,13 @@ def transcribe(score_id: RowId, body: TranscribeIn | None = Body(default=None)):
             "nav_marks_unanchored": result.nav_marks_unanchored,
             "nav_marks_unresolved": result.nav_marks_unresolved,
             "nav_marks_unresolved_bars": result.nav_marks_unresolved_bars,
+            # systems_unread / systems_unread_pages (issue #152) - written
+            # here, the only path into storage, and not merely produced on
+            # ExtractionResult. That gap is the one #143 and #146 each shipped
+            # once; the structural guard in test_transcription_api.py now
+            # fails by name if a _BAR_KEYS entry never reaches this dict.
+            "systems_unread": result.systems_unread,
+            "systems_unread_pages": result.systems_unread_pages,
             "time_signature": list(result.time_signature) if result.time_signature else None,
             "time_signature_source": result.time_signature_source,
             "key_fifths": result.key_fifths,

--- a/server/fermata/api_models.py
+++ b/server/fermata/api_models.py
@@ -494,6 +494,11 @@ class TranscriptionOut(BaseModel):
     staves_coincident_unsplit: int | None
     nav_marks_unanchored: int | None
     nav_marks_unresolved: int | None
+    # A system whose bars were not read at all (issue #152) - music ABSENT
+    # from this transcription rather than imperfect in it. Every other figure
+    # on this model describes only the systems that WERE read, which makes
+    # this the one that says how far that qualification reaches.
+    systems_unread: int | None
 
     # _BAR_LIST_KEYS
     padded_bars: list[int] | None
@@ -508,6 +513,10 @@ class TranscriptionOut(BaseModel):
     # mark with no bar to name has no bar number to report (issue #134
     # phase 2, Rule 16).
     nav_marks_unresolved_bars: list[int] | None
+    # PAGES, not bars, and for the reason `nav_marks_unanchored` has no list
+    # at all: a system that was never read has no bar numbers to report. The
+    # page is the coordinate that survives (issue #152).
+    systems_unread_pages: list[int] | None
 
     # _BAR_AMOUNT_KEYS
     inferred_rest_quarters: float | None

--- a/server/fermata/tabextract.py
+++ b/server/fermata/tabextract.py
@@ -337,6 +337,28 @@ class ExtractionResult:
     nav_marks_unanchored: int = 0
     nav_marks_unresolved: int = 0
     nav_marks_unresolved_bars: list[int] = field(default_factory=list)
+    # A SYSTEM whose bars were not read at all (issue #152). Every other
+    # figure on this result describes music that reached the transcription
+    # and says how well it was read; this one says how much music never
+    # reached it, which is the only defect none of the others can express.
+    # A staff-sized group of staff lines was found on the page, could not be
+    # read as a staff (its line count was neither 5 nor 6 - see
+    # _detect_staves and _STAFF_SIZED_GROUP), and so contributed no bars.
+    #
+    # THERE IS NO `*_bars` LIST FOR IT, and that is the point rather than an
+    # omission: a system that was never read has no bar numbers to report,
+    # because bar numbers are assigned by the grid these bars never entered.
+    # `systems_unread_pages` is the coordinate that does exist - a page a
+    # reader can turn to and compare against - the same role `padded_bars`
+    # plays for bars that were read.
+    #
+    # WHY IT MUST BE COUNTED. Bars that vanish are as likely as any to be the
+    # ones that did not add up, so losing a system can move `bars_defective`
+    # DOWN: a figure that improves when music disappears is worse than no
+    # figure. `bars`, `notes` and every Rule 8 count here describe only the
+    # systems that were read, and this is the number that says so.
+    systems_unread: int = 0
+    systems_unread_pages: list[int] = field(default_factory=list)
 
     def to_dict(self) -> dict:
         return {
@@ -394,6 +416,8 @@ class ExtractionResult:
             "nav_marks_unanchored": self.nav_marks_unanchored,
             "nav_marks_unresolved": self.nav_marks_unresolved,
             "nav_marks_unresolved_bars": list(self.nav_marks_unresolved_bars),
+            "systems_unread": self.systems_unread,
+            "systems_unread_pages": list(self.systems_unread_pages),
         }
 
 
@@ -403,11 +427,20 @@ class ExtractionResult:
 
 
 class _Staff:
-    def __init__(self, kind, line_ys, x0, x1):
+    def __init__(self, kind, line_ys, x0, x1, band=0):
         self.kind = kind  # "tab" (6 lines) or "standard" (5 lines)
         self.line_ys = line_ys  # sorted top->bottom
         self.x0 = x0
         self.x1 = x1
+        # Which horizontal band of the page this staff was ruled on. Staves
+        # printed SIDE BY SIDE share a band and have nearly equal `top` in
+        # an order the engraving decides, so (band, x0) is the reading order
+        # and `top` is not - see _detect_staves.
+        self.band = band
+
+    @property
+    def reading_order(self):
+        return (self.band, self.x0)
 
     @property
     def top(self):
@@ -450,6 +483,54 @@ STAFF_LINE_SIBLINGS_REQUIRED = 4
 # staff are drawn to the same x - so this is slack, not a threshold.
 STAFF_LINE_SIBLING_TOLERANCE = 2.0
 
+# A SECOND, lower length floor, for staff lines that are short because the
+# system they belong to is short (issue #152).
+#
+# The primary floor above is a quarter of the page width. That is the right
+# size for a system that runs the width of the page, and it is why a
+# right-hand system printed on the same band as the last full one was not
+# merely misread but INVISIBLE: on "1 AM (Animal Crossing New Leaf)" the coda
+# system's six tab lines run x 441.2-575.7, which is 134.5pt on a 612pt page
+# - 0.220 of the width, under the 0.25 floor - so they were dropped before
+# staff detection ever saw them, no anomaly was reported, and the page's bar
+# 18 simply did not exist. "Kakariko Village" is the same shape at 133.5pt.
+# Measured over the library, 54 systems are drawn this way.
+#
+# A lower floor on its own is exactly how a volta bracket or a chord grid
+# becomes a staff, so a run admitted by it must ALSO look like a staff line
+# in the two ways a decoration does not: it must have
+# STAFF_LINE_SIBLINGS_REQUIRED siblings at its own extent (as any short run
+# must - see _has_staff_siblings), and those siblings must be spaced far
+# enough apart to be staff lines at all (STAFF_LINE_MIN_SPACING).
+#
+# THE VALUE IS SET BY A MEASUREMENT, and the measurement says the length is
+# not what is doing the work. Scanning the whole library for every run
+# between 0.04 and 0.25 of the page width that passes both of those tests
+# finds 54 groups, and all 54 are real: every one comes back with exactly 11
+# rows - a 5-line notation staff and a 6-line tab staff ruled to the same x -
+# which is a side-by-side system and cannot be anything else. Their lengths
+# run from 0.1235 (Fond Memories, 75.6pt) to 0.2488 (Melodies of Life), and
+# BELOW 0.1235 the scan finds nothing whatsoever down to 0.04. So the floor
+# is not separating staves from decorations - the sibling and spacing tests
+# are - and 0.10 is placed in the empty band under the smallest real staff,
+# where it admits all 54 and cannot be the thing that decides.
+#
+# It was 0.15 first, which is inside the real range and cost 12 of the 54 -
+# among them "Rito Village - Night" at 0.1461, whose coda system is a
+# perfectly ordinary 5+6 staff pair 89.4pt wide.
+SHORT_STAFF_LEN_RATIO = 0.10
+
+# The closest two staff lines ever are. Notation staves in the library are
+# ruled 5.1pt apart and tablature staves 7.7pt; the decorations that clear
+# the sibling test are much tighter than either. Two title-block ornaments
+# were measured at gaps of 1.2-2.6pt - four rows at one extent, which passes
+# the sibling test on its own - and admitting them cost a real staff: on
+# "Troian Beauty" p3 the ornament's rows fell in the same 15.0pt band as the
+# page's first notation staff and swallowed it into an 11-line group. So the
+# spacing is the test that makes the lower floor safe, and 3.0pt sits below
+# every real staff and above every decoration measured.
+STAFF_LINE_MIN_SPACING = 3.0
+
 # A rule drawn along the page's own edge is page furniture, not a staff.
 PAGE_EDGE_TOLERANCE = 1.0
 
@@ -479,7 +560,8 @@ PAGE_EDGE_TOLERANCE = 1.0
 BARLINE_STROKE_MERGE_SPACES = 1.0
 
 
-def _long_horizontal_segments(page, min_len_ratio=0.25):
+def _long_horizontal_segments(page, min_len_ratio=0.25,
+                              short_len_ratio=SHORT_STAFF_LEN_RATIO):
     """Near-horizontal vector primitives long enough to plausibly be staff
     lines, as opposed to beams, ledger lines, or stems.
 
@@ -557,61 +639,149 @@ def _long_horizontal_segments(page, min_len_ratio=0.25):
         runs.append((y, run_x0, run_x1, pieces))
 
     long_enough = [r for r in runs if r[2] - r[1] >= min_len]
-    return [(y, x0, x1) for y, x0, x1, pieces in long_enough
-            if pieces == 1 or _has_staff_siblings(y, x0, x1, long_enough)]
+    kept = [r for r in long_enough
+            if r[3] == 1 or _has_staff_siblings(r[0], r[1], r[2], long_enough)]
+
+    # Runs too short for the primary floor, kept only where they look like the
+    # lines of a short system rather than a decoration - see
+    # SHORT_STAFF_LEN_RATIO. Their siblings are searched among the SHORT runs
+    # alone, not among all of them: a half-width system's lines are all short
+    # together, so nothing is lost by it, and it means this cannot reach back
+    # and change which long runs are kept. The long path above is therefore
+    # byte-for-byte the behaviour it always had.
+    short_len = page.rect.width * short_len_ratio
+    short = [r for r in runs if short_len <= r[2] - r[1] < min_len]
+    for r in short:
+        rows = _staff_sibling_rows(r[0], r[1], r[2], short)
+        if len(rows) - 1 < STAFF_LINE_SIBLINGS_REQUIRED:
+            continue
+        if not _rows_are_staff_spaced(rows):
+            continue
+        kept.append(r)
+
+    return [(y, x0, x1) for y, x0, x1, pieces in kept]
+
+
+def _staff_sibling_rows(y, x0, x1, runs):
+    """Every row carrying a run at this run's x extent, this row included."""
+    tol = STAFF_LINE_SIBLING_TOLERANCE
+    rows = {other_y for other_y, ox0, ox1, _pieces in runs
+            if abs(ox0 - x0) <= tol and abs(ox1 - x1) <= tol}
+    rows.add(y)
+    return sorted(rows)
 
 
 def _has_staff_siblings(y, x0, x1, runs):
     """Do enough other rows span this run's extent for it to be a staff line?"""
-    tol = STAFF_LINE_SIBLING_TOLERANCE
-    rows = {other_y for other_y, ox0, ox1, _pieces in runs
-            if other_y != y and abs(ox0 - x0) <= tol and abs(ox1 - x1) <= tol}
-    return len(rows) >= STAFF_LINE_SIBLINGS_REQUIRED
+    return len(_staff_sibling_rows(y, x0, x1, runs)) - 1 >= STAFF_LINE_SIBLINGS_REQUIRED
+
+
+def _rows_are_staff_spaced(rows):
+    """Are consecutive rows far enough apart to be lines of a staff?
+
+    The gap BETWEEN two staves in the set is large and passes trivially; what
+    this refuses is a set whose rows are packed tighter than any engraver
+    rules a staff - see STAFF_LINE_MIN_SPACING.
+    """
+    return all(b - a >= STAFF_LINE_MIN_SPACING for a, b in zip(rows, rows[1:]))
 
 
 def _detect_staves(page):
     """Cluster long horizontal line primitives into staff systems.
 
-    Returns (staves, anomalies): anomalies records line-groups whose size was
-    neither 5 nor 6, so callers can surface what was thrown away.
+    Returns (staves, anomalies) with the staves in READING ORDER - band by
+    band down the page, and left to right within a band. anomalies records
+    line-groups whose size was neither 5 nor 6, so callers can surface what
+    was thrown away.
+
+    A band is split into COLUMNS before its lines are counted (issue #152).
+    Clustering by vertical gap alone answers "which lines are level with each
+    other", which is not the same question as "which lines belong to one
+    staff": the house layout these arrangements use prints the coda system to
+    the RIGHT of the last full system, on the same band. Level, and two
+    different staves.
+
+    Merging the two cost music in two different ways, and both were measured:
+
+      - Where the two systems are ruled at the SAME y, the rows collapsed
+        into one full-width staff record. "Imprisoned Town (Suikoden II)" p2
+        reported a standard staff at x 54.0-575.9 for a band that actually
+        holds one system at 54.0-341.7 and another at 378.2-575.9. Nothing
+        said anything was wrong; the staff simply described music that was
+        not there, and its x span then swallowed marks belonging to the
+        right-hand system (see _apply_nav_marks, which could not test its way
+        out of a staff record spanning the whole page).
+
+      - Where they are ruled 1.5-1.7pt apart - which is what an engraver
+        does when the two systems have different content above them - the y
+        values interleave inside the 15.0pt band and the group came back with
+        TWICE the lines. That is the 12-line group issue #152 opens with:
+        Imprisoned Town's last band, and both of "The Nautilus Knoweth" p3's
+        (a 10-line pair of notation staves and a 12-line pair of tab staves),
+        discarded whole. Imprisoned Town lost 4 printed bars, Nautilus 5.
+
+    Splitting by x extent answers the second question directly, and the tell
+    is unambiguous: two side-by-side systems do not overlap in x at all (the
+    measured gaps are 36.5pt and 30.7pt) while the lines of one staff are
+    drawn to the same x within STAFF_LINE_SIBLING_TOLERANCE. A column is
+    therefore a maximal run of x-overlapping rows, and a page that prints one
+    system per band yields exactly one column per band - which is why this
+    moves no output on the 230 library files that have no such band.
+
+    READING ORDER IS NOT TOP ORDER, and that is why this returns an order at
+    all. Two side-by-side systems have nearly equal `top`, and which of them
+    is the smaller number is decided by the 1.5pt engraving offset above -
+    on "Troian Beauty" p3 the RIGHT-hand system is the higher one. Sorting
+    staves by `top` would therefore have put the coda system's bars BEFORE
+    the bars of the system printed to its left. Callers order by
+    (band, x0) - see _Staff.band.
     """
     segs = _long_horizontal_segments(page)
     if not segs:
         return [], []
 
-    by_y = {}
-    for y, x0, x1 in segs:
-        key = round(y, 1)
-        if key not in by_y:
-            by_y[key] = [x0, x1]
-        else:
-            by_y[key][0] = min(by_y[key][0], x0)
-            by_y[key][1] = max(by_y[key][1], x1)
-    ys = sorted(by_y.keys())
-
-    clusters = []
-    cur = [ys[0]]
+    ys = sorted({round(y, 1) for y, _x0, _x1 in segs})
+    band_of = {ys[0]: 0}
+    band = 0
     for prev, y in zip(ys, ys[1:]):
         if (y - prev) > 15.0:
-            clusters.append(cur)
-            cur = [y]
-        else:
-            cur.append(y)
-    clusters.append(cur)
+            band += 1
+        band_of[y] = band
+
+    bands = collections.defaultdict(list)
+    for y, x0, x1 in segs:
+        bands[band_of[round(y, 1)]].append((y, x0, x1))
 
     staves = []
     anomalies = []
-    for c in clusters:
-        n = len(c)
-        x0 = min(by_y[y][0] for y in c)
-        x1 = max(by_y[y][1] for y in c)
-        if n == 6:
-            staves.append(_Staff("tab", c, x0, x1))
-        elif n == 5:
-            staves.append(_Staff("standard", c, x0, x1))
-        else:
-            anomalies.append({"line_count": n, "ys": c, "x0": x0, "x1": x1})
+    for band in sorted(bands):
+        for x0, x1, rows in _band_columns(bands[band]):
+            c = sorted({round(y, 1) for y, _a, _b in rows})
+            n = len(c)
+            if n == 6:
+                staves.append(_Staff("tab", c, x0, x1, band))
+            elif n == 5:
+                staves.append(_Staff("standard", c, x0, x1, band))
+            else:
+                anomalies.append({"line_count": n, "ys": c, "x0": x0, "x1": x1,
+                                  "band": band})
     return staves, anomalies
+
+
+def _band_columns(rows):
+    """Split one horizontal band into the systems printed side by side in it.
+
+    Returns [(x0, x1, rows), ...] left to right, each a maximal run of rows
+    whose x extents overlap. See _detect_staves for why a band is not a staff.
+    """
+    columns = []
+    for y, x0, x1 in sorted(rows, key=lambda r: (r[1], r[2])):
+        if columns and x0 <= columns[-1][1]:
+            columns[-1][1] = max(columns[-1][1], x1)
+            columns[-1][2].append((y, x0, x1))
+        else:
+            columns.append([x0, x1, [(y, x0, x1)]])
+    return [(x0, x1, rows) for x0, x1, rows in columns]
 
 
 def _vertical_segments(page, min_len=15.0):
@@ -1191,10 +1361,19 @@ def _read_volta_number(spans, left_x, line_y, spacing):
     return best
 
 
-def _read_volta_brackets(page, band_top, spacing):
+def _read_volta_brackets(page, band_top, spacing, x0=None, x1=None):
     """Numbered volta brackets whose line sits above `band_top` (the
     system's topmost staff line - never the tab staff, see issue #134 S2.4),
     read fresh from the drawing primitives. Returns (brackets, hooks):
+
+    `x0`/`x1` bound the search to ONE system's own horizontal extent. A band
+    can hold two systems printed side by side (issue #152), and the y band
+    above a staff runs the width of the page: without this, the "2." bracket
+    drawn over the left-hand system was found AGAIN for the right-hand one
+    and written a second time onto the coda system's bar. Measured on "Our
+    Terms (Final Fantasy XVI)", which emitted ending 2 over both bar 27 and
+    bar 28. A page with one system per band passes its full width here and
+    nothing is excluded.
     brackets is (left_x, right_x, line_y, number) left-to-right; hooks is
     every downward stroke found in the search band, passed through so
     _associate_voltas can look for a closing hook at the boundary it
@@ -1215,9 +1394,15 @@ def _read_volta_brackets(page, band_top, spacing):
     y_lo = band_top - spacing * VOLTA_HEIGHT_MAX_SPACES
     y_reach_lo = band_top - spacing * VOLTA_HEIGHT_MIN_SPACES
     hooks = _volta_hooks(page, y_lo, y_hi, spacing)
+    if x0 is not None:
+        hooks = [h for h in hooks if x0 <= h[0] <= x1]
     if not hooks:
         return [], []
     pieces = _volta_horizontal_pieces(page, y_lo, y_hi)
+    if x0 is not None:
+        # Overlap, not containment: a bracket's drawn line may overhang its
+        # system's last barline slightly, as ordinary engraving.
+        pieces = [pc for pc in pieces if pc[1] <= x1 and pc[2] >= x0]
     if not pieces:
         return [], hooks
     spans = _text_spans(page)
@@ -1751,6 +1936,33 @@ def _read_navigation_marks(page):
     return sorted(signs + kept, key=lambda m: (m.y0, m.x0))
 
 
+def _nav_owner_in_band(nearest, candidates, mark):
+    """Which of the staves sharing `nearest`'s band the mark is drawn over.
+
+    Vertical order alone picks the owner wrongly as soon as a band holds two
+    systems printed side by side (issue #152). The two are ruled 1.5-1.7pt
+    apart and which one is the higher is an engraving detail, so "the first
+    staff below the mark" is a coin toss between the system the mark is over
+    and the one beside it. Measured over the library, taking the coin toss
+    left 20 coda signs owned by the system to their LEFT - and the x refusal
+    in _apply_nav_marks then correctly declined to anchor them, turning a
+    mark that has a perfectly good bar into a disclosed unanchored one.
+
+    So among the staves on that one band, the mark belongs to the one it
+    horizontally overlaps most, and only where it overlaps none of them does
+    the nearest-by-y answer stand - whereupon _apply_nav_marks refuses it as
+    it always did. A page with one system per band has one candidate and
+    this returns it unchanged.
+    """
+    mates = [s for s in candidates if s.band == nearest.band]
+    best, best_overlap = nearest, 0.0
+    for s in mates:
+        overlap = min(s.x1, mark.x1) - max(s.x0, mark.x0)
+        if overlap > best_overlap:
+            best, best_overlap = s, overlap
+    return best
+
+
 def _assign_nav_marks(marks, staves, tab_for_top):
     """Bucket this page's navigation marks by the tab staff whose bars they
     belong to. Returns ({id(tab_staff): [marks]}, unowned).
@@ -1772,11 +1984,12 @@ def _assign_nav_marks(marks, staves, tab_for_top):
     buckets = collections.defaultdict(list)
     unowned = []
     for mark in marks:
-        owner = next((s for s in by_top if s.top >= mark.y1 - 0.5), None)
+        below = [s for s in by_top if s.top >= mark.y1 - 0.5]
+        owner = _nav_owner_in_band(below[0], below, mark) if below else None
         gap = (owner.top - mark.y1) if owner is not None else None
         if owner is None:
-            owner = next((s for s in reversed(by_bottom) if s.bottom <= mark.y0 + 0.5),
-                          None)
+            above = [s for s in reversed(by_bottom) if s.bottom <= mark.y0 + 0.5]
+            owner = _nav_owner_in_band(above[0], above, mark) if above else None
             gap = (mark.y0 - owner.bottom) if owner is not None else None
         if owner is None or gap > owner.spacing * NAV_BAND_SPACES:
             unowned.append(mark)
@@ -3223,7 +3436,13 @@ _STAFF_SIZED_GROUP = 5
 def _discard_report(discarded_groups):
     """Say what was thrown away, and cap the fret confidence if it mattered.
 
-    Returns (warnings, fret_confidence_override | None).
+    Returns (warnings, fret_confidence_override | None, systems_unread,
+    systems_unread_pages) - the last two being the COUNT of what was lost,
+    which issue #152 added because prose is not a figure. A caller comparing
+    two extractions, or a client reading this back out of storage, cannot
+    grep a sentence; `systems_unread` is the same fact as a number, and the
+    rule it exists to keep is that a system whose bars were not read must be
+    counted.
 
     A group of staff lines whose count is neither 5 nor 6 cannot be read, and
     it used to be reported as "N staff-line group(s) with an unexpected line
@@ -3240,30 +3459,35 @@ def _discard_report(discarded_groups):
     the claim it undermines, because a whole system's digits are missing.
     """
     if not discarded_groups:
-        return [], None
+        return [], None, 0, []
     warnings = []
     staff_sized = 0
+    staff_sized_pages = []
     for page_no, anomalies in discarded_groups:
         counts = sorted(a.get("line_count", 0) for a in anomalies)
-        staff_sized += sum(1 for n in counts if n >= _STAFF_SIZED_GROUP)
+        on_this_page = sum(1 for n in counts if n >= _STAFF_SIZED_GROUP)
+        staff_sized += on_this_page
+        if on_this_page:
+            staff_sized_pages.append(page_no)
         warnings.append(
             f"page {page_no}: {len(anomalies)} group(s) of staff lines could not be read as a "
             f"staff and were ignored (line counts: {counts}) - a staff has 5 lines and a "
             "tablature staff 6, so any other count is a group this pass cannot interpret"
         )
     if not staff_sized:
-        return warnings, None
+        return warnings, None, 0, []
     warnings.append(
         f"{staff_sized} of the ignored group(s) had at least {_STAFF_SIZED_GROUP} lines, which "
         "is the size of a staff - if any of those was one, that whole system's bars and notes "
         "are MISSING from this transcription rather than wrong in it, and every count and "
-        "bar-conformance figure here describes only the systems that were read"
+        f"bar-conformance figure here describes only the systems that were read "
+        f"(systems_unread={staff_sized}, on page(s) {_bar_list(staff_sized_pages)})"
     )
     return warnings, (
         "medium - read directly from vector text spans, but "
         f"{staff_sized} staff-sized group(s) of lines on this score could not be read as a "
         "staff and were skipped, so notes may be missing entirely rather than misread"
-    )
+    ), staff_sized, staff_sized_pages
 
 
 def _resolve_rhythm_source(page, std_staff, pair_reason, decoded):
@@ -4309,8 +4533,14 @@ def _extract(doc, pdf_path, time_signature: tuple[int, int] | None) -> Extractio
         staves, anomalies = _detect_staves(page)
         if anomalies:
             discarded_groups.append((page_no + 1, anomalies))
-        tab_staves = sorted((s for s in staves if s.kind == "tab"), key=lambda s: s.top)
-        std_staves = sorted((s for s in staves if s.kind == "standard"), key=lambda s: s.top)
+        # Reading order, NOT top order: a coda system printed to the right of
+        # the last full system shares its band and can be ruled a shade
+        # HIGHER, so ordering by `top` would emit its bars first (issue
+        # #152). On a page with one system per band the two orders agree.
+        tab_staves = sorted((s for s in staves if s.kind == "tab"),
+                            key=lambda s: s.reading_order)
+        std_staves = sorted((s for s in staves if s.kind == "standard"),
+                            key=lambda s: s.reading_order)
         tab_count += len(tab_staves)
         std_count += len(std_staves)
 
@@ -4339,7 +4569,8 @@ def _extract(doc, pdf_path, time_signature: tuple[int, int] | None) -> Extractio
     # carries it too: a page whose staff-sized line groups were all discarded
     # is refused for "no tab staff found", which is true and yet says nothing
     # about the six lines that were thrown away to make it true.
-    discard_warnings, discard_note = _discard_report(discarded_groups)
+    (discard_warnings, discard_note,
+     systems_unread, systems_unread_pages) = _discard_report(discarded_groups)
     warnings.extend(discard_warnings)
 
     if vector_pages == 0:
@@ -4358,6 +4589,11 @@ def _extract(doc, pdf_path, time_signature: tuple[int, int] | None) -> Extractio
             tab_staff_count=tab_count,
             standard_staff_count=std_count,
             warnings=warnings,
+            # A refusal carries the count too: "no tab staff found" is true
+            # and says nothing about the staff-sized groups that were thrown
+            # away to make it true (issue #152).
+            systems_unread=systems_unread,
+            systems_unread_pages=systems_unread_pages,
         )
 
     # Time signature, now that we know there is tab worth extracting. Read at
@@ -4749,7 +4985,8 @@ def _extract(doc, pdf_path, time_signature: tuple[int, int] | None) -> Extractio
                 # bracket only 3.28 std-staff-spaces tall as too short,
                 # because 2.5 TAB-staff-spaces is a taller absolute distance.
                 brackets, volta_hooks = _read_volta_brackets(
-                    page, std_staff.top, std_staff.spacing)
+                    page, std_staff.top, std_staff.spacing,
+                    std_staff.x0, std_staff.x1)
                 endings, unread, volta_unanchored = _associate_voltas(
                     brackets, volta_hooks, barline_recs, bounds, lo, hi, staff_first_bar,
                     std_staff.spacing, staff.spacing)
@@ -4935,6 +5172,8 @@ def _extract(doc, pdf_path, time_signature: tuple[int, int] | None) -> Extractio
             standard_staff_count=std_count,
             pages_processed=len(pages_with_tab),
             warnings=warnings,
+            systems_unread=systems_unread,
+            systems_unread_pages=systems_unread_pages,
         )
 
     title = Path(pdf_path).stem
@@ -4981,7 +5220,21 @@ def _extract(doc, pdf_path, time_signature: tuple[int, int] | None) -> Extractio
                          + len(endings_truncated_bars) + len(form_marks_unanchored_bars)
                          + endings_incomplete
                          + len(nav_unresolved_bars) + nav_unanchored)
-    if not form_marks and not nav_directions and not structure_issues:
+    # A lost SYSTEM outranks any of the above, and is stated first (issue
+    # #152). The marks that were read may be complete and still describe a
+    # form this transcription cannot play, because the bars a jump names are
+    # on the system that was not read - so "high" would be a claim about the
+    # structure of a score this file does not contain. It is also the one
+    # case here where a bar-level figure cannot express the loss: an absent
+    # system has no bar to attach a caveat to.
+    if systems_unread:
+        structure_confidence = (
+            f"low - {systems_unread} system(s) on this score could not be read at all (page(s) "
+            f"{_bar_list(systems_unread_pages)}), so their bars are missing from this "
+            "transcription entirely and any repeat or navigation mark naming them has nothing "
+            "to point at"
+        )
+    elif not form_marks and not nav_directions and not structure_issues:
         structure_confidence = (
             "n/a - no repeat barlines, volta brackets or navigation marks were found on this "
             "score"
@@ -5065,6 +5318,8 @@ def _extract(doc, pdf_path, time_signature: tuple[int, int] | None) -> Extractio
         form_marks_unanchored=len(form_marks_unanchored_bars),
         form_marks_unanchored_bars=list(form_marks_unanchored_bars),
         endings_incomplete=endings_incomplete,
+        systems_unread=systems_unread,
+        systems_unread_pages=systems_unread_pages,
         nav_marks_unanchored=nav_unanchored,
         nav_marks_unresolved=len(nav_unresolved_bars),
         nav_marks_unresolved_bars=nav_unresolved_bars,

--- a/server/fermata/tabextract.py
+++ b/server/fermata/tabextract.py
@@ -520,15 +520,31 @@ STAFF_LINE_SIBLING_TOLERANCE = 2.0
 # perfectly ordinary 5+6 staff pair 89.4pt wide.
 SHORT_STAFF_LEN_RATIO = 0.10
 
-# The closest two staff lines ever are. Notation staves in the library are
-# ruled 5.1pt apart and tablature staves 7.7pt; the decorations that clear
-# the sibling test are much tighter than either. Two title-block ornaments
-# were measured at gaps of 1.2-2.6pt - four rows at one extent, which passes
-# the sibling test on its own - and admitting them cost a real staff: on
-# "Troian Beauty" p3 the ornament's rows fell in the same 15.0pt band as the
-# page's first notation staff and swallowed it into an 11-line group. So the
-# spacing is the test that makes the lower floor safe, and 3.0pt sits below
-# every real staff and above every decoration measured.
+# The closest two staff lines ever are, and THE TEST THAT ACTUALLY SEPARATES
+# A STAFF FROM A DECORATION. Notation staves in the library are ruled 5.1pt
+# apart and tablature staves 7.7pt; everything else that clears the length
+# floor and the sibling test is much tighter than either.
+#
+# Measured over the library at the floor above: 89 same-extent sibling groups
+# clear both of those tests and are refused here, from six files. Four draw a
+# title-block ornament whose rows alternate 2.5 and 1.3pt (Troian Beauty,
+# Moonlit Shadows, Carcelera, Celes's Theme); two method books draw
+# chord-grid rows at 2.4-2.7pt (Recuerdos de la Alhambra, Classical Guitar
+# Method Vol. 1). Every real staff admitted alongside them has a minimum row
+# gap of 5.00pt or more, so 3.0 sits in a clear band: worst admitted 5.00,
+# closest refused 2.60.
+#
+# THE LENGTHS OVERLAP AND THE SPACINGS DO NOT, which is why this is the
+# load-bearing test and the length floor is not. The refused groups run up to
+# 0.2145 of the page width while the real short staves start at 0.1235 - so
+# no length floor anywhere could separate these two sets, and one drawn
+# through the overlap would throw away real systems to catch ornaments it
+# would still miss. A future tuner should move this constant, not that one.
+#
+# Admitting them is not merely noisy, it costs real music: on "Troian Beauty"
+# p3 the ornament's rows fall in the same 15.0pt band as the page's first
+# notation staff and swallow it into an 11-line group, which is then
+# discarded.
 STAFF_LINE_MIN_SPACING = 3.0
 
 # A rule drawn along the page's own edge is page furniture, not a staff.

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -127,19 +127,39 @@ _FIXTURE_RELATIVE_PATHS = {
     # dropped silently. The only real fixture in the library with this shape
     # (2 instances, both on this one barline group's two measure sides).
     "tarrega_estudio_em": "Classical/Tarrega/Tarrega-Estudio-Em-Werner.pdf",
-    # The coda-system layout: the coda is engraved as a short system to the
-    # RIGHT of the last full system, on the same band. That right-hand
-    # system is lost whole by the staff detector (issue #152), and the coda
-    # sign it carries then sits 7.5 staff spaces past the left-hand system's
-    # right end - where clamping put it on that system's LAST bar, which is
-    # the bar the D.S. jumps FROM. The page prints its coda at bar 18.
-    # (issue #134 phase 2 adversarial review, blocker 2)
+    # The coda-system layout, in the two shapes issue #152 covers. In both,
+    # the coda is engraved as a short system to the RIGHT of the last full
+    # system, on the same horizontal band.
+    #
+    # SHAPE 1 - the right-hand system's staff lines are SHORT (134.5pt on a
+    # 612pt page, under the old 0.25 length floor), so they never reached
+    # staff detection at all and the system was invisible: no staff, no
+    # anomaly, no bars, nothing said. 40 files library-wide. The page prints
+    # 18 bars and the extractor reported 17.
     "one_am": "Patreon/John Oeth/Animal Crossing/1 AM (Animal Crossing New Leaf).pdf",
-    # The same layout with a D.C. rather than a D.S., and a coda the page
-    # prints at bar 37 that the clamp emitted at 36.
+    # The same shape with a D.C. rather than a D.S.: the page prints 37 bars
+    # and the extractor reported 36.
     "kakariko_village": (
         "Patreon/John Oeth/The Legend of Zelda/"
         "Kakariko Village (The Legend of Zelda Series).pdf"),
+    # SHAPE 2 - both systems on the band are long enough to be seen, but
+    # they are ruled 1.5-1.7pt apart, so their rows interleave inside the
+    # 15.0pt cluster gap and the pair came back as ONE group with twice the
+    # lines, which was discarded whole. Imprisoned Town's last band is a
+    # 12-line tab group (its two notation staves, ruled at the SAME y,
+    # having silently merged into one full-width staff instead); the page
+    # prints 35 bars and the extractor reported 31.
+    "imprisoned_town": "Patreon/John Oeth/Suikoden/Imprisoned Town (Suikoden II).pdf",
+    # The same shape showing BOTH halves of it at once: a 10-line group (two
+    # notation staves) and a 12-line group (two tab staves) on one band,
+    # both discarded. Named in issue #153 as the one coda sign no test
+    # inside the navigation reader could reach, because the staff its mark
+    # was measured against spanned the whole page width. The page prints 58
+    # bars - a three-bar system opening at 54 and a two-bar coda system
+    # opening at 57 beside it - and the extractor reported 53.
+    "nautilus_knoweth": (
+        "Patreon/John Oeth/Final Fantasy/FF XIV/"
+        "The Nautilus Knoweth (Final Fantasy XIV Endwalker).pdf"),
     # A "To Coda" on a score that draws no coda sign and prints no coda
     # label anywhere - so `nav_marks_unresolved` is genuinely 1, on a score
     # whose every other structure figure is 0 (issue #134 phase 2).
@@ -430,6 +450,24 @@ def kakariko_village_pdf() -> Path:
     if p is None:
         skip_without_library(
             "FERMATA_TEST_LIBRARY not set (or missing 'Kakariko Village' fixture)")
+    return p
+
+
+@pytest.fixture
+def imprisoned_town_pdf() -> Path:
+    p = _fixture_path("imprisoned_town")
+    if p is None:
+        skip_without_library(
+            "FERMATA_TEST_LIBRARY not set (or missing 'Imprisoned Town' fixture)")
+    return p
+
+
+@pytest.fixture
+def nautilus_knoweth_pdf() -> Path:
+    p = _fixture_path("nautilus_knoweth")
+    if p is None:
+        skip_without_library(
+            "FERMATA_TEST_LIBRARY not set (or missing 'The Nautilus Knoweth' fixture)")
     return p
 
 

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -150,6 +150,16 @@ _FIXTURE_RELATIVE_PATHS = {
     # having silently merged into one full-width staff instead); the page
     # prints 35 bars and the extractor reported 31.
     "imprisoned_town": "Patreon/John Oeth/Suikoden/Imprisoned Town (Suikoden II).pdf",
+    # A system that is STILL lost after issue #152, and lost for a different
+    # reason - so `systems_unread` has a score with a genuinely nonzero count
+    # to be exercised on. Page 1's third band comes back as a 7-line group:
+    # an ordinary 6-line tab staff ruled at 7.7pt, plus ONE extra rule 14.3pt
+    # below the last line, which falls inside the 15.0pt cluster gap. Not two
+    # systems side by side - the stray rule spans the same full width the
+    # staff does - so no split by x extent can separate them, and the group
+    # is discarded whole with its bars.
+    "dynamis": (
+        "Patreon/John Oeth/Final Fantasy/FF XIV/Dynamis (Final Fantasy XIV Endwalker).pdf"),
     # The same shape showing BOTH halves of it at once: a 10-line group (two
     # notation staves) and a 12-line group (two tab staves) on one band,
     # both discarded. Named in issue #153 as the one coda sign no test
@@ -450,6 +460,14 @@ def kakariko_village_pdf() -> Path:
     if p is None:
         skip_without_library(
             "FERMATA_TEST_LIBRARY not set (or missing 'Kakariko Village' fixture)")
+    return p
+
+
+@pytest.fixture
+def dynamis_pdf() -> Path:
+    p = _fixture_path("dynamis")
+    if p is None:
+        skip_without_library("FERMATA_TEST_LIBRARY not set (or missing 'Dynamis' fixture)")
     return p
 
 

--- a/server/tests/test_engraved_fixtures.py
+++ b/server/tests/test_engraved_fixtures.py
@@ -1281,23 +1281,34 @@ def test_a_degraded_system_names_the_bars_it_produced(engraved):
     assert "The bars they produced are: 1, 2, 3, 4." in named
 
 
-def test_a_final_system_too_short_to_detect_loses_its_bars(engraved):
-    """A known limitation, engraved so that it is a tripwire rather than a
-    sentence in a README.
+def test_a_final_system_too_short_to_detect_is_read(engraved):
+    """The tripwire this fixture was engraved to be, now that it has fired.
 
-    A staff is found by the length of its lines, and an engraver does not
-    stretch a final system that is only part full - so a two-bar last system
-    has lines under the length floor and is not detected at all. This fixture
-    writes eight bars and six are read. The silence is the part worth
-    knowing: `tab_only` is twelve bars precisely to avoid this, and if that
-    had been the only fixture nothing here would say it happens."""
+    A staff used to be found by the length of its lines alone, and an
+    engraver does not stretch a final system that is only part full - so this
+    fixture's two-bar last system had lines under the length floor and was
+    not detected at all. Eight bars were engraved and six were read, with
+    nothing saying so. `tab_only` is twelve bars precisely to avoid the same
+    fate, and had that been the only fixture nothing here would have said it
+    happened.
+
+    Issue #152 is that defect at library scale - the same floor hides the
+    right-hand coda system on 40 of the library's files - and this asserts
+    the fix on a page whose contents are known exactly, because they were
+    written here: all eight bars, from two tab staves, one of them short.
+    See tabextract.SHORT_STAFF_LEN_RATIO for the floor that admits it and
+    STAFF_LINE_MIN_SPACING for what keeps a decoration from coming with it.
+    """
     assert len(source_beats("tab_only_short_last_system")) == 8
     result = tabextract.extract(engraved("tab_only_short_last_system"))
     assert result.extractable
-    assert result.bars == 6, "six of the eight bars engraved"
-    assert result.tab_staff_count == 1, "the second system was not found at all"
-    assert not any("were not detected" in w for w in result.warnings), (
-        "and nothing reports the two missing bars - which is the defect")
+    assert result.bars == 8, "every bar engraved, including the short system's two"
+    assert result.tab_staff_count == 2, "the short second system is a staff"
+    assert result.notes == 32
+    # Nothing was lost, so nothing is counted as lost - the counter is only
+    # honest if it can also say zero (issue #152).
+    assert result.systems_unread == 0
+    assert result.systems_unread_pages == []
 
 
 # ---------------------------------------------------------------------------

--- a/server/tests/test_tabextract.py
+++ b/server/tests/test_tabextract.py
@@ -2708,8 +2708,13 @@ def test_lennas_theme_reads_a_volta_that_opens_a_system(lenna_theme_pdf):
     """
     result = tabextract.extract(lenna_theme_pdf)
     assert result.extractable
-    assert result.bars == 13
+    # 17, not the 13 this pinned before issue #152: the page's last band
+    # prints TWO systems side by side (bars 14-15 on the left, 16-17 on the
+    # right), and the pair came back as a 10-line and a 12-line group that
+    # were discarded whole. 17 is the number printed on the page.
+    assert result.bars == 17
     assert result.bars_unread == 0
+    assert result.systems_unread == 0
 
     from test_engraved_fixtures import _barline_structure
     structure = _barline_structure(result.musicxml)
@@ -2719,7 +2724,10 @@ def test_lennas_theme_reads_a_volta_that_opens_a_system(lenna_theme_pdf):
         "bar_style": "light-heavy", "ending": ("1", "stop"), "repeat": "backward"}
     assert structure[11]["left"] == {"ending": ("2", "start")}
     assert structure[11]["right"] == {"ending": ("2", "discontinue")}
-    assert set(structure) == {3, 10, 11}
+    # Bars 15 and 17 join the structure with the recovered systems: 17 is the
+    # score's final barline, which was on the system that used to be lost.
+    assert set(structure) == {3, 10, 11, 15, 17}
+    assert structure[17]["right"] == {"bar_style": "light-heavy"}
 
     # Reading the volta cannot move a single Rule 8 figure - form marks carry
     # no duration.
@@ -2729,7 +2737,13 @@ def test_lennas_theme_reads_a_volta_that_opens_a_system(lenna_theme_pdf):
     assert result.endings_incomplete == 0
 
     loaded = _load_musicxml_with_alphatab(result.musicxml, repeats=True)
-    expected_order = list(range(1, 11)) + list(range(3, 10)) + [11, 12, 13]
+    # ... and the recovered bars 14-17 play out at the end, in the order the
+    # page prints them (issue #152): 14-15 on the left-hand system of the
+    # last band, 16-17 on the one beside it. (On this page the right-hand
+    # system is ruled 1.0pt LOWER, so top order and reading order agree -
+    # test_a_right_hand_coda_system_is_read_in_its_printed_order pins the
+    # case where they do not.)
+    expected_order = list(range(1, 11)) + list(range(3, 10)) + list(range(11, 18))
     assert loaded["tickLookup"] == expected_order
 
 
@@ -3112,49 +3126,140 @@ def test_a_mark_drawn_entirely_outside_the_staff_is_refused_not_clamped():
     assert refused == [before]
 
 
-def test_a_coda_drawn_on_a_lost_right_hand_system_is_disclosed_not_moved(
-        one_am_pdf, kakariko_village_pdf):
-    """Blocker 2 of the adversarial review, on the two pages it was verified
-    against by reading them.
+def test_a_right_hand_coda_system_is_read_in_its_printed_order(
+        one_am_pdf, kakariko_village_pdf, imprisoned_town_pdf, nautilus_knoweth_pdf):
+    """Issue #152 on the four library pages it was verified against by
+    reading them, asserted by the bar numbers those pages PRINT.
 
-    Both engrave their coda as a short system to the RIGHT of the last full
-    system on the same band. That right-hand system is lost whole by the
-    staff detector - a pre-existing defect, filed as #152, and one that moves
-    no bar count - so its coda sign has no bars of its own and used to be
-    clamped onto the last bar of the system beside it. That is the bar the
-    D.S./D.C. jump closes, so the score said "jump from here" and "the coda
-    starts here" about the same measure, and `nav_marks_unanchored` said 0.
+    All four engrave the coda as a short system to the RIGHT of the last
+    full system, on the same horizontal band. All four lost it - by two
+    different routes, both fixed here (see _detect_staves):
 
-    1 AM prints its coda at bar 18 and was emitting it at 17; Kakariko
-    Village prints 37 and was emitting 36. Now: no coda measure at all, one
-    unanchored mark each, and the "To Coda" left without a target and
-    disclosed as unresolved rather than pointed at the jump's own bar.
+      - 1 AM and Kakariko Village rule that system's staff lines short
+        enough to fall under the length floor, so it was never seen at all:
+        no staff, no anomaly, and no bars, with nothing saying so.
 
-    This catches 40 of the 41 such marks in the library. The residual is
-    named in _apply_nav_marks' docstring: The Nautilus Knoweth's last band
-    has its two systems MERGED into 10- and 12-line groups rather than
-    dropped, so its coda attaches to the system above, whose staff record
-    spans the whole page width - no x test can reach that one."""
+      - Imprisoned Town and The Nautilus Knoweth rule both systems long, a
+        shade apart, so the pair clustered as one group with twice the lines
+        and was discarded as unreadable.
+
+    The bar numbers below are the ones printed on the pages, not the ones
+    the extractor happened to produce: 1 AM prints its coda at 18, Kakariko
+    at 37, Imprisoned Town at 34 (of 35), Nautilus at 57 (of 58). Each was
+    previously one bar short of its coda, or four to five short of its end.
+
+    THE ORDER IS AN ASSERTION, not a by-product. On 1 AM the right-hand
+    system is ruled 0.3pt HIGHER than the one beside it, so ordering staves
+    by `top` - which is what this did - puts the coda system's bar FIRST and
+    numbers the page backwards. The coda landing on the LAST bar is what
+    says reading order beat top order.
+
+    This also closes issue #153's named residual. Nautilus's coda sign could
+    not be refused by any x test, because the staff record it was measured
+    against spanned the whole page width; here it anchors to the bar the
+    page prints it over, and nav_marks_unanchored falls to 0 on all four.
+    """
     from test_engraved_fixtures import _navigation_structure
 
     one_am = tabextract.extract(one_am_pdf)
     assert one_am.extractable
+    assert one_am.bars == 18, "the page prints 18 bars"
     assert _navigation_structure(one_am.musicxml) == {
         1: [("before", "segno", {"segno": "segno"})],
-        8: [("after", "To Coda", None)],
+        8: [("after", "To Coda", {"tocoda": "coda"})],
         17: [("after", "D.S. al Coda", {"dalsegno": "segno"})],
+        18: [("before", "coda", {"coda": "coda"})],
     }
-    assert one_am.nav_marks_unanchored == 1
-    assert one_am.nav_marks_unresolved_bars == [8, 17]
+    # The jump and the coda are now on DIFFERENT bars, which is the whole
+    # point: the clamp used to put both on 17.
+    assert one_am.nav_marks_unanchored == 0
+    assert one_am.nav_marks_unresolved_bars == []
+    assert one_am.systems_unread == 0
 
     kakariko = tabextract.extract(kakariko_village_pdf)
     assert kakariko.extractable
+    assert kakariko.bars == 37, "the page prints 37 bars"
     assert _navigation_structure(kakariko.musicxml) == {
-        19: [("after", "To Coda", None)],
+        19: [("after", "To Coda", {"tocoda": "coda"})],
         36: [("after", "D.C. al Coda", {"dacapo": "yes"})],
+        37: [("before", "coda", {"coda": "coda"})],
     }
-    assert kakariko.nav_marks_unanchored == 1
-    assert kakariko.nav_marks_unresolved_bars == [19, 36]
+    assert kakariko.nav_marks_unanchored == 0
+    assert kakariko.nav_marks_unresolved_bars == []
+    assert kakariko.systems_unread == 0
+
+    # The 12-line route. Its two notation staves were ruled at the same y and
+    # had merged into one full-width staff, so this page lost a whole band of
+    # four printed bars (32-35) while reporting a staff for it.
+    imprisoned = tabextract.extract(imprisoned_town_pdf)
+    assert imprisoned.extractable
+    assert imprisoned.bars == 35, "the page prints 35 bars"
+    assert _navigation_structure(imprisoned.musicxml) == {
+        14: [("after", "To Coda", {"tocoda": "coda"})],
+        33: [("after", "D.C. al Coda", {"dacapo": "yes"})],
+        34: [("before", "coda", {"coda": "coda"})],
+    }
+    assert imprisoned.nav_marks_unanchored == 0
+    assert imprisoned.systems_unread == 0
+
+    # Both groups at once - a 10-line pair of notation staves and a 12-line
+    # pair of tab staves on one band - and issue #153's named residual.
+    nautilus = tabextract.extract(nautilus_knoweth_pdf)
+    assert nautilus.extractable
+    assert nautilus.bars == 58, "the page prints 58 bars"
+    assert _navigation_structure(nautilus.musicxml) == {
+        16: [("after", "To Coda", {"tocoda": "coda"})],
+        56: [("after", "D.C. al Coda", {"dacapo": "yes"})],
+        57: [("before", "coda", {"coda": "coda"})],
+    }
+    assert nautilus.nav_marks_unanchored == 0
+    assert nautilus.systems_unread == 0
+
+
+def test_the_two_systems_on_one_band_are_separate_staves(
+        imprisoned_town_pdf, one_am_pdf):
+    """The geometry issue #152 turns on, asserted directly rather than only
+    through the bar counts it produces.
+
+    Imprisoned Town's last band holds two systems whose staff lines do not
+    overlap in x at all - 54.0-341.7 and 378.2-575.9, a 36.5pt gap - and
+    whose tab staves are ruled 1.7pt apart, which is what interleaved them
+    into one 12-line group inside the 15.0pt cluster gap. Its notation
+    staves are ruled at the IDENTICAL y, which is the other half of the same
+    defect: those merged silently into a single staff record spanning
+    54.0-575.9, describing music across a 36.5pt gap where the page draws
+    none.
+
+    1 AM is the short-lines route, and pins the ordering hazard: its
+    right-hand system is ruled HIGHER (683.9 against 684.2), so `top` alone
+    orders that band right to left.
+    """
+    import fitz
+
+    with fitz.open(imprisoned_town_pdf) as doc:
+        staves, anomalies = tabextract._detect_staves(doc[1])
+    assert anomalies == [], "no 12-line group is left to discard"
+    last = [s for s in staves if s.band == max(t.band for t in staves)]
+    assert [(s.kind, round(s.x0, 1), round(s.x1, 1)) for s in last] == [
+        ("tab", 54.0, 341.7), ("tab", 378.2, 575.9)]
+    # ... and the notation band above it is two staves too, not the one
+    # full-width record it used to be.
+    stds = [s for s in staves if s.kind == "standard" and s.top > 600]
+    assert [(round(s.x0, 1), round(s.x1, 1)) for s in stds] == [
+        (54.0, 341.7), (378.2, 575.9)]
+
+    with fitz.open(one_am_pdf) as doc:
+        staves, anomalies = tabextract._detect_staves(doc[0])
+    assert anomalies == []
+    band = max(s.band for s in staves)
+    last = [s for s in staves if s.band == band]
+    assert [(round(s.top, 1), round(s.x0, 1)) for s in last] == [
+        (684.2, 54.0), (683.9, 441.2)]
+    # The right-hand system is the HIGHER of the two, so reading order and
+    # top order genuinely disagree here - and reading order is what comes
+    # back, left to right.
+    assert last[1].top < last[0].top
+    assert [s.reading_order for s in last] == sorted(s.reading_order for s in last)
 
 
 def test_performance_prose_naming_a_jump_writes_no_jump(kaine_salvation_pdf):
@@ -3178,17 +3283,25 @@ def test_the_sign_inside_a_to_coda_does_not_become_the_coda_it_points_at(
         bygone_days_pdf):
     """Blocker 4 of the adversarial review, on the page it was verified
     against. Bygone Days engraves "To Coda (sign)" closing bar 12 and its
-    real coda head opening bar 25. The glyph inside the instruction was read
+    real coda head opening bar 24. The glyph inside the instruction was read
     as a coda section head, and being the first one seen it took bar 12 - so
     the "To Coda" pointed at its own measure and the score wrote
-    `coda="coda"` twice."""
+    `coda="coda"` twice.
+
+    The coda head is bar 24, not the 25 this pinned before issue #152: this
+    page's last band prints two systems side by side (22-23 on the left, the
+    one-bar coda 24 on the right) ruled at the same y, which merged into ONE
+    full-width staff record spanning the gap between them - and the gap
+    produced a bar boundary the page does not draw, so the score came out a
+    bar long. 24 is the number printed on the page."""
     result = tabextract.extract(bygone_days_pdf)
     assert result.extractable
+    assert result.bars == 24, "the page prints 24 bars"
     from test_engraved_fixtures import _navigation_structure
     assert _navigation_structure(result.musicxml) == {
         12: [("after", "To Coda", {"tocoda": "coda"})],
         23: [("after", "D.C. al Coda", {"dacapo": "yes"})],
-        25: [("before", "coda", {"coda": "coda"})],
+        24: [("before", "coda", {"coda": "coda"})],
     }
     assert result.musicxml.count("<coda />") == 1
     assert result.nav_marks_unresolved == 0
@@ -3427,25 +3540,45 @@ def test_a_refused_coda_changes_the_disclosure_wording_and_not_a_single_count():
     assert refused_flag is False
 
 
-def test_the_unresolved_warning_says_which_cause_it_was(
-        one_am_pdf, phantom_train_pdf):
-    """The same distinction on the two real scores that isolate it.
+def test_the_unresolved_warning_says_which_cause_it_was(phantom_train_pdf):
+    """The two causes of an unresolved jump still say which one they were.
 
-    *1 AM* draws its coda on a system this transcription loses, so its
-    "To Coda" is unresolved for a reason the unanchored count is already
-    reporting. *Phantom Train* prints a "To Coda" on a score that draws no
-    coda sign and no coda label anywhere at all - genuinely target-less, and
-    `nav_marks_unanchored` is 0 for it, so there is nothing else to point
-    at."""
-    refused = tabextract.extract(one_am_pdf)
-    assert refused.nav_marks_unanchored == 1
-    assert any("draws on a system this transcription does not hold" in w
-               for w in refused.warnings), refused.warnings
+    *Phantom Train* prints a "To Coda" on a score that draws no coda sign
+    and no coda label anywhere at all - genuinely target-less - and is
+    asserted against the real page.
 
+    THE OTHER CAUSE NO LONGER HAPPENS IN THIS LIBRARY, so it is exercised
+    directly instead of through a score. A coda REFUSED for having no bar to
+    name used to be the reason for 79 of the library's 87 unresolved bars;
+    since issue #152 reads the systems those codas were drawn on,
+    `nav_marks_unanchored` is 0 across all 297 files and no score reaches
+    this branch. The branch is still right and still reachable - a mark can
+    be drawn outside its staff's x span for reasons other than a lost system
+    - so it keeps its test, on a constructed refusal rather than on a score
+    that would silently stop covering it."""
     absent = tabextract.extract(phantom_train_pdf)
     assert absent.nav_marks_unanchored == 0
     assert any("al Coda with no coda read" in w for w in absent.warnings), \
         absent.warnings
+
+    # A "To Coda" that was anchored, and a coda sign that was not. The
+    # instruction goes out without its jump either way; what differs is
+    # which sentence the reader gets.
+    to_coda = tabextract._NavMark("tocoda", "To Coda", 10.0, 0, 60.0, 5)
+    coda_sign = tabextract._NavMark("coda", "", 900.0, 0, 910.0, 5)
+    directions, unresolved, coda_was_refused = tabextract._resolve_nav_marks(
+        [(4, to_coda)], refused=[coda_sign])
+    assert unresolved == [4], "the bar carrying the instruction is disclosed"
+    assert coda_was_refused, "and the cause is the refused coda, not an absent one"
+    # Written as the words the page prints, with no <sound> jump beside it -
+    # naming a coda this file does not hold would make it play a form nobody
+    # engraved.
+    assert directions[4]["after"] == [{"words": "To Coda", "sound": None}]
+
+    # With nothing refused, the same bar is unresolved for the other reason.
+    _d, unresolved, coda_was_refused = tabextract._resolve_nav_marks([(4, to_coda)])
+    assert unresolved == [4]
+    assert not coda_was_refused
 
 
 def _library_pdfs(library_root):
@@ -3468,6 +3601,7 @@ def test_library_wide_repeat_structure_leaves_conformance_untouched(library_root
     scores_with_structure = 0
     scores_with_navigation = 0
     scores_with_endings_truncated = 0
+    scores_with_systems_unread = 0
     extractable = 0
     for pdf in _library_pdfs(library_root):
         try:
@@ -3490,6 +3624,7 @@ def test_library_wide_repeat_structure_leaves_conformance_untouched(library_root
         totals["unison_digits_shared"] += result.unison_digits_shared
         totals["nav_marks_unanchored"] += result.nav_marks_unanchored
         totals["nav_marks_unresolved"] += result.nav_marks_unresolved
+        totals["systems_unread"] += result.systems_unread
         totals["coda_signs"] += result.musicxml.count("<coda />")
         totals["segno_signs"] += result.musicxml.count("<segno />")
         totals["nav_directions"] += (result.musicxml.count("<direction ")
@@ -3497,6 +3632,8 @@ def test_library_wide_repeat_structure_leaves_conformance_untouched(library_root
         totals["structure_" + result.confidence["structure"].split(" ")[0]] += 1
         if result.endings_truncated:
             scores_with_endings_truncated += 1
+        if result.systems_unread:
+            scores_with_systems_unread += 1
         if "<repeat " in result.musicxml or "<ending " in result.musicxml:
             scores_with_structure += 1
         if (result.musicxml.count("<direction ")
@@ -3530,15 +3667,45 @@ def test_library_wide_repeat_structure_leaves_conformance_untouched(library_root
     # bars_overfull +4, bars_short -19, bars_defective -15, bars_padded +26,
     # inferred_rest_quarters +22.0 - with bars (64), notes (411) and every
     # other score's output byte-for-byte unchanged.
+    #
+    # AND THEN MOVED BY ISSUE #152, WHICH IS THE ONE CHANGE HERE THAT IS
+    # SUPPOSED TO MOVE THEM. Everything above this line is about reading the
+    # same music better; #152 is about reading music that was not being read
+    # at all - a system printed to the RIGHT of the last full one on the same
+    # band. So the conformance figures MUST move: the recovered bars carry
+    # notes, and those notes add up or fail to add up like any others.
+    #
+    # Measured score by score against this branch's parent: PLACEHOLDER_IDENT
+    # of the 297 files come out BYTE-IDENTICAL, and all PLACEHOLDER_CHANGED
+    # that differ are files whose bar count changed. No score's output moved
+    # without its bar count moving, which is the check that this reads new
+    # music rather than re-reading the old music differently.
+    #
+    # 3 scores LOSE a bar - Our Terms 29->28, Bygone Days 25->24 and The
+    # Crestlands 39->38 - and those three are corrections too, verified
+    # against the printed pages: their two side-by-side systems were ruled at
+    # the same y and had merged into ONE full-width staff record, so the gap
+    # between the systems produced a bar boundary the page does not draw. Our
+    # Terms prints 28 bars, Bygone Days 24, and The Crestlands 37 plus a
+    # pickup measure.
     assert extractable == 293
-    assert totals["bars"] == 10632
-    assert totals["bars_unread"] == 23
-    assert totals["notes"] == 98704             # 98688 + 12 + 4 (issue #137)
-    assert totals["bars_overfull"] == 1573       # 1569 + 4 (issue #154)
-    assert totals["bars_short"] == 4188          # 4207 - 19 (issue #154)
-    assert totals["bars_defective"] == 5317      # 5332 - 15 (issue #154)
-    assert totals["bars_padded"] == 3603         # 3577 + 26 (issue #154)
-    assert totals["inferred_rest_quarters"] == 4899.0   # 4877.0 + 22.0 (issue #154)
+    assert totals["bars"] == P_BARS
+    assert totals["bars_unread"] == P_BARS_UNREAD
+    assert totals["notes"] == P_NOTES
+    assert totals["bars_overfull"] == P_OVERFULL
+    assert totals["bars_short"] == P_SHORT
+    assert totals["bars_defective"] == P_DEFECTIVE
+    assert totals["bars_padded"] == P_PADDED
+    assert totals["inferred_rest_quarters"] == P_IRQ
+    # The systems still lost, named. Both are 7-line groups - a 6-line tab
+    # staff with ONE extra full-width rule ruled 14.3pt below it, inside the
+    # 15.0pt cluster gap - which is a different defect from #152's two
+    # systems side by side, and one no split by x extent can reach, because
+    # the stray rule spans the same extent the staff does. Dynamis p1 and
+    # Hide, Hideaway p2. Before this change the same measurement over the
+    # library counted 41 such systems across 22 files.
+    assert totals["systems_unread"] == P_SYSU
+    assert scores_with_systems_unread == P_SYSU_SCORES
     # The whole of #137's effect on this library, disclosed as data: 16 notes
     # given a fret number read for their coincident twin. It equals the note
     # delta above exactly (+12 +4), which is the check that no note came back
@@ -3556,8 +3723,12 @@ def test_library_wide_repeat_structure_leaves_conformance_untouched(library_root
     # and the drawn right end snaps to no boundary) is written over its
     # first bar only. Measured directly against the spec's own predicted 3 -
     # the gap is the review's own finding, not a regression to chase here.
-    assert totals["endings_truncated"] == 25
-    assert scores_with_endings_truncated == 22
+    # 25 + 3 (issue #152): Hollow, Our Terms and Link is Awake each gain one,
+    # all three on a system that was previously not read at all, whose volta
+    # bracket has no closing hook drawn and so is written over its first bar
+    # only - the same disclosure these 25 already were, on new music.
+    assert totals["endings_truncated"] == 28
+    assert scores_with_endings_truncated == 25
     # "Expect large" (issue #134's own phrasing): the census found 190 of 297
     # scores carrying a repeat barline or a volta. A floor rather than a pin,
     # since which scores the maintainer's library holds can change.
@@ -3578,8 +3749,11 @@ def test_library_wide_repeat_structure_leaves_conformance_untouched(library_root
     # 581 (176 jumps, 150 codas, 147 "To Coda", 88 segnos, 20 "Fine"), of
     # which 11 are on pages this extractor does not process at all - which
     # carry no bars either - and 43 are disclosed as unanchored below.
-    # 581 - 11 - 43 = 527.
-    assert totals["nav_directions"] == 527
+    # 581 - 11 - 43 = 527, before issue #152.
+    #
+    # 527 + PLACEHOLDER_NAVD (issue #152): the 43 marks that used to be
+    # disclosed as unanchored now name a bar and are written as directions.
+    assert totals["nav_directions"] == P_NAVDIR
     assert scores_with_navigation == 166
     # 109 coda signs written, of the 156 the library draws. The 47 not
     # written: 41 sit entirely past their staff's right end, on the
@@ -3603,8 +3777,14 @@ def test_library_wide_repeat_structure_leaves_conformance_untouched(library_root
     # is Rito Village - Night: issue #154 fixed load_music_fonts rejecting
     # its Maestro subset by resource name (embedded as "CIDFont+F1") before
     # the fingerprint that would have recognised it regardless ever ran.
-    assert totals["coda_signs"] == 109
-    assert totals["segno_signs"] == 88
+    #
+    # 109 + 41 (issue #152), and the accounting is exact: of the 43 marks
+    # that were unanchored, 41 are coda signs - the 40 sitting entirely past
+    # their staff's right end, plus Imprisoned Town's, whose system had no
+    # bars at all - and every one of them now anchors to the bar its page
+    # prints it over. The other 2 were a "D.S. 2" and Imprisoned Town's D.C.
+    assert totals["coda_signs"] == P_CODA
+    assert totals["segno_signs"] == P_SEGNO
     # The disclosure, pinned rather than assumed. 87 BARS (the counter counts
     # distinct bars, so two instructions closing one bar contribute one)
     # carry an instruction naming a jump this transcription holds no target
@@ -3629,8 +3809,22 @@ def test_library_wide_repeat_structure_leaves_conformance_untouched(library_root
     # coda signs and one "D.S. 2"), and Imprisoned Town's two, whose last
     # system's tab staff comes back as a 12-line anomaly so that system has
     # no bars at all.
-    assert totals["nav_marks_unresolved"] == 87
-    assert totals["nav_marks_unanchored"] == 43
+    # ISSUE #152 ANSWERS BOTH OF THESE, and answers them by reading the music
+    # rather than by describing the loss better. 87 -> 8 and 43 -> 0.
+    #
+    # 8 bars over 7 files, and every one is now a score that genuinely names
+    # a target its page does not draw: Rebel Army Theme, Vamo alla Flamenco,
+    # Phantom Train, Hollow, Spoken Without End, Heartgem's Burden (2) and
+    # Rito Village - whose Maestro embed this decoder reads no glyphs from,
+    # so its "D.S." has no segno to point at whatever else is fixed. The
+    # other 79 were all the lost coda system, exactly as the note on
+    # _resolve_nav_marks predicted.
+    #
+    # 0 unanchored. Not "near zero" - the library now holds no navigation
+    # mark at all that was read off a page and has no bar to name, because
+    # the systems those marks were drawn over are read.
+    assert totals["nav_marks_unresolved"] == 8
+    assert totals["nav_marks_unanchored"] == 0
     # What all of that costs the score a reader actually sees. On this
     # branch's parent the library reports 263 scores at `structure` high, 29
     # medium and 1 "n/a - nothing found"; reading navigation marks moves 43
@@ -3639,8 +3833,15 @@ def test_library_wide_repeat_structure_leaves_conformance_untouched(library_root
     # downgraded for a D.S. whose segno was on the page all along, which is
     # the figure that makes the mislabel a user-visible defect rather than a
     # tidiness one.
-    assert totals["structure_high"] == 221
-    assert totals["structure_medium"] == 72
+    # And issue #152 moves 34 of the medium ones back to high, because the
+    # thing they were medium FOR was a mark that could not be placed on a
+    # system this transcription did not hold. The 2 "low" are the two scores
+    # that still lose a system: a lost system outranks every other structure
+    # term, since the marks that were read may be complete and still describe
+    # a form built out of bars the file does not contain.
+    assert totals["structure_high"] == 255
+    assert totals["structure_medium"] == 36
+    assert totals["structure_low"] == 2
     assert totals["structure_n/a"] == 0
 
 

--- a/server/tests/test_tabextract.py
+++ b/server/tests/test_tabextract.py
@@ -3126,6 +3126,131 @@ def test_a_mark_drawn_entirely_outside_the_staff_is_refused_not_clamped():
     assert refused == [before]
 
 
+def _page_with_rules(rules, width=612.0, height=792.0):
+    """A one-page PDF carrying exactly the horizontal rules given, as
+    (y, x0, x1). Built rather than engraved on purpose.
+
+    Two systems printed side by side on one band is a horizontal-frame
+    layout, which plain MusicXML has no way to express - so the engraved
+    fixtures cannot produce the geometry issue #152 turns on, and the four
+    library pages that do are gitignored and skip in CI. Drawing the rules
+    directly is what lets the split be tested where it has to hold: the
+    input to _detect_staves is line primitives and nothing else, so a page
+    of line primitives exercises exactly the code under test and no more.
+    """
+    import fitz
+
+    doc = fitz.open()
+    page = doc.new_page(width=width, height=height)
+    shape = page.new_shape()
+    for y, x0, x1 in rules:
+        shape.draw_line(fitz.Point(x0, y), fitz.Point(x1, y))
+    shape.finish(width=0.5)
+    shape.commit()
+    return doc
+
+
+def _staff_rules(top, x0, x1, lines, spacing):
+    return [(top + i * spacing, x0, x1) for i in range(lines)]
+
+
+def test_two_systems_on_one_band_split_into_two_staves_when_interleaved():
+    """The 12-line group of issue #152, as geometry, in CI.
+
+    Two 6-line tab staves printed side by side and ruled 1.7pt apart - the
+    offset an engraver produces when the two systems carry different content
+    above them. Their y values interleave inside the 15.0pt cluster gap, so
+    clustering by vertical gap alone returned ONE group of twelve lines,
+    which is neither 5 nor 6 and was discarded whole, taking the band's bars
+    with it. This is Imprisoned Town's last band and both of The Nautilus
+    Knoweth's, to scale.
+    """
+    doc = _page_with_rules(
+        _staff_rules(300.0, 54.0, 341.7, 6, 7.7)
+        + _staff_rules(301.7, 378.2, 575.9, 6, 7.7))
+    with doc:
+        staves, anomalies = tabextract._detect_staves(doc[0])
+
+    assert anomalies == [], "no 12-line group survives the split"
+    assert [(s.kind, round(s.x0, 1), round(s.x1, 1)) for s in staves] == [
+        ("tab", 54.0, 341.7), ("tab", 378.2, 575.9)]
+    # One band, and the two are ordered left to right within it.
+    assert len({s.band for s in staves}) == 1
+    assert [s.reading_order for s in staves] == sorted(s.reading_order for s in staves)
+
+
+def test_two_systems_ruled_at_the_same_y_are_not_one_full_width_staff():
+    """The other half of the same defect, and the quieter one.
+
+    Where the two systems are ruled at the IDENTICAL y - which is what
+    Imprisoned Town does with its notation staves, and Bygone Days and Our
+    Terms with both - the rows collapsed into a single staff record spanning
+    the whole band, 54.0 to 575.9. Nothing was reported: the extractor
+    simply held a staff that claimed music across the 36.5pt gap where the
+    page draws none, and the gap then produced a bar boundary the page does
+    not draw, so those scores came out a bar LONG.
+    """
+    doc = _page_with_rules(
+        _staff_rules(300.0, 54.0, 341.7, 5, 5.1)
+        + _staff_rules(300.0, 378.2, 575.9, 5, 5.1))
+    with doc:
+        staves, anomalies = tabextract._detect_staves(doc[0])
+
+    assert anomalies == []
+    assert [(s.kind, round(s.x0, 1), round(s.x1, 1)) for s in staves] == [
+        ("standard", 54.0, 341.7), ("standard", 378.2, 575.9)]
+    assert not any(s.x0 < 100 and s.x1 > 500 for s in staves), (
+        "no staff may span the gap between the two systems")
+
+
+def test_a_short_system_is_read_but_a_tight_ornament_is_not():
+    """What makes the lower length floor safe (issue #152).
+
+    A half-width system's staff lines are under the 0.25-of-page-width floor
+    - 89.4pt to 134.5pt across the library - so a second, lower floor admits
+    them. On its own that is exactly how a decoration becomes a staff, and
+    two title-block ornaments in the library prove it: four rows at one
+    extent, over 100pt long, which clears both the length floor and the
+    sibling test. What they do not clear is the SPACING: they are ruled
+    1.2-2.6pt apart, where no engraver rules a staff closer than 5.1.
+
+    Admitting one cost a real staff rather than merely adding a phantom: on
+    Troian Beauty p3 the ornament's rows fell in the same 15.0pt band as the
+    page's first notation staff and swallowed it into an 11-line group.
+    """
+    ornament = [(100.0, 200.0, 320.0), (102.5, 200.0, 320.0),
+                (103.8, 200.0, 320.0), (106.4, 200.0, 320.0),
+                (107.6, 200.0, 320.0)]
+    doc = _page_with_rules(
+        ornament
+        + _staff_rules(300.0, 54.0, 450.8, 6, 7.7)
+        + _staff_rules(300.0, 486.5, 575.9, 6, 7.7))
+    with doc:
+        staves, anomalies = tabextract._detect_staves(doc[0])
+
+    # The 89.4pt right-hand system is read...
+    assert [(s.kind, round(s.x0, 1), round(s.x1, 1)) for s in staves] == [
+        ("tab", 54.0, 450.8), ("tab", 486.5, 575.9)]
+    # ... and the ornament is not a staff, at any count.
+    assert all(a["line_count"] < 5 for a in anomalies), anomalies
+    assert not any(round(s.x0, 1) == 200.0 for s in staves)
+
+
+def test_rows_packed_tighter_than_a_staff_are_not_staff_lines():
+    """STAFF_LINE_MIN_SPACING on its own terms, both sides of it.
+
+    The gap BETWEEN two staves at one extent is large and must pass - a
+    notation staff and the tab staff below it are ruled to the same x, so
+    the sibling set spans both and holds one gap of 40pt among gaps of 5.
+    """
+    assert tabextract._rows_are_staff_spaced([100.0, 105.1, 110.2, 115.3, 120.4])
+    assert tabextract._rows_are_staff_spaced([100.0, 107.7, 115.4, 155.0, 162.7])
+    assert not tabextract._rows_are_staff_spaced(
+        [100.0, 102.5, 103.8, 106.4, 107.6])
+    # One tight gap anywhere is enough to refuse the set.
+    assert not tabextract._rows_are_staff_spaced([100.0, 105.1, 106.3, 111.4])
+
+
 def test_a_right_hand_coda_system_is_read_in_its_printed_order(
         one_am_pdf, kakariko_village_pdf, imprisoned_town_pdf, nautilus_knoweth_pdf):
     """Issue #152 on the four library pages it was verified against by

--- a/server/tests/test_tabextract.py
+++ b/server/tests/test_tabextract.py
@@ -3800,8 +3800,8 @@ def test_library_wide_repeat_structure_leaves_conformance_untouched(library_root
     # band. So the conformance figures MUST move: the recovered bars carry
     # notes, and those notes add up or fail to add up like any others.
     #
-    # Measured score by score against this branch's parent: PLACEHOLDER_IDENT
-    # of the 297 files come out BYTE-IDENTICAL, and all PLACEHOLDER_CHANGED
+    # Measured score by score against this branch's parent: 220
+    # of the 297 files come out BYTE-IDENTICAL, and all 77
     # that differ are files whose bar count changed. No score's output moved
     # without its bar count moving, which is the check that this reads new
     # music rather than re-reading the old music differently.
@@ -3814,14 +3814,14 @@ def test_library_wide_repeat_structure_leaves_conformance_untouched(library_root
     # Terms prints 28 bars, Bygone Days 24, and The Crestlands 37 plus a
     # pickup measure.
     assert extractable == 293
-    assert totals["bars"] == P_BARS
-    assert totals["bars_unread"] == P_BARS_UNREAD
-    assert totals["notes"] == P_NOTES
-    assert totals["bars_overfull"] == P_OVERFULL
-    assert totals["bars_short"] == P_SHORT
-    assert totals["bars_defective"] == P_DEFECTIVE
-    assert totals["bars_padded"] == P_PADDED
-    assert totals["inferred_rest_quarters"] == P_IRQ
+    assert totals["bars"] == 10762               # 10632 + 130 (issue #152)
+    assert totals["bars_unread"] == 20           # 23 - 3 (issue #152)
+    assert totals["notes"] == 99461              # 98704 + 757 (issue #152)
+    assert totals["bars_overfull"] == 1590       # 1573 + 17 (issue #152)
+    assert totals["bars_short"] == 4216          # 4188 + 28 (issue #152)
+    assert totals["bars_defective"] == 5359      # 5317 + 42 (issue #152)
+    assert totals["bars_padded"] == 3619         # 3603 + 16 (issue #152)
+    assert totals["inferred_rest_quarters"] == 4923.0   # 4899.0 + 24.0 (issue #152)
     # The systems still lost, named. Both are 7-line groups - a 6-line tab
     # staff with ONE extra full-width rule ruled 14.3pt below it, inside the
     # 15.0pt cluster gap - which is a different defect from #152's two
@@ -3829,8 +3829,8 @@ def test_library_wide_repeat_structure_leaves_conformance_untouched(library_root
     # the stray rule spans the same extent the staff does. Dynamis p1 and
     # Hide, Hideaway p2. Before this change the same measurement over the
     # library counted 41 such systems across 22 files.
-    assert totals["systems_unread"] == P_SYSU
-    assert scores_with_systems_unread == P_SYSU_SCORES
+    assert totals["systems_unread"] == 2
+    assert scores_with_systems_unread == 2
     # The whole of #137's effect on this library, disclosed as data: 16 notes
     # given a fret number read for their coincident twin. It equals the note
     # delta above exactly (+12 +4), which is the check that no note came back
@@ -3876,9 +3876,9 @@ def test_library_wide_repeat_structure_leaves_conformance_untouched(library_root
     # carry no bars either - and 43 are disclosed as unanchored below.
     # 581 - 11 - 43 = 527, before issue #152.
     #
-    # 527 + PLACEHOLDER_NAVD (issue #152): the 43 marks that used to be
+    # 527 + 43 (issue #152): the 43 marks that used to be
     # disclosed as unanchored now name a bar and are written as directions.
-    assert totals["nav_directions"] == P_NAVDIR
+    assert totals["nav_directions"] == 570
     assert scores_with_navigation == 166
     # 109 coda signs written, of the 156 the library draws. The 47 not
     # written: 41 sit entirely past their staff's right end, on the
@@ -3908,8 +3908,8 @@ def test_library_wide_repeat_structure_leaves_conformance_untouched(library_root
     # their staff's right end, plus Imprisoned Town's, whose system had no
     # bars at all - and every one of them now anchors to the bar its page
     # prints it over. The other 2 were a "D.S. 2" and Imprisoned Town's D.C.
-    assert totals["coda_signs"] == P_CODA
-    assert totals["segno_signs"] == P_SEGNO
+    assert totals["coda_signs"] == 150
+    assert totals["segno_signs"] == 88
     # The disclosure, pinned rather than assumed. 87 BARS (the counter counts
     # distinct bars, so two instructions closing one bar contribute one)
     # carry an instruction naming a jump this transcription holds no target
@@ -3937,18 +3937,18 @@ def test_library_wide_repeat_structure_leaves_conformance_untouched(library_root
     # ISSUE #152 ANSWERS BOTH OF THESE, and answers them by reading the music
     # rather than by describing the loss better. 87 -> 8 and 43 -> 0.
     #
-    # 8 bars over 7 files, and every one is now a score that genuinely names
+    # 7 bars over 6 files, and every one is now a score that genuinely names
     # a target its page does not draw: Rebel Army Theme, Vamo alla Flamenco,
-    # Phantom Train, Hollow, Spoken Without End, Heartgem's Burden (2) and
-    # Rito Village - whose Maestro embed this decoder reads no glyphs from,
-    # so its "D.S." has no segno to point at whatever else is fixed. The
-    # other 79 were all the lost coda system, exactly as the note on
-    # _resolve_nav_marks predicted.
+    # Phantom Train, Hollow, Spoken Without End and Heartgem's Burden (2).
+    # The other 80 were all the lost coda system, exactly as the note on
+    # _resolve_nav_marks predicted. Rito Village was on this list until
+    # issue #154 let its segno be read at all; between the two changes it
+    # now both reads its segno and holds the bars its coda names.
     #
     # 0 unanchored. Not "near zero" - the library now holds no navigation
     # mark at all that was read off a page and has no bar to name, because
     # the systems those marks were drawn over are read.
-    assert totals["nav_marks_unresolved"] == 8
+    assert totals["nav_marks_unresolved"] == 7
     assert totals["nav_marks_unanchored"] == 0
     # What all of that costs the score a reader actually sees. On this
     # branch's parent the library reports 263 scores at `structure` high, 29
@@ -3964,8 +3964,8 @@ def test_library_wide_repeat_structure_leaves_conformance_untouched(library_root
     # that still lose a system: a lost system outranks every other structure
     # term, since the marks that were read may be complete and still describe
     # a form built out of bars the file does not contain.
-    assert totals["structure_high"] == 255
-    assert totals["structure_medium"] == 36
+    assert totals["structure_high"] == 256
+    assert totals["structure_medium"] == 35
     assert totals["structure_low"] == 2
     assert totals["structure_n/a"] == 0
 

--- a/server/tests/test_tabextract.py
+++ b/server/tests/test_tabextract.py
@@ -3823,12 +3823,13 @@ def test_library_wide_repeat_structure_leaves_conformance_untouched(library_root
     assert totals["bars_padded"] == 3619         # 3603 + 16 (issue #152)
     assert totals["inferred_rest_quarters"] == 4923.0   # 4899.0 + 24.0 (issue #152)
     # The systems still lost, named. Both are 7-line groups - a 6-line tab
-    # staff with ONE extra full-width rule ruled 14.3pt below it, inside the
-    # 15.0pt cluster gap - which is a different defect from #152's two
-    # systems side by side, and one no split by x extent can reach, because
-    # the stray rule spans the same extent the staff does. Dynamis p1 and
-    # Hide, Hideaway p2. Before this change the same measurement over the
-    # library counted 41 such systems across 22 files.
+    # staff ruled at 7.7pt with ONE extra full-width rule below its last
+    # line, close enough to fall inside the 15.0pt cluster gap: Dynamis p1 at
+    # 14.3pt and Hide, Hideaway p2 at 12.8pt. A different defect from #152's
+    # two systems side by side, and one no split by x extent can reach,
+    # because the stray rule spans the same extent the staff does. Before
+    # this change the same measurement over the library counted 41 such
+    # systems across 22 files.
     assert totals["systems_unread"] == 2
     assert scores_with_systems_unread == 2
     # The whole of #137's effect on this library, disclosed as data: 16 notes
@@ -4021,7 +4022,12 @@ def test_library_wide_note_ids_are_unique_and_valid_ncnames(library_root):
     is for. What this identity catches is scope creep or a miscount in
     EITHER independent count feeding it. (Cross-check, not asserted: on the
     library this was measured against, the identity holds as
-    100017 == 98704 sounding + 1313 rests.)
+    100809 == 99461 sounding + 1348 rests. It read
+    100017 == 98704 + 1313 until issue #152 read the systems printed beside
+    the last one on a band - 130 recovered bars carrying 757 sounding notes
+    and 35 rests - which is exactly the library-composition dependence the
+    paragraph above declines to pin, arriving from a decoder change rather
+    than from the library gaining a file.)
     """
     scores_checked = 0
     identity_mismatches = []

--- a/server/tests/test_transcription_api.py
+++ b/server/tests/test_transcription_api.py
@@ -401,7 +401,11 @@ BAR_KEYS = ("bars_overfull", "bars_short", "bars_defective", "bars_measured",
             # And for issue #134 phase 2's navigation disclosures, added to
             # _BAR_KEYS and exercised here in the same change rather than
             # left for a later review to find missing.
-            "nav_marks_unanchored", "nav_marks_unresolved")
+            "nav_marks_unanchored", "nav_marks_unresolved",
+            # And for issue #152's lost-system counter, in the same change
+            # as _BAR_KEYS and the confidence_json write - the reload path
+            # exercised here rather than assumed.
+            "systems_unread")
 # Which bars, and how much silence - the figures that only exist as data. The
 # warning prose caps its bar list, and the profile document promises a consumer
 # that `inferred_rest_quarters` is the sum of the `<forward>` durations in the
@@ -414,7 +418,10 @@ BAR_DETAIL_KEYS = ("padded_bars", "unread_bars", "inferred_rest_quarters",
                    "spacing_bars", "degraded_bars",
                    "repeats_unread_bars", "endings_unread_bars",
                    "endings_truncated_bars", "form_marks_unanchored_bars",
-                   "nav_marks_unresolved_bars")
+                   "nav_marks_unresolved_bars",
+                   # Pages, not bars - a system that was never read has no
+                   # bar numbers to report (issue #152).
+                   "systems_unread_pages")
 
 
 def test_bar_conformance_survives_a_reload(app_env, engraved, monkeypatch, insert_score):

--- a/server/tests/test_transcription_api.py
+++ b/server/tests/test_transcription_api.py
@@ -862,6 +862,56 @@ def test_repeat_and_volta_disclosures_survive_the_api_round_trip(
                for w in fetched["warnings"])
 
 
+def test_a_lost_system_survives_the_api_round_trip(
+    app_env, dynamis_pdf, monkeypatch, insert_score
+):
+    """Issue #152's counter, on a score whose count is genuinely nonzero.
+
+    Every other figure this API reports describes the systems that WERE
+    read. `systems_unread` is the one that says how far that qualification
+    reaches - music ABSENT from the transcription rather than imperfect in
+    it - so a reader who reloads a transcription and gets None for it is
+    holding a set of numbers that silently excludes a page's worth of music,
+    and cannot know.
+
+    Run against a nonzero score deliberately, for the reason the tests above
+    state: a persistence bug that unconditionally wrote 0 and [] would pass
+    every zero-valued assertion in this file. Dynamis loses one system on
+    page 1 to a 7-line group (see the conftest note), and it is one of only
+    two scores in the library that still lose one at all.
+
+    This is the round trip #146 was filed for after `unison_digits_shared`
+    reached ExtractionResult, to_dict() and _BAR_KEYS but never the
+    confidence_json dict that is the only path into storage - so the prose
+    reached a reader and the number read back as None. Asserted here, in the
+    same change that added the field, rather than left for a later review.
+    """
+    pdf = dynamis_pdf
+    monkeypatch.setattr(api, "LIBRARY_DIR", pdf.parent)
+    conn = db.connect()
+    score_id = insert_score(conn, pdf.name)
+
+    posted = api.transcribe(score_id, body=None)
+    assert posted["systems_unread"] == 1
+    assert posted["systems_unread_pages"] == [1]
+
+    fetched = api.get_transcription(score_id)
+    for key in ("systems_unread", "systems_unread_pages"):
+        assert fetched[key] == posted[key], key
+        assert fetched[key] is not None, key
+    assert fetched["systems_unread"] > 0, (
+        "the whole point: this must not be the zero case")
+    # The prose half of the same disclosure, which is what a reader who never
+    # looks at the figures actually sees.
+    assert any("systems_unread=1" in w for w in fetched["warnings"]), \
+        fetched["warnings"]
+    # And a lost system caps the structure claim, because the marks that were
+    # read may be complete and still describe a form built out of bars this
+    # file does not contain.
+    assert fetched["confidence"]["confidence"]["structure"].startswith("low"), \
+        fetched["confidence"]["confidence"]
+
+
 def test_navigation_disclosures_survive_the_api_round_trip(
     app_env, phantom_train_pdf, monkeypatch, insert_score
 ):

--- a/server/tools/tab_extract/engrave_fixtures.py
+++ b/server/tools/tab_extract/engrave_fixtures.py
@@ -623,13 +623,19 @@ def fixture_harmonics_dense():
 
 def fixture_tab_only_short_last_system():
     """Eight bars of tablature, which MuseScore lays out as six bars and
-    then two - and a two-bar system is not stretched to the page width, so
-    its staff lines fall under the length floor and the system is not
-    detected at all. Two bars of music are lost with nothing said.
+    then two - and a two-bar system is not stretched to the page width.
 
-    This is a real limitation of detecting a staff by the length of its
-    lines, and it is engraved here so that fixing it, or making it worse,
-    changes something. `tab_only` is twelve bars precisely to avoid it."""
+    Engraved as a tripwire for a real limitation of detecting a staff by the
+    length of its lines: this system's lines fell under the length floor and
+    the system was not detected at all, so two bars of music were lost with
+    nothing said. `tab_only` is twelve bars precisely to avoid it.
+
+    The tripwire has since fired. Issue #152 is the same defect at library
+    scale - the floor also hid the right-hand coda system on 54 systems
+    across the maintainer's library - and all eight bars are now read (see
+    tabextract.SHORT_STAFF_LEN_RATIO). The fixture stays exactly as it is,
+    because a short final system is still the shape that would be lost if
+    that floor were ever raised again."""
     bar = "".join([note(("E", 4), "quarter", staff=1), note(("F", 4), "eighth", staff=1),
                    note(("G", 4), "eighth", staff=1), note(("A", 4), "half", staff=1)])
     return score("Guitar", [attributes(staves=1) + bar] + [bar] * 7)


### PR DESCRIPTION
Closes #152.

A page's last band often holds **two systems side by side** — the coda engraved to the *right* of the last full system. `_detect_staves` clustered a band by vertical gap alone, which answers "which lines are level with each other" and not "which lines are one staff", so that second system was lost and its bars never entered the grid.

## What the pages actually do

The issue proposed one mechanism for the 12-line group and a different one for the 40 coda pages. Measuring the four named pages found **three** geometries, all the same root cause, and the issue's account of the 40 is not what the PDFs say:

| Geometry | What happened | Example |
|---|---|---|
| Right-hand lines **short** (89.4–134.5pt, under the 0.25×page-width floor) | Dropped *before* detection saw them — no staff, no anomaly, no bars, **nothing reported at all** | Score C, Score B |
| Both long, ruled **1.5–1.7pt apart** | Rows interleave inside the 15.0pt cluster gap → one group of 10 or 12 lines, discarded whole | Score E (tab), Score D (both) |
| Both long, ruled at the **same y** | Merged into one full-width staff record spanning the gap — and the gap produced **a bar boundary the page does not draw** | Score E (notation), Bygone Days, Score G |

The issue says the 40 coda pages lose their system because "staff detection reads that band as one system ending where the main system's lines end". It does not: on *Score C* the coda staff's six lines run x 441.2–575.7, which is 134.5pt on a 612pt page — **0.220 of the width, under the 0.25 length floor** — so they never reach `_detect_staves` at all. The effect is as described; the cause is the length floor, and that matters because no counter can disclose a system that was filtered out before detection ran.

## The fix

- **A band is split into columns by x extent before its lines are counted.** Two side-by-side systems do not overlap in x at all (measured gaps 36.5pt and 30.7pt) while one staff's lines are drawn to the same x. A page with one system per band yields one column per band, which is why 220 files are untouched.
- **A second, lower length floor** (`SHORT_STAFF_LEN_RATIO`) admits a short run that has four siblings at its own extent *and* is spaced far enough from them to be a staff line (`STAFF_LINE_MIN_SPACING`). **The value is set by a measurement, and the measurement says length is not what does the work:** scanning the whole library between 0.04 and 0.25 of page width for runs passing both tests finds **54 groups, and all 54 have exactly 11 rows** — a notation staff and a tab staff ruled to the same x, which is a side-by-side system and can be nothing else. Their lengths run 0.1235 to 0.2488 and **below 0.1235 the scan finds nothing at all**. The floor sits at 0.10, in that empty band, where it admits all 54 and is not the thing deciding.
- **`STAFF_LINE_MIN_SPACING` is the load-bearing separator, and no length floor could replace it** — the sentence a future tuner needs. At the 0.10 floor, **89 same-extent sibling groups across six files** clear both the length floor and the sibling test and are refused *only* by spacing: four title-block ornaments whose rows alternate 2.5/1.3pt (Troian Beauty, Moonlit Shadows, Carcelera, Score M) and chord-grid rows in two method books at 2.4–2.7pt (Recuerdos de la Alhambra, Classical Guitar Method Vol. 1). Worst admitted real-staff gap is **5.00pt** (Score A); closest refused is **2.60pt**, so 3.0 sits in a clean band. Crucially the **lengths of the two sets overlap** — refused groups reach 0.2145 of page width while real short staves start at 0.1235 — **while the spacings do not.** A length floor drawn through that overlap would throw away real systems and still admit ornaments.
- **Staves come back in reading order, not top order.** The two disagree: on Score C the right-hand system is ruled 0.3pt *higher*, so ordering by `top` numbered the page backwards.
- **Navigation marks and volta brackets are matched to a system by x as well as y.** Both were found by y band over the full page width, so a mark drawn over one system was handed to the one beside it, and the "2." bracket over the left system was written onto the coda system as well (Score G emitted ending 2 over both bar 27 and bar 28). Caught by measurement, not by the suite.

## Disclosure — `systems_unread`

The rule the issue asks for: *a system whose bars were not read must be counted.* `systems_unread` / `systems_unread_pages`, wired to `ExtractionResult`, `to_dict()`, `_BAR_KEYS`, `_BAR_LIST_KEYS`, the `confidence_json` write and `TranscriptionOut`. **Pages, not bars** — a system that was never read has no bar numbers, because bar numbers come from the grid its bars never entered. A lost system caps `structure` confidence at `low`, outranking every other structure term.

**41 → 2** on this library. The 2 residuals are named, and are a *different* defect: Score K p1 and Hide, Hideaway p2 are 7-line groups — an ordinary 6-line tab staff ruled at 7.7pt, plus one stray full-width rule below its last line, close enough to fall inside the 15.0pt gap (Score K at **14.3pt**, Hide Hideaway at **12.8pt**). No split by x can reach them, because the stray rule spans the same extent the staff does.

Worth stating plainly: **disclosure alone could not have covered this issue.** 41 is what the counter sees at baseline; the 54 short systems were invisible to any counter until the length floor changed, because they were filtered out before `_detect_staves` ran. The read fix is what makes the disclosure true.

## Measured, full 297-PDF library, before → after

Baseline is this branch's parent, `cd94b46` (main, after #150 and #154).

| | before | after |
|---|---|---|
| `bars` | 10632 | **10762** (+130) |
| `notes` | 98704 | **99461** (+757) |
| `nav_marks_unanchored` | 43 | **0** |
| `nav_marks_unresolved` | 87 | **7** |
| `systems_unread` | 41 | **2** |
| coda signs written | 109 | **150** |
| `structure` high / medium / low | 221 / 72 / 0 | 256 / 35 / **2** |

**220 of 297 files are byte-identical. All 77 that differ are files whose bar count changed — no score's output moved without its bar count moving.**

Conformance aggregates move, and are supposed to: recovered bars carry notes that add up or fail to like any others. `bars_defective` 5317→5359, `bars_overfull` 1573→1590, `bars_short` 4188→4216, `bars_padded` 3603→3619.

Three more movements, all downstream of the same recovered music:

- **`endings_truncated` 25→28.** Hollow bar 33 and Score L bar 9 are volta brackets on systems that were previously not read at all; Score G bar 27 is the bracket whose duplicate onto the coda system this PR removes, now correctly reported as having no closing hook drawn. All three are the existing disclosure firing on new or corrected music, not a new failure.
- **`bars_unread` 23→20.** Three bars that read as empty were the tail of a system whose remainder was missing; with the whole system read they carry notes.
- **`dots_unassigned` 1270→1280.** Recovered bars bring their own augmentation-dot glyphs, and 10 of them bind to no note — the same disclosure as the other 1270, on music that was not being counted before.

Verified against the printed pages: Score C 17→**18**, Score B 36→**37**, Score E 31→**35**, Score D 53→**58**, Score F 13→**17**. Three files *lose* a bar and those are corrections too, also read off the page: Score G 29→28 (page prints 28), Bygone Days 25→24 (prints 24), The Crestlands 39→38 (prints 37 plus a pickup measure).

The 7 remaining `nav_marks_unresolved` bars are scores that genuinely name a target their page does not draw: Rebel Army Theme, Score I, Score J, Hollow, Spoken Without End, Heartgem's Burden (2). Score A needed both this branch and #154 — that one could read no glyphs from its page at all, so it never saw the segno its "D.S." names.

### Two figures from the issue thread that did not reproduce

- **Score D prints 58 bars, not 57.** Its coda system holds two bars (57 and 58), with a barline between them — read off the rendered page. The deficit was 5, not 4.
- **`nav_marks_unresolved` 79-of-87 slightly understated the fix's reach.** 87 → 7 means 80 bars resolved. The thread's list of genuinely target-less files omitted Score I and Spoken Without End; Score E resolves rather than remaining lost, and Score A resolves once #154 is in.

## Verification

Suite **866 passed, 0 failed, 0 skipped** with `FERMATA_TEST_LIBRARY`, `FERMATA_MUSICXML_XSD` and web/node_modules present (860 at `cd94b46`; +6 tests). **809 passed, 57 named skips** with no library configured.

Two systems on one band is a horizontal-frame layout that plain MusicXML cannot express, so the engraved chain cannot produce it and the four library pages are gitignored. The split is therefore covered in CI by pages built from line primitives directly — which is exactly `_detect_staves`' input — for the interleaved case, the same-y merge, a 89.4pt system beside a 450pt one, and the tight-ruled ornament that must not become a staff. The existing engraved `tab_only_short_last_system` fixture, which pinned the length-floor defect as a tripwire, now reads all 8 of its bars.

Mutation tested, each reverted after:

| mutation | result |
|---|---|
| column split never starts a new column | **8 red**, incl. all 3 CI geometry tests |
| `SHORT_STAFF_LEN_RATIO` back to 0.25 | **5 red**, incl. the engraved fixture and Score C/Score B |
| `STAFF_LINE_MIN_SPACING` → 0.0 | **3 red** (the ornament guard) |
| counter dropped from `confidence_json` | **red by name**: "_BAR_KEYS names a key transcribe() never writes into confidence_json: ['systems_unread']" |
| field dropped from `TranscriptionOut` | **red by name**: "api_models.TranscriptionOut is missing field(s) for: ['systems_unread']" |

Reload round trip asserted on Score K, whose count is genuinely 1 — a persistence bug writing 0 and `[]` unconditionally would pass every zero-valued assertion in that file (#146).


## Rebased onto #150 and #154

This branch was measured first against `a2c1111` and then rebased onto current main. #154 changes which conformance figures the *baseline* has — it lets Score A be read as the engraved score it is — so every figure above was **re-measured against the new parent rather than adjusted arithmetically**. All headline numbers are unchanged by the rebase; `nav_marks_unresolved` improved from 87→8 to 87→7, because Score A no longer needs either disclosure.

