### PR TITLE
Honour a page turn pressed before the page it turns to exists (#168)

### DIFF
--- a/web/src/lib/PdfViewer.svelte
+++ b/web/src/lib/PdfViewer.svelte
@@ -37,6 +37,24 @@
   let currentPage = $state(1);
   let halfPage = $state(false);
   let saveTimer;
+  // A page turn asked for before that page's canvas exists to scroll to.
+  //
+  // The document's page COUNT is known the moment its metadata parses, which
+  // is a few hundred milliseconds before renderAllPages() has appended a
+  // single canvas - so for that whole window the HUD already reads "1 / 2",
+  // the arrow keys are already live, and goto()'s `?.` silently swallowed
+  // every turn: onKey called preventDefault(), the key was consumed, and
+  // nothing happened, with nothing left to retry it. A pedal tap on a score
+  // that has just been opened is exactly that press, and it is what made
+  // issue #168's spec fail on CI (measured on an idle machine: the HUD read
+  // "1 / 2" at 293ms with zero canvases in the container; page 2's canvas
+  // arrived at 327ms - and CI load widens that gap, it does not close it).
+  // Remembered here instead, and honoured as soon as rendering reaches it.
+  let pendingPage = null;
+  // Whether a turn like that was actually honoured, so the score.last_page
+  // restore below does not immediately yank the reader back off the page
+  // they just asked for.
+  let turnedBeforeRestore = false;
 
   // half-page advance defaults on each time gig mode is entered, but the
   // performer can still turn it off without it snapping back mid-set
@@ -87,6 +105,16 @@
         canvas.dataset.page = n;
         container.appendChild(canvas);
         await renderPageInto(page, canvas, width, dpr);
+        // A turn pressed before this page existed. Clamped to the last page
+        // here rather than in goto(), because goto() may well have run before
+        // pageCount was known at all and so had nothing to clamp against.
+        // Pages are appended in order, so nothing rendered after this one can
+        // move it - no need to wait for the whole document to finish.
+        if (pendingPage !== null && Math.min(pendingPage, pdfDoc.numPages) === n) {
+          pendingPage = null;
+          turnedBeforeRestore = true;
+          canvas.scrollIntoView({ block: "start" });
+        }
       }
     }
 
@@ -157,7 +185,7 @@
       );
       container.querySelectorAll(".pdf-page").forEach((c) => observer.observe(c));
 
-      if (score.last_page > 1) {
+      if (score.last_page > 1 && !turnedBeforeRestore) {
         container
           .querySelector(`[data-page="${score.last_page}"]`)
           ?.scrollIntoView({ block: "start" });
@@ -179,6 +207,11 @@
 
     return () => {
       cancelled = true;
+      // both belong to the document this pass loaded; a re-run (a different
+      // score) must not inherit a turn pressed against the old one, nor its
+      // permission to skip the new one's last_page restore
+      pendingPage = null;
+      turnedBeforeRestore = false;
       observer?.disconnect();
       resizeObserver?.disconnect();
       clearTimeout(saveTimer);
@@ -187,20 +220,32 @@
   });
 
   function goto(page) {
-    const target = Math.max(1, Math.min(pageCount, page));
-    container
-      .querySelector(`[data-page="${target}"]`)
-      ?.scrollIntoView({ block: "start", behavior: "smooth" });
+    // pageCount is 0 until the document's metadata has parsed. Clamping
+    // against it then would fold every early turn onto page 1 - which is
+    // where the reader already is - so only clamp once there is a count to
+    // clamp to; renderAllPages() does the rest (see pendingPage above).
+    const target = pageCount ? Math.max(1, Math.min(pageCount, page)) : Math.max(1, page);
+    const canvas = container.querySelector(`[data-page="${target}"]`);
+    if (canvas) {
+      pendingPage = null;
+      canvas.scrollIntoView({ block: "start", behavior: "smooth" });
+    } else {
+      pendingPage = target;
+    }
   }
 
   function turn(dir) {
-    if (gigMode && halfPage) {
+    // The half-page step needs the current page's rendered height to measure
+    // against; before that canvas exists there is nothing to measure and
+    // nothing to scroll, so this falls through to goto() - which can at
+    // least remember the turn - instead of scrolling an empty container by a
+    // viewport height and losing the press (#168).
+    const current = container.querySelector(`[data-page="${currentPage}"]`);
+    if (gigMode && halfPage && current) {
       // step off the current page's actual rendered height (plus its share
       // of the gap) rather than the viewport, so repeated half-turns track
       // bar lines instead of drifting against page/container padding
-      const current = container.querySelector(`[data-page="${currentPage}"]`);
-      const step = current ? current.getBoundingClientRect().height + 18 : container.clientHeight;
-      container.scrollBy({ top: dir * step * 0.5, behavior: "smooth" });
+      container.scrollBy({ top: dir * (current.getBoundingClientRect().height + 18) * 0.5, behavior: "smooth" });
     } else {
       goto(currentPage + dir);
     }

--- a/web/tests/browser/practice-shortcuts.spec.js
+++ b/web/tests/browser/practice-shortcuts.spec.js
@@ -675,6 +675,18 @@ test.describe("side-by-side layout: PDF page-turning keeps its keys", () => {
   });
 
   test("ArrowRight turns the PDF page", async ({ page }) => {
+    // The canvases, NOT the HUD, are what proves this pane can turn a page.
+    // PdfViewer publishes the page COUNT the moment the document's metadata
+    // parses - so ".hud span" reads "1 / 2" a few hundred milliseconds
+    // before renderAllPages has appended anything to scroll TO (measured on
+    // an idle machine: HUD at 293ms with zero canvases, page 2's canvas at
+    // 327ms; CI load widens that gap). Waiting only on the HUD is what made
+    // this test fail on CI twice - issue #168 - and it is not a slow-product
+    // flake to be waited out: the press inside that window was CONSUMED and
+    // dropped, so no retry of the assertion could ever have recovered it.
+    // PdfViewer no longer drops it (it remembers the turn), and this waits
+    // for the real barrier so the test is not resting on that recovery.
+    await expect(page.locator(".pdf-page")).toHaveCount(2);
     await expect(page.locator(".hud span")).toHaveText("1 / 2");
     await page.keyboard.press("ArrowRight");
     await expect(page.locator(".hud span")).toHaveText("2 / 2");
@@ -684,6 +696,44 @@ test.describe("side-by-side layout: PDF page-turning keeps its keys", () => {
     await page.keyboard.press(" ");
     await page.waitForTimeout(300);
     await expect(playButton(page)).toHaveText(/Play/);
+  });
+});
+
+// The other half of #168: the test above now waits for the pages, but the
+// PRODUCT still has to survive a reader who does not. A pedal sends nothing
+// but arrow keys and there is no mouse to fall back on (issue #106's own
+// reasoning), so a tap on a score that is still loading has to land - and it
+// used to be swallowed whole, because PdfViewer accepted the key
+// (preventDefault) and then scrolled to a `[data-page]` element that did not
+// exist yet, via an `?.` that made the miss invisible.
+//
+// Held open deliberately here rather than raced for: the PDF body is not
+// released until AFTER the key has been pressed, so the press provably lands
+// in the window this is about instead of landing there only when a loaded CI
+// runner happens to be slow. That makes the "1 / …" below - PdfViewer's own
+// wording for a page count it does not have yet - a fact of the test, not a
+// hope.
+test.describe("a page turn pressed before the PDF has rendered", () => {
+  test("is honoured once the pages arrive, not dropped", async ({ page }) => {
+    await stubScoreApi(page, transcriptionResponse({ warnings: [], confidence: CLEAN_CONFIDENCE }));
+    let release;
+    const held = new Promise((resolve) => (release = resolve));
+    await page.route("**/api/scores/1/file", async (route) => {
+      await held;
+      await route.fulfill({ body: buildMultiPagePdf(2), contentType: "application/pdf" });
+    });
+    await page.goto("/#/score/1");
+    await expect(playButton(page)).toBeEnabled({ timeout: 15_000 });
+    await expect(page.getByRole("button", { name: "Side by side", exact: true })).toHaveClass(/on/);
+    // Nothing of the document has been read yet - no page count, no canvases.
+    await expect(page.locator(".hud span")).toHaveText("1 / …");
+    await expect(page.locator(".pdf-page")).toHaveCount(0);
+
+    await page.keyboard.press("ArrowRight");
+    release();
+
+    await expect(page.locator(".pdf-page")).toHaveCount(2);
+    await expect(page.locator(".hud span")).toHaveText("2 / 2");
   });
 });
 
@@ -714,6 +764,9 @@ test.describe("gig mode itself", () => {
     // the evidence gig mode is genuinely active, not merely that "f" was
     // pressed.
     await expect(page.getByRole("button", { name: "Side by side", exact: true })).toHaveCount(0);
+    // Same barrier as the side-by-side test above, for the same reason
+    // (#168) - this test shares the hole and only wins the race more often.
+    await expect(page.locator(".pdf-page")).toHaveCount(2);
     await expect(page.locator(".hud span")).toHaveText("1 / 2");
     await page.keyboard.press("ArrowRight");
     await expect(page.locator(".hud span")).toHaveText("2 / 2");

--- a/web/tests/spec-floors/browser-practice-shortcuts-168.json
+++ b/web/tests/spec-floors/browser-practice-shortcuts-168.json
@@ -1,0 +1,5 @@
+{
+  "file": "tests/browser/practice-shortcuts.spec.js",
+  "count": 1,
+  "reason": "issue #168: a page turn pressed while the PDF is still loading is remembered and honoured once its page renders, rather than consumed by the key handler and silently dropped."
+}


### PR DESCRIPTION
Closes #168.

## What was actually wrong

Not a slow product and not a short timeout. The keypress was **accepted and
then thrown away**, so no amount of assertion retrying could ever have
recovered it.

`PdfViewer.svelte` publishes the document's page **count** the instant its
metadata parses:

```js
pdfDoc = await pdfjs.getDocument(api.fileUrl(score.id)).promise;
pageCount = pdfDoc.numPages;      // <- HUD now reads "1 / 2"
await renderAllPages(computeWidth());   // <- canvases appear only now
```

For the whole gap between those two lines the HUD already reads `1 / 2`, the
arrow keys are already live, and the container holds **no canvases at all**.
`goto()` then did:

```js
container.querySelector(`[data-page="${target}"]`)?.scrollIntoView(...)
```

The `?.` made the miss invisible: `onKey` had already called
`preventDefault()`, the key was consumed, and nothing happened.

The spec's only readiness barrier was that same HUD text, so it was
explicitly waiting on a signal that is published *before* the pane can act.

### Measured

A probe instrumented the page with a rAF loop recording when the HUD first
reads `1 / 2` and when each canvas appears. On an **idle** local machine:

| event | t |
| --- | --- |
| HUD reads `1 / 2` | 293 ms |
| canvases in container at that moment | **0** |
| page 1's canvas appended | 308 ms |
| page 2's canvas appended | 327 ms |

A 34 ms window in which the test's barrier is satisfied and the product
cannot answer. CI load widens it; it does not close it.

### Causality proved, not inferred

Injecting an 800 ms delay at the top of `renderAllPages` (nothing else
changed) reproduced the exact CI signature **100% of the time**, in both
affected tests:

```
✘ practice-shortcuts.spec.js:677 › ArrowRight turns the PDF page (5.7s)
✘ practice-shortcuts.spec.js:707 › gig mode ... arrow keys turn pages (5.7s)
    Expected: "2 / 2"
    Received: "1 / 2"
```

That second failure is the same hole in the gig-mode test, which has simply
been winning the race so far.

## Bisect verdict: neither #164 nor #161. It predates both.

`git log -- web/src/lib/PdfViewer.svelte` names four commits, and the newest
before this one is #92's:

- the `?.`-swallowing `goto()` is from the **initial release** (`d8af6f4`)
- publishing `pageCount` *before* rendering is from **gig mode** (`67c9fb4`)
- the spec that leans on the HUD as its barrier is from **#92** (`31b4d68`)

Neither #164 (`56bc384`) nor #161 (`9c66248`) touches `PdfViewer.svelte` at
all. #164 added 839 lines to `score-render.js` - the *staff* pane, which in
the side-by-side layout renders concurrently on the same main thread during
exactly this window - and the suite grew from 289 to 327 specs. Those widened
an old window rather than opening a new one, which is why this reads as a
regression from the outside and why the first sighting was two days earlier
on #159's CI.

## The fix

**Product** (`PdfViewer.svelte`) - a turn the pane accepts is never dropped:

- `goto()` remembers a target whose canvas does not exist yet in `pendingPage`
  instead of silently no-oping.
- `renderAllPages()` honours it the moment that page renders (clamped to the
  last page, since `goto()` may have run before there was any count to clamp
  against).
- `goto()` no longer clamps against `pageCount` while it is still `0`, which
  used to fold every early turn onto page 1.
- `turn()`'s gig half-page branch falls through to `goto()` when the current
  page's canvas is not there to measure against, instead of scrolling an
  empty container by a viewport height.
- the `score.last_page` restore stands down if such a turn was honoured, so
  the reader is not yanked back off the page they just asked for.

**Spec** - the barrier is the canvases, not the HUD:

- both page-turn tests now wait for `.pdf-page` to reach 2 before sending a key.
- a new test proves the product fix directly, and **deterministically**: the
  PDF body is held on the route until *after* `ArrowRight` has been pressed
  (so the press provably lands in the window), then released; the turn must
  still land on page 2.

## Verification

- **Mutation**: with `goto()` reverted to its pre-fix form and everything else
  in place, the new test fails with the same `Expected "2 / 2" / Received
  "1 / 2"`. It can go red.
- **The fix alone closes the race**: with the 800 ms forced render delay *and*
  the old HUD-only barrier restored, both previously-failing tests pass. The
  spec barrier is defence in depth; the product fix is the fix.
- **Acceptance**: 20 consecutive full-suite runs, **all green** - 327 passed in
  every one (5.0m each), and `practice-shortcuts.spec.js:677` recorded a `✓`
  in all 20. No failure line appears in any of the 20 logs. Run in three
  back-to-back batches (11 / 4 / 5) with no code change between them, because
  this machine kills a background task about an hour in; one earlier run was
  aborted mid-suite by that kill and was discarded and re-run rather than
  counted.
- Suite: 327 tests (326 before, +1 new). New spec-floor entry
  `tests/spec-floors/browser-practice-shortcuts-168.json`.
