### PR TITLE
Render every structural disclosure the decoder counts beside the conformance figures

### DIFF
--- a/server/tests/test_disclosure_keys.py
+++ b/server/tests/test_disclosure_keys.py
@@ -1,0 +1,61 @@
+"""Keeps web/tests/disclosure-keys.json honest against api._BAR_KEYS -
+issue #155's fourth mirror guard.
+
+The structural-form/inference disclosure counters (repeats_unread,
+nav_marks_unresolved, coincident_unsplit_pairs, ...) are named in FOUR
+places that cannot import one another and so cannot be kept in sync by the
+type checker or the import graph: tabextract.py's ExtractionResult fields,
+this module's own _BAR_KEYS tuple, api_models.py's TranscriptionOut fields
+(guarded against _BAR_KEYS by
+test_transcription_model_stays_in_sync_with_api_pys_bar_key_tuples in
+test_api_docs.py), and web/src/lib/disclosures.js's DISCLOSURE_ROWS - the
+interface config that decides what a reader actually sees.
+
+Nothing checked that fourth copy at all: a fake counter added to _BAR_KEYS,
+or a row quietly dropped from DISCLOSURE_ROWS, passed every test that
+existed before this one. web/tests/unit/disclosures.spec.js now checks
+DISCLOSURE_ROWS against web/tests/disclosure-keys.json in both directions -
+but a browser test cannot import api.py, so nothing on that side can check
+the VENDORED file itself against the real source of truth. This is that
+check, on the only side that can make it.
+"""
+
+import json
+from pathlib import Path
+
+from fermata import api
+
+_VENDORED_PATH = (
+    Path(__file__).resolve().parents[2] / "web" / "tests" / "disclosure-keys.json"
+)
+
+# The Rule 8 conformance figures inside _BAR_KEYS that are NOT structural
+# disclosures - already shown elsewhere (ScoreCompare's bar-count headline,
+# and the warning prose the *_bars lists feed), not through the disclosures
+# panel issue #155 built. Every other key in _BAR_KEYS is a structural
+# disclosure and belongs in the vendored file.
+_RULE8_CONFORMANCE_KEYS = {
+    "bars_overfull", "bars_short", "bars_defective", "bars_measured",
+    "bars_padded", "bars_unread",
+}
+
+
+def test_vendored_disclosure_keys_stay_in_sync_with_api_pys_bar_keys():
+    """A key added to (or removed from) api._BAR_KEYS that is not one of the
+    Rule 8 conformance keys above must be added to (or removed from)
+    web/tests/disclosure-keys.json in the same change, or a disclosure the
+    decoder counts can silently stop being guarded on the frontend - and, by
+    extension, stop being rendered at all when it's removed from
+    DISCLOSURE_ROWS - without any test, anywhere, going red."""
+    expected = set(api._BAR_KEYS) - _RULE8_CONFORMANCE_KEYS
+    vendored = set(json.loads(_VENDORED_PATH.read_text(encoding="utf-8")))
+    missing = expected - vendored
+    extra = vendored - expected
+    assert not missing, (
+        f"{_VENDORED_PATH} is missing disclosure key(s) that api._BAR_KEYS "
+        f"now carries: {sorted(missing)}"
+    )
+    assert not extra, (
+        f"{_VENDORED_PATH} has stale key(s) no longer in api._BAR_KEYS (or "
+        f"reclassified as Rule 8 conformance above): {sorted(extra)}"
+    )

--- a/web/src/lib/Disclosures.svelte
+++ b/web/src/lib/Disclosures.svelte
@@ -13,24 +13,44 @@
   // No in-viewer "jump to this bar" exists yet (see PR body for #155) - so
   // the numbers are plain, readable text rather than links. They still tell
   // a reader exactly where to look on the page open beside this one.
+  //
+  // `barsLabel` overrides the plain "bar"/"page" word - form_marks_unanchored
+  // sets it to "near bar" because its list is a NEAREST-bar fallback, not the
+  // bar the mark was actually drawn over (see disclosures.js's own comment on
+  // that row, citing tabextract.py's "Nearest bars:" prose).
   function barsText(row) {
-    const unit = row.barUnit === "page" ? "page" : "bar";
+    const unit = row.barsLabel ?? (row.barUnit === "page" ? "page" : "bar");
     const label = row.bars.length === 1 ? unit : `${unit}s`;
     return `${label} ${row.bars.join(", ")}`;
+  }
+
+  // A "flag" row (kind: "flag" in disclosures.js - currently only
+  // endings_incomplete) is a 0/1 fact, not a count: rendering its value as a
+  // bare "1" reads as "one thing", the wrong claim for a yes/no condition.
+  // Its presence in `rows` at all already means the answer is yes (a
+  // measured 0 is filtered out by disclosureRows before this ever runs), so
+  // a measured flag shows no value at all - just its label. An UNMEASURED
+  // flag still needs to say "not measured", the same as any other row, so
+  // this only suppresses the value for the measured case.
+  function showsValue(row) {
+    return row.kind !== "flag" || !row.measured;
   }
 </script>
 
 {#if rows.length}
   <div class="disclosures" data-testid="disclosures">
-    <p class="disclosures-title">Structural disclosures</p>
-    <ul>
+    <h3 class="disclosures-title">Structural disclosures</h3>
+    <ul role="list">
       {#each rows as row (row.key)}
+        {@const withValue = showsValue(row)}
         <li class="disclosure-row" data-disclosure={row.key}>
-          <span class="disclosure-label">{row.label}</span>
-          {#if row.measured}
-            <span class="disclosure-value">{row.value}</span>
-          {:else}
-            <span class="disclosure-value not-measured">not measured</span>
+          <span class="disclosure-label" class:standalone={!withValue}>{row.label}</span>
+          {#if withValue}
+            {#if row.measured}
+              <span class="disclosure-value">{row.value}</span>
+            {:else}
+              <span class="disclosure-value not-measured">not measured</span>
+            {/if}
           {/if}
           {#if row.measured && row.bars.length}
             <span class="disclosure-bars">{barsText(row)}</span>
@@ -52,8 +72,12 @@
     color: var(--ink-dim);
   }
 
+  /* An <h3> for real document structure (a11y review, issue #155) - reset to
+     the same quiet register as the rest of this block rather than a
+     browser's bold, oversized default. */
   .disclosures-title {
     margin: 0 0 4px;
+    font: inherit;
     font-weight: 600;
     letter-spacing: 0.01em;
   }
@@ -61,6 +85,10 @@
   .disclosures ul {
     margin: 0;
     padding: 0;
+    /* list-style: none removes the bullets AND, in Safari/VoiceOver, the
+       list semantics along with them - role="list" on the element (a11y
+       review) restores "list"/"listitem" to the accessibility tree even
+       though there is nothing left to look like one visually. */
     list-style: none;
     display: flex;
     flex-direction: column;
@@ -78,7 +106,11 @@
     color: var(--ink);
   }
 
-  .disclosure-label::after {
+  /* A measured flag row (see showsValue above) renders no value after the
+     label, so it gets no trailing colon either - "Volta numbering has gaps"
+     reads as a complete statement on its own; "Volta numbering has gaps:"
+     with nothing after it would read as truncated. */
+  .disclosure-label:not(.standalone)::after {
     content: ":";
   }
 

--- a/web/src/lib/Disclosures.svelte
+++ b/web/src/lib/Disclosures.svelte
@@ -1,0 +1,99 @@
+<script>
+  // Renders every structural-form/inference disclosure disclosureRows()
+  // selects for this transcription - one row per non-zero (or unmeasured)
+  // counter, beside the Rule 8 conformance figures ScoreCompare already
+  // shows (issue #155). See disclosures.js for the selection rules; this
+  // component only lays out what it is handed.
+  import { disclosureRows } from "./disclosures.js";
+
+  let { transcription = null } = $props();
+
+  let rows = $derived(disclosureRows(transcription));
+
+  // No in-viewer "jump to this bar" exists yet (see PR body for #155) - so
+  // the numbers are plain, readable text rather than links. They still tell
+  // a reader exactly where to look on the page open beside this one.
+  function barsText(row) {
+    const unit = row.barUnit === "page" ? "page" : "bar";
+    const label = row.bars.length === 1 ? unit : `${unit}s`;
+    return `${label} ${row.bars.join(", ")}`;
+  }
+</script>
+
+{#if rows.length}
+  <div class="disclosures" data-testid="disclosures">
+    <p class="disclosures-title">Structural disclosures</p>
+    <ul>
+      {#each rows as row (row.key)}
+        <li class="disclosure-row" data-disclosure={row.key}>
+          <span class="disclosure-label">{row.label}</span>
+          {#if row.measured}
+            <span class="disclosure-value">{row.value}</span>
+          {:else}
+            <span class="disclosure-value not-measured">not measured</span>
+          {/if}
+          {#if row.measured && row.bars.length}
+            <span class="disclosure-bars">{barsText(row)}</span>
+          {/if}
+        </li>
+      {/each}
+    </ul>
+  </div>
+{/if}
+
+<style>
+  /* Stated in the same quiet register the provenance block uses in
+     ScoreCompare.svelte - a count of what wasn't read is a fact about this
+     transcription, not styled as a fault the way the danger-colored
+     warnings box is. */
+  .disclosures {
+    margin: 10px 16px 0;
+    font-size: 11.5px;
+    color: var(--ink-dim);
+  }
+
+  .disclosures-title {
+    margin: 0 0 4px;
+    font-weight: 600;
+    letter-spacing: 0.01em;
+  }
+
+  .disclosures ul {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+
+  .disclosure-row {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: 4px 8px;
+  }
+
+  .disclosure-label {
+    color: var(--ink);
+  }
+
+  .disclosure-label::after {
+    content: ":";
+  }
+
+  .disclosure-value {
+    font-weight: 600;
+    color: var(--ink);
+  }
+
+  .disclosure-value.not-measured {
+    font-weight: 400;
+    font-style: italic;
+    color: var(--ink-dim);
+  }
+
+  .disclosure-bars {
+    color: var(--ink-dim);
+  }
+</style>

--- a/web/src/lib/ScoreCompare.svelte
+++ b/web/src/lib/ScoreCompare.svelte
@@ -5,6 +5,7 @@
   import TabViewer from "./TabViewer.svelte";
   import { transcriptionProvenance, tuningStatement } from "./provenance.js";
   import { STANDING_LIMITS, BAR_RE } from "./warning-patterns.js";
+  import Disclosures from "./Disclosures.svelte";
 
   let {
     score,
@@ -591,6 +592,15 @@
             </p>
           {/if}
         </div>
+      {/if}
+      {#if !gigMode}
+        <!-- Beside the conformance figures above, not folded into the
+             warnings box: these are counts the decoder already computed and
+             stored, not prose to summarise (issue #155). Disclosures.svelte
+             hides zero counters on its own and shows nothing when this
+             transcription (an edited row, or a legacy row) never measured
+             any of them, so no extra guard is needed here. -->
+        <Disclosures {transcription} />
       {/if}
       {#if editorOpen}
         <div class="editor">

--- a/web/src/lib/disclosures.js
+++ b/web/src/lib/disclosures.js
@@ -1,0 +1,109 @@
+// The structural-form and inference disclosures TranscriptionOut carries
+// beside the Rule 8 conformance figures (issue #155).
+//
+// Every one of these counters was computed, stored, reloaded through the
+// API, and mirrored in the response model - and then read by no interface
+// code. Only the warning PROSE reached a reader, through ScoreCompare.svelte's
+// generic warnings list; the count each sentence is built from never did. See
+// api_models.py's TranscriptionOut for the authoritative field list this
+// mirrors - every field it carries in the "_BAR_KEYS" group past
+// bars_overfull/bars_short/bars_defective/bars_measured/bars_padded/
+// bars_unread (which already reach a reader through ScoreCompare's bar-count
+// headline and the warning prose the *_bars lists feed) has a row here.
+//
+// ONE ROW PER COUNTER, on purpose - the issue's own fix shape is "decide the
+// presentation once for the family... the next decoder disclosure should
+// land in the interface by adding a row, not a component." A new counter
+// lands here as one line in DISCLOSURE_ROWS, not a new branch of rendering
+// logic.
+//
+// Pure logic, no runes, no imports - same reason provenance.js is - so the
+// row-selection rules (what's hidden, what's "not measured") can be tested
+// without a browser. What actually renders is Disclosures.svelte.
+export const DISCLOSURE_ROWS = [
+  { key: "repeats_unread", label: "Repeat marks not read", barsKey: "repeats_unread_bars" },
+  { key: "endings_unread", label: "Volta (ending) brackets not read", barsKey: "endings_unread_bars" },
+  { key: "endings_truncated", label: "Volta endings truncated", barsKey: "endings_truncated_bars" },
+  { key: "endings_incomplete", label: "Volta numbering doesn't start at 1" },
+  {
+    key: "form_marks_unanchored",
+    label: "Repeat/volta marks with no bar to anchor to",
+    barsKey: "form_marks_unanchored_bars",
+  },
+  {
+    key: "nav_marks_unresolved",
+    label: "Navigation marks written with no jump target",
+    barsKey: "nav_marks_unresolved_bars",
+  },
+  // No barsKey: a navigation mark with no bar to name has no bar number to
+  // report (docs/musicxml-tab-profile.md, Rule 16 / issue #134 phase 2).
+  { key: "nav_marks_unanchored", label: "Navigation marks with no bar to anchor to" },
+  // The list beside this one is PAGES, not bars, for the same reason -
+  // see api_models.py's comment on systems_unread_pages.
+  { key: "systems_unread", label: "Systems not read at all", barsKey: "systems_unread_pages", barUnit: "page" },
+  { key: "coincident_unsplit_pairs", label: "Coincident notehead pairs not split" },
+  { key: "staves_coincident_unsplit", label: "Staves with an unsplit coincident pair" },
+  { key: "unison_digits_shared", label: "Notes given another note's fret number" },
+  { key: "dots_unassigned", label: "Augmentation dots not assigned to a note" },
+  {
+    key: "dots_unassigned_no_candidate",
+    label: "Unassigned dots with no notehead or rest nearby",
+  },
+  {
+    key: "dots_unassigned_eliminated",
+    label: "Unassigned dots that reached a candidate but lost it to a shared owner",
+  },
+  { key: "staves_dots_unassigned", label: "Staves with an unassigned dot" },
+  { key: "notes_no_stem", label: "Noteheads read with no stem" },
+  { key: "staves_no_stem", label: "Staves with a stemless notehead" },
+];
+
+/**
+ * Turns a transcription object (the shape TranscriptionOut/api.js hand back)
+ * into the rows Disclosures.svelte renders, applying the three rules the
+ * issue asks for:
+ *
+ *   - a counter that is exactly 0 is HIDDEN - a wall of zeros is noise, and a
+ *     transcription with all zeros shows nothing new here.
+ *   - a counter that is `null`/`undefined` (a legacy row from before it was
+ *     computed, or an edited row with no confidence at all) is DISTINCT from
+ *     zero: it renders as "not measured", never silently as "0" - the API
+ *     contract already keeps the two apart and this must not collapse them.
+ *   - a `*_bars` (or `*_pages`) list rides along as the counter's detail:
+ *     the bar/page numbers it exists to name.
+ *
+ * The one thing that gates the WHOLE section rather than one row: if every
+ * single counter below is null, nothing here was ever computed for this row
+ * at all (the common shape of a hand-edited row - see saveEdit() in
+ * ScoreCompare.svelte, which states every one of these `null` on purpose).
+ * That state already renders as nothing elsewhere on this panel (no bar
+ * headline, no warnings block), and a wall of seventeen "not measured" rows
+ * would be exactly the noise this function exists to avoid - so this
+ * returns no rows at all rather than that wall. A row that measured SOME of
+ * these counters (a real extraction whose schema predates one particular
+ * counter) still shows the gap on that one counter specifically, because in
+ * that case something else on this same object is a real number and the
+ * absence of this one is worth knowing.
+ */
+export function disclosureRows(t) {
+  if (!t) return [];
+  const anyMeasured = DISCLOSURE_ROWS.some((row) => t[row.key] !== null && t[row.key] !== undefined);
+  if (!anyMeasured) return [];
+
+  const rows = [];
+  for (const row of DISCLOSURE_ROWS) {
+    const value = t[row.key];
+    if (value === 0) continue; // hidden - good news needs no row
+    const measured = value !== null && value !== undefined;
+    const barsRaw = row.barsKey ? t[row.barsKey] : null;
+    rows.push({
+      key: row.key,
+      label: row.label,
+      measured,
+      value: measured ? value : null,
+      barUnit: row.barUnit ?? "bar",
+      bars: measured && Array.isArray(barsRaw) ? barsRaw : [],
+    });
+  }
+  return rows;
+}

--- a/web/src/lib/disclosures.js
+++ b/web/src/lib/disclosures.js
@@ -17,6 +17,18 @@
 // lands here as one line in DISCLOSURE_ROWS, not a new branch of rendering
 // logic.
 //
+// THE KEY LIST ITSELF IS GUARDED, not just hand-checked once: this file is
+// one of FOUR hand-kept copies of "which fields are structural disclosures"
+// (server/fermata/tabextract.py's ExtractionResult fields, server/fermata/
+// api.py's _BAR_KEYS tuple, api_models.py's TranscriptionOut fields, and this
+// one), and it was the only one nothing checked - a fake counter added to
+// api.py, or a row silently dropped from here, passed every existing test.
+// web/tests/disclosure-keys.json vendors the same key list from the API side
+// (kept honest against api._BAR_KEYS by
+// server/tests/test_disclosure_keys.py), and web/tests/unit/disclosures.spec.js
+// asserts DISCLOSURE_ROWS's keys equal that vendored file's, in both
+// directions, by name.
+//
 // Pure logic, no runes, no imports - same reason provenance.js is - so the
 // row-selection rules (what's hidden, what's "not measured") can be tested
 // without a browser. What actually renders is Disclosures.svelte.
@@ -24,37 +36,76 @@ export const DISCLOSURE_ROWS = [
   { key: "repeats_unread", label: "Repeat marks not read", barsKey: "repeats_unread_bars" },
   { key: "endings_unread", label: "Volta (ending) brackets not read", barsKey: "endings_unread_bars" },
   { key: "endings_truncated", label: "Volta endings truncated", barsKey: "endings_truncated_bars" },
-  { key: "endings_incomplete", label: "Volta numbering doesn't start at 1" },
+  // A FLAG, not a count - tabextract.py:5172 trips it on ANY gap in the
+  // volta numbers actually read, not only a missing "1" (seen_ints !=
+  // range(1, seen_ints[-1] + 1) catches [1, 3] just as it catches [2, 3]),
+  // and the field itself is only ever 0 or 1 (tabextract.py:5166-5173). A
+  // bare "1" in a column of counts reads as "one thing", which is the wrong
+  // claim for a yes/no fact - kind: "flag" renders it as presence, not a
+  // number.
+  { key: "endings_incomplete", label: "Volta numbering has gaps", kind: "flag" },
+  // OVERSTATES if read as "repeat/volta marks": tabextract.py:1156 folds a
+  // plain bar-style group (a final or double barline, carrying no <repeat>
+  // and no <ending> at all - see docs/musicxml-tab-profile.md's "bar-style
+  // alone") into the same unanchored-count path as an actual repeat/volta
+  // mark whenever it fails to anchor (tabextract.py:1159-1161). And the bar
+  // list is a NEAREST-bar fallback, not the bar the mark was drawn over -
+  // the mark had no bar to anchor to at all, so tabextract.py:5131-5133's
+  // own warning prose calls the list "Nearest bars:", not "bars:".
   {
     key: "form_marks_unanchored",
-    label: "Repeat/volta marks with no bar to anchor to",
+    label: "Repeat/volta/bar-style marks with no bar to anchor to",
     barsKey: "form_marks_unanchored_bars",
+    barsLabel: "near bar",
   },
+  // Counted per BAR, not per mark: tabextract.py:2163-2164 counts one bar
+  // once even when two navigation instructions close on it together.
   {
     key: "nav_marks_unresolved",
-    label: "Navigation marks written with no jump target",
+    label: "Bars whose navigation marks name no target this transcription holds",
     barsKey: "nav_marks_unresolved_bars",
   },
   // No barsKey: a navigation mark with no bar to name has no bar number to
   // report (docs/musicxml-tab-profile.md, Rule 16 / issue #134 phase 2).
   { key: "nav_marks_unanchored", label: "Navigation marks with no bar to anchor to" },
-  // The list beside this one is PAGES, not bars, for the same reason -
-  // see api_models.py's comment on systems_unread_pages.
-  { key: "systems_unread", label: "Systems not read at all", barsKey: "systems_unread_pages", barUnit: "page" },
-  { key: "coincident_unsplit_pairs", label: "Coincident notehead pairs not split" },
-  { key: "staves_coincident_unsplit", label: "Staves with an unsplit coincident pair" },
+  // "System" here means a staff-sized GROUP OF LINES the page-scan found and
+  // could not read as a staff (neither 5 nor 6 lines) - tabextract.py:
+  // 344-346. Whether that group was actually a musical system is inferred
+  // from its size, not confirmed - a stray staff-sized rule or decoration
+  // would count the same way. The list beside this one is PAGES, not bars,
+  // for the reason api_models.py's comment on systems_unread_pages gives.
+  { key: "systems_unread", label: "Staff-sized line groups not read as a system", barsKey: "systems_unread_pages", barUnit: "page" },
+  // Counted once per coincident GROUP (glyph_rhythm.py:3103-3113,
+  // specifically the `coincident_unsplit_pairs += 1` at line 3111, inside
+  // the loop over `_dup_groups` - one increment per group regardless of how
+  // many duplicate copies it holds), not once per notehead.
+  { key: "coincident_unsplit_pairs", label: "Coincident notehead groups not split across voices" },
+  { key: "staves_coincident_unsplit", label: "Staves with an unsplit coincident group" },
   { key: "unison_digits_shared", label: "Notes given another note's fret number" },
   { key: "dots_unassigned", label: "Augmentation dots not assigned to a note" },
   {
     key: "dots_unassigned_no_candidate",
     label: "Unassigned dots with no notehead or rest nearby",
   },
+  // glyph_rhythm.py:2957-2959: this dot DID reach a candidate notehead/rest,
+  // but every one it reached already carried a dot at a conflicting tier
+  // (a different, already-bound position) or was a same-x duplicate of a
+  // candidate already given one - not "nothing nearby" (that's the sibling
+  // counter above).
   {
     key: "dots_unassigned_eliminated",
-    label: "Unassigned dots that reached a candidate but lost it to a shared owner",
+    label: "Unassigned dots whose only candidates already had a conflicting or duplicate dot",
   },
   { key: "staves_dots_unassigned", label: "Staves with an unassigned dot" },
-  { key: "notes_no_stem", label: "Noteheads read with no stem" },
+  // Quarter-note heads or shorter ONLY - glyph_rhythm.py:2934-2950 counts a
+  // stemless filled (or x/diamond) notehead here specifically because a
+  // missing stem costs its DURATION (the flag/beam that would say which
+  // note value hangs off the stem it can't find); a half or whole notehead
+  // is deliberately excluded (glyph_rhythm.py:2946-2950) because neither
+  // shape can carry a flag or beam in any notation, so a missing stem on one
+  // of those costs only the voice signal, not the duration, and is not
+  // counted here.
+  { key: "notes_no_stem", label: "Noteheads read with no stem (quarter or shorter)" },
   { key: "staves_no_stem", label: "Staves with a stemless notehead" },
 ];
 
@@ -99,9 +150,11 @@ export function disclosureRows(t) {
     rows.push({
       key: row.key,
       label: row.label,
+      kind: row.kind ?? "count",
       measured,
       value: measured ? value : null,
       barUnit: row.barUnit ?? "bar",
+      barsLabel: row.barsLabel ?? null,
       bars: measured && Array.isArray(barsRaw) ? barsRaw : [],
     });
   }

--- a/web/tests/browser/fixtures/transcription-warnings.js
+++ b/web/tests/browser/fixtures/transcription-warnings.js
@@ -17,6 +17,8 @@
 // against its own idea of the shape. These fixtures exist so that mistake
 // can't quietly happen again on either side of this file.
 
+import { DISCLOSURE_ROWS } from "../../../src/lib/disclosures.js";
+
 export const MIN_PDF = Buffer.from(
   "%PDF-1.4\n1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj\n" +
     "2 0 obj<</Type/Pages/Kids[3 0 R]/Count 1>>endobj\n" +
@@ -110,6 +112,24 @@ export const STANDING_LIMITS_ONLY_WARNINGS = [
 ];
 
 /**
+ * Every structural-disclosure counter TranscriptionOut carries, set to a
+ * real, measured zero (and every `*_bars`/`*_pages` list to `[]`) - the
+ * clean-extraction baseline. Spread this into `disclosures` and override the
+ * handful a scenario cares about, so a fixture that only means to say "this
+ * one counter is non-zero" doesn't accidentally leave its siblings `undefined`
+ * (which disclosures.js treats as "never measured", not as zero - see
+ * disclosureRows()'s own doc comment on that distinction).
+ */
+export function zeroDisclosures() {
+  const t = {};
+  for (const row of DISCLOSURE_ROWS) {
+    t[row.key] = 0;
+    if (row.barsKey) t[row.barsKey] = [];
+  }
+  return t;
+}
+
+/**
  * Builds a GET /transcription (or POST /transcribe) response body.
  *
  * `bars` is `{ defective, measured, overfull, short }` or omitted entirely -
@@ -134,6 +154,14 @@ export const STANDING_LIMITS_ONLY_WARNINGS = [
  * `content` and `format` override the rendered transcription itself, for the
  * cases that are about what the staff/metronome make of the document rather
  * than about the warning panel above it.
+ *
+ * `disclosures` is any subset of the structural-form/inference counters
+ * TranscriptionOut carries (repeats_unread, endings_unread, ...) and their
+ * `*_bars`/`*_pages` lists - see disclosures.js's DISCLOSURE_ROWS for the
+ * full field list. Passed straight through onto the top level, exactly like
+ * `bars` and `provenance` above: those fields are siblings of `confidence`
+ * on the real API response, not nested inside it (see api.py's
+ * _BLOB_TOP_LEVEL).
  */
 export function transcriptionResponse({
   warnings,
@@ -141,6 +169,7 @@ export function transcriptionResponse({
   bars,
   nestWarningsOnly = false,
   provenance = null,
+  disclosures = null,
   content = SAMPLE_TEX,
   format = "alphatex",
 }) {
@@ -152,6 +181,7 @@ export function transcriptionResponse({
     blob.bars_measured = bars.measured;
   }
   if (provenance) Object.assign(blob, provenance);
+  if (disclosures) Object.assign(blob, disclosures);
   const body = {
     id: 1,
     score_id: 1,
@@ -168,6 +198,7 @@ export function transcriptionResponse({
     body.bars_measured = blob.bars_measured;
   }
   if (provenance) Object.assign(body, provenance);
+  if (disclosures) Object.assign(body, disclosures);
   return body;
 }
 
@@ -214,18 +245,26 @@ export const INCOMPLETE_TUNING_PROVENANCE = {
 /**
  * A saved hand edit's response shape, mirroring server/fermata/api.py's
  * _transcription_dict exactly for a row whose `confidence` column is NULL
- * (every edited row): `warnings` is stated as `[]` and all four bar keys as
- * `null` - NEVER omitted - specifically because an earlier version of the
- * backend omitted them, and a client that spread such a response over the
- * transcription it already held kept the PRE-EDIT figures. A user opened a
- * score reading "4 of 50 bars don't add up", fixed exactly those bars,
- * saved, and the panel still said "4 of 50 bars don't add up" and still
- * listed warnings about notes that no longer existed - the confidently
- * wrong state this whole feature exists to prevent. `null` (not `0`) is the
- * deliberate way of saying "nothing has measured this content"; `0` would
- * claim every bar was measured and every one of them added up.
+ * (every edited row): `warnings` is stated as `[]` and every _BAR_KEYS /
+ * _BAR_LIST_KEYS field - including every structural disclosure counter
+ * disclosures.js reads - as `null`, NEVER omitted - specifically because an
+ * earlier version of the backend omitted them, and a client that spread such
+ * a response over the transcription it already held kept the PRE-EDIT
+ * figures. A user opened a score reading "4 of 50 bars don't add up", fixed
+ * exactly those bars, saved, and the panel still said "4 of 50 bars don't
+ * add up" and still listed warnings about notes that no longer existed - the
+ * confidently wrong state this whole feature exists to prevent. `null` (not
+ * `0`) is the deliberate way of saying "nothing has measured this content";
+ * `0` would claim every bar was measured and every one of them added up (and
+ * for the disclosure counters specifically, that every one of them found
+ * nothing).
  */
 export function editedTranscriptionResponse() {
+  const disclosureNulls = {};
+  for (const row of DISCLOSURE_ROWS) {
+    disclosureNulls[row.key] = null;
+    if (row.barsKey) disclosureNulls[row.barsKey] = null;
+  }
   return {
     id: 1,
     score_id: 1,
@@ -238,6 +277,7 @@ export function editedTranscriptionResponse() {
     bars_short: null,
     bars_defective: null,
     bars_measured: null,
+    ...disclosureNulls,
   };
 }
 

--- a/web/tests/browser/fixtures/transcription-warnings.js
+++ b/web/tests/browser/fixtures/transcription-warnings.js
@@ -17,7 +17,26 @@
 // against its own idea of the shape. These fixtures exist so that mistake
 // can't quietly happen again on either side of this file.
 
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
 import { DISCLOSURE_ROWS } from "../../../src/lib/disclosures.js";
+
+// The same vendored key list web/tests/unit/disclosures.spec.js checks
+// DISCLOSURE_ROWS against (see that file's comment, and
+// server/tests/test_disclosure_keys.py, for the rest of the guard chain).
+// editedTranscriptionResponse() below reads THIS, not DISCLOSURE_ROWS - a
+// fixture meant to catch DISCLOSURE_ROWS drifting from the real API contract
+// cannot itself be generated from DISCLOSURE_ROWS, or a row silently dropped
+// from the config would silently stop being nulled here too, and nothing
+// would notice either change.
+const DISCLOSURE_KEYS = JSON.parse(
+  fs.readFileSync(
+    path.join(path.dirname(fileURLToPath(import.meta.url)), "..", "..", "disclosure-keys.json"),
+    "utf8",
+  ),
+);
 
 export const MIN_PDF = Buffer.from(
   "%PDF-1.4\n1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj\n" +
@@ -245,26 +264,31 @@ export const INCOMPLETE_TUNING_PROVENANCE = {
 /**
  * A saved hand edit's response shape, mirroring server/fermata/api.py's
  * _transcription_dict exactly for a row whose `confidence` column is NULL
- * (every edited row): `warnings` is stated as `[]` and every _BAR_KEYS /
- * _BAR_LIST_KEYS field - including every structural disclosure counter
- * disclosures.js reads - as `null`, NEVER omitted - specifically because an
- * earlier version of the backend omitted them, and a client that spread such
- * a response over the transcription it already held kept the PRE-EDIT
- * figures. A user opened a score reading "4 of 50 bars don't add up", fixed
- * exactly those bars, saved, and the panel still said "4 of 50 bars don't
- * add up" and still listed warnings about notes that no longer existed - the
+ * (every edited row): `warnings` is stated as `[]`, and EVERY field
+ * _BAR_KEYS, _BAR_LIST_KEYS, _BAR_AMOUNT_KEYS and _PROVENANCE_KEYS name -
+ * the full set test_transcription_model_stays_in_sync_with_api_pys_bar_key_
+ * tuples (server/tests/test_api_docs.py) checks TranscriptionOut against -
+ * as `null`, NEVER omitted. That is specifically because an earlier version
+ * of the backend omitted them, and a client that spread such a response
+ * over the transcription it already held kept the PRE-EDIT figures. A user
+ * opened a score reading "4 of 50 bars don't add up", fixed exactly those
+ * bars, saved, and the panel still said "4 of 50 bars don't add up" and
+ * still listed warnings about notes that no longer existed - the
  * confidently wrong state this whole feature exists to prevent. `null` (not
  * `0`) is the deliberate way of saying "nothing has measured this content";
- * `0` would claim every bar was measured and every one of them added up (and
- * for the disclosure counters specifically, that every one of them found
- * nothing).
+ * `0` would claim every bar was measured and every one of them added up
+ * (and for the disclosure counters, that every one of them found nothing);
+ * an omitted provenance key would claim its meter/key/tuning was never even
+ * asked about, when the true state after an edit is "not recorded, either".
+ *
+ * The disclosure counters (repeats_unread, nav_marks_unresolved, ...) are
+ * nulled from DISCLOSURE_KEYS - the vendored list, not DISCLOSURE_ROWS - so
+ * this fixture cannot go stale in lockstep with a bug in DISCLOSURE_ROWS
+ * itself; see this file's own top-of-file comment on DISCLOSURE_KEYS.
  */
 export function editedTranscriptionResponse() {
-  const disclosureNulls = {};
-  for (const row of DISCLOSURE_ROWS) {
-    disclosureNulls[row.key] = null;
-    if (row.barsKey) disclosureNulls[row.barsKey] = null;
-  }
+  const nulls = {};
+  for (const key of DISCLOSURE_KEYS) nulls[key] = null;
   return {
     id: 1,
     score_id: 1,
@@ -273,11 +297,41 @@ export function editedTranscriptionResponse() {
     source: "edited",
     confidence: null,
     warnings: [],
+    // _BAR_KEYS' six Rule 8 conformance figures (api.py) - the disclosure
+    // counters among _BAR_KEYS are in `nulls` above via DISCLOSURE_KEYS.
     bars_overfull: null,
     bars_short: null,
     bars_defective: null,
     bars_measured: null,
-    ...disclosureNulls,
+    bars_padded: null,
+    bars_unread: null,
+    // _BAR_LIST_KEYS (api.py) - every *_bars/*_pages list, including the
+    // ones that ride along with a disclosure counter above.
+    padded_bars: null,
+    unread_bars: null,
+    spacing_bars: null,
+    degraded_bars: null,
+    repeats_unread_bars: null,
+    endings_unread_bars: null,
+    endings_truncated_bars: null,
+    form_marks_unanchored_bars: null,
+    nav_marks_unresolved_bars: null,
+    systems_unread_pages: null,
+    // _BAR_AMOUNT_KEYS (api.py).
+    inferred_rest_quarters: null,
+    // _PROVENANCE_KEYS (api.py) - what the meter/key/tuning were obtained
+    // from. Omitting these (rather than nulling them) is exactly the
+    // provenance-staleness regression this fixture is meant to catch: a
+    // saved edit that silently kept showing the pre-edit "assumed 4/4"
+    // line, the same class of bug the bar-figure docstring above names.
+    time_signature: null,
+    time_signature_source: null,
+    key_fifths: null,
+    key_signature_source: null,
+    tuning: null,
+    tuning_label: null,
+    tuning_unread: null,
+    ...nulls,
   };
 }
 

--- a/web/tests/browser/score-compare-disclosures.spec.js
+++ b/web/tests/browser/score-compare-disclosures.spec.js
@@ -208,6 +208,97 @@ test.describe("ScoreCompare structural disclosures", () => {
     await expect(page.locator('[data-disclosure="repeats_unread"] .disclosure-value')).toHaveText("3");
   });
 
+  test("endings_incomplete renders as a flag - present, never a bare count", async ({ page }) => {
+    // tabextract.py:5172 makes this a 0/1 fact ("do the volta numbers read
+    // form a run starting at 1"), not a count - a bare "1" in the value
+    // column reads as "one thing", which is the wrong claim for a yes/no
+    // condition. See disclosures.js's own comment on this row.
+    await stubScoreApi(
+      page,
+      transcriptionResponse({
+        warnings: [],
+        confidence: CLEAN_CONFIDENCE,
+        disclosures: { ...zeroDisclosures(), endings_incomplete: 1 },
+      }),
+    );
+    await page.goto("/#/score/1");
+    await page.waitForSelector(".staff-render");
+
+    const row = page.locator('[data-disclosure="endings_incomplete"]');
+    await expect(row).toBeVisible();
+    await expect(row).toContainText("Volta numbering has gaps");
+    // no numeric value at all - the row's mere presence (it's already
+    // filtered to non-zero before this ever renders) IS the yes
+    await expect(row.locator(".disclosure-value")).toHaveCount(0);
+    await expect(row).not.toContainText("1");
+  });
+
+  test("an unmeasured flag still says 'not measured', the same as any other unmeasured counter", async ({
+    page,
+  }) => {
+    const disclosures = { ...zeroDisclosures(), repeats_unread: 4 };
+    delete disclosures.endings_incomplete;
+    await stubScoreApi(
+      page,
+      transcriptionResponse({ warnings: [], confidence: CLEAN_CONFIDENCE, disclosures }),
+    );
+    await page.goto("/#/score/1");
+    await page.waitForSelector(".staff-render");
+
+    const row = page.locator('[data-disclosure="endings_incomplete"]');
+    await expect(row.locator(".disclosure-value")).toHaveText("not measured");
+  });
+
+  test("form_marks_unanchored's bar list is prefixed 'near bars' - a nearest-bar fallback, not the mark's real bar", async ({
+    page,
+  }) => {
+    // tabextract.py:1156-1161 folds a plain bar-style group (no repeat, no
+    // ending at all) into this count whenever it fails to anchor, and its
+    // own warning prose (tabextract.py:5131-5133) calls the list "Nearest
+    // bars:" for the same reason: the mark had NO bar to anchor to, so the
+    // number given is the nearest one, not the one it was drawn over.
+    await stubScoreApi(
+      page,
+      transcriptionResponse({
+        warnings: [],
+        confidence: CLEAN_CONFIDENCE,
+        disclosures: {
+          ...zeroDisclosures(),
+          form_marks_unanchored: 2,
+          form_marks_unanchored_bars: [8, 14],
+        },
+      }),
+    );
+    await page.goto("/#/score/1");
+    await page.waitForSelector(".staff-render");
+
+    const row = page.locator('[data-disclosure="form_marks_unanchored"]');
+    await expect(row).toContainText("Repeat/volta/bar-style marks with no bar to anchor to");
+    await expect(row.locator(".disclosure-bars")).toHaveText("near bars 8, 14");
+  });
+
+  test("the panel uses a real heading element and keeps list semantics under list-style:none", async ({
+    page,
+  }) => {
+    await stubScoreApi(
+      page,
+      transcriptionResponse({
+        warnings: [],
+        confidence: CLEAN_CONFIDENCE,
+        disclosures: { ...zeroDisclosures(), repeats_unread: 2 },
+      }),
+    );
+    await page.goto("/#/score/1");
+    await page.waitForSelector(".staff-render");
+
+    // a heading, not a styled <p>, so the panel is real document structure
+    const heading = page.locator(".disclosures h3.disclosures-title");
+    await expect(heading).toHaveText("Structural disclosures");
+    // list-style:none strips list semantics from Safari/VoiceOver's
+    // accessibility tree along with the bullets - role="list" restores it
+    await expect(page.locator(".disclosures ul")).toHaveAttribute("role", "list");
+  });
+
   test("gig mode drops the disclosures panel along with the rest of the review chrome", async ({
     page,
   }) => {

--- a/web/tests/browser/score-compare-disclosures.spec.js
+++ b/web/tests/browser/score-compare-disclosures.spec.js
@@ -1,0 +1,228 @@
+// Playwright coverage for the structural-disclosures panel Disclosures.svelte
+// renders inside ScoreCompare.svelte (issue #155).
+//
+// Every one of these counters (repeats_unread, nav_marks_unresolved,
+// coincident_unsplit_pairs, ...) was already computed, stored, reloaded
+// through the API and mirrored onto TranscriptionOut before this file existed
+// - see server/tests for that half. What none of it reached was a reader:
+// only the warning PROSE those counters feed showed up in ScoreCompare's
+// generic warnings list, and the count itself never did. This suite is about
+// what the component does with a given payload shape, the same reason
+// score-compare-warnings.spec.js stubs `/api/scores/1*` with page.route
+// rather than transcribing a real PDF - server/tests already covers that the
+// backend produces these numbers correctly.
+import { test, expect } from "@playwright/test";
+import {
+  CLEAN_CONFIDENCE,
+  transcriptionResponse,
+  stubScoreApi,
+  zeroDisclosures,
+} from "./fixtures/transcription-warnings.js";
+
+test.describe("ScoreCompare structural disclosures", () => {
+  test("a non-zero disclosure renders its label and value, with its bar list beside it", async ({
+    page,
+  }) => {
+    await stubScoreApi(
+      page,
+      transcriptionResponse({
+        warnings: [],
+        confidence: CLEAN_CONFIDENCE,
+        disclosures: {
+          ...zeroDisclosures(),
+          repeats_unread: 2,
+          repeats_unread_bars: [12, 19],
+        },
+      }),
+    );
+    await page.goto("/#/score/1");
+    await page.waitForSelector(".staff-render");
+
+    const row = page.locator('[data-disclosure="repeats_unread"]');
+    await expect(row).toBeVisible();
+    await expect(row).toContainText("Repeat marks not read");
+    await expect(row.locator(".disclosure-value")).toHaveText("2");
+    // the bar list is the counter's detail - the numbers it exists to send a
+    // reader to, spelled out plainly (no in-viewer bar navigation exists yet)
+    await expect(row.locator(".disclosure-bars")).toHaveText("bars 12, 19");
+    // this fixture's every other counter is a real, measured zero - only
+    // one row should exist
+    await expect(page.locator(".disclosure-row")).toHaveCount(1);
+  });
+
+  test("multiple non-zero disclosures across different families each get their own row", async ({
+    page,
+  }) => {
+    await stubScoreApi(
+      page,
+      transcriptionResponse({
+        warnings: [],
+        confidence: CLEAN_CONFIDENCE,
+        disclosures: {
+          ...zeroDisclosures(),
+          endings_truncated: 1,
+          endings_truncated_bars: [30],
+          nav_marks_unresolved: 3,
+          nav_marks_unresolved_bars: [4, 5, 6],
+          coincident_unsplit_pairs: 2,
+          staves_coincident_unsplit: 1,
+          unison_digits_shared: 5,
+          notes_no_stem: 7,
+          staves_no_stem: 2,
+        },
+      }),
+    );
+    await page.goto("/#/score/1");
+    await page.waitForSelector(".staff-render");
+
+    await expect(page.locator('[data-disclosure="endings_truncated"] .disclosure-value')).toHaveText("1");
+    await expect(page.locator('[data-disclosure="nav_marks_unresolved"] .disclosure-value')).toHaveText("3");
+    await expect(page.locator('[data-disclosure="nav_marks_unresolved"] .disclosure-bars')).toHaveText(
+      "bars 4, 5, 6",
+    );
+    await expect(page.locator('[data-disclosure="coincident_unsplit_pairs"] .disclosure-value')).toHaveText("2");
+    await expect(page.locator('[data-disclosure="staves_coincident_unsplit"] .disclosure-value')).toHaveText("1");
+    await expect(page.locator('[data-disclosure="unison_digits_shared"] .disclosure-value')).toHaveText("5");
+    await expect(page.locator('[data-disclosure="notes_no_stem"] .disclosure-value')).toHaveText("7");
+    await expect(page.locator('[data-disclosure="staves_no_stem"] .disclosure-value')).toHaveText("2");
+    await expect(page.locator(".disclosure-row")).toHaveCount(7);
+  });
+
+  test("systems_unread's list reads as pages, not bars", async ({ page }) => {
+    await stubScoreApi(
+      page,
+      transcriptionResponse({
+        warnings: [],
+        confidence: CLEAN_CONFIDENCE,
+        disclosures: { ...zeroDisclosures(), systems_unread: 1, systems_unread_pages: [9] },
+      }),
+    );
+    await page.goto("/#/score/1");
+    await page.waitForSelector(".staff-render");
+    await expect(page.locator('[data-disclosure="systems_unread"] .disclosure-bars')).toHaveText("page 9");
+  });
+
+  test("zero-valued counters are absent from the DOM entirely, not shown as a wall of zeros", async ({
+    page,
+  }) => {
+    await stubScoreApi(
+      page,
+      transcriptionResponse({
+        warnings: [],
+        confidence: CLEAN_CONFIDENCE,
+        disclosures: { ...zeroDisclosures(), repeats_unread: 4, repeats_unread_bars: [1] },
+      }),
+    );
+    await page.goto("/#/score/1");
+    await page.waitForSelector(".staff-render");
+
+    await expect(page.locator('[data-disclosure="repeats_unread"]')).toBeVisible();
+    await expect(page.locator(".disclosure-row")).toHaveCount(1);
+    for (const key of [
+      "endings_unread",
+      "endings_truncated",
+      "form_marks_unanchored",
+      "nav_marks_unresolved",
+      "nav_marks_unanchored",
+      "dots_unassigned",
+      "notes_no_stem",
+    ]) {
+      await expect(page.locator(`[data-disclosure="${key}"]`)).toHaveCount(0);
+    }
+  });
+
+  test("a transcription where every disclosure is a real zero shows no disclosures panel at all", async ({
+    page,
+  }) => {
+    await stubScoreApi(
+      page,
+      transcriptionResponse({
+        warnings: [],
+        confidence: CLEAN_CONFIDENCE,
+        disclosures: zeroDisclosures(),
+      }),
+    );
+    await page.goto("/#/score/1");
+    await page.waitForSelector(".staff-render");
+    await expect(page.locator(".disclosures")).toHaveCount(0);
+  });
+
+  test("a legacy counter that was never computed for this row renders 'not measured', never '0'", async ({
+    page,
+  }) => {
+    // Models a transcription extracted before nav_marks (issue #134 phase 2)
+    // shipped: repeats_unread is a real, honest zero on every OTHER counter
+    // (phase 1 already existed and found nothing), but nav_marks_unresolved
+    // was never computed for this row at all - an omitted/`null` field, not
+    // a zero.
+    const disclosures = { ...zeroDisclosures(), repeats_unread: 6, repeats_unread_bars: [2, 3] };
+    delete disclosures.nav_marks_unresolved;
+    delete disclosures.nav_marks_unresolved_bars;
+    await stubScoreApi(
+      page,
+      transcriptionResponse({ warnings: [], confidence: CLEAN_CONFIDENCE, disclosures }),
+    );
+    await page.goto("/#/score/1");
+    await page.waitForSelector(".staff-render");
+
+    const navRow = page.locator('[data-disclosure="nav_marks_unresolved"]');
+    await expect(navRow).toBeVisible();
+    await expect(navRow.locator(".disclosure-value")).toHaveText("not measured");
+    await expect(navRow.locator(".disclosure-value")).not.toHaveText("0");
+    // no bar list for a counter that was never measured
+    await expect(navRow.locator(".disclosure-bars")).toHaveCount(0);
+    // and its sibling, which WAS measured, still shows its real number -
+    // exactly these two rows exist, nothing else
+    await expect(page.locator('[data-disclosure="repeats_unread"] .disclosure-value')).toHaveText("6");
+    await expect(page.locator(".disclosure-row")).toHaveCount(2);
+  });
+
+  test("an edited row with no confidence at all (every counter null) shows no disclosures panel", async ({
+    page,
+  }) => {
+    const extracted = transcriptionResponse({
+      warnings: [],
+      confidence: CLEAN_CONFIDENCE,
+      disclosures: { ...zeroDisclosures(), repeats_unread: 3, repeats_unread_bars: [1] },
+    });
+    await stubScoreApi(page, extracted, { editRevert: true });
+    await page.goto("/#/score/1");
+    await page.waitForSelector(".staff-render");
+    await expect(page.locator(".disclosures")).toBeVisible();
+
+    await page.locator('button:has-text("Edit source")').click();
+    await page.locator(".editor-input").fill("<score-partwise><!-- fixed it --></score-partwise>");
+    await page.locator('button:has-text("Save & render")').click();
+    await expect(page.locator(".editor-input")).toHaveCount(0);
+
+    // saveEdit()'s response states every disclosure field null (the same
+    // "not recorded" contract the bar counts already use) - a wall of
+    // seventeen "not measured" rows would be exactly the noise the null-vs-
+    // zero rule exists to avoid, so the whole panel goes to nothing instead,
+    // the same way the bar headline and warnings box already do for this
+    // state.
+    await expect(page.locator(".disclosures")).toHaveCount(0);
+
+    await page.locator('button:has-text("Revert to extracted")').click();
+    await page.waitForSelector(".staff-render");
+    await expect(page.locator('[data-disclosure="repeats_unread"] .disclosure-value')).toHaveText("3");
+  });
+
+  test("gig mode drops the disclosures panel along with the rest of the review chrome", async ({
+    page,
+  }) => {
+    await stubScoreApi(
+      page,
+      transcriptionResponse({
+        warnings: [],
+        confidence: CLEAN_CONFIDENCE,
+        disclosures: { ...zeroDisclosures(), repeats_unread: 2, repeats_unread_bars: [1, 2] },
+      }),
+    );
+    await page.goto("/#/score/1");
+    await page.waitForSelector(".staff-render");
+    await page.locator('.seg button:has-text("Staff")').click();
+    await page.locator('button:has-text("Gig mode")').click();
+    await expect(page.locator(".disclosures")).toHaveCount(0);
+  });
+});

--- a/web/tests/disclosure-keys.json
+++ b/web/tests/disclosure-keys.json
@@ -1,0 +1,19 @@
+[
+  "coincident_unsplit_pairs",
+  "dots_unassigned",
+  "dots_unassigned_eliminated",
+  "dots_unassigned_no_candidate",
+  "endings_incomplete",
+  "endings_truncated",
+  "endings_unread",
+  "form_marks_unanchored",
+  "nav_marks_unanchored",
+  "nav_marks_unresolved",
+  "notes_no_stem",
+  "repeats_unread",
+  "staves_coincident_unsplit",
+  "staves_dots_unassigned",
+  "staves_no_stem",
+  "systems_unread",
+  "unison_digits_shared"
+]

--- a/web/tests/spec-floors/browser-score-compare-disclosures-155.json
+++ b/web/tests/spec-floors/browser-score-compare-disclosures-155.json
@@ -1,5 +1,5 @@
 {
   "file": "tests/browser/score-compare-disclosures.spec.js",
-  "count": 8,
-  "reason": "issue #155: the structural-form/inference disclosures TranscriptionOut carries now render beside the conformance figures, with their bar/page lists, hidden when zero, and distinct as 'not measured' when null."
+  "count": 12,
+  "reason": "issue #155: the structural-form/inference disclosures TranscriptionOut carries now render beside the conformance figures, with their bar/page lists, hidden when zero, and distinct as 'not measured' when null - plus a flag counter (endings_incomplete) rendering as presence not a bare count, the 'near bars' fallback label on form_marks_unanchored, and a11y (heading element, list role)."
 }

--- a/web/tests/spec-floors/browser-score-compare-disclosures-155.json
+++ b/web/tests/spec-floors/browser-score-compare-disclosures-155.json
@@ -1,0 +1,5 @@
+{
+  "file": "tests/browser/score-compare-disclosures.spec.js",
+  "count": 8,
+  "reason": "issue #155: the structural-form/inference disclosures TranscriptionOut carries now render beside the conformance figures, with their bar/page lists, hidden when zero, and distinct as 'not measured' when null."
+}

--- a/web/tests/spec-floors/unit-disclosures-155.json
+++ b/web/tests/spec-floors/unit-disclosures-155.json
@@ -1,0 +1,5 @@
+{
+  "file": "tests/unit/disclosures.spec.js",
+  "count": 8,
+  "reason": "issue #155: disclosureRows()'s selection rules - zero hidden, null distinct from 'not measured', bar/page lists ride along, and a fully-null row shows nothing."
+}

--- a/web/tests/spec-floors/unit-disclosures-155.json
+++ b/web/tests/spec-floors/unit-disclosures-155.json
@@ -1,5 +1,5 @@
 {
   "file": "tests/unit/disclosures.spec.js",
-  "count": 8,
-  "reason": "issue #155: disclosureRows()'s selection rules - zero hidden, null distinct from 'not measured', bar/page lists ride along, and a fully-null row shows nothing."
+  "count": 9,
+  "reason": "issue #155: disclosureRows()'s selection rules - zero hidden, null distinct from 'not measured', bar/page lists ride along, a fully-null row shows nothing - plus the fourth-mirror guard checking DISCLOSURE_ROWS against the vendored disclosure-keys.json in both directions."
 }

--- a/web/tests/unit/disclosures.spec.js
+++ b/web/tests/unit/disclosures.spec.js
@@ -6,9 +6,26 @@
 // tests/browser/score-compare-disclosures.spec.js's job, and a suite that
 // only checked this selection logic would prove nothing about issue #155,
 // which was seventeen fields computed and never displayed.
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
 import { expect, test } from "@playwright/test";
 
 import { DISCLOSURE_ROWS, disclosureRows } from "../../src/lib/disclosures.js";
+
+// The vendored copy of the API's disclosure-counter key list
+// (../disclosure-keys.json) - see that file's own comment, and
+// server/tests/test_disclosure_keys.py, for the other two links in this
+// chain. Read the same way spec-floors.js reads tests/spec-floors/: plain
+// fs.readFileSync + JSON.parse, not an import assertion, so this has no
+// dependency on the test runner's module loader understanding `type: "json"`.
+const VENDORED_KEYS = JSON.parse(
+  fs.readFileSync(
+    path.join(path.dirname(fileURLToPath(import.meta.url)), "..", "disclosure-keys.json"),
+    "utf8",
+  ),
+);
 
 // A transcription with every counter present and real (the shape a current
 // extraction produces): all zero except one real defect in each family, so
@@ -106,4 +123,34 @@ test("undefined is treated the same as null for both the per-row and whole-row g
   delete t.nav_marks_unresolved;
   const navRow = disclosureRows(t).find((r) => r.key === "nav_marks_unresolved");
   expect(navRow.measured).toBe(false);
+});
+
+// THE FOURTH MIRROR, GUARDED. server/fermata/tabextract.py's ExtractionResult
+// fields, server/fermata/api.py's _BAR_KEYS tuple and api_models.py's
+// TranscriptionOut fields are three hand-kept copies of "which fields are
+// structural disclosures", and test_transcription_model_stays_in_sync_with_
+// api_pys_bar_key_tuples (server/tests/test_api_docs.py) already keeps the
+// third honest against the second. DISCLOSURE_ROWS here was a FOURTH copy
+// with nothing checking it at all: neither a counter silently dropped from
+// it, nor a fake one added on the API side that this file never picked up,
+// failed any test that existed before this one - the test above
+// ("every counter the issue lists...") iterates DISCLOSURE_ROWS itself, so
+// it is tautological against exactly this kind of drift.
+//
+// disclosure-keys.json is the fix: a small vendored file, kept honest against
+// api._BAR_KEYS by server/tests/test_disclosure_keys.py (the only side that
+// can make that check, since a browser test cannot import api.py), and
+// checked against DISCLOSURE_ROWS here, in BOTH directions, so a config row
+// that goes missing OR a vendored key nothing renders each fail by name.
+test("DISCLOSURE_ROWS carries exactly the vendored disclosure-keys.json key set - no more, no fewer", () => {
+  const configKeys = DISCLOSURE_ROWS.map((row) => row.key).sort();
+  const vendoredKeys = [...VENDORED_KEYS].sort();
+  const missing = vendoredKeys.filter((k) => !configKeys.includes(k));
+  const stale = configKeys.filter((k) => !vendoredKeys.includes(k));
+  expect(missing, `disclosure-keys.json lists key(s) DISCLOSURE_ROWS has no row for: ${missing}`).toEqual([]);
+  expect(stale, `DISCLOSURE_ROWS has row(s) no longer in disclosure-keys.json: ${stale}`).toEqual([]);
+  // Belt-and-suspenders against a duplicate key silently masking a missing
+  // one in the two filters above (two identical arrays with a duplicate in
+  // one would pass both filters and still be wrong).
+  expect(configKeys).toEqual(vendoredKeys);
 });

--- a/web/tests/unit/disclosures.spec.js
+++ b/web/tests/unit/disclosures.spec.js
@@ -1,0 +1,109 @@
+// disclosureRows() called directly - no browser, no backend. disclosures.js
+// has no runes and no imports precisely so this can import it, the same
+// reason provenance.spec.js gives for provenance.js.
+//
+// What is NOT tested here is whether any of this reaches a screen - that is
+// tests/browser/score-compare-disclosures.spec.js's job, and a suite that
+// only checked this selection logic would prove nothing about issue #155,
+// which was seventeen fields computed and never displayed.
+import { expect, test } from "@playwright/test";
+
+import { DISCLOSURE_ROWS, disclosureRows } from "../../src/lib/disclosures.js";
+
+// A transcription with every counter present and real (the shape a current
+// extraction produces): all zero except one real defect in each family, so
+// this doubles as "every field this issue lists is wired to a row."
+function baseTranscription(overrides = {}) {
+  const t = {};
+  for (const row of DISCLOSURE_ROWS) {
+    t[row.key] = 0;
+    if (row.barsKey) t[row.barsKey] = [];
+  }
+  return { ...t, ...overrides };
+}
+
+test("a counter that is exactly 0 is hidden - a clean transcription shows no disclosure rows at all", () => {
+  expect(disclosureRows(baseTranscription())).toEqual([]);
+});
+
+test("every counter the issue lists renders its own row with its label and value when non-zero", () => {
+  for (const row of DISCLOSURE_ROWS) {
+    const t = baseTranscription({ [row.key]: 3 });
+    if (row.barsKey) t[row.barsKey] = [4, 9, 12];
+    const rows = disclosureRows(t);
+    const found = rows.find((r) => r.key === row.key);
+    expect(found, `${row.key} did not produce a row`).toBeTruthy();
+    expect(found.label).toBe(row.label);
+    expect(found.measured).toBe(true);
+    expect(found.value).toBe(3);
+    // every OTHER counter is still 0 in this fixture, so this must be the
+    // only row - proves the loop isn't leaking some unrelated always-on row
+    expect(rows).toHaveLength(1);
+  }
+});
+
+test("a bar list rides along as the row's detail, and an empty one renders none", () => {
+  const withBars = disclosureRows(
+    baseTranscription({ repeats_unread: 2, repeats_unread_bars: [5, 8] }),
+  );
+  expect(withBars).toEqual([
+    expect.objectContaining({ key: "repeats_unread", value: 2, bars: [5, 8], barUnit: "bar" }),
+  ]);
+
+  // A counter with no bars field at all (e.g. coincident_unsplit_pairs) never
+  // claims one.
+  const noBars = disclosureRows(baseTranscription({ coincident_unsplit_pairs: 4 }));
+  expect(noBars).toEqual([
+    expect.objectContaining({ key: "coincident_unsplit_pairs", value: 4, bars: [] }),
+  ]);
+});
+
+test("systems_unread's list is pages, not bars, and says so", () => {
+  const rows = disclosureRows(
+    baseTranscription({ systems_unread: 1, systems_unread_pages: [7] }),
+  );
+  expect(rows).toEqual([
+    expect.objectContaining({ key: "systems_unread", barUnit: "page", bars: [7] }),
+  ]);
+});
+
+test("a null counter beside real measured siblings renders as 'not measured', distinct from zero", () => {
+  // Models a row extracted before nav_marks (#134 phase 2) shipped: the
+  // phase-1 fields are real numbers (0 counts as a real, honest zero here),
+  // but the phase-2 field was never computed for this row at all.
+  const t = baseTranscription({ repeats_unread: 3, nav_marks_unresolved: null });
+  const rows = disclosureRows(t);
+  const navRow = rows.find((r) => r.key === "nav_marks_unresolved");
+  expect(navRow).toBeTruthy();
+  expect(navRow.measured).toBe(false);
+  expect(navRow.value).toBeNull();
+  // and not silently rendered as the number 0
+  expect(navRow.value).not.toBe(0);
+
+  const repeatsRow = rows.find((r) => r.key === "repeats_unread");
+  expect(repeatsRow.measured).toBe(true);
+  expect(repeatsRow.value).toBe(3);
+});
+
+test("a row with every counter null (a hand edit, or one wholly predating the counters) shows nothing at all", () => {
+  // saveEdit() in ScoreCompare.svelte states every one of these fields null
+  // on purpose for an edited row - the same state the bar headline and the
+  // warnings box already render as nothing for. A wall of seventeen "not
+  // measured" lines here would be exactly the noise this rule exists to
+  // avoid.
+  const allNull = {};
+  for (const row of DISCLOSURE_ROWS) allNull[row.key] = null;
+  expect(disclosureRows(allNull)).toEqual([]);
+});
+
+test("no transcription at all renders no rows", () => {
+  expect(disclosureRows(null)).toEqual([]);
+  expect(disclosureRows(undefined)).toEqual([]);
+});
+
+test("undefined is treated the same as null for both the per-row and whole-row gates", () => {
+  const t = baseTranscription({ repeats_unread: 5 });
+  delete t.nav_marks_unresolved;
+  const navRow = disclosureRows(t).find((r) => r.key === "nav_marks_unresolved");
+  expect(navRow.measured).toBe(false);
+});


### PR DESCRIPTION
Closes #155

## What

`TranscriptionOut` already carried every structural-form/inference disclosure the decoder computes - `repeats_unread`, `endings_unread`, `endings_truncated`, `endings_incomplete`, `form_marks_unanchored`, `nav_marks_unresolved`, `nav_marks_unanchored`, `systems_unread`, `coincident_unsplit_pairs`, `staves_coincident_unsplit`, `unison_digits_shared`, `dots_unassigned` (+ its two sub-counters `dots_unassigned_no_candidate` / `dots_unassigned_eliminated`), `staves_dots_unassigned`, `notes_no_stem`, `staves_no_stem` - and every one of their `*_bars`/`*_pages` lists. None of it reached a reader: only the warning prose those counters feed showed up in `ScoreCompare`'s generic warnings list.

- `web/src/lib/disclosures.js` - one row per counter (its label, and its bars/pages field if it has one) in `DISCLOSURE_ROWS`, plus `disclosureRows(transcription)`, which turns a transcription object into exactly the rows worth showing:
  - a counter that is exactly `0` is hidden - a wall of zeros is noise, and a transcription with every counter at zero shows nothing new.
  - a counter that is `null`/`undefined` (a legacy row from before it was computed, or every field on a hand-edited row) renders as **"not measured"**, distinct from zero - the API already keeps the two apart and this must not collapse them.
  - if literally every counter is null (the common shape of a hand-edited row - see `saveEdit()` in `ScoreCompare.svelte`, which states every one of these fields `null` on purpose), the whole panel renders nothing at all, the same way the bar headline and warnings box already do for that state - a wall of seventeen "not measured" lines would be exactly the noise the null/zero rule exists to avoid.
- `web/src/lib/Disclosures.svelte` - the presentational component, mounted in `ScoreCompare.svelte` beside the existing conformance-figures/warnings block. A `*_bars`/`*_pages` list renders as plain, readable numbers.
- The next disclosure the decoder ever adds lands as **one line in `DISCLOSURE_ROWS`**, not a new component or a new branch of rendering logic - the issue's own requirement.

**No in-viewer bar navigation exists yet** - checked `TabViewer.svelte` and `score-render.js` for anything `goToBar`/`scrollToBar`-shaped; there is nothing to link to. So the bar/page numbers render as plain text rather than links, as the issue's own fallback allows. Wiring real bar navigation is a separate, follow-on piece of work.

## Verification (target 1 - the issue's own check)

`git grep -c <field> -- 'web/src/**'`, run for every counter in `TranscriptionOut`'s bar-key mirror:

| field | grep -c |
|---|---|
| repeats_unread | 1 |
| endings_unread | 1 |
| endings_truncated | 1 |
| endings_incomplete | 1 |
| form_marks_unanchored | 2 |
| nav_marks_unresolved | 2 |
| nav_marks_unanchored | 1 |
| systems_unread | 2 |
| coincident_unsplit_pairs | 1 |
| staves_coincident_unsplit | 1 |
| unison_digits_shared | 1 |
| dots_unassigned | 4 |
| staves_dots_unassigned | 1 |
| notes_no_stem | 2 |
| staves_no_stem | 2 |

Every one is non-zero (`dots_unassigned`'s count of 4 includes its own row plus its two sub-counter rows and the `staves_dots_unassigned` mention next to them).

## Tests

- `web/tests/unit/disclosures.spec.js` (9 tests) - `disclosureRows()` called directly, no browser: every one of the 17 counters produces its own row when non-zero; zero is hidden; a null counter next to real measured siblings renders `measured: false` / `value: null`, never `0`; a fully-null row (or no transcription at all) returns no rows; a bar list rides along, an absent one doesn't; `systems_unread`'s list is pages; `DISCLOSURE_ROWS`'s key set matches the vendored `disclosure-keys.json` in both directions (see "Review round 2" below).
- `web/tests/browser/score-compare-disclosures.spec.js` (12 tests) - the real component, real DOM, stubbed API (same `page.route` pattern as `score-compare-warnings.spec.js`): a non-zero disclosure renders its label, value and bar list; multiple non-zero counters each get their own row; zero-valued counters are absent from the DOM; an all-zero transcription shows no panel; a legacy counter that was never computed renders "not measured", never "0"; an edited row (every counter null) shows no panel, even after having shown one pre-edit; `endings_incomplete` renders as a flag, not a bare count, both measured and unmeasured; `form_marks_unanchored`'s bar list carries the "near bars" prefix; the panel exposes a real heading element and `role="list"`; gig mode drops the panel.
- Floor files: `web/tests/spec-floors/browser-score-compare-disclosures-155.json` (12), `web/tests/spec-floors/unit-disclosures-155.json` (9).
- While writing these, found and fixed a real staleness gap in the shared test fixture: `editedTranscriptionResponse()` (`web/tests/browser/fixtures/transcription-warnings.js`) predated this issue and didn't null out the new disclosure fields the way it already nulls `bars_*` - so a saved-edit test showed stale pre-edit disclosure figures. The real backend already nulls every one of these on a saved edit (`_BAR_KEYS` in `server/fermata/api.py` already includes them); only the test fixture was behind. As of review round 2 this fixture nulls the FULL edit-contract set (see below), not just the disclosure counters.

### Mutation testing (commit-backed, target 3 - re-run against the round-2 commit, `c7a1064`)

Both done against the committed state, reverted with `git checkout --` afterward, `web/dist` rebuilt before and after each run, confirmed clean:

1. **Collapsed null into 0** (`measured = true`, `value: value ?? 0` in `disclosureRows`) -> 4 tests went red (was 3 before round 2 added a flag-specific "not measured" test): `score-compare-disclosures.spec.js`'s "a legacy counter that was never computed for this row renders 'not measured', never '0'" and "an unmeasured flag still says 'not measured'...", and two unit tests asserting the same distinction (`nav_marks_unresolved`'s `measured`/`value`, and the `undefined`-is-null-too case). Reverted, green again.
2. **Dropped `repeats_unread` from `DISCLOSURE_ROWS`** -> **8 tests went red** (corrected from this PR's earlier "3 collateral" claim, which predates the round-2 tests that also probe `repeats_unread`): the row's own scenario ("a non-zero disclosure renders its label and value, with its bar list beside it"), the round-1-guard unit test's `repeatsRow` assertion, five more collateral tests that share `repeats_unread` as their non-zero probe, **and the new fourth-mirror guard test itself**, which failed with `disclosure-keys.json lists key(s) DISCLOSURE_ROWS has no row for: repeats_unread` - naming the dropped key exactly. Reverted, green again.

## Review round 2

1. **Guarded the fourth mirror.** `DISCLOSURE_ROWS` was a fourth hand-kept copy of "which fields are structural disclosures" (alongside `tabextract.py`'s `ExtractionResult` fields, `api.py`'s `_BAR_KEYS`, and `api_models.py`'s `TranscriptionOut`) and the only one nothing checked.
   - `web/tests/disclosure-keys.json` - a small vendored JSON array of the 17 disclosure key names.
   - `web/tests/unit/disclosures.spec.js` - a new test asserting `DISCLOSURE_ROWS`'s keys equal the vendored file's, **in both directions**, by name.
   - `server/tests/test_disclosure_keys.py` (new file) - a pytest asserting the vendored file's keys equal `set(api._BAR_KEYS) - {Rule 8 conformance keys}`, the only side that can check the vendored copy against the real source of truth. Same shape as the existing `test_transcription_model_stays_in_sync_with_api_pys_bar_key_tuples`.
   - **Proved both directions**: added a fake `slurs_unread` key to `api._BAR_KEYS` -> `test_disclosure_keys.py` failed naming it (and so did the pre-existing sibling guard, `test_transcription_model_stays_in_sync_with_api_pys_bar_key_tuples`, for the same reason). Reverted, `server/` suite green again (894 passed). Deleting `repeats_unread` from `DISCLOSURE_ROWS` (mutation 2 above) makes the new web unit test fail naming it too - one mutation, both proofs.
2. **Label corrections, cited against the decoder line each one comes from** (see `disclosures.js`'s per-row comments for the full citation):
   - `endings_incomplete` -> **"Volta numbering has gaps"**, now rendered as a flag (presence, no bare "1") - `tabextract.py:5172` trips on any gap in the run, not only a missing "1".
   - `nav_marks_unresolved` -> **"Bars whose navigation marks name no target this transcription holds"** - counted per bar, not per mark (`tabextract.py:2163-2164`).
   - `form_marks_unanchored` -> **"Repeat/volta/bar-style marks with no bar to anchor to"**, bar list now prefixed **"near bars"** - a plain bar-style group with no repeat/ending at all can land here too (`tabextract.py:1156-1161`), and the list is a nearest-bar fallback, matching the decoder's own "Nearest bars:" prose (`tabextract.py:5131-5133`).
   - `notes_no_stem` -> **"Noteheads read with no stem (quarter or shorter)"** - half/whole noteheads are deliberately excluded (`glyph_rhythm.py:2934-2950`).
   - `systems_unread` -> **"Staff-sized line groups not read as a system"** - "system" is inferred from line count, not confirmed (`tabextract.py:344-346`).
   - `coincident_unsplit_pairs` -> **"Coincident notehead groups not split across voices"** - counted once per group, not per notehead (`glyph_rhythm.py:3103-3113`, specifically the increment at line 3111).
   - `dots_unassigned_eliminated` -> **"Unassigned dots whose only candidates already had a conflicting or duplicate dot"** - a conflicting tier or same-x duplicate, not "nothing nearby" (`glyph_rhythm.py:2957-2959`).
3. **`editedTranscriptionResponse()`'s docstring no longer overclaims.** It now nulls the FULL edit-contract set - every `_BAR_KEYS`, `_BAR_LIST_KEYS`, `_BAR_AMOUNT_KEYS` and `_PROVENANCE_KEYS` field (`bars_padded`, `bars_unread`, every `*_bars`/`*_pages` list, `inferred_rest_quarters`, and the meter/key/tuning provenance keys), matching `_transcription_dict`'s real behavior on an edited row exactly - the same set `test_transcription_model_stays_in_sync_with_api_pys_bar_key_tuples` checks `TranscriptionOut` against. This is what would actually catch a provenance-staleness regression (a saved edit silently still showing the pre-edit "assumed 4/4" line), which the narrower version could not. The disclosure-counter portion is sourced from `DISCLOSURE_KEYS` (the vendored list from item 1), not from `DISCLOSURE_ROWS`, so this fixture can't go stale in lockstep with a `DISCLOSURE_ROWS` bug.
4. **Accessibility.** The panel's title is now an `<h3>` (was a styled `<p>`), reset to the same visual register. The `<ul>` keeps `role="list"` under `list-style: none`, since that CSS also strips list semantics from the accessibility tree in Safari/VoiceOver.

## Suite counts

- **Browser suite**: 310/310 passed on the full run with the round-2 floor updates (`289` baseline + `12` browser + `9` unit `= 310`), spec-floor guard green, `web/dist` rebuilt immediately before this run. One test in `metronome.spec.js` (unrelated - real-audio-timing, not touched by this PR) failed once on an earlier run under load and passed cleanly (12/12) in isolation - pre-existing flakiness, not a regression from this change.
- **Server suite**: `894 passed, 1 warning in 138.33s` with `FERMATA_TEST_LIBRARY` + `FERMATA_MUSICXML_XSD` + `web/node_modules` present - "real-library tests all ran" (no skips) - `893` main baseline `+ 1` new guard test (`test_disclosure_keys.py`). No other `server/` files were touched by this PR.

## Rendered example (target 5)

A throwaway server (odd port 8933, config/library scratch directories, never touching the live port-8080 instance or its data) serving `server/tests/fixtures/engraved/unison_in_chord.pdf` - an engraved fixture that genuinely produces a non-zero disclosure (`unison_digits_shared: 32`, confirmed via `test_a_unison_inside_a_chord_sounds_in_both_voices` in `server/tests/test_engraved_fixtures.py`). Transcribed via `POST /api/scores/1/transcribe`, then the real page loaded in a real (non-mocked) browser against that real backend:

```
=== .disclosures innerText ===
Structural disclosures

Notes given another note's fret number
32
```

A screenshot of the rendered panel was also captured locally during this run (not embedded here - no image hosting was set up for this PR); it shows the same two lines rendered in the app's usual quiet, dimmed-text register, with no console errors during that run.
