### PR TITLE
Never hand a TAB staff without a fretted note to the renderer

### DIFF
--- a/docs/musicxml-tab-profile.md
+++ b/docs/musicxml-tab-profile.md
@@ -323,9 +323,21 @@ off for exactly that staff before the first render (`showTablature = false`,
 the same lever this project already relies on to keep a percussion staff's
 tuning from being offered as tab - see `disqualifyUnstrungTabStaves` in
 `web/src/lib/score-render.js`) rather than asking alphaTab to draw a staff
-whose `TabBarRenderer.collectSpaces` indexes a note's absent string straight
-off the end of its own per-line array. Standard notation on the same staff,
-or another staff in the same track, is unaffected.
+whose `TabBarRenderer.collectSpaces` indexes `tuning.length - note.string`
+with no bounds check.
+
+That check is a range, not "was a string ever read": alphaTab's importer maps
+a `<string>` value S (1..N, MusicXML's own convention) to `note.string =
+tuning.length - S + 1` with no validation, so an out-of-range S - `0` or
+`N + 1`, say - round-trips to an out-of-range `note.string` that still passes
+`Note.isStringed` (`string >= 0`). The only condition that keeps every note
+inside `collectSpaces`'s array is `1 <= note.string <= tuning.length`; a check
+against `isStringed` alone still crashes on exactly this shape. Standard
+notation on the same staff, or another staff in the same track, is
+unaffected - only tablature drawing for the disqualified staff is turned off,
+and disclosed rather than left silent (`host.dataset.scoreTabWithheld` and a
+distinct viewer notice, `tabWithheldMessage` - "no notation or tablature" is
+false for a score that had a TAB staff and lost it to one bad note).
 
 **Rule 10.** Every note that sounds also carries `<pitch>`, and its pitch
 agrees with its string, fret, the declared tuning and any capo.

--- a/docs/musicxml-tab-profile.md
+++ b/docs/musicxml-tab-profile.md
@@ -300,6 +300,33 @@ so string numbers start at 1. A conforming file's string numbers are all within
 the instrument's string count, so that each resolves against a declared
 `<staff-tuning>`.
 
+**What a producer does when it cannot fret a note.** `musicxml.build()` never
+writes a sounding note with `<pitch>` and no `<technical>` half - a note it
+has a (string, fret) pair for gets both, written together; a note it does not
+is written as a `<rest>` of the same duration instead (Rule 11 covers the one
+case that reaches this: a fret number MusicXML's `<octave>` cannot express).
+There is no third shape. This is a structural property of the emitter's own
+branching, not a claim that happens to hold on every fixture measured against
+it - see `test_library_wide_every_sounding_note_carries_string_and_fret` and
+its engraved-fixtures counterpart in the test suite, which check it against
+every PDF this project can commit or point `FERMATA_TEST_LIBRARY` at, and
+found nothing (issue #165).
+
+**What a consumer does when a file does not hold to this.** Rule 9 binds a
+*producer*; nothing stops a file this project did not write - a direct
+`.musicxml`/`.mxl` upload, or one hand-edited afterward - from declaring a TAB
+staff and leaving some of its notes unfretted anyway, which third-party
+notation software does for a tab staff LINKED to a notation staff and left
+for the reading application to fret. A staff like that cannot be honestly
+drawn as tablature, and Fermata's renderer does not try: it turns tablature
+off for exactly that staff before the first render (`showTablature = false`,
+the same lever this project already relies on to keep a percussion staff's
+tuning from being offered as tab - see `disqualifyUnstrungTabStaves` in
+`web/src/lib/score-render.js`) rather than asking alphaTab to draw a staff
+whose `TabBarRenderer.collectSpaces` indexes a note's absent string straight
+off the end of its own per-line array. Standard notation on the same staff,
+or another staff in the same track, is unaffected.
+
 **Rule 10.** Every note that sounds also carries `<pitch>`, and its pitch
 agrees with its string, fret, the declared tuning and any capo.
 

--- a/docs/rendering.md
+++ b/docs/rendering.md
@@ -774,6 +774,30 @@ layer runs in, so it matters here more than it would elsewhere. Nothing in
 Fermata does that today: scores arrive as alphaTex or MusicXML and go through an
 importer. Delegating to `canCreate` covers the case regardless.
 
+**The unfretted-note case is not handled by the library, so this layer handles
+it first (issue #165).** `canCreate` for the tab factory checks only
+`staff.showTablature && staff.tuning.length > 0` — nothing about whether the
+staff's individual *notes* carry a usable fretted position. A staff can pass
+that check and still crash paint: `TabBarRenderer.collectSpaces` indexes a
+per-line array by `tuning.length - note.string` with no bounds check, and a
+note whose `<string>` was never read, or was out of MusicXML's own 1..N range,
+still satisfies `note.isStringed` (`string >= 0`) while indexing off the end
+of the array — alphaTab catches the resulting exception internally and only
+logs it, so the failure is silent rather than a dead view. So the menu this
+section describes is no longer purely `canCreate`'s own answer: before
+`supportedProfiles` is asked anything, `disqualifyUnstrungTabStaves` walks
+every staff already flagged `showTablature` and turns that flag off for any
+whose notes are not all within range — the exact lever `Staff.finish` uses
+for a percussion staff, just thrown by this layer instead of the library,
+because the library does not throw it here on its own. `canCreate` then sees
+precisely what the percussion case above already taught it to expect: a
+staff that answers "no" for `tab` before it is ever asked. The disqualified
+count is disclosed rather than left silent — `host.dataset.scoreTabWithheld`
+and a distinct viewer notice (`tabWithheldMessage`, score-render.js) —
+because "no notation or tablature" (this score never had either) and "had
+tablature, withheld it" (one bad note took an otherwise-good staff down with
+it) are different facts about the file, and only one of them is true.
+
 ### The resize handler that cannot be turned off
 
 The library registers its own resize handler in its constructor, throttled at a

--- a/server/tests/fixtures/engraved/README.md
+++ b/server/tests/fixtures/engraved/README.md
@@ -39,7 +39,7 @@ sounding note), and must never be fed to a MusicXML consumer - alphaTab
 included - as if it were the extractor's output. Doing exactly that, once,
 crashed alphaTab's `TabBarRenderer.collectSpaces` during paint (issue #165).
 
-A couple of fixtures also carry `<name>.transcription.musicxml`: the actual
+One fixture (`navigation`, so far) also carries `<name>.transcription.musicxml`: the actual
 output of `tabextract.extract()` run on the committed PDF, regenerated and
 checked byte for byte (modulo a pinned `<encoding-date>`) by
 `engrave_fixtures.py --check`'s `write_transcriptions()`. This is the real

--- a/server/tests/fixtures/engraved/README.md
+++ b/server/tests/fixtures/engraved/README.md
@@ -29,6 +29,27 @@ The whole chain is in the repository:
 Nothing purchased or downloaded can go in this directory. That is how the
 gap this directory exists to close was created.
 
+**`<name>.musicxml` is the engraving SOURCE, not a transcription.** It is
+what MuseScore was asked to draw - for a tab-and-notation fixture, that
+includes the tab staff's own notes, written as plain `<pitch>` with no
+`<string>`/`<fret>` at all, because MuseScore frets them itself while
+engraving. It is therefore not a conforming file under
+docs/musicxml-tab-profile.md (Rule 9 requires `<string>`/`<fret>` on every
+sounding note), and must never be fed to a MusicXML consumer - alphaTab
+included - as if it were the extractor's output. Doing exactly that, once,
+crashed alphaTab's `TabBarRenderer.collectSpaces` during paint (issue #165).
+
+A couple of fixtures also carry `<name>.transcription.musicxml`: the actual
+output of `tabextract.extract()` run on the committed PDF, regenerated and
+checked byte for byte (modulo a pinned `<encoding-date>`) by
+`engrave_fixtures.py --check`'s `write_transcriptions()`. This is the real
+ground truth, always a single TAB staff with `<string>`/`<fret>` on every
+note - see `TRANSCRIPTION_FIXTURES` in `engrave_fixtures.py` for which names
+have one. It exists for consumers that cannot call the Python extractor at
+test time, currently the web browser test suite
+(`web/tests/browser/fixtures/navigation-score.js`), which needs real
+transcription bytes to feed the real alphaTab importer through.
+
 ## What each one is for
 
 | fixture | shape it covers |

--- a/server/tests/fixtures/engraved/navigation.transcription.musicxml
+++ b/server/tests/fixtures/engraved/navigation.transcription.musicxml
@@ -1,0 +1,602 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.musicxml.org/xsd/musicxml.xsd">
+  <work>
+    <work-title>navigation</work-title>
+  </work>
+  <identification>
+    <encoding>
+      <software>Fermata</software>
+      <encoding-date>2026-08-29</encoding-date>
+    </encoding>
+  </identification>
+  <part-list>
+    <score-part id="P1">
+      <part-name>Guitar</part-name>
+      <score-instrument id="P1-I1">
+        <instrument-name>Guitar</instrument-name>
+      </score-instrument>
+      <midi-instrument id="P1-I1">
+        <midi-channel>1</midi-channel>
+        <midi-program>25</midi-program>
+      </midi-instrument>
+    </score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>480</divisions>
+        <key>
+          <fifths>0</fifths>
+        </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+        </time>
+        <clef>
+          <sign>TAB</sign>
+          <line>5</line>
+        </clef>
+        <staff-details>
+          <staff-lines>6</staff-lines>
+          <staff-tuning line="1">
+            <tuning-step>E</tuning-step>
+            <tuning-octave>2</tuning-octave>
+          </staff-tuning>
+          <staff-tuning line="2">
+            <tuning-step>A</tuning-step>
+            <tuning-octave>2</tuning-octave>
+          </staff-tuning>
+          <staff-tuning line="3">
+            <tuning-step>D</tuning-step>
+            <tuning-octave>3</tuning-octave>
+          </staff-tuning>
+          <staff-tuning line="4">
+            <tuning-step>G</tuning-step>
+            <tuning-octave>3</tuning-octave>
+          </staff-tuning>
+          <staff-tuning line="5">
+            <tuning-step>B</tuning-step>
+            <tuning-octave>3</tuning-octave>
+          </staff-tuning>
+          <staff-tuning line="6">
+            <tuning-step>E</tuning-step>
+            <tuning-octave>4</tuning-octave>
+          </staff-tuning>
+        </staff-details>
+      </attributes>
+      <direction placement="above">
+        <direction-type>
+          <segno />
+        </direction-type>
+        <sound segno="segno" />
+      </direction>
+      <note id="n1-1-0-0">
+        <pitch>
+          <step>E</step>
+          <octave>3</octave>
+        </pitch>
+        <duration>480</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <notations>
+          <technical>
+            <string>4</string>
+            <fret>2</fret>
+          </technical>
+        </notations>
+      </note>
+      <note id="n1-1-1-0">
+        <pitch>
+          <step>F</step>
+          <octave>3</octave>
+        </pitch>
+        <duration>480</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <notations>
+          <technical>
+            <string>4</string>
+            <fret>3</fret>
+          </technical>
+        </notations>
+      </note>
+      <note id="n1-1-2-0">
+        <pitch>
+          <step>G</step>
+          <octave>3</octave>
+        </pitch>
+        <duration>480</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <notations>
+          <technical>
+            <string>3</string>
+            <fret>0</fret>
+          </technical>
+        </notations>
+      </note>
+      <note id="n1-1-3-0">
+        <pitch>
+          <step>A</step>
+          <octave>3</octave>
+        </pitch>
+        <duration>480</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <notations>
+          <technical>
+            <string>3</string>
+            <fret>2</fret>
+          </technical>
+        </notations>
+      </note>
+    </measure>
+    <measure number="2">
+      <note id="n2-1-0-0">
+        <pitch>
+          <step>E</step>
+          <octave>3</octave>
+        </pitch>
+        <duration>480</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <notations>
+          <technical>
+            <string>4</string>
+            <fret>2</fret>
+          </technical>
+        </notations>
+      </note>
+      <note id="n2-1-1-0">
+        <pitch>
+          <step>F</step>
+          <octave>3</octave>
+        </pitch>
+        <duration>480</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <notations>
+          <technical>
+            <string>4</string>
+            <fret>3</fret>
+          </technical>
+        </notations>
+      </note>
+      <note id="n2-1-2-0">
+        <pitch>
+          <step>G</step>
+          <octave>3</octave>
+        </pitch>
+        <duration>480</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <notations>
+          <technical>
+            <string>3</string>
+            <fret>0</fret>
+          </technical>
+        </notations>
+      </note>
+      <note id="n2-1-3-0">
+        <pitch>
+          <step>A</step>
+          <octave>3</octave>
+        </pitch>
+        <duration>480</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <notations>
+          <technical>
+            <string>3</string>
+            <fret>2</fret>
+          </technical>
+        </notations>
+      </note>
+      <direction placement="above">
+        <direction-type>
+          <words>To Coda</words>
+        </direction-type>
+        <sound tocoda="coda" />
+      </direction>
+    </measure>
+    <measure number="3">
+      <note id="n3-1-0-0">
+        <pitch>
+          <step>E</step>
+          <octave>3</octave>
+        </pitch>
+        <duration>480</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <notations>
+          <technical>
+            <string>4</string>
+            <fret>2</fret>
+          </technical>
+        </notations>
+      </note>
+      <note id="n3-1-1-0">
+        <pitch>
+          <step>F</step>
+          <octave>3</octave>
+        </pitch>
+        <duration>480</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <notations>
+          <technical>
+            <string>4</string>
+            <fret>3</fret>
+          </technical>
+        </notations>
+      </note>
+      <note id="n3-1-2-0">
+        <pitch>
+          <step>G</step>
+          <octave>3</octave>
+        </pitch>
+        <duration>480</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <notations>
+          <technical>
+            <string>3</string>
+            <fret>0</fret>
+          </technical>
+        </notations>
+      </note>
+      <note id="n3-1-3-0">
+        <pitch>
+          <step>A</step>
+          <octave>3</octave>
+        </pitch>
+        <duration>480</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <notations>
+          <technical>
+            <string>3</string>
+            <fret>2</fret>
+          </technical>
+        </notations>
+      </note>
+    </measure>
+    <measure number="4">
+      <note id="n4-1-0-0">
+        <pitch>
+          <step>E</step>
+          <octave>3</octave>
+        </pitch>
+        <duration>480</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <notations>
+          <technical>
+            <string>4</string>
+            <fret>2</fret>
+          </technical>
+        </notations>
+      </note>
+      <note id="n4-1-1-0">
+        <pitch>
+          <step>F</step>
+          <octave>3</octave>
+        </pitch>
+        <duration>480</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <notations>
+          <technical>
+            <string>4</string>
+            <fret>3</fret>
+          </technical>
+        </notations>
+      </note>
+      <note id="n4-1-2-0">
+        <pitch>
+          <step>G</step>
+          <octave>3</octave>
+        </pitch>
+        <duration>480</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <notations>
+          <technical>
+            <string>3</string>
+            <fret>0</fret>
+          </technical>
+        </notations>
+      </note>
+      <note id="n4-1-3-0">
+        <pitch>
+          <step>A</step>
+          <octave>3</octave>
+        </pitch>
+        <duration>480</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <notations>
+          <technical>
+            <string>3</string>
+            <fret>2</fret>
+          </technical>
+        </notations>
+      </note>
+      <direction placement="above">
+        <direction-type>
+          <words>D.S. al Coda</words>
+        </direction-type>
+        <sound dalsegno="segno" />
+      </direction>
+    </measure>
+    <measure number="5">
+      <note id="n5-1-0-0">
+        <pitch>
+          <step>E</step>
+          <octave>3</octave>
+        </pitch>
+        <duration>480</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <notations>
+          <technical>
+            <string>4</string>
+            <fret>2</fret>
+          </technical>
+        </notations>
+      </note>
+      <note id="n5-1-1-0">
+        <pitch>
+          <step>F</step>
+          <octave>3</octave>
+        </pitch>
+        <duration>480</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <notations>
+          <technical>
+            <string>4</string>
+            <fret>3</fret>
+          </technical>
+        </notations>
+      </note>
+      <note id="n5-1-2-0">
+        <pitch>
+          <step>G</step>
+          <octave>3</octave>
+        </pitch>
+        <duration>480</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <notations>
+          <technical>
+            <string>3</string>
+            <fret>0</fret>
+          </technical>
+        </notations>
+      </note>
+      <note id="n5-1-3-0">
+        <pitch>
+          <step>A</step>
+          <octave>3</octave>
+        </pitch>
+        <duration>480</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <notations>
+          <technical>
+            <string>3</string>
+            <fret>2</fret>
+          </technical>
+        </notations>
+      </note>
+    </measure>
+    <measure number="6">
+      <direction placement="above">
+        <direction-type>
+          <coda />
+        </direction-type>
+        <sound coda="coda" />
+      </direction>
+      <note id="n6-1-0-0">
+        <pitch>
+          <step>E</step>
+          <octave>3</octave>
+        </pitch>
+        <duration>480</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <notations>
+          <technical>
+            <string>4</string>
+            <fret>2</fret>
+          </technical>
+        </notations>
+      </note>
+      <note id="n6-1-1-0">
+        <pitch>
+          <step>F</step>
+          <octave>3</octave>
+        </pitch>
+        <duration>480</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <notations>
+          <technical>
+            <string>4</string>
+            <fret>3</fret>
+          </technical>
+        </notations>
+      </note>
+      <note id="n6-1-2-0">
+        <pitch>
+          <step>G</step>
+          <octave>3</octave>
+        </pitch>
+        <duration>480</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <notations>
+          <technical>
+            <string>3</string>
+            <fret>0</fret>
+          </technical>
+        </notations>
+      </note>
+      <note id="n6-1-3-0">
+        <pitch>
+          <step>A</step>
+          <octave>3</octave>
+        </pitch>
+        <duration>480</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <notations>
+          <technical>
+            <string>3</string>
+            <fret>2</fret>
+          </technical>
+        </notations>
+      </note>
+    </measure>
+    <measure number="7">
+      <note id="n7-1-0-0">
+        <pitch>
+          <step>E</step>
+          <octave>3</octave>
+        </pitch>
+        <duration>480</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <notations>
+          <technical>
+            <string>4</string>
+            <fret>2</fret>
+          </technical>
+        </notations>
+      </note>
+      <note id="n7-1-1-0">
+        <pitch>
+          <step>F</step>
+          <octave>3</octave>
+        </pitch>
+        <duration>480</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <notations>
+          <technical>
+            <string>4</string>
+            <fret>3</fret>
+          </technical>
+        </notations>
+      </note>
+      <note id="n7-1-2-0">
+        <pitch>
+          <step>G</step>
+          <octave>3</octave>
+        </pitch>
+        <duration>480</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <notations>
+          <technical>
+            <string>3</string>
+            <fret>0</fret>
+          </technical>
+        </notations>
+      </note>
+      <note id="n7-1-3-0">
+        <pitch>
+          <step>A</step>
+          <octave>3</octave>
+        </pitch>
+        <duration>480</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <notations>
+          <technical>
+            <string>3</string>
+            <fret>2</fret>
+          </technical>
+        </notations>
+      </note>
+      <direction placement="above">
+        <direction-type>
+          <words>Fine</words>
+        </direction-type>
+        <sound fine="yes" />
+      </direction>
+    </measure>
+    <measure number="8">
+      <note id="n8-1-0-0">
+        <pitch>
+          <step>E</step>
+          <octave>3</octave>
+        </pitch>
+        <duration>480</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <notations>
+          <technical>
+            <string>4</string>
+            <fret>2</fret>
+          </technical>
+        </notations>
+      </note>
+      <note id="n8-1-1-0">
+        <pitch>
+          <step>F</step>
+          <octave>3</octave>
+        </pitch>
+        <duration>480</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <notations>
+          <technical>
+            <string>4</string>
+            <fret>3</fret>
+          </technical>
+        </notations>
+      </note>
+      <note id="n8-1-2-0">
+        <pitch>
+          <step>G</step>
+          <octave>3</octave>
+        </pitch>
+        <duration>480</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <notations>
+          <technical>
+            <string>3</string>
+            <fret>0</fret>
+          </technical>
+        </notations>
+      </note>
+      <note id="n8-1-3-0">
+        <pitch>
+          <step>A</step>
+          <octave>3</octave>
+        </pitch>
+        <duration>480</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <notations>
+          <technical>
+            <string>3</string>
+            <fret>2</fret>
+          </technical>
+        </notations>
+      </note>
+      <direction placement="above">
+        <direction-type>
+          <words>D.C. al Fine</words>
+        </direction-type>
+        <sound dacapo="yes" />
+      </direction>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+      </barline>
+    </measure>
+  </part>
+</score-partwise>

--- a/server/tests/test_engraved_fixtures.py
+++ b/server/tests/test_engraved_fixtures.py
@@ -2281,6 +2281,33 @@ def test_the_committed_musicxml_still_matches_its_generator():
     assert drifted == [], drifted
 
 
+def test_the_committed_transcription_still_matches_what_the_extractor_reads(engraved):
+    """The companion of the check above, for the second artifact
+    TRANSCRIPTION_FIXTURES commits: `<name>.transcription.musicxml`, the
+    actual output of tabextract.extract() on the committed PDF - not the
+    engraving source, which is what the check above covers.
+
+    This is the one that matters for issue #165: the web browser suite has no
+    Python to call at test time, so it reads this committed file as ground
+    truth for what alphaTab renders. A drifted copy would mean that suite is
+    silently testing stale extractor output - and, before this file existed
+    at all, the browser suite was reading the engraving source instead, which
+    is not a conforming file under docs/musicxml-tab-profile.md Rule 9 and
+    crashed alphaTab's TabBarRenderer.collectSpaces the one time that
+    happened."""
+    import importlib.util
+    from pathlib import Path
+
+    script = Path(__file__).resolve().parents[1] / "tools" / "tab_extract" / "engrave_fixtures.py"
+    spec = importlib.util.spec_from_file_location("engrave_fixtures", script)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    for name in module.TRANSCRIPTION_FIXTURES:
+        engraved(name)  # fails loudly (not a skip) if the PDF is missing
+    drifted = module.write_transcriptions(check_only=True)
+    assert drifted == [], drifted
+
+
 # ---------------------------------------------------------------------------
 # Rule 17: note identifiers, pinned across every committed engraved fixture
 # ---------------------------------------------------------------------------
@@ -2321,3 +2348,52 @@ def test_every_engraved_fixtures_note_id_is_unique_and_a_valid_ncname():
     # stopped running against anything at all.
     assert checked >= 20, "fewer engraved fixtures were checked than expected"
     assert total_notes > 0
+
+
+# ---------------------------------------------------------------------------
+# Rule 9: every sounding note carries <string> and <fret>
+# ---------------------------------------------------------------------------
+
+
+def test_every_engraved_fixtures_sounding_note_carries_string_and_fret():
+    """Issue #165. musicxml.build() either writes a note with a full
+    (string, fret, midi) triple or writes no pitched note at all (an
+    unwritable one becomes a rest, per Rule 11) - never a `<pitch>` with no
+    `<notations><technical><string>`/`<fret>` beside it. That is a structural
+    property of build()'s own branching (see the `if not writable` / `else`
+    split in build()), not a coincidence of what this repository's fixtures
+    happen to contain, so this checks it holds for every committed engraved
+    PDF - the full extraction pipeline, not build() called directly with a
+    hand-assembled beats model.
+
+    The bug issue #165 reports was never here: it was a browser test fixture
+    (web/tests/browser/fixtures/navigation-score.js) reading
+    navigation.musicxml - the ENGRAVING SOURCE MuseScore was asked to draw,
+    whose tab-staff notes carry no string/fret at all because MuseScore
+    assigns them itself while engraving - and feeding it to alphaTab
+    mislabelled as "the transcription... produced by the extractor". That
+    file was never a conforming file under this profile and this test does
+    not read it; see navigation.transcription.musicxml and
+    TRANSCRIPTION_FIXTURES in engrave_fixtures.py for the artifact that
+    actually is one."""
+    checked = 0
+    total_sounding = 0
+    stringless = []
+    for pdf in sorted(ENGRAVED_DIR.glob("*.pdf")):
+        result = tabextract.extract(pdf)
+        if not result.extractable or not result.musicxml:
+            continue
+        root = ET.fromstring(result.musicxml)
+        for note in root.findall("./part/measure/note"):
+            if note.find("rest") is not None:
+                continue
+            total_sounding += 1
+            technical = note.find("notations/technical")
+            string_el = technical.find("string") if technical is not None else None
+            fret_el = technical.find("fret") if technical is not None else None
+            if string_el is None or fret_el is None:
+                stringless.append((pdf.name, note.get("id")))
+        checked += 1
+    assert stringless == [], f"TAB-staff note(s) with no <string>/<fret>: {stringless[:10]}"
+    assert checked >= 20, "fewer engraved fixtures were checked than expected"
+    assert total_sounding > 0

--- a/server/tests/test_engraved_fixtures.py
+++ b/server/tests/test_engraved_fixtures.py
@@ -47,6 +47,7 @@ coverage and is not is worse than none:
     there.
 """
 import collections
+import os
 import re
 import xml.etree.ElementTree as ET
 
@@ -2306,6 +2307,50 @@ def test_the_committed_transcription_still_matches_what_the_extractor_reads(engr
         engraved(name)  # fails loudly (not a skip) if the PDF is missing
     drifted = module.write_transcriptions(check_only=True)
     assert drifted == [], drifted
+
+
+def test_the_committed_transcriptions_validate_against_xsd():
+    """Neither of test_musicxml.py's two XSD checks reads
+    `<name>.transcription.musicxml` at all: test_validates_against_xsd
+    validates hand-built samples from musicxml.build(), and
+    test_the_published_examples_validate_against_xsd validates
+    docs/examples/*.musicxml - a different, hand-published navigation.musicxml
+    example, not this one. This is the check that actually covers the
+    TRANSCRIPTION_FIXTURES artifact: schema validation catches every
+    child-order mistake in Rule 4 and every out-of-range value in Rule 11
+    (see docs/musicxml-tab-profile.md's "Checking a file"), and this file is
+    what the web browser suite trusts as ground truth for issue #165 - it
+    being schema-valid is not optional.
+
+    Skipped unless FERMATA_MUSICXML_XSD points at a local musicxml.xsd, the
+    same condition and the same reason as both of test_musicxml.py's checks:
+    the schema's own xs:import elements name remote URLs, and a test that
+    silently depends on the network is worse than one that says it was
+    skipped."""
+    import importlib.util
+    from pathlib import Path
+
+    path = os.environ.get("FERMATA_MUSICXML_XSD")
+    if not path or not os.path.isfile(path):
+        pytest.skip("FERMATA_MUSICXML_XSD not set to a musicxml.xsd")
+    lxml_etree = pytest.importorskip("lxml.etree")
+
+    script = Path(__file__).resolve().parents[1] / "tools" / "tab_extract" / "engrave_fixtures.py"
+    spec = importlib.util.spec_from_file_location("engrave_fixtures", script)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    schema = lxml_etree.XMLSchema(lxml_etree.parse(path))
+    checked = 0
+    for name in module.TRANSCRIPTION_FIXTURES:
+        transcription = ENGRAVED_DIR / f"{name}.transcription.musicxml"
+        assert transcription.is_file(), transcription
+        doc = lxml_etree.parse(str(transcription))
+        if not schema.validate(doc):
+            errors = "; ".join(f"line {e.line}: {e.message}" for e in schema.error_log)
+            pytest.fail(f"{transcription.name} failed MusicXML 4.0 validation: {errors}")
+        checked += 1
+    assert checked > 0
 
 
 # ---------------------------------------------------------------------------

--- a/server/tests/test_tabextract.py
+++ b/server/tests/test_tabextract.py
@@ -4223,6 +4223,57 @@ def test_library_wide_note_ids_are_unique_and_valid_ncnames(library_root):
     assert scores_checked >= 250, f"only {scores_checked} scores were checked"
 
 
+def test_library_wide_every_sounding_note_carries_string_and_fret(library_root):
+    """Rule 9, library-wide (issue #165). Every `<note>` this project emits
+    that is not a `<rest>` carries `<notations><technical><string>` and
+    `<fret>` - musicxml.build() writes a note with the full (string, fret,
+    midi) triple or writes no pitched note at all, never one in between (see
+    the `if not writable` / `else` split in build()). Checked here at the
+    scale a real library reaches, the same shape as
+    test_library_wide_note_ids_are_unique_and_valid_ncnames just above.
+
+    Issue #165's own crash was not this: it was a browser test fixture
+    reading the ENGRAVING SOURCE of navigation.pdf (whose tab-staff notes
+    MuseScore fretted itself while engraving, never a conforming file under
+    this profile) as if it were the extractor's own transcription. This test
+    is the direct check that the transcription side has no such gap anywhere
+    in the library - measured at 0 stringless sounding notes across 297
+    library PDFs plus the 30 committed engraved fixtures before this issue
+    was ever opened."""
+    scores_checked = 0
+    total_sounding = 0
+    stringless = []
+    for pdf in _library_pdfs(library_root):
+        try:
+            result = tabextract.extract(pdf)
+        except Exception:
+            continue
+        if not result.extractable or not result.musicxml:
+            continue
+        root = ET.fromstring(result.musicxml)
+        notes = root.findall("./part/measure/note")
+        if not notes:
+            continue
+        scores_checked += 1
+        for note in notes:
+            if note.find("rest") is not None:
+                continue
+            total_sounding += 1
+            technical = note.find("notations/technical")
+            string_el = technical.find("string") if technical is not None else None
+            fret_el = technical.find("fret") if technical is not None else None
+            if string_el is None or fret_el is None:
+                stringless.append((pdf.name, note.get("id")))
+
+    _assert_no_offenders([f"{name}:{note_id}" for name, note_id in stringless],
+                          "TAB-staff note(s) with no <string>/<fret>")
+    assert total_sounding > 0
+    # A floor rather than a pin, for the same reason the note-id sweep above
+    # uses one: which PDFs extract cleanly can change, but the check must not
+    # have silently stopped running against anything close to the library.
+    assert scores_checked >= 250, f"only {scores_checked} scores were checked"
+
+
 def test_no_emitted_note_is_longer_than_the_bar_it_sits_in(library_root):
     """Issue #109's own self-check, which needs no reference to a printed
     page: a note whose written value exceeds its bar's meter is impossible

--- a/server/tools/tab_extract/engrave_fixtures.py
+++ b/server/tools/tab_extract/engrave_fixtures.py
@@ -12,7 +12,7 @@ THE CHAIN, all of it in the repository:
     FIXTURES (below)  ->  <name>.musicxml  ->  MuseScore  ->  <name>.pdf
 
 `<name>.musicxml` is the ENGRAVING SOURCE - what MuseScore was asked to draw,
-not what the extractor reads back. For a couple of fixtures, something
+not what the extractor reads back. For one fixture so far, something
 outside the Python test suite (the web browser test suite, which has no
 Python to call at test time) needs the real TRANSCRIPTION too - the actual
 output of tabextract.extract() run on the committed PDF - and that is a

--- a/server/tools/tab_extract/engrave_fixtures.py
+++ b/server/tools/tab_extract/engrave_fixtures.py
@@ -11,15 +11,30 @@ THE CHAIN, all of it in the repository:
 
     FIXTURES (below)  ->  <name>.musicxml  ->  MuseScore  ->  <name>.pdf
 
+`<name>.musicxml` is the ENGRAVING SOURCE - what MuseScore was asked to draw,
+not what the extractor reads back. For a couple of fixtures, something
+outside the Python test suite (the web browser test suite, which has no
+Python to call at test time) needs the real TRANSCRIPTION too - the actual
+output of tabextract.extract() run on the committed PDF - and that is a
+second, separate committed file: `<name>.transcription.musicxml`, for the
+names in TRANSCRIPTION_FIXTURES below. The two are not interchangeable: the
+engraving source's tab-staff notes carry no `<string>`/`<fret>` at all
+(MuseScore assigns them itself while engraving), so it is not a conforming
+file under docs/musicxml-tab-profile.md and must never be handed to a
+renderer expecting Rule 9 - doing exactly that, once, crashed alphaTab's
+`TabBarRenderer.collectSpaces` (issue #165).
+
 Run with no arguments to rebuild the MusicXML and, if MuseScore is
 installed, re-engrave the PDFs:
 
     python server/tools/tab_extract/engrave_fixtures.py
 
-    --check     rewrite nothing; report whether the committed MusicXML
-                still matches what this script would write (a fixture whose
-                source drifted from its generator is no longer regenerable)
-    --musicxml  write the MusicXML only, no engraving
+    --check     rewrite nothing; report whether the committed MusicXML and
+                transcription files still match what this script would
+                write (a fixture whose source drifted from its generator is
+                no longer regenerable)
+    --musicxml  write the engraving-source MusicXML only, no engraving and
+                no transcription regeneration (that needs a current PDF)
     --report    engrave, then print what the extractor makes of each PDF
 
 MuseScore is found via $MUSESCORE, or the usual install locations. Any
@@ -31,6 +46,7 @@ coordinates and can change what the tests measure.
 import argparse
 import contextlib
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -1123,6 +1139,59 @@ def write_musicxml(check_only=False):
     return drifted
 
 
+# Fixtures that also need a committed TRANSCRIPTION artifact: the actual
+# output of tabextract.extract() run on the committed PDF, as distinct from
+# the `<name>.musicxml` beside it (the engraving source MuseScore was asked
+# to draw). Only fixtures something outside the Python test suite needs to
+# read get one - currently just the web browser test suite, which has no
+# Python to call at test time and needs real ground truth to feed the real
+# alphaTab importer/renderer through (issue #165: the engraving source is
+# not a conforming file - its tab-staff notes carry no <string>/<fret> at
+# all, MuseScore having been left to assign them itself while engraving -
+# and reading it directly as if it were a transcription crashed
+# TabBarRenderer.collectSpaces the one time that happened).
+TRANSCRIPTION_FIXTURES = ("navigation",)
+
+# musicxml.build's own default for <encoding-date> is today's date, which
+# would make this file drift every time it is regenerated for no reason a
+# diff could ever explain - the same problem docs/examples/monophonic.musicxml
+# solves by pinning one. Pinned here the same way, to the date this file was
+# first committed.
+_TRANSCRIPTION_ENCODING_DATE = "2026-08-29"
+
+_ENCODING_DATE_RE = re.compile(r"<encoding-date>[^<]*</encoding-date>")
+
+
+def write_transcriptions(check_only=False):
+    """Regenerate `<name>.transcription.musicxml` for each name in
+    TRANSCRIPTION_FIXTURES: tabextract.extract() run on the already-engraved
+    `<name>.pdf`, with <encoding-date> pinned so the file does not drift on
+    its own. Requires the PDF to already exist and be current - run after
+    engrave(), never instead of it."""
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+    from fermata import tabextract
+
+    drifted = []
+    for name in TRANSCRIPTION_FIXTURES:
+        pdf = FIXTURE_DIR / f"{name}.pdf"
+        if not pdf.is_file():
+            raise SystemExit(f"{pdf} is missing - engrave the fixtures first")
+        result = tabextract.extract(pdf)
+        if not result.extractable:
+            raise SystemExit(f"{name}.pdf did not extract: {result.reason}")
+        wanted = _ENCODING_DATE_RE.sub(
+            f"<encoding-date>{_TRANSCRIPTION_ENCODING_DATE}</encoding-date>", result.musicxml)
+        path = FIXTURE_DIR / f"{name}.transcription.musicxml"
+        if check_only:
+            have = path.read_text(encoding="utf-8") if path.is_file() else None
+            if have != wanted:
+                drifted.append(f"{name}.transcription.musicxml")
+            continue
+        path.write_text(wanted, encoding="utf-8")
+        print(f"  wrote {path.name} ({len(wanted)} bytes)")
+    return drifted
+
+
 def engrave(musescore):
     for name in sorted(FIXTURES):
         src = FIXTURE_DIR / f"{name}.musicxml"
@@ -1236,6 +1305,7 @@ def main():
 
     if args.check:
         drifted = write_musicxml(check_only=True)
+        drifted += write_transcriptions(check_only=True)
         if drifted:
             raise SystemExit(
                 "these fixtures' committed MusicXML no longer matches this script: "
@@ -1257,6 +1327,8 @@ def main():
     engrave(musescore)
     rasterise()
     synthesise_fake_music_font()
+    print("transcriptions:")
+    write_transcriptions()
     if args.report:
         report()
 

--- a/web/src/lib/TabViewer.svelte
+++ b/web/src/lib/TabViewer.svelte
@@ -1,7 +1,7 @@
 <script>
   import { untrack } from "svelte";
   import { api } from "./api.js";
-  import { createScoreView, UNRENDERABLE_MESSAGE } from "./score-render.js";
+  import { createScoreView, UNRENDERABLE_MESSAGE, tabWithheldMessage } from "./score-render.js";
   import { getSettings, setSetting, STAFF_THEMES, STAFF_THEME_LABELS } from "./settings.svelte.js";
   import Metronome from "./Metronome.svelte";
 
@@ -73,6 +73,13 @@
   // and rendering no buttons at all during that window is what avoids
   // offering a choice this component cannot yet vouch for.
   let profileOptions = $state(null);
+  // How many staves score-render.js's disqualifyUnstrungTabStaves() turned
+  // tablature off for on the current score (issue #165) - 0 for the ordinary
+  // case. Read only where profileOptions.length === 0, to choose
+  // tabWithheldMessage() over UNRENDERABLE_MESSAGE: a score that had a TAB
+  // clef and mostly-fretted notes but lost its only drawable staff to one bad
+  // note must not be told it never had notation or tablature at all.
+  let tabWithheldCount = $state(0);
   let playing = $state(false);
   let playerReady = $state(false);
   let speed = $state(1);
@@ -181,6 +188,7 @@
     // unknown again for this score, not "same as the last one" - see the
     // comment on profileOptions's declaration
     profileOptions = null;
+    tabWithheldCount = 0;
     // untrack: everything below is driven imperatively once the view exists;
     // tracking it here would tear down and rebuild the renderer (and stop
     // playback) on a profile switch or a toggle.
@@ -209,8 +217,13 @@
         // empty array here, not a fallback list; the empty-state notice in
         // the markup below is what tells the profileOptions.length === 0
         // case apart from "still loading" (profileOptions still null).
-        onProfiles: (profiles) => {
+        // `withheld` (issue #165) is how many staves lost tablature to
+        // disqualifyUnstrungTabStaves() - kept so the empty-state notice can
+        // tell "never had notation or tablature" apart from "had tablature,
+        // withheld it"; see tabWithheldCount's own declaration.
+        onProfiles: (profiles, _unrenderable, withheld) => {
           profileOptions = profiles;
+          tabWithheldCount = withheld ?? 0;
         },
         // The highlighted button has to follow what actually finished
         // drawing, not what was most recently requested - setProfile() below
@@ -621,8 +634,17 @@
     source rather than shown, so this plain sentence - not a stack trace - is
     the only thing a guitarist sees. The staff area below stays in the DOM
     (score-render.js's `host` binding needs a stable element) but is hidden
-    rather than left showing whatever the failed render left behind. -->
-    <p class="notice">{UNRENDERABLE_MESSAGE}</p>
+    rather than left showing whatever the failed render left behind.
+
+    Two different sentences share this slot (issue #165): a score that never
+    had notation or tablature at all gets UNRENDERABLE_MESSAGE, and a score
+    that had a TAB staff disqualifyUnstrungTabStaves() had to withhold gets
+    tabWithheldMessage() instead - "no notation or tablature" is false for
+    the second case, which can be a TAB clef, real tuning and every note but
+    one correctly fretted. -->
+    <p class="notice">
+      {tabWithheldCount > 0 ? tabWithheldMessage(tabWithheldCount) : UNRENDERABLE_MESSAGE}
+    </p>
   {/if}
 
   <div class="score-scroll" class:hidden={profileOptions?.length === 0} bind:this={scroller}>

--- a/web/src/lib/score-render.js
+++ b/web/src/lib/score-render.js
@@ -202,12 +202,30 @@ export function supportedProfiles(tracks) {
   }
 }
 
-/** Shown in place of the staff view when supportedProfiles() comes back empty. */
+/** Shown in place of the staff view when supportedProfiles() comes back empty
+ * and no tab staff was withheld - a score with nothing drawable at all under
+ * any profile. See tabWithheldMessage() for the case this must NOT be shown
+ * for: a score that DID have tablature, some of which had to be turned off. */
 export const UNRENDERABLE_MESSAGE = "This score has no notation or tablature the staff view can draw.";
+
+/** The distinct notice for a score `disqualifyUnstrungTabStaves()` emptied
+ * `supportedProfiles()` for by withholding tablature - "no notation or
+ * tablature" (UNRENDERABLE_MESSAGE) is false for this score: it has a TAB
+ * clef, real tuning and, in the case that motivated this, 31 of 32 correctly
+ * fretted notes. One bad note took the whole staff down with it, and the
+ * viewer has to say so distinctly rather than claim the score never had
+ * either (issue #165). */
+export function tabWithheldMessage(count) {
+  const staves = count === 1 ? "its one tablature staff" : `${count} of its tablature staves`;
+  return (
+    `This score has tablature, but ${staves} could not be drawn: at least one note has no ` +
+    "fretted position. Every note on that staff needs a matching string and fret to render it."
+  );
+}
 
 /**
  * A staff whose `showTablature` is true but whose notes are not all
- * strung, disqualified from tab rendering in place (issue #165).
+ * fretted, disqualified from tab rendering in place (issue #165).
  *
  * docs/musicxml-tab-profile.md Rule 9 requires `<string>`/`<fret>` on every
  * sounding note of a conforming FILE, and Fermata's own emitter (see
@@ -219,16 +237,28 @@ export const UNRENDERABLE_MESSAGE = "This score has no notation or tablature the
  * declare a tab staff (tuning, TAB clef) and still leave some of that
  * staff's notes without a fretted position - third-party notation software
  * writes exactly that shape when a tab staff is LINKED to a notation staff
- * and left for the reading application to fret. alphaTab's own TAB renderer
- * assumes every note it is asked to draw carries one: a note whose `string`
- * was never set defaults to -1 (not stringed), which is still indexed into
- * `TabBarRenderer.collectSpaces`'s per-line array as
- * `spaces[tuning.length - str]` - out of bounds for -1, so the array slot
- * read back is `undefined` and `.push()` on it throws, straight out of
- * paint. Measured on exactly this shape: the exception is caught inside
- * alphaTab's own API layer and only logged, not re-thrown, so the page
- * still reports a finished render and passes any check that does not
- * itself read console output - while drawing almost nothing of that staff.
+ * and left for the reading application to fret.
+ *
+ * THE PREDICATE IS AN ARRAY INDEX, NOT "was a string ever set". alphaTab's
+ * MusicXML importer maps a `<string>` element's value S (1 = highest,
+ * MusicXML's own convention) to `note.string = staff.tuning.length - S + 1`
+ * (`_parseTechnical`'s `"string"` case) with no range check, so an
+ * out-of-range S round-trips to an out-of-range `note.string` that is still
+ * `>= 0` - `note.isStringed` (`this.string >= 0`) says yes. `<string>0</string>`
+ * on a 6-line staff becomes `note.string = 7`; `<string>7</string>` becomes
+ * `note.string = 0`. Both pass `isStringed` and both still crash: painting
+ * indexes a per-staff-line array as `spaces[tuning.length - note.string]`,
+ * which is `spaces[-1]` for the first and `spaces[6]` for the second - one
+ * argument short of the array (built `tuning.length` entries long, valid
+ * indices 0..tuning.length-1), so the slot read back is `undefined` and
+ * `.push()` on it throws, straight out of paint. The only condition that
+ * actually keeps every note inside that array is `note.string` between 1 and
+ * `tuning.length` inclusive - checked below, not `isStringed`. Measured on
+ * exactly this shape (a `<string>7</string>` on a 6-line staff): the
+ * exception is caught inside alphaTab's own API layer and only logged, not
+ * re-thrown, so the page still reports a finished render and passes any
+ * check that does not itself read console output - while drawing almost
+ * nothing of that staff.
  *
  * The honest response is the one Rule 9's own producer-side guidance
  * describes for a note that genuinely has no string: this staff cannot be
@@ -243,6 +273,15 @@ export const UNRENDERABLE_MESSAGE = "This score has no notation or tablature the
  * track, is unaffected: only tablature drawing for the disqualified staff
  * is turned off.
  *
+ * Returns the list of disqualified staves so the caller can disclose what
+ * happened - see the scoreLoaded handler below, which sets
+ * `host.dataset.scoreTabWithheld` and logs, the same pattern
+ * applyLoadedNavigation uses for `data-score-jumps-unread` a few lines
+ * above it, and passes the count on to onProfiles() so the viewer can tell
+ * "no notation or tablature at all" (UNRENDERABLE_MESSAGE) apart from "had
+ * tablature, withheld it" (tabWithheldMessage()) rather than only being able
+ * to show the former for both.
+ *
  * Called from the scoreLoaded handler, before supportedProfiles() reads the
  * score - same timing requirement as the profile correction beside it, and
  * for the same reason: AlphaTabApiBase triggers scoreLoaded synchronously
@@ -253,37 +292,29 @@ export function disqualifyUnstrungTabStaves(score) {
   for (const track of score?.tracks ?? []) {
     for (const staff of track?.staves ?? []) {
       if (!staff?.showTablature) continue;
-      let hasUnstrungNote = false;
+      const lines = staff.tuning?.length ?? 0;
+      let hasUnfrettedNote = false;
       for (const bar of staff.bars ?? []) {
         for (const voice of bar?.voices ?? []) {
           for (const beat of voice?.beats ?? []) {
             if (beat?.isRest) continue;
             for (const note of beat?.notes ?? []) {
-              if (!note?.isStringed) {
-                hasUnstrungNote = true;
+              if (!(note?.string >= 1 && note.string <= lines)) {
+                hasUnfrettedNote = true;
                 break;
               }
             }
-            if (hasUnstrungNote) break;
+            if (hasUnfrettedNote) break;
           }
-          if (hasUnstrungNote) break;
+          if (hasUnfrettedNote) break;
         }
-        if (hasUnstrungNote) break;
+        if (hasUnfrettedNote) break;
       }
-      if (hasUnstrungNote) {
+      if (hasUnfrettedNote) {
         staff.showTablature = false;
         disqualified.push(staff);
       }
     }
-  }
-  if (disqualified.length) {
-    console.warn(
-      `score-render: ${disqualified.length} staff(es) declared as tablature carry a note with ` +
-        "no fretted position - drawing them as tablature would crash the renderer's paint " +
-        "(issue #165), so tablature is turned off for just those staves. This is not Fermata's " +
-        "own transcription shape; it happens on a directly uploaded file whose tab staff is " +
-        "under-specified.",
-    );
   }
   return disqualified;
 }
@@ -1749,11 +1780,17 @@ async function readMusicXml(bytes) {
  * @param opts.onError      (message) load or render failed
  * @param opts.onPassComplete  one pass finished (drives the tempo ladder)
  * @param opts.onLayout     (layout) the chosen layout changed
- * @param opts.onProfiles   (profiles, unrenderable) the profiles this score
- *                          supports changed - fires once a score has loaded.
- *                          `profiles` can be empty; `unrenderable` is true in
- *                          exactly that case, when nothing about this score
- *                          can be drawn under any profile
+ * @param opts.onProfiles   (profiles, unrenderable, tabWithheldCount) the
+ *                          profiles this score supports changed - fires once
+ *                          a score has loaded. `profiles` can be empty;
+ *                          `unrenderable` is true in exactly that case, when
+ *                          nothing about this score can be drawn under any
+ *                          profile. `tabWithheldCount` is how many staves
+ *                          disqualifyUnstrungTabStaves() turned tablature off
+ *                          for (issue #165) - a caller showing its own
+ *                          unrenderable notice needs this to tell "no
+ *                          notation or tablature at all" apart from "had
+ *                          tablature, withheld it"; see tabWithheldMessage()
  * @param opts.onProfileApplied  (profile) a render has actually finished
  *                          successfully with this profile showing - the
  *                          signal a caller should wait for before treating a
@@ -2578,7 +2615,27 @@ export function createScoreView(host, opts = {}) {
     // honestly drawn as tablature must be disqualified before canDraw is
     // asked about it, or "tab"/"scoretab" would still be offered for a staff
     // whose paint throws (issue #165) - see disqualifyUnstrungTabStaves.
-    disqualifyUnstrungTabStaves(loadedScore);
+    const tabWithheld = disqualifyUnstrungTabStaves(loadedScore);
+    // Disclosed the same way applyLoadedNavigation discloses an unread
+    // navigation mark a few lines above: a dataset attribute a test (or a
+    // person with devtools open) can read, plus a console line, present only
+    // when there is something to disclose - "not withheld" and "no score
+    // loaded yet" both read as the attribute being absent, same convention
+    // dataset.scoreProfiles documents at its own delete call below.
+    if (host) {
+      if (tabWithheld.length) {
+        host.dataset.scoreTabWithheld = String(tabWithheld.length);
+        console.info(
+          `score-render: ${tabWithheld.length} staff(es) declared as tablature carry a note ` +
+            "with no fretted position - drawing them as tablature would crash the renderer's " +
+            "paint (issue #165), so tablature is turned off for just those staves. This is not " +
+            "Fermata's own transcription shape; it happens on a directly uploaded file whose " +
+            "tab staff is under-specified.",
+        );
+      } else {
+        delete host.dataset.scoreTabWithheld;
+      }
+    }
     scoreProfiles = supportedProfiles(api.tracks?.length ? api.tracks : loadedScore.tracks);
     unrenderable = scoreProfiles.length === 0;
     if (!unrenderable && !scoreProfiles.includes(profile)) {
@@ -2589,7 +2646,11 @@ export function createScoreView(host, opts = {}) {
     metronome.scoreLoaded(loadedScore);
     onScoreTempo(loadedScore?.tempo ?? null, tempoProvenance(loadedScore));
     publish();
-    onProfiles(scoreProfiles, unrenderable);
+    // Third argument: how many staves disqualifyUnstrungTabStaves() withheld,
+    // so a caller whose profiles came back empty can tell "no notation or
+    // tablature at all" apart from "had tablature, withheld it" - see
+    // tabWithheldMessage() and TabViewer.svelte's use of it.
+    onProfiles(scoreProfiles, unrenderable, tabWithheld.length);
     // A freshly loaded score starts at bar one, not wherever the previous
     // score's cursor happened to be left - see the dataset.cursorTick reset
     // above for the same reasoning applied to the attribute this reflects.

--- a/web/src/lib/score-render.js
+++ b/web/src/lib/score-render.js
@@ -205,6 +205,89 @@ export function supportedProfiles(tracks) {
 /** Shown in place of the staff view when supportedProfiles() comes back empty. */
 export const UNRENDERABLE_MESSAGE = "This score has no notation or tablature the staff view can draw.";
 
+/**
+ * A staff whose `showTablature` is true but whose notes are not all
+ * strung, disqualified from tab rendering in place (issue #165).
+ *
+ * docs/musicxml-tab-profile.md Rule 9 requires `<string>`/`<fret>` on every
+ * sounding note of a conforming FILE, and Fermata's own emitter (see
+ * musicxml.build's note-writing branch) never violates it - a note it
+ * cannot fret is dropped to a rest, never written half-specified. Nothing
+ * here enforces that on Fermata's own output, because nothing needs to:
+ * this is a defence for input this project did not write. A directly
+ * uploaded `.musicxml`/`.mxl` file, or a hand-edited one, can legally
+ * declare a tab staff (tuning, TAB clef) and still leave some of that
+ * staff's notes without a fretted position - third-party notation software
+ * writes exactly that shape when a tab staff is LINKED to a notation staff
+ * and left for the reading application to fret. alphaTab's own TAB renderer
+ * assumes every note it is asked to draw carries one: a note whose `string`
+ * was never set defaults to -1 (not stringed), which is still indexed into
+ * `TabBarRenderer.collectSpaces`'s per-line array as
+ * `spaces[tuning.length - str]` - out of bounds for -1, so the array slot
+ * read back is `undefined` and `.push()` on it throws, straight out of
+ * paint. Measured on exactly this shape: the exception is caught inside
+ * alphaTab's own API layer and only logged, not re-thrown, so the page
+ * still reports a finished render and passes any check that does not
+ * itself read console output - while drawing almost nothing of that staff.
+ *
+ * The honest response is the one Rule 9's own producer-side guidance
+ * describes for a note that genuinely has no string: this staff cannot be
+ * drawn as tablature, so it is not offered as one. `showTablature = false`
+ * is the exact lever alphaTab's own `TabBarRendererFactory.canCreate`
+ * checks (`staff.showTablature && staff.tuning.length > 0`), and the one
+ * this project already relies on for the same purpose on a percussion
+ * staff (see mirroredCanDraw's comment on `Staff.finish`) - so a staff this
+ * function disqualifies is skipped by alphaTab's own renderer selection,
+ * not merely hidden from the profile buttons canDraw/supportedProfiles
+ * offer. Standard notation on the SAME staff, or another staff in the same
+ * track, is unaffected: only tablature drawing for the disqualified staff
+ * is turned off.
+ *
+ * Called from the scoreLoaded handler, before supportedProfiles() reads the
+ * score - same timing requirement as the profile correction beside it, and
+ * for the same reason: AlphaTabApiBase triggers scoreLoaded synchronously
+ * and only renders once every listener has returned.
+ */
+export function disqualifyUnstrungTabStaves(score) {
+  const disqualified = [];
+  for (const track of score?.tracks ?? []) {
+    for (const staff of track?.staves ?? []) {
+      if (!staff?.showTablature) continue;
+      let hasUnstrungNote = false;
+      for (const bar of staff.bars ?? []) {
+        for (const voice of bar?.voices ?? []) {
+          for (const beat of voice?.beats ?? []) {
+            if (beat?.isRest) continue;
+            for (const note of beat?.notes ?? []) {
+              if (!note?.isStringed) {
+                hasUnstrungNote = true;
+                break;
+              }
+            }
+            if (hasUnstrungNote) break;
+          }
+          if (hasUnstrungNote) break;
+        }
+        if (hasUnstrungNote) break;
+      }
+      if (hasUnstrungNote) {
+        staff.showTablature = false;
+        disqualified.push(staff);
+      }
+    }
+  }
+  if (disqualified.length) {
+    console.warn(
+      `score-render: ${disqualified.length} staff(es) declared as tablature carry a note with ` +
+        "no fretted position - drawing them as tablature would crash the renderer's paint " +
+        "(issue #165), so tablature is turned off for just those staves. This is not Fermata's " +
+        "own transcription shape; it happens on a directly uploaded file whose tab staff is " +
+        "under-specified.",
+    );
+  }
+  return disqualified;
+}
+
 // ---------------------------------------------------------------- layout
 
 // Widths are of the score container, not the window: a side-by-side PDF
@@ -2491,6 +2574,11 @@ export function createScoreView(host, opts = {}) {
     // the loaded score, and the midi generated after it returns has to see
     // the finished model rather than the imported one.
     applyLoadedNavigation(loadedScore);
+    // Also before supportedProfiles() reads the score: a staff that cannot be
+    // honestly drawn as tablature must be disqualified before canDraw is
+    // asked about it, or "tab"/"scoretab" would still be offered for a staff
+    // whose paint throws (issue #165) - see disqualifyUnstrungTabStaves.
+    disqualifyUnstrungTabStaves(loadedScore);
     scoreProfiles = supportedProfiles(api.tracks?.length ? api.tracks : loadedScore.tracks);
     unrenderable = scoreProfiles.length === 0;
     if (!unrenderable && !scoreProfiles.includes(profile)) {

--- a/web/tests/browser/fixtures/navigation-score.js
+++ b/web/tests/browser/fixtures/navigation-score.js
@@ -6,19 +6,40 @@
 // and nothing short of the real loader can answer that.
 //
 // THE HEADLINE FIXTURE IS NOT BUILT HERE. It is read, byte for byte, off
-// server/tests/fixtures/engraved/navigation.musicxml - the transcription of
-// the committed navigation.pdf, produced by the extractor and checked into
-// the repository by issue #134. That file is the acceptance case, and a
-// hand-written imitation of it would only prove that this file and the spec
-// beside it agree with each other. The two built fixtures below cover the
-// shapes that transcription does NOT have: a jump crossing a repeat, and a
-// jump whose target the score never draws.
+// server/tests/fixtures/engraved/navigation.transcription.musicxml - the
+// actual output of tabextract.extract() run on the committed navigation.pdf,
+// regenerated and checked byte for byte by
+// server/tools/tab_extract/engrave_fixtures.py's write_transcriptions() (see
+// TRANSCRIPTION_FIXTURES there). A hand-written imitation of it would only
+// prove that this file and the spec beside it agree with each other. The two
+// built fixtures below cover the shapes that transcription does NOT have: a
+// jump crossing a repeat, and a jump whose target the score never draws.
+//
+// THIS USED TO READ navigation.musicxml INSTEAD (issue #165). That file is a
+// different thing entirely: the ENGRAVING SOURCE MuseScore was asked to draw
+// - two staves, notation over tab, the tab staff's notes carrying `<pitch>`
+// and no `<string>`/`<fret>` at all, because MuseScore frets them itself
+// while engraving. It was never a conforming file under
+// docs/musicxml-tab-profile.md Rule 9, and was never "produced by the
+// extractor" despite what this comment used to claim - it is the *input* to
+// MuseScore, one step before the extractor ever runs. Feeding it to alphaTab
+// as if it were a transcription crashed `TabBarRenderer.collectSpaces`
+// during paint: caught internally and logged rather than thrown, so the page
+// still reported `data-score-render-ok`, drew its play button and passed
+// every assertion here - while drawing almost nothing (12 SVG text glyphs,
+// 0 paths, measured on the unfixed page). Nothing in this file asserted
+// console output for that score, which is how it went unnoticed. See
+// NAVIGATION_UNSTRUNG_TAB_MUSICXML and stubNavigationUnstrungTabScore below,
+// which keep exercising that exact shape on purpose - now as a check that
+// the renderer degrades a staff it cannot honestly tab rather than crashing,
+// not as a stand-in for ground truth.
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import zlib from "node:zlib";
 
 const here = path.dirname(fileURLToPath(import.meta.url));
+const ENGRAVED_DIR = path.join(here, "..", "..", "..", "..", "server", "tests", "fixtures", "engraved");
 
 /**
  * The committed transcription of navigation.pdf: eight 4/4 bars carrying a
@@ -31,7 +52,22 @@ const here = path.dirname(fileURLToPath(import.meta.url));
  * all.
  */
 export const NAVIGATION_MUSICXML = fs.readFileSync(
-  path.join(here, "..", "..", "..", "..", "server", "tests", "fixtures", "engraved", "navigation.musicxml"),
+  path.join(ENGRAVED_DIR, "navigation.transcription.musicxml"),
+  "utf-8",
+);
+
+/**
+ * The ENGRAVING SOURCE navigation.pdf was drawn from - two staves, notation
+ * over tab, the tab staff's notes carrying no `<string>`/`<fret>` (issue
+ * #165; see the header comment above). Kept and read on purpose, not
+ * deleted: it is a real shape a directly-uploaded MusicXML/.mxl file can
+ * have (Fermata's own transcriptions never have it - see
+ * musicxml.build()'s note-writing branch - but nothing stops a third-party
+ * export or a hand-edited file from linking a tab staff to notation without
+ * fretting it), and the renderer must not crash on it either way.
+ */
+export const NAVIGATION_UNSTRUNG_TAB_MUSICXML = fs.readFileSync(
+  path.join(ENGRAVED_DIR, "navigation.musicxml"),
   "utf-8",
 );
 
@@ -479,6 +515,20 @@ async function stubOneScore(page, id, title, xml) {
 /** Score id 11: the committed navigation.pdf transcription. */
 export async function stubNavigationScore(page) {
   await stubOneScore(page, 11, "Navigation fixture", NAVIGATION_MUSICXML);
+}
+
+/**
+ * Score id 23: the navigation.pdf ENGRAVING SOURCE (issue #165) - two
+ * staves, notation over tab, the tab staff's notes carrying no
+ * `<string>`/`<fret>`. Before this issue's fix, opening this exact document
+ * crashed `TabBarRenderer.collectSpaces` during paint; the crash was caught
+ * internally by alphaTab and logged rather than thrown, so nothing here
+ * failed until a test actually looked at console output. See
+ * "a TAB staff the renderer cannot honestly draw degrades instead of
+ * crashing" in navigation.spec.js.
+ */
+export async function stubNavigationUnstrungTabScore(page) {
+  await stubOneScore(page, 23, "Navigation unstrung-tab fixture", NAVIGATION_UNSTRUNG_TAB_MUSICXML);
 }
 
 /** Score id 12: repeats and a D.S. al Coda in one piece. */

--- a/web/tests/browser/fixtures/navigation-score.js
+++ b/web/tests/browser/fixtures/navigation-score.js
@@ -27,8 +27,11 @@
 // during paint: caught internally and logged rather than thrown, so the page
 // still reported `data-score-render-ok`, drew its play button and passed
 // every assertion here - while drawing almost nothing (12 SVG text glyphs,
-// 0 paths, measured on the unfixed page). Nothing in this file asserted
-// console output for that score, which is how it went unnoticed. See
+// measured on the unfixed page, against 53+ once the tab staff draws - glyph
+// COUNT is what discriminates a broken render from a healthy one here, not
+// glyph TYPE: a healthy page draws 0 SVG `<path>` elements too, alphaTab
+// having nothing on this fixture it renders as one). Nothing in this file
+// asserted console output for that score, which is how it went unnoticed. See
 // NAVIGATION_UNSTRUNG_TAB_MUSICXML and stubNavigationUnstrungTabScore below,
 // which keep exercising that exact shape on purpose - now as a check that
 // the renderer degrades a staff it cannot honestly tab rather than crashing,
@@ -70,6 +73,73 @@ export const NAVIGATION_UNSTRUNG_TAB_MUSICXML = fs.readFileSync(
   path.join(ENGRAVED_DIR, "navigation.musicxml"),
   "utf-8",
 );
+
+/**
+ * The TAB-ONLY worst case disqualifyUnstrungTabStaves() has to handle
+ * (issue #165, adversarial review): one part, one staff, a TAB clef and a
+ * real six-line tuning - Fermata's own conforming shape - eight notes, seven
+ * of them correctly fretted and the eighth carrying `<string>7</string>` on
+ * a six-line staff. That is out of MusicXML's own range (strings count from
+ * 1) but still `>= 0`, so `Note.isStringed` alone says yes - it is the
+ * out-of-bounds ARRAY INDEX that crashes `TabBarRenderer.collectSpaces`, not
+ * an absent string, and this is the shape that proves the guard checks the
+ * right thing. It is also the shape where withholding tablature empties
+ * `supportedProfiles()` entirely - no notation staff to fall back to - so
+ * this is what exercises tabWithheldMessage() rather than
+ * UNRENDERABLE_MESSAGE.
+ *
+ * Hand-built rather than derived from a real score, like
+ * NAVIGATION_TWO_VOICE_MARK_MUSICXML and NAVIGATION_TIMEWISE_MUSICXML above:
+ * Fermata's own emitter never writes an out-of-range string
+ * (musicxml.build()'s `if not 1 <= string <= len(tuning): continue` drops
+ * it), so nothing in this project's own pipeline produces this shape - only
+ * a directly uploaded or hand-edited file can.
+ */
+export const TAB_ONLY_INVALID_STRING_MUSICXML = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <work><work-title>Tab-only invalid-string fixture</work-title></work>
+  <part-list>
+    <score-part id="P1"><part-name>Guitar</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>4</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>TAB</sign><line>5</line></clef>
+        <staff-details>
+          <staff-lines>6</staff-lines>
+          <staff-tuning line="1"><tuning-step>E</tuning-step><tuning-octave>2</tuning-octave></staff-tuning>
+          <staff-tuning line="2"><tuning-step>A</tuning-step><tuning-octave>2</tuning-octave></staff-tuning>
+          <staff-tuning line="3"><tuning-step>D</tuning-step><tuning-octave>3</tuning-octave></staff-tuning>
+          <staff-tuning line="4"><tuning-step>G</tuning-step><tuning-octave>3</tuning-octave></staff-tuning>
+          <staff-tuning line="5"><tuning-step>B</tuning-step><tuning-octave>3</tuning-octave></staff-tuning>
+          <staff-tuning line="6"><tuning-step>E</tuning-step><tuning-octave>4</tuning-octave></staff-tuning>
+        </staff-details>
+      </attributes>
+      <note><pitch><step>E</step><octave>2</octave></pitch><duration>4</duration><voice>1</voice><type>quarter</type>
+        <notations><technical><string>6</string><fret>0</fret></technical></notations></note>
+      <note><pitch><step>A</step><octave>2</octave></pitch><duration>4</duration><voice>1</voice><type>quarter</type>
+        <notations><technical><string>5</string><fret>0</fret></technical></notations></note>
+      <note><pitch><step>D</step><octave>3</octave></pitch><duration>4</duration><voice>1</voice><type>quarter</type>
+        <notations><technical><string>7</string><fret>0</fret></technical></notations></note>
+      <note><pitch><step>G</step><octave>3</octave></pitch><duration>4</duration><voice>1</voice><type>quarter</type>
+        <notations><technical><string>3</string><fret>0</fret></technical></notations></note>
+    </measure>
+    <measure number="2">
+      <note><pitch><step>B</step><octave>3</octave></pitch><duration>4</duration><voice>1</voice><type>quarter</type>
+        <notations><technical><string>2</string><fret>0</fret></technical></notations></note>
+      <note><pitch><step>E</step><octave>4</octave></pitch><duration>4</duration><voice>1</voice><type>quarter</type>
+        <notations><technical><string>1</string><fret>0</fret></technical></notations></note>
+      <note><pitch><step>G</step><octave>4</octave></pitch><duration>4</duration><voice>1</voice><type>quarter</type>
+        <notations><technical><string>1</string><fret>3</fret></technical></notations></note>
+      <note><pitch><step>A</step><octave>4</octave></pitch><duration>4</duration><voice>1</voice><type>quarter</type>
+        <notations><technical><string>1</string><fret>5</fret></technical></notations></note>
+    </measure>
+  </part>
+</score-partwise>
+`;
 
 const DIVISIONS = 480; // ticks per quarter note
 const PITCHES = ["C", "D", "E", "F", "G", "A", "B", "C"];
@@ -529,6 +599,17 @@ export async function stubNavigationScore(page) {
  */
 export async function stubNavigationUnstrungTabScore(page) {
   await stubOneScore(page, 23, "Navigation unstrung-tab fixture", NAVIGATION_UNSTRUNG_TAB_MUSICXML);
+}
+
+/**
+ * Score id 24: the TAB-ONLY worst case (issue #165 adversarial review) - a
+ * single TAB staff, no notation staff to fall back to, one of its eight
+ * notes carrying an out-of-range `<string>7</string>`. Withholding
+ * tablature here empties supportedProfiles() entirely, which is what
+ * exercises tabWithheldMessage() rather than a partial degradation.
+ */
+export async function stubNavigationTabOnlyInvalidStringScore(page) {
+  await stubOneScore(page, 24, "Navigation tab-only invalid-string fixture", TAB_ONLY_INVALID_STRING_MUSICXML);
 }
 
 /** Score id 12: repeats and a D.S. al Coda in one piece. */

--- a/web/tests/browser/navigation.spec.js
+++ b/web/tests/browser/navigation.spec.js
@@ -66,7 +66,9 @@ import {
   stubNavigationTimewiseScore,
   stubNavigationUnresolvedScore,
   stubNavigationUnstrungTabScore,
+  stubNavigationTabOnlyInvalidStringScore,
 } from "./fixtures/navigation-score.js";
+import { tabWithheldMessage, UNRENDERABLE_MESSAGE } from "../../src/lib/score-render.js";
 
 const host = (page) => page.locator(".at-host");
 const playButton = (page) => page.locator(".player button.primary");
@@ -412,6 +414,30 @@ async function drawnGlyphCount(page) {
   return await page.evaluate(() => document.querySelectorAll(".at-host svg text").length);
 }
 
+/** `data-score-profiles`, split on its comma delimiter (publish() in
+ * score-render.js writes `scoreProfiles.join(",")`) - [] once a score has
+ * loaded and found nothing drawable, since "".split(",") is [""] not []. */
+async function dataScoreProfiles(page) {
+  const raw = await host(page).getAttribute("data-score-profiles");
+  return raw ? raw.split(",") : [];
+}
+
+/** `data-score-tab-withheld` - the count disqualifyUnstrungTabStaves()
+ * disqualified, as a string, or null when the attribute is absent (nothing
+ * withheld - see its own delete call in score-render.js's scoreLoaded
+ * handler). */
+async function dataScoreTabWithheld(page) {
+  return await host(page).getAttribute("data-score-tab-withheld");
+}
+
+/** The empty-state notice's text, or null when that element is not in the
+ * DOM at all (a score that DOES have something drawable never renders
+ * `.notice`). */
+async function noticeText(page) {
+  const notice = page.locator(".notice");
+  return (await notice.count()) ? await notice.textContent() : null;
+}
+
 test.describe("a TAB staff without a fretted position does not crash the renderer", () => {
   test("the real navigation.pdf transcription renders clean, with tab glyphs drawn", async ({
     page,
@@ -433,8 +459,13 @@ test.describe("a TAB staff without a fretted position does not crash the rendere
     // of the fixture actually drew. The real transcription draws its full
     // eight bars of tab digits and navigation text; > 40 is comfortably past
     // "a handful of leftover notation glyphs" and nowhere near a tight pin
-    // on the exact digit count.
+    // on the exact digit count. (A healthy page also draws 0 SVG <path>
+    // elements on this fixture - alphaTab has nothing here it renders as
+    // one - so glyph COUNT is what discriminates a broken render, not glyph
+    // type; see fixtures/navigation-score.js's header comment.)
     expect(await drawnGlyphCount(page)).toBeGreaterThan(40);
+    // Nothing was withheld: every note in the real transcription is fretted.
+    expect(await dataScoreTabWithheld(page)).toBeNull();
   });
 
   test("a staff whose tab notes are not all fretted degrades instead of crashing", async ({
@@ -459,5 +490,61 @@ test.describe("a TAB staff without a fretted position does not crash the rendere
     // full - only the tab staff's rendering is turned off - so this is well
     // past the 12-glyph broken count without pinning an exact number.
     expect(await drawnGlyphCount(page)).toBeGreaterThan(40);
+    // The strong assertion, not just "still draws something": the tab
+    // profile was actually dropped from what this score offers, while the
+    // notation half - a real staff, unaffected by the other one's defect -
+    // stayed offered. Asserting only the glyph count above could pass for
+    // the wrong reason (e.g. a bug that left "tab" offered but drew nothing
+    // under it); this reads the renderer's own account of what it decided.
+    const profiles = await dataScoreProfiles(page);
+    expect(profiles).not.toContain("tab");
+    expect(profiles).toContain("score");
+    // Disclosed, not silently dropped (issue #165 review): one staff was
+    // withheld, and a person with devtools open (or a future test) can see
+    // it and why - see disqualifyUnstrungTabStaves's own dataset write.
+    expect(await dataScoreTabWithheld(page)).toBe("1");
+    // This score still has a notation staff to fall back to, so it is not
+    // the "nothing left to draw" case - no notice element at all.
+    expect(await noticeText(page)).toBeNull();
+  });
+
+  test("a TAB-only score with one out-of-range string degrades and discloses why, not the generic empty-score notice", async ({
+    page,
+  }) => {
+    // The adversarial-review shape: isStringed() alone (string >= 0) is NOT
+    // the crash condition - alphaTab maps a <string> element's value S to
+    // note.string = tuning.length - S + 1 with no range check, so
+    // <string>7</string> on a 6-line staff round-trips to note.string = 0,
+    // which still satisfies isStringed and still runs
+    // collectSpaces's `spaces[tuning.length - note.string]` off the end of
+    // its own array. Guarding on isStringed instead of the 1..tuning.length
+    // range reproduces the exact original crash here - see the mutation
+    // record for this file.
+    //
+    // This is also the ONE staff the score has - no notation staff to fall
+    // back to - so withholding it empties supportedProfiles() entirely, and
+    // the generic UNRENDERABLE_MESSAGE ("no notation or tablature") would be
+    // false: this score has a TAB clef, a real six-line tuning and seven of
+    // its eight notes correctly fretted.
+    // Not openScore(): this score is genuinely unrenderable (every staff
+    // disqualified, supportedProfiles() empty), so data-score-render-ok
+    // never becomes "true" and the play button's own readiness is a
+    // different question from the one this test asks. publish() still
+    // writes data-score-profiles as soon as scoreLoaded runs, though - ""
+    // once profiles is known to be empty, present (not absent) precisely
+    // because a score HAS loaded - so waiting on that value is the correct
+    // sync point for "this score's degraded/disclosed state has settled".
+    const errors = watchForErrors(page);
+    await stubNavigationTabOnlyInvalidStringScore(page);
+    await page.goto("/#/score/24");
+    await expect(host(page)).toHaveAttribute("data-score-profiles", "", { timeout: 30_000 });
+    await page.waitForTimeout(500);
+    expect(errors.consoleErrors).toEqual([]);
+    expect(errors.pageErrors).toEqual([]);
+    expect(await dataScoreTabWithheld(page)).toBe("1");
+    expect(await dataScoreProfiles(page)).toEqual([]);
+    const text = await noticeText(page);
+    expect(text).toBe(tabWithheldMessage(1));
+    expect(text).not.toBe(UNRENDERABLE_MESSAGE);
   });
 });

--- a/web/tests/browser/navigation.spec.js
+++ b/web/tests/browser/navigation.spec.js
@@ -65,6 +65,7 @@ import {
   stubNavigationScore,
   stubNavigationTimewiseScore,
   stubNavigationUnresolvedScore,
+  stubNavigationUnstrungTabScore,
 } from "./fixtures/navigation-score.js";
 
 const host = (page) => page.locator(".at-host");
@@ -383,5 +384,80 @@ test.describe("navigation marks reach playback", () => {
         timeout: 90_000,
       })
       .toBe("1 2 3 4 1 2 6");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Issue #165: a TAB-staff note with no <string> must not crash the renderer
+// ---------------------------------------------------------------------------
+
+/** Every console message Playwright reports as an error, plus any uncaught
+ * page exception - the check "the committed navigation transcription plays
+ * the form it carries" above never made, which is exactly how issue #165's
+ * crash went unnoticed: alphaTab catches TabBarRenderer's paint exceptions
+ * internally and logs them rather than throwing, so a page that draws almost
+ * nothing can still set data-score-render-ok, enable the play button and
+ * pass every assertion that does not itself read the console. */
+function watchForErrors(page) {
+  const consoleErrors = [];
+  const pageErrors = [];
+  page.on("console", (m) => {
+    if (m.type() === "error") consoleErrors.push(m.text());
+  });
+  page.on("pageerror", (e) => pageErrors.push(String(e)));
+  return { consoleErrors, pageErrors };
+}
+
+async function drawnGlyphCount(page) {
+  return await page.evaluate(() => document.querySelectorAll(".at-host svg text").length);
+}
+
+test.describe("a TAB staff without a fretted position does not crash the renderer", () => {
+  test("the real navigation.pdf transcription renders clean, with tab glyphs drawn", async ({
+    page,
+  }) => {
+    // The ground truth for issue #165's own "Verifying" checklist: every
+    // TAB-staff note in the committed transcription carries <string> and
+    // <fret> (see server/tests/test_engraved_fixtures.py's and
+    // test_tabextract.py's Rule 9 sweeps for the structural proof), so this
+    // is the render-side half - the score page actually draws it, with
+    // nothing logged to the console.
+    const errors = watchForErrors(page);
+    await stubNavigationScore(page);
+    await openScore(page, 11);
+    await page.waitForTimeout(1000);
+    expect(errors.consoleErrors).toEqual([]);
+    expect(errors.pageErrors).toEqual([]);
+    // Measured on the unfixed page (reading navigation.musicxml, the
+    // engraving source, straight into alphaTab): 12 glyphs - almost nothing
+    // of the fixture actually drew. The real transcription draws its full
+    // eight bars of tab digits and navigation text; > 40 is comfortably past
+    // "a handful of leftover notation glyphs" and nowhere near a tight pin
+    // on the exact digit count.
+    expect(await drawnGlyphCount(page)).toBeGreaterThan(40);
+  });
+
+  test("a staff whose tab notes are not all fretted degrades instead of crashing", async ({
+    page,
+  }) => {
+    // Issue #165's actual reproduction: navigation.pdf's own ENGRAVING
+    // SOURCE (two staves, notation over tab, the tab staff's notes carrying
+    // no <string>/<fret> because MuseScore frets them itself while
+    // engraving) fed to the real renderer as if it were a score - the shape
+    // a directly uploaded MusicXML/.mxl file can legally have even though
+    // Fermata's own transcriptions never produce it. Before
+    // disqualifyUnstrungTabStaves existed, this threw straight out of
+    // TabBarRenderer.paintStaffLines (caught and logged by alphaTab, not
+    // re-thrown - see watchForErrors above), drawing 12 glyphs total.
+    const errors = watchForErrors(page);
+    await stubNavigationUnstrungTabScore(page);
+    await openScore(page, 23);
+    await page.waitForTimeout(1000);
+    expect(errors.consoleErrors).toEqual([]);
+    expect(errors.pageErrors).toEqual([]);
+    // The notation staff (the same 32 notes, standard clef) still draws in
+    // full - only the tab staff's rendering is turned off - so this is well
+    // past the 12-glyph broken count without pinning an exact number.
+    expect(await drawnGlyphCount(page)).toBeGreaterThan(40);
   });
 });

--- a/web/tests/spec-floors/browser-navigation-165.json
+++ b/web/tests/spec-floors/browser-navigation-165.json
@@ -1,5 +1,5 @@
 {
   "file": "tests/browser/navigation.spec.js",
-  "count": 2,
-  "reason": "issue #165: a TAB-staff note with no fretted position must not crash the renderer's paint - the real navigation.pdf transcription renders clean with tab glyphs drawn, and a staff whose tab data is under-specified (a shape Fermata's own emitter never produces, but a directly uploaded MusicXML/.mxl file can) degrades to notation-only instead of throwing out of TabBarRenderer.collectSpaces."
+  "count": 3,
+  "reason": "issue #165: a TAB-staff note with no fretted position must not crash the renderer's paint - the real navigation.pdf transcription renders clean with tab glyphs drawn, a notation+tab score whose tab data is under-specified degrades to notation-only (and discloses withholding it) instead of throwing out of TabBarRenderer.collectSpaces, and a TAB-only score with one out-of-range <string> (isStringed() alone is not the crash condition - it is an array index) degrades and shows a distinct notice rather than the generic 'no notation or tablature' one."
 }

--- a/web/tests/spec-floors/browser-navigation-165.json
+++ b/web/tests/spec-floors/browser-navigation-165.json
@@ -1,0 +1,5 @@
+{
+  "file": "tests/browser/navigation.spec.js",
+  "count": 2,
+  "reason": "issue #165: a TAB-staff note with no fretted position must not crash the renderer's paint - the real navigation.pdf transcription renders clean with tab glyphs drawn, and a staff whose tab data is under-specified (a shape Fermata's own emitter never produces, but a directly uploaded MusicXML/.mxl file can) degrades to notation-only instead of throwing out of TabBarRenderer.collectSpaces."
+}


### PR DESCRIPTION
Closes #165

## Diagnosis

Neither `tabextract.py`'s string assignment nor `musicxml.py`'s note emission has a gap. `musicxml.build()` writes a sounding note with a full `(string, fret, midi)` triple or writes no pitched note at all - never one in between (see the `if not writable` / `else` split in `build()`). Printed evidence:

- `tabextract.extract(navigation.pdf)` on its own produces 32 sounding notes, all 32 carrying `<string>`/`<fret>`.
- A sweep of every score `tabextract.extract()` can read found **0** stringless sounding notes, before this change and after (the emission path is untouched, see below). This headline number aggregates two separate tests: `test_library_wide_every_sounding_note_carries_string_and_fret` (297 library PDFs, `test_tabextract.py`) and `test_every_engraved_fixtures_sounding_note_carries_string_and_fret` (30 committed engraved fixtures, `test_engraved_fixtures.py`) - 327 PDFs and 0 stringless notes combined, 6 of the 327 correctly non-extractable (raster scan / notation-only).

The crash was a **fixture-generation/mislabeling gap**: `web/tests/browser/fixtures/navigation-score.js` read `server/tests/fixtures/engraved/navigation.musicxml` and, in its own comment, called it "the transcription of the committed navigation.pdf, produced by the extractor." It is not - that file is the two-staff MuseScore **engraving source**, whose tab-staff notes carry `<pitch>` and no `<string>`/`<fret>` at all because MuseScore assigns frets itself while engraving. Feeding it straight to alphaTab reproduced the exact crash the issue names:

```
[AlphaTab][API] An unexpected error occurred TypeError: Cannot read properties of undefined (reading 'push')
    at collectSpaces ...
    at paintStaffLines ...
```

`TabBarRenderer.collectSpaces` indexes `spaces[tuning.length - note.string]` with no bounds check. alphaTab catches the exception inside its own API layer and only logs it, so the page still reported `data-score-render-ok`, enabled the play button and passed every existing assertion - while drawing 12 SVG text glyphs (a healthy render of this fixture draws 0 SVG `<path>` elements too, so glyph *count* is what discriminates a broken render here, not glyph type). Nothing in the test suite checked console output for that score, which is how it went unnoticed.

## Fix

Three parts:

1. **The browser fixture now reads real ground truth.** `navigation-score.js`'s `NAVIGATION_MUSICXML` reads a new committed file, `navigation.transcription.musicxml` - the actual output of `tabextract.extract()` on the committed `navigation.pdf`, regenerated and checked byte-for-byte (modulo a pinned `<encoding-date>`) by a new `write_transcriptions()` in `engrave_fixtures.py`, wired into `--check`, and now also validated against the MusicXML 4.0 XSD by its own test (neither of `test_musicxml.py`'s two existing XSD checks reads this file). The old two-staff document is kept, renamed `NAVIGATION_UNSTRUNG_TAB_MUSICXML`, and repurposed as a deliberate regression case. This is currently the only fixture with a committed transcription artifact - `TRANSCRIPTION_FIXTURES` names it explicitly, so the count is honest as the set grows.

2. **The renderer no longer trusts a TAB staff's notes - and checks the right thing.** `score-render.js` gained `disqualifyUnstrungTabStaves()`, called from `scoreLoaded` before `supportedProfiles()`: any staff declared as tablature whose notes are not all *fretted* has `showTablature` turned off before the first render. An earlier version of this guard checked `note.isStringed` (`string >= 0`), which a first review round caught as wrong: alphaTab maps a MusicXML `<string>` value S to `note.string = tuning.length - S + 1` with **no range check**, so `<string>0</string>` on a 6-line staff becomes `note.string = 7` and `<string>7</string>` becomes `note.string = 0` - both still `>= 0`, both still crash `collectSpaces`. The guard now checks the actual separating condition, `1 <= note.string <= staff.tuning.length`, verified against a new TAB-only fixture with one out-of-range `<string>7</string>` on a six-line staff (reproduced on the wrong predicate, confirmed fixed on the right one).

3. **Withholding tablature is disclosed, and the empty-score notice tells the truth.** `host.dataset.scoreTabWithheld` (deleted when nothing was withheld) plus a `console.info`, mirroring the pattern `applyLoadedNavigation` already uses for an unread navigation mark twenty lines above it. And the worst case - a TAB-only score where withholding its one staff empties `supportedProfiles()` entirely - used to show "This score has no notation or tablature the staff view can draw", which is false for a score with a TAB clef, a real tuning and mostly-good notes. It now shows a distinct, honest message (`tabWithheldMessage`) instead.

Documented in `docs/musicxml-tab-profile.md` beside Rule 9, in `docs/rendering.md`'s "Asking the renderer what it can draw" (the offered menu is no longer purely `canCreate`'s own answer - this layer removes a staff first, the same lever the pre-existing percussion case uses, just thrown by Fermata instead of alphaTab), and in `server/tests/fixtures/engraved/README.md`.

## Verification

**Library sweep (Rule 9), before and after** - identical, because `server/fermata/musicxml.py` and `server/fermata/tabextract.py` are untouched by this change (`git diff origin/main -- server/fermata/musicxml.py server/fermata/tabextract.py` is empty): 327 PDFs (297 library + 30 fixtures) swept across two tests, 0 stringless sounding notes both times.

**Every other score's output is byte-identical.** SHA-256 of `tabextract.extract()`'s `.musicxml` for all 327 PDFs, computed on the pre-fix tree (`git stash`) and the post-fix tree: `diff` between the two hash files is empty.

**The fixture renders clean, and the crash is genuinely gone - not just for this one fixture.** Three tests in `navigation.spec.js`:
- the real `navigation.pdf` transcription (score 11) renders with 0 console errors, 0 page errors, >40 drawn SVG glyphs (was 12, unfixed), nothing withheld.
- a notation+tab score whose tab data is under-specified (score 23) degrades instead of crashing: 0 console errors, `data-score-profiles` actually drops `"tab"` while keeping `"score"` (not just "still draws something"), `data-score-tab-withheld` = `"1"`, no empty-score notice (this score still has notation to fall back to).
- a TAB-only score with one out-of-range `<string>7</string>` on a six-line staff (score 24, new): 0 console errors, `data-score-profiles` is empty, `data-score-tab-withheld` = `"1"`, and the notice shown is the distinct `tabWithheldMessage`, not the generic `UNRENDERABLE_MESSAGE`.

**XSD.** `navigation.transcription.musicxml` validates against MusicXML 4.0's schema, checked by its own new test (`test_the_committed_transcriptions_validate_against_xsd`) since neither existing XSD test reads it.

**`engrave_fixtures.py --check`** stays green.

**Mutation testing**, each applied, rebuilt, confirmed red, reverted:
- `musicxml.py`: made `_append_note` skip `<notations>` for `string == 1` - the Rule 9 sweep tests failed.
- `score-render.js` (first round): reverted `disqualifyUnstrungTabStaves` entirely - reproduced the original crash on the notation+tab fixture.
- `score-render.js` (review fix): reverted the range check back to `isStringed` alone - the new TAB-only out-of-range-string test failed (the guard never fired, `data-score-profiles` stayed `"tab,scoretab"` instead of going empty) and a direct console probe on the same input reproduced the identical `collectSpaces` stack trace verbatim.

**Full suites, derived baselines** (`FERMATA_TEST_LIBRARY` set, `FERMATA_MUSICXML_XSD` set, `web/node_modules` junctioned from the main checkout):
- Python: before **904 passed**, 0 failed, 0 skipped -> after **908 passed** (+4 new tests: 3 from the first round, +1 XSD test from review), 0 failed, 0 skipped.
- Web browser/unit: before **327 tests** -> after **330 tests** (+3 new: 2 from the first round, +1 TAB-only case from review), all passing both times.

## Test plan

- [x] `pytest -rs` (library + XSD configured) - 908 passed, 0 failed, 0 skipped
- [x] `npm run test:browser` - 330 passed, spec-floor guard green
- [x] `python server/tools/tab_extract/engrave_fixtures.py --check` - green
- [x] Mutation-tested the Python emitter, and both the original guard and the corrected predicate on the JS side
- [x] Library-wide Rule 9 sweep (327 PDFs across two tests): 0 stringless before and after
- [x] Per-score MusicXML output byte-identical before/after (SHA-256 diff empty)
- [x] Withheld-tablature disclosure and the distinct empty-score notice, specced against both a partial (notation+tab) and total (tab-only) degradation
