### PR TITLE
Move, rename, delete and reorganise scores from the library (#56)

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,16 @@ them.
 - **Organize** — collections (from your folder layout), free-form tags,
   favorites, content-type labels (notation / tab / both), full-text search,
   and duplicate detection by file contents.
+- **Reorganize, from the app** — move and rename scores, make and rename
+  folders, move a batch in one go. The change is applied to the real file on
+  disk and the score follows it, so its practice history, tags, goals and any
+  transcription stay attached. Every bulk move shows you exactly what it will
+  do before it does it, and nothing is ever overwritten.
+- **Delete that isn't destruction** — deleting a score moves its file to a
+  trash folder inside your library and keeps everything hanging off it; Trash
+  puts it back exactly as it was. Destroying it for good is a separate,
+  deliberate second step that tells you what it will destroy — and even then,
+  the practice you logged against it stays in your history.
 - **Upload** — drag files in through the browser; they land in your library
   folder and are indexed immediately.
 - **Single container** — SQLite inside, two volume mounts, no external

--- a/docs/api.md
+++ b/docs/api.md
@@ -142,8 +142,12 @@ so every endpoint that takes a score id can still reach one:
 - **Practice already logged is untouched and still counted.** A deleted score
   still appears in `practice/summary`'s `top_scores` and in `practice/history`'s
   `by_score`, with its hours — dropping it would leave those breakdowns not
-  adding up to the totals beside them. Both now carry `deleted: true` so a
-  client can stop offering a route into a score the library no longer holds.
+  adding up to the totals beside them. Both carry `deleted: true`, and
+  `practice/sessions` carries `score_deleted: true` on each session naming that
+  piece, so a client can stop offering a route into a score the library no
+  longer holds. `score_deleted` is **not** `score_missing`: the first means the
+  score is in the trash and can be put back, the second means its row is gone
+  and there is no piece left to name.
 
 Deleting a score whose file has **already** gone is allowed and answers
 `file_moved: false` with `trashed_to: null` — nothing was moved, because there

--- a/docs/api.md
+++ b/docs/api.md
@@ -118,10 +118,38 @@ instead - which is why renaming a file and renaming a piece are two different
 requests here.
 
 A move or a delete is refused with `409` while a library scan is running, and a
-scan declines to start while one is being applied. One thing reconciles the
-library at a time: a scan decides what to write from a directory listing taken
-when it started, so a file moving underneath it would read as a file that went
-missing.
+scan declines to start while one is being applied. One thing that **moves or
+removes an existing file** runs at a time: a scan decides what to write from a
+directory listing taken when it started, so a file moving underneath it would
+read as a file that went missing. `POST /api/upload` and `POST
+/api/library/folders` are deliberately outside that rule — the first only ever
+creates a file at a path nothing claims, the second creates a directory — and
+`scanner.hold_library_still` documents why each is safe.
+
+### What a deleted score may still be asked for
+
+A deleted score's row is still there, which is what makes deleting recoverable,
+so every endpoint that takes a score id can still reach one:
+
+- **Reads answer normally** — `GET /api/scores/{id}`, its `/file`, `/thumb`,
+  `/transcription` and `/practice`. The trash view is built out of exactly those
+  responses, and being able to look at a score before destroying it for ever is
+  the point of a trash you can change your mind from.
+- **Writes are refused with `409`** — `PATCH /api/scores/{id}`, logging practice
+  against it by either route, setting a goal about it, and extracting, saving or
+  deleting its transcription. Each means "work on this piece"; nothing in the
+  interface offers them for a score in the trash.
+- **Practice already logged is untouched and still counted.** A deleted score
+  still appears in `practice/summary`'s `top_scores` and in `practice/history`'s
+  `by_score`, with its hours — dropping it would leave those breakdowns not
+  adding up to the totals beside them. Both now carry `deleted: true` so a
+  client can stop offering a route into a score the library no longer holds.
+
+Deleting a score whose file has **already** gone is allowed and answers
+`file_moved: false` with `trashed_to: null` — nothing was moved, because there
+was nothing to move. Restoring it (or any score whose trashed file has since
+been removed by hand) answers `file_restored: false` and puts the score back in
+the library flagged `missing_since`, which is the state it was in before.
 
 ## Who else reads this contract
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -74,6 +74,55 @@ column - is documented in more depth in
 transcription endpoints read and write is documented in
 [docs/musicxml-tab-profile.md](musicxml-tab-profile.md).
 
+## The endpoints that write to your files
+
+Everything else in this API reads the library and writes only to Fermata's own
+database. The library-management endpoints (issue #56) move, rename and delete
+a person's own sheet music, so they are documented here as a group as well as
+individually in `/docs`:
+
+| Endpoint | What it does |
+| --- | --- |
+| `POST /api/scores/{id}/move` | Moves one score's file to another folder, renames it, or both. |
+| `POST /api/library/move` | Moves several scores into one folder. **Dry run by default.** |
+| `GET /api/library/folders` | The library's folder tree, for offering destinations. |
+| `POST /api/library/folders` | Creates a folder. |
+| `POST /api/library/folders/rename` | Renames a folder, taking its scores with it. **Dry run by default.** |
+| `DELETE /api/scores/{id}` | Deletes a score: the file goes to the trash, the row and its history stay. |
+| `GET /api/trash` | Scores that have been deleted and not destroyed. |
+| `POST /api/trash/{id}/restore` | Puts a deleted score back where it came from. |
+| `DELETE /api/trash/{id}` | Destroys a deleted score for good. The only endpoint here that really deletes. |
+
+Five rules hold across all of them, and a client can rely on each:
+
+- **Nothing is written outside the library folder.** The check is on the
+  resolved path, so a symlink out of the library is refused as well as a `..`.
+- **Deleting is a move.** The file goes to a `.fermata-trash` folder inside the
+  library and the score row is marked with `deleted_at`; its practice sessions,
+  goals, tags and transcription stay attached, and the response counts each of
+  them. Destroying takes a second, deliberate request.
+- **Nothing is destroyed as a side effect of an organisational change.** A move
+  onto an existing file is refused rather than overwriting it, and a batch
+  containing one blocked line applies none of it.
+- **A bulk operation is a dry run unless `dry_run: false` is sent.** The
+  response shape is the same either way, so the preview is a preview of the
+  thing itself.
+- **The score row follows the file by content hash** - the same identity test
+  the scanner's relink uses - so a move cannot attach one score's practice
+  history to another score's music.
+
+Moving a file re-derives only `collection` and `series`, which are read off the
+folders. `title`, `composer` and `source` are statements about the music, can
+have been corrected by hand, and are edited with `PATCH /api/scores/{id}`
+instead - which is why renaming a file and renaming a piece are two different
+requests here.
+
+A move or a delete is refused with `409` while a library scan is running, and a
+scan declines to start while one is being applied. One thing reconciles the
+library at a time: a scan decides what to write from a directory listing taken
+when it started, so a file moving underneath it would read as a file that went
+missing.
+
 ## Who else reads this contract
 
 A planned companion server speaks the Model Context Protocol, an open

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -127,9 +127,12 @@ you either put it back or destroy it deliberately. Three things follow:
   leave it.
 - **If you back up `library/` too, back up that folder with it** — or, if you
   would rather not carry deleted files around, empty the Trash view first.
-  Deleting the folder by hand is safe for your database (nothing is lost from
-  it) but it does destroy those files, and the scores will then say they
-  cannot be put back.
+  Deleting the folder by hand is safe for your database: nothing is lost from
+  it, and the scores can still be put back. What comes back in that case is the
+  score — its practice history, tags, goals and transcription — flagged as
+  **file missing**, which is the same state any score whose file has gone shows.
+  Put the file back in your library, scan, and it recovers by itself. The bytes
+  you deleted by hand are gone, though; Fermata cannot get those back.
 
 ### Taking a backup
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -113,6 +113,24 @@ transcriptions live only in the database in that folder. Losing `config/`
 without a backup means losing that work, even though every PDF is still
 sitting untouched in `library/`.
 
+### The one folder in `library/` that is Fermata's
+
+Deleting a score in Fermata does not delete the file. It moves it to
+`library/.fermata-trash/`, and the score — with its practice history, tags,
+goals and transcription — stays in the database, listed under **Trash**, until
+you either put it back or destroy it deliberately. Three things follow:
+
+- **Scans ignore that folder entirely**, so nothing in it is ever taken for a
+  score in your library, and nothing you deleted quietly comes back.
+- **It counts toward your disk usage** until you empty it. Nothing empties it
+  on a timer; a deleted score stays deleted-not-destroyed for as long as you
+  leave it.
+- **If you back up `library/` too, back up that folder with it** — or, if you
+  would rather not carry deleted files around, empty the Trash view first.
+  Deleting the folder by hand is safe for your database (nothing is lost from
+  it) but it does destroy those files, and the scores will then say they
+  cannot be put back.
+
 ### Taking a backup
 
 Stop the container first, so the database isn't being written to mid-copy:

--- a/server/fermata/api.py
+++ b/server/fermata/api.py
@@ -2295,12 +2295,27 @@ def _relink_moved_file(conn, row, dest_rel: str) -> None:
             "Scan the library and try again.",
         )
     stat = dest.stat()
+    _repoint_row(conn, row["id"], dest_rel, stat.st_size, stat.st_mtime)
+
+
+def _repoint_row(conn, score_id: int, dest_rel: str, size=None, mtime=None) -> None:
+    """Say where a score's file is now, and re-derive the two fields that
+    describe where it lives.
+
+    `size` and `mtime` are omitted for a score whose file is NOT THERE - see
+    rename_folder, which has to carry a score marked missing along with the
+    folder it is filed under. There is nothing to stat, and the figures the row
+    already carries are the last true ones: overwriting them with zeroes would
+    make the scanner's unchanged-file shortcut re-read the file the day it comes
+    back, which is harmless, and would make the stored size a lie in the
+    meantime, which is not.
+    """
     collection, series = _location_fields(dest_rel)
-    conn.execute(
-        """UPDATE scores SET path = ?, collection = ?, series = ?, size = ?, mtime = ?
-           WHERE id = ?""",
-        (dest_rel, collection, series, stat.st_size, stat.st_mtime, row["id"]),
-    )
+    fields = {"path": dest_rel, "collection": collection, "series": series}
+    if size is not None:
+        fields["size"], fields["mtime"] = size, mtime
+    sets = ", ".join(f"{k} = ?" for k in fields)
+    conn.execute(f"UPDATE scores SET {sets} WHERE id = ?", [*fields.values(), score_id])
 
 
 def _plan_line(row, dest_rel: str, status: str, reason: str | None = None) -> dict:
@@ -2646,12 +2661,26 @@ def rename_folder(body: FolderRenameIn):
     try:
         with scanner.hold_library_still():
             with write_tx() as conn:
-                rows = conn.execute(
-                    "SELECT * FROM scores WHERE deleted_at IS NULL AND path LIKE ?"
-                    " ORDER BY path",
-                    (prefix.replace("%", r"\%").replace("_", r"\_") + "%",),
-                ).fetchall()
-                rows = [r for r in rows if r["path"].startswith(prefix)]
+                # ESCAPE IS NOT OPTIONAL HERE. `_` is a single-character
+                # wildcard in LIKE, and folder names full of underscores are
+                # exactly what this library's own filenames look like
+                # ("Terra_s Theme"). Without the escape clause the escaping
+                # below would be literal backslashes in the pattern and a folder
+                # with an underscore in its name would match NOTHING - so
+                # renaming it would move the folder on disk and re-point not one
+                # score, silently. The startswith() pass after it is the belt to
+                # this brace: LIKE is what lets SQLite use the index, and Python
+                # is what decides.
+                pattern = prefix.replace("\\", r"\\").replace("%", r"\%").replace("_", r"\_")
+                rows = [
+                    r
+                    for r in conn.execute(
+                        "SELECT * FROM scores WHERE deleted_at IS NULL"
+                        " AND path LIKE ? ESCAPE '\\' ORDER BY path",
+                        (pattern + "%",),
+                    ).fetchall()
+                    if r["path"].startswith(prefix)
+                ]
                 plan = []
                 for r in rows:
                     dest_rel = to_rel + "/" + r["path"][len(prefix):]
@@ -2686,7 +2715,18 @@ def rename_folder(body: FolderRenameIn):
                     try:
                         for line in plan:
                             row = _score_row(conn, line["score_id"])
-                            _relink_moved_file(conn, row, line["to_path"])
+                            if row["missing_since"] is not None:
+                                # A score under this folder whose file is not
+                                # there. It still has to follow the rename, or
+                                # it is left filed under a folder name that no
+                                # longer exists - and there is nothing to hash,
+                                # so the content check _relink_moved_file makes
+                                # would be a FileNotFoundError and a 500 for the
+                                # ordinary case of renaming a folder holding one
+                                # score whose file went astray.
+                                _repoint_row(conn, row["id"], line["to_path"])
+                            else:
+                                _relink_moved_file(conn, row, line["to_path"])
                     except Exception:
                         dest.rename(source)
                         raise
@@ -2738,6 +2778,27 @@ def _free_path(rel: str, conn=None, exclude_id: int | None = None) -> str:
     raise HTTPException(409, f"nothing could be put back at {rel} - a thousand names were taken")
 
 
+def _tidy_trash_folder(rel: str) -> None:
+    """Remove a per-score trash folder once its file has left it.
+
+    Only ever the one folder, only when it is empty, and only inside the trash -
+    so this cannot reach anything of the person's. Without it the trash fills up
+    with empty numbered directories, one per score ever deleted, which is a
+    small thing that makes the folder look like a mess a person might be tempted
+    to clear out by hand.
+
+    Failure is deliberately silent: a leftover empty folder is not worth failing
+    a restore that has already succeeded over.
+    """
+    parts = PurePosixPath(rel).parts
+    if len(parts) < 2 or parts[0] != scanner.TRASH_DIR_NAME:
+        return
+    try:
+        _resolve_in_library("/".join(parts[:2])).rmdir()
+    except OSError:
+        pass
+
+
 def _attached_counts(conn, score_id: int) -> dict:
     """How much of somebody's own work is hanging off this score row.
 
@@ -2785,7 +2846,7 @@ def delete_score(score_id: RowId):
                 # and cannot collide, and the folder says which row the file
                 # belongs to if anybody ever looks in there by hand.
                 trash_rel = f"{scanner.TRASH_DIR_NAME}/{score_id}/{name}"
-                trash_rel = _free_path(trash_rel)
+                trash_rel = _free_path(trash_rel, conn, exclude_id=score_id)
                 source = _resolve_in_library(row["path"])
                 if source.is_file():
                     _move_file_on_disk(source, _resolve_in_library(trash_rel))
@@ -2872,6 +2933,7 @@ def restore_score(score_id: RowId):
                     (score_id,),
                 )
                 _relink_moved_file(conn, row, target)
+                _tidy_trash_folder(row["path"])
     except scanner.LibraryBusy as exc:
         raise _busy(exc) from None
     conn = connect()
@@ -2915,6 +2977,7 @@ def purge_score(score_id: RowId):
                     # Fermata itself put in its own trash folder.
                     path.unlink()
                     removed = row["path"]
+                    _tidy_trash_folder(row["path"])
                 conn.execute("DELETE FROM scores WHERE id = ?", (score_id,))
                 scanner.record_deliberate_shrink(conn)
                 title = row["title"]

--- a/server/fermata/api.py
+++ b/server/fermata/api.py
@@ -2337,6 +2337,19 @@ def _plan_move(conn, row, dest_rel: str, claimed: set[str]) -> dict:
     are both reported as blocked rather than the second one silently landing on
     the first.
     """
+    if row["deleted_at"] is not None:
+        # Checked FIRST, and before the unchanged shortcut, because a deleted
+        # score has a perfectly good file sitting in the trash: without this it
+        # would be moved back out into the library while its row stays marked
+        # deleted, leaving a file nothing in the library shows and a trash entry
+        # whose file is not in the trash. Restoring is an action with a button,
+        # and it is the only thing that takes a score out of the trash.
+        return _plan_line(
+            row,
+            dest_rel,
+            "blocked",
+            "that score is in the trash. Put it back from there first, and then move it.",
+        )
     if dest_rel == row["path"]:
         return _plan_line(row, dest_rel, "unchanged")
     if row["missing_since"] is not None:

--- a/server/fermata/api.py
+++ b/server/fermata/api.py
@@ -1,8 +1,10 @@
 import json
+import logging
+import os
 import re
 import shutil
 from datetime import datetime, timedelta, timezone
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Annotated
 
 from fastapi import (
@@ -24,6 +26,9 @@ from .api_models import (
     CollectionOut,
     CurrentGoalOut,
     DuplicateGroupOut,
+    FolderCreateOut,
+    FolderOut,
+    FolderRenameOut,
     GoalDeleteOut,
     GoalListOut,
     GoalOut,
@@ -31,6 +36,7 @@ from .api_models import (
     InstrumentDeleteOut,
     InstrumentOut,
     InstrumentPresetOut,
+    LibraryMoveOut,
     LogPracticeOut,
     PracticeHistoryOut,
     PracticeReviewOut,
@@ -38,8 +44,12 @@ from .api_models import (
     PracticeSummaryOut,
     ScanStatusOut,
     ScanTriggerOut,
+    ScoreDeleteOut,
+    ScoreMoveOut,
     ScoreOut,
     ScorePracticeOut,
+    ScorePurgeOut,
+    ScoreRestoreOut,
     SessionDeleteOut,
     SessionListOut,
     SettingsOut,
@@ -53,10 +63,17 @@ from .api_models import (
 from .config import FILE_TYPES, LIBRARY_DIR
 from .db import DEFAULT_OWNER, connect, tx, write_tx
 from .glyph_rhythm import VALID_TS_DENOMINATORS
+from .metadata import parse_path
 from .tabextract import analyze as analyze_pdf, extract as extract_pdf
 from .thumbs import thumb_path
 
 router = APIRouter(prefix="/api")
+
+# Used by the library-management routes at the bottom of this file, for the one
+# case where a filesystem operation fails in a way a person cannot see: a file
+# that could not be put back after a failed move. Everything else these routes
+# have to say, they say in the response.
+log = logging.getLogger("fermata.api")
 
 # Every route below carries a `tags=[...]` entry grouping it in /docs, and a
 # `response_model=` pinning its shape - see api_models.py for what each model
@@ -434,12 +451,24 @@ def list_scores(
     source or series; `practiced` is 'recent' (practised in the last 14 days)
     or 'neglected' (present on disk, and either never practised or not
     practised in 30 days) - see the query's own comments for why those two
-    views disagree about a score whose file has gone missing."""
+    views disagree about a score whose file has gone missing.
+
+    A DELETED SCORE IS NEVER HERE, under any filter - it is in GET /api/trash
+    until it is restored or destroyed. A score whose FILE has gone missing is a
+    different thing and is still here, carrying `missing_since`: Fermata not
+    being able to find a file is not the same statement as somebody having
+    thrown it away."""
     if practiced and practiced not in VALID_PRACTICED:
         raise HTTPException(422, f"practiced must be one of {sorted(VALID_PRACTICED)}")
     conn = connect()
     sql = "SELECT DISTINCT s.* FROM scores s"
-    where, params = [], []
+    # A deleted score is not in the library, and no filter brings it back here -
+    # it is in the trash, which has its own endpoint (#56). This is deliberately
+    # unconditional rather than a `deleted` parameter: every view built on this
+    # one (the grid, the collection counts, "needs attention") would otherwise
+    # have to remember to pass it, and forgetting once puts a score somebody
+    # deleted back in front of them.
+    where, params = ["s.deleted_at IS NULL"], []
     if tag:
         sql += " JOIN score_tags st ON st.score_id = s.id JOIN tags t ON t.id = st.tag_id"
         where.append("t.name = ?")
@@ -525,14 +554,15 @@ def list_duplicates():
     conn = connect()
     dupes = conn.execute(
         """SELECT hash, COUNT(*) AS count FROM scores
-           WHERE missing_since IS NULL
+           WHERE missing_since IS NULL AND deleted_at IS NULL
            GROUP BY hash HAVING COUNT(*) > 1
            ORDER BY count DESC, hash"""
     ).fetchall()
     groups = []
     for d in dupes:
         rows = conn.execute(
-            "SELECT * FROM scores WHERE hash = ? AND missing_since IS NULL ORDER BY path",
+            "SELECT * FROM scores WHERE hash = ? AND missing_since IS NULL"
+            " AND deleted_at IS NULL ORDER BY path",
             (d["hash"],),
         ).fetchall()
         groups.append({"hash": d["hash"], "count": d["count"], "scores": _with_tags(conn, rows)})
@@ -562,7 +592,7 @@ def list_collections():
                   SUM(CASE WHEN missing_since IS NULL THEN 1 ELSE 0 END) AS count,
                   SUM(CASE WHEN missing_since IS NULL THEN 0 ELSE 1 END) AS missing
              FROM scores
-            WHERE collection IS NOT NULL
+            WHERE collection IS NOT NULL AND deleted_at IS NULL
          GROUP BY collection ORDER BY collection"""
     ).fetchall()
     return [dict(r) for r in rows]
@@ -573,8 +603,9 @@ def list_tags():
     """Every tag in use, and how many scores carry it."""
     conn = connect()
     rows = conn.execute(
-        """SELECT t.name, COUNT(st.score_id) AS count FROM tags t
+        """SELECT t.name, COUNT(s.id) AS count FROM tags t
            LEFT JOIN score_tags st ON st.tag_id = t.id
+           LEFT JOIN scores s ON s.id = st.score_id AND s.deleted_at IS NULL
            GROUP BY t.id ORDER BY t.name"""
     ).fetchall()
     return [dict(r) for r in rows]
@@ -2023,3 +2054,878 @@ async def upload(file: UploadFile, folder: str = "Uploads"):
         shutil.copyfileobj(file.file, out)
     scanner.start_scan()
     return {"saved": str(dest.relative_to(LIBRARY_DIR))}
+
+
+# ---------------------------------------------------------------------------
+# MANAGING THE LIBRARY: moving, renaming, deleting and reorganising (#56).
+#
+# THIS IS THE ONE PART OF FERMATA THAT WRITES TO SOMEBODY'S OWN FILES. Every
+# other endpoint reads the library and writes only to Fermata's own database.
+# These move, rename and delete a person's sheet music, and getting one wrong
+# loses something that is not ours to lose. Five rules follow from that, and
+# every route below obeys all five:
+#
+#   1. NOTHING IS WRITTEN OUTSIDE THE LIBRARY FOLDER. Every destination goes
+#      through _safe_parts and then _resolve_in_library, which is a check on the
+#      RESOLVED path rather than on the text of it - so a symlink pointing out
+#      of the library is refused as well as a `..`.
+#
+#   2. DELETING IS A MOVE, NOT A DELETE. A deleted score's file goes to a trash
+#      folder inside the library and its row is marked, keeping the practice
+#      history, goals, tags and transcription attached (see db.py's notes on
+#      deleted_at). Destroying anything takes a second, separate request to a
+#      different route that says what it destroys.
+#
+#   3. NOTHING IS DESTROYED AS A SIDE EFFECT OF AN ORGANISATIONAL CHANGE. A
+#      move that would land on an existing file is refused; it never overwrites.
+#      A batch whose plan contains one blocked line applies none of it.
+#
+#   4. A BULK OPERATION IS A DRY RUN UNTIL SOMEBODY SAYS OTHERWISE. `dry_run`
+#      defaults to true on both routes that touch more than one score, so the
+#      obvious call - and any client that forgets the flag exists - shows the
+#      plan rather than performing it.
+#
+#   5. THE SCORE ROW FOLLOWS THE FILE BY CONTENT HASH, which is the identity
+#      test the scanner already uses, applied to a file whose row we already
+#      know (see _relink_moved_file). There is no second notion of what makes a
+#      file "the same score".
+# ---------------------------------------------------------------------------
+
+# What a single path segment may be. No separators (those are what splits the
+# string in the first place), no empty segment, and nothing that is only dots -
+# "." and ".." are the two that escape a directory, and a segment of "..." is
+# not a name anybody meant to type either. Control characters are excluded
+# because a newline in a filename is a filename that cannot be read back out of
+# a log or a listing.
+_VALID_SEGMENT = re.compile(r"^(?!\.+$)[^/\\\x00-\x1f]+$")
+
+# The move dialog offers folders to move into, and a library with a deep tree
+# would otherwise hand a tablet a list thousands long. Deep enough for the
+# Collection/Composer/Series/... layout parse_path describes, and then some.
+MAX_FOLDER_DEPTH = 8
+
+
+def _library_dir():
+    """The library root, read through the module global rather than captured.
+
+    api.py binds LIBRARY_DIR by value at import (`from .config import ...`), and
+    the tests repoint that binding - so every function here has to read it at
+    call time or it will happily reorganise the developer's real library from
+    inside a test run.
+    """
+    return LIBRARY_DIR
+
+
+def _require_library():
+    """Refuse to touch anything if the library folder is not there.
+
+    Same reasoning as upload()'s check: a missing library folder is a mount that
+    did not appear, and this is the last moment at which a move can decline
+    rather than write into an empty directory that will vanish with the
+    container.
+    """
+    root = _library_dir()
+    if not root.is_dir():
+        raise HTTPException(
+            503,
+            f"the library folder {root} is not there, so there is nothing to reorganise. "
+            "This is usually a drive or volume that did not mount - see "
+            "docs/deployment.md. Nothing has been changed.",
+        )
+    return root
+
+
+def _safe_parts(folder: str, field: str = "folder") -> tuple[str, ...]:
+    """Split a client-supplied folder into segments, or refuse it.
+
+    REFUSES rather than sanitises, which is the opposite of what upload() does
+    with the same shape of input (it silently drops `..`). The difference is
+    what happens next: an upload lands a new file somewhere slightly unexpected,
+    while a move takes a file somebody already has and puts it there. Silently
+    moving a score to a folder other than the one that was asked for is not a
+    smaller failure than refusing.
+    """
+    raw = (folder or "").strip().replace("\\", "/")
+    if raw.startswith("/") or re.match(r"^[A-Za-z]:", raw):
+        raise HTTPException(422, f"{field} must be inside the library, not an absolute path")
+    parts = tuple(p for p in raw.split("/") if p)
+    for part in parts:
+        if not _VALID_SEGMENT.match(part):
+            raise HTTPException(
+                422,
+                f"{field} segment {part!r} is not a usable folder name - no separators, no "
+                "'..', and no control characters",
+            )
+    if parts and parts[0] == scanner.TRASH_DIR_NAME:
+        raise HTTPException(
+            422,
+            f"{scanner.TRASH_DIR_NAME} is Fermata's trash folder, not a place to put scores. "
+            "Delete a score to send it there, and restore it to bring it back.",
+        )
+    return parts
+
+
+def _safe_filename(name: str) -> str:
+    """A file name, with its extension checked against FILE_TYPES.
+
+    The extension has to stay something the scanner recognises: renaming a PDF
+    to `.txt` would leave a file the library can no longer see, which is a
+    deletion wearing a rename's clothes.
+    """
+    cleaned = (name or "").strip()
+    if not cleaned or not _VALID_SEGMENT.match(cleaned):
+        raise HTTPException(
+            422,
+            "filename is not a usable file name - no folders, no '..', and no control "
+            "characters",
+        )
+    suffix = Path(cleaned).suffix.lower()
+    if suffix not in FILE_TYPES:
+        raise HTTPException(
+            422,
+            f"filename must keep a score file extension ({', '.join(sorted(FILE_TYPES))}); "
+            f"{suffix or 'no extension'} is not one Fermata can read",
+        )
+    return cleaned
+
+
+def _resolve_in_library(rel: str) -> Path:
+    """The absolute path for a library-relative one, checked to be inside it.
+
+    The check is on the RESOLVED path, so it also refuses a destination that
+    only reaches outside the library through a symlink - which no amount of
+    inspecting the text of the path can catch. This is the check issue #56 asks
+    for by name ("refuse to write outside the configured library directory, and
+    test that"), and it is deliberately the last word rather than the first: the
+    segment rules above are what produce a good error message, and this is what
+    makes the guarantee true.
+    """
+    root = _library_dir()
+    candidate = root.joinpath(*PurePosixPath(rel).parts)
+    try:
+        resolved = Path(os.path.realpath(candidate))
+        root_resolved = Path(os.path.realpath(root))
+    except OSError as exc:  # pragma: no cover - realpath on a sane path
+        raise HTTPException(422, f"that path cannot be used: {exc}") from None
+    if resolved != root_resolved and not resolved.is_relative_to(root_resolved):
+        raise HTTPException(
+            422,
+            "that would put the file outside your library folder, which Fermata will not "
+            "do. Nothing has been changed.",
+        )
+    return candidate
+
+
+def _destination_for(row, folder: str | None, filename: str | None) -> str:
+    """Where this score's file would end up, as a library-relative path."""
+    current = PurePosixPath(row["path"])
+    parts = _safe_parts(folder) if folder is not None else current.parent.parts
+    name = _safe_filename(filename) if filename is not None else current.name
+    if parts and parts[0] == "":  # PurePosixPath('a.pdf').parent is '.', not ''
+        parts = ()
+    parts = tuple(p for p in parts if p not in ("", "."))
+    return "/".join([*parts, name])
+
+
+def _location_fields(rel: str) -> tuple[str | None, str | None]:
+    """The two fields that describe WHERE a score is, re-derived from its path.
+
+    A move changes where a score lives, so `collection` and `series` - which are
+    read straight off the folders, and which the sidebar presents as the folder
+    tree - have to follow it or the sidebar starts describing a layout that is
+    no longer there.
+
+    `title`, `composer` and `source` deliberately do NOT follow. Those are
+    statements about the music rather than about the filesystem, they can have
+    been corrected by hand through PATCH /api/scores/{id}, and re-deriving them
+    from a path would silently undo that correction every time somebody tidied a
+    folder. That is why moving and renaming metadata are two different
+    operations in this API: this one moves the file, PATCH edits the facts.
+    """
+    meta = parse_path(rel)
+    return meta.collection, meta.series
+
+
+def _move_file_on_disk(src: Path, dest: Path) -> None:
+    """Move one file, creating the folders above it, never overwriting.
+
+    os.replace would be atomic and is exactly wrong here: it replaces the
+    destination silently, which is the one thing rule 3 above forbids. The
+    existence check is racy against something outside Fermata writing the same
+    path in the same millisecond, and that race is accepted - the alternative is
+    an exclusive create plus a copy plus a delete, which turns a rename into a
+    read and write of the whole file for a case that needs a second process
+    writing into the library at the exact moment of a move.
+    """
+    if dest.exists():
+        raise HTTPException(409, f"there is already a file at {dest}")
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        src.rename(dest)
+    except OSError:
+        # Different filesystems under one library tree (a bind mount inside a
+        # bind mount) make rename fail with EXDEV; shutil.move copies and
+        # unlinks, which is slower and works.
+        shutil.move(str(src), str(dest))
+
+
+def _relink_moved_file(conn, row, dest_rel: str) -> None:
+    """Point the score row at where its file now is - by content, not by trust.
+
+    The hash is recomputed at the destination and checked against the one the
+    row already carries, and that check is the whole of this function's claim to
+    be safe. It is the same identity test scanner._scan_file's relink makes,
+    for the same reason: the bytes are what say two paths hold the same score.
+    Here it is applied to a file whose row is already known, so the answer is
+    yes or no rather than a search - but a NO still has to be an error, because
+    a mismatch means the file changed under Fermata between being listed and
+    being moved, and pointing the row at it anyway would attach somebody's
+    practice history to different music.
+
+    size and mtime are refreshed alongside, so the next scan's unchanged-file
+    shortcut recognises the file rather than re-reading and re-hashing it.
+    """
+    dest = _resolve_in_library(dest_rel)
+    moved_hash = scanner.hash_file(dest)
+    if moved_hash != row["hash"]:
+        raise HTTPException(
+            409,
+            "the file changed while it was being moved, so Fermata stopped rather than "
+            "attach this score's practice history and transcription to different music. "
+            "Scan the library and try again.",
+        )
+    stat = dest.stat()
+    collection, series = _location_fields(dest_rel)
+    conn.execute(
+        """UPDATE scores SET path = ?, collection = ?, series = ?, size = ?, mtime = ?
+           WHERE id = ?""",
+        (dest_rel, collection, series, stat.st_size, stat.st_mtime, row["id"]),
+    )
+
+
+def _plan_line(row, dest_rel: str, status: str, reason: str | None = None) -> dict:
+    return {
+        "score_id": row["id"],
+        "title": row["title"],
+        "from_path": row["path"],
+        "to_path": dest_rel,
+        "status": status,
+        "reason": reason,
+    }
+
+
+def _plan_move(conn, row, dest_rel: str, claimed: set[str]) -> dict:
+    """One line of a move plan: what would happen to this score, and why not.
+
+    `claimed` carries the destinations earlier lines in the same batch have
+    already taken, so two scores with the same file name moving into one folder
+    are both reported as blocked rather than the second one silently landing on
+    the first.
+    """
+    if dest_rel == row["path"]:
+        return _plan_line(row, dest_rel, "unchanged")
+    if row["missing_since"] is not None:
+        return _plan_line(
+            row,
+            dest_rel,
+            "blocked",
+            "Fermata cannot find this score's file, so there is nothing to move. Put the "
+            "file back and scan, or delete the score if it is really gone.",
+        )
+    source = _resolve_in_library(row["path"])
+    if not source.is_file():
+        return _plan_line(
+            row,
+            dest_rel,
+            "blocked",
+            "this score's file is not where Fermata last saw it - scan the library and "
+            "try again.",
+        )
+    if dest_rel in claimed:
+        return _plan_line(
+            row,
+            dest_rel,
+            "blocked",
+            "another score in this same move would be put at that exact path, and Fermata "
+            "will not overwrite one of your files with another. Rename one of them first.",
+        )
+    taken = conn.execute(
+        "SELECT id, title FROM scores WHERE path = ? AND id != ?", (dest_rel, row["id"])
+    ).fetchone()
+    if taken is not None:
+        return _plan_line(
+            row, dest_rel, "blocked", f"{taken['title']} is already at that path"
+        )
+    if _resolve_in_library(dest_rel).exists():
+        return _plan_line(
+            row, dest_rel, "blocked", "there is already a file at that path"
+        )
+    claimed.add(dest_rel)
+    return _plan_line(row, dest_rel, "move")
+
+
+def _apply_plan(conn, plan: list[dict]) -> None:
+    """Carry out every 'move' line, or leave the library exactly as it was.
+
+    A blocked line anywhere refuses the whole batch - a half-applied
+    reorganisation is worse than none, because the person now has to work out
+    which half. If a move fails part way through (a file locked, a folder gone
+    read-only), the ones already made are put back before the error is raised,
+    and the surrounding write_tx rolls the rows back with it.
+    """
+    blocked = [line for line in plan if line["status"] == "blocked"]
+    if blocked:
+        raise HTTPException(
+            409,
+            "nothing was moved. "
+            + " ".join(f"{line['title']}: {line['reason']}" for line in blocked),
+        )
+    done: list[tuple[Path, Path]] = []
+    try:
+        for line in plan:
+            if line["status"] != "move":
+                continue
+            row = _score_row(conn, line["score_id"])
+            source = _resolve_in_library(row["path"])
+            dest = _resolve_in_library(line["to_path"])
+            _move_file_on_disk(source, dest)
+            done.append((source, dest))
+            _relink_moved_file(conn, row, line["to_path"])
+    except Exception:
+        for source, dest in reversed(done):
+            try:
+                dest.rename(source)
+            except OSError:  # pragma: no cover - the filesystem refusing twice
+                log.error(
+                    "could not put %s back at %s after a failed move - the file is at the "
+                    "new path and the database has been rolled back, so a scan will "
+                    "re-link it",
+                    dest,
+                    source,
+                )
+        raise
+
+
+class ScoreMoveIn(BaseModel):
+    """Where one score's file should go.
+
+    Both `folder` and `filename` are optional and at least one is required:
+    omitting the folder keeps the score where it is (so this is a rename), and
+    omitting the filename keeps its name (so this is a move). An empty string
+    for `folder` is the library root, and is not the same as omitting it.
+
+    `dry_run` defaults FALSE here and TRUE on the two bulk routes. A person
+    moving one score has that score in front of them and has said which folder;
+    making them confirm a one-line plan first is ceremony, not safety. A batch
+    is the case where what is about to happen is not obvious, which is what
+    issue #56's dry-run-by-default rule is about.
+    """
+
+    folder: str | None = None
+    filename: str | None = None
+    dry_run: bool = False
+
+
+class LibraryMoveIn(BaseModel):
+    """Several scores into one folder. See LibraryMoveOut for the plan shape."""
+
+    score_ids: list[Count] = Field(min_length=1, max_length=500)
+    folder: str
+    # True by default, on purpose - see move_scores' docstring.
+    dry_run: bool = True
+
+
+class FolderIn(BaseModel):
+    path: str = Field(max_length=1000)
+
+
+class FolderRenameIn(BaseModel):
+    from_path: str = Field(max_length=1000)
+    to_path: str = Field(max_length=1000)
+    # True by default, on purpose - see rename_folder's docstring.
+    dry_run: bool = True
+
+
+def _busy(exc: scanner.LibraryBusy) -> HTTPException:
+    """A scan (or another change) is in flight - see scanner.hold_library_still.
+
+    409 rather than 503: nothing is wrong with the server, the request simply
+    conflicts with something already happening, and it will succeed unchanged in
+    a moment.
+    """
+    return HTTPException(409, str(exc))
+
+
+@router.post("/scores/{score_id}/move", tags=[TAG_LIBRARY], response_model=ScoreMoveOut)
+def move_score(score_id: RowId, body: ScoreMoveIn):
+    """Move one score's file to another folder in the library, rename it, or
+    both, and bring the score row with it.
+
+    `folder` is a library-relative folder (omit it to keep the score where it
+    is); `filename` renames the file within that folder and must keep an
+    extension Fermata can read. `dry_run` answers with the plan and changes
+    nothing.
+
+    THIS RENAMES THE FILE, NOT THE PIECE. A score's title, composer and source
+    are edited with PATCH /api/scores/{id} and are deliberately left alone here
+    - they can have been corrected by hand, and a tidy-up of the folders must
+    not quietly undo that. The two location fields that ARE read off the path,
+    `collection` and `series`, do follow the file. Everything else on the score
+    - its practice history, goals, tags, transcription, favourite, last page
+    read and instrument - is attached to the row, and the row is updated rather
+    than replaced, so all of it survives the move untouched.
+    """
+    _require_library()
+    if body.folder is None and body.filename is None:
+        raise HTTPException(422, "give a folder to move into, a filename to rename to, or both")
+    try:
+        with scanner.hold_library_still():
+            with write_tx() as conn:
+                row = _score_row(conn, score_id)
+                dest_rel = _destination_for(row, body.folder, body.filename)
+                _resolve_in_library(dest_rel)
+                plan = [_plan_move(conn, row, dest_rel, set())]
+                if not body.dry_run:
+                    _apply_plan(conn, plan)
+    except scanner.LibraryBusy as exc:
+        raise _busy(exc) from None
+    conn = connect()
+    return {
+        "dry_run": body.dry_run,
+        "applied": not body.dry_run,
+        "moves": plan,
+        "score": _with_tags(conn, [_score_row(conn, score_id)])[0],
+    }
+
+
+@router.get("/library/folders", tags=[TAG_LIBRARY], response_model=list[FolderOut])
+def list_folders():
+    """Every folder in the library, for a move dialog to offer as a
+    destination.
+
+    Read from the filesystem rather than from the stored paths, so a folder
+    created a moment ago and still empty is offered - which is the whole point
+    of being able to create one. The trash and any other dot-folder are left
+    out: those belong to Fermata or to a sync client, not to the person's
+    library.
+    """
+    root = _require_library()
+    conn = connect()
+    counts: dict[str, int] = {}
+    for r in conn.execute("SELECT path FROM scores WHERE deleted_at IS NULL"):
+        parent = PurePosixPath(r["path"]).parent
+        key = "" if str(parent) == "." else str(parent)
+        counts[key] = counts.get(key, 0) + 1
+    folders = [
+        {
+            "path": "",
+            "name": "Library root",
+            "depth": 0,
+            "score_count": counts.get("", 0),
+        }
+    ]
+    for path in sorted(root.rglob("*")):
+        if not path.is_dir():
+            continue
+        rel = path.relative_to(root).as_posix()
+        parts = PurePosixPath(rel).parts
+        if len(parts) > MAX_FOLDER_DEPTH or any(p.startswith(".") for p in parts):
+            continue
+        folders.append(
+            {
+                "path": rel,
+                "name": parts[-1],
+                "depth": len(parts),
+                "score_count": counts.get(rel, 0),
+            }
+        )
+    return folders
+
+
+@router.post("/library/folders", tags=[TAG_LIBRARY], response_model=FolderCreateOut)
+def create_folder(body: FolderIn):
+    """Create a folder in the library, so scores can be moved into it.
+
+    Creating a folder that is already there is not an error - the caller asked
+    to have that folder and does - but the answer says which of the two
+    happened.
+    """
+    _require_library()
+    parts = _safe_parts(body.path, "path")
+    if not parts:
+        raise HTTPException(422, "give a folder name")
+    rel = "/".join(parts)
+    target = _resolve_in_library(rel)
+    existed = target.is_dir()
+    if target.exists() and not existed:
+        raise HTTPException(409, f"{rel} is a file, not a folder")
+    try:
+        target.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        # The segment rules cannot know what a particular filesystem will
+        # accept: Windows reserves a handful of names outright (CON, NUL, and
+        # friends) and refuses trailing dots, and any filesystem can be full or
+        # read-only. Refusing with what the filesystem actually said beats a
+        # 500 for something a person can simply rename around.
+        raise HTTPException(422, f"your filesystem would not take that folder name: {exc}") from None
+    return {"created": rel, "existed": existed}
+
+
+@router.post("/library/move", tags=[TAG_LIBRARY], response_model=LibraryMoveOut)
+def move_scores(body: LibraryMoveIn):
+    """Move several scores into one folder, keeping each one's file name.
+
+    A DRY RUN UNLESS `dry_run` IS EXPLICITLY FALSE. Issue #56 asks for that by
+    name and it is the default here rather than an option, so a client that has
+    never heard of the flag gets the plan and not the reorganisation.
+
+    All or nothing: if any line of the plan is blocked - a name collision, a
+    file that is not where Fermata thinks it is - none of the moves are made.
+    Half a reorganisation is worse than none, because the person then has to
+    work out which half happened.
+    """
+    _require_library()
+    parts = _safe_parts(body.folder)
+    folder = "/".join(parts)
+    try:
+        with scanner.hold_library_still():
+            with write_tx() as conn:
+                plan: list[dict] = []
+                claimed: set[str] = set()
+                for score_id in body.score_ids:
+                    row = _score_row(conn, score_id)
+                    dest_rel = "/".join([*parts, PurePosixPath(row["path"]).name])
+                    _resolve_in_library(dest_rel)
+                    plan.append(_plan_move(conn, row, dest_rel, claimed))
+                if not body.dry_run:
+                    _apply_plan(conn, plan)
+    except scanner.LibraryBusy as exc:
+        raise _busy(exc) from None
+    return {
+        "dry_run": body.dry_run,
+        "applied": not body.dry_run,
+        "folder": folder,
+        "moves": plan,
+        "moved": sum(1 for line in plan if line["status"] == "move"),
+        "unchanged": sum(1 for line in plan if line["status"] == "unchanged"),
+        "blocked": sum(1 for line in plan if line["status"] == "blocked"),
+    }
+
+
+@router.post("/library/folders/rename", tags=[TAG_LIBRARY], response_model=FolderRenameOut)
+def rename_folder(body: FolderRenameIn):
+    """Rename a folder, or move it under another one, taking its scores with it.
+
+    A DRY RUN UNLESS `dry_run` IS EXPLICITLY FALSE, for the same reason
+    /library/move is: this is the operation that restructures a whole shelf at
+    once.
+
+    The FOLDER is renamed on disk, in one step, rather than its scores being
+    moved out of it one at a time - so anything else in there (a cover image, a
+    text file, a subfolder Fermata does not index) goes along too, which is what
+    somebody renaming a folder means. Every score underneath it, at any depth,
+    is then re-pointed at its new path.
+    """
+    _require_library()
+    from_parts = _safe_parts(body.from_path, "from_path")
+    to_parts = _safe_parts(body.to_path, "to_path")
+    if not from_parts or not to_parts:
+        raise HTTPException(422, "give both the folder to rename and its new path")
+    from_rel, to_rel = "/".join(from_parts), "/".join(to_parts)
+    if to_rel == from_rel:
+        raise HTTPException(422, "the new path is the same as the old one")
+    if to_parts[: len(from_parts)] == from_parts:
+        raise HTTPException(422, "a folder cannot be moved inside itself")
+    source = _resolve_in_library(from_rel)
+    dest = _resolve_in_library(to_rel)
+    if not source.is_dir():
+        raise HTTPException(404, f"there is no folder {from_rel} in your library")
+    if dest.exists():
+        raise HTTPException(409, f"{to_rel} already exists")
+    prefix = from_rel + "/"
+    try:
+        with scanner.hold_library_still():
+            with write_tx() as conn:
+                rows = conn.execute(
+                    "SELECT * FROM scores WHERE deleted_at IS NULL AND path LIKE ?"
+                    " ORDER BY path",
+                    (prefix.replace("%", r"\%").replace("_", r"\_") + "%",),
+                ).fetchall()
+                rows = [r for r in rows if r["path"].startswith(prefix)]
+                plan = []
+                for r in rows:
+                    dest_rel = to_rel + "/" + r["path"][len(prefix):]
+                    # A row can name a path with no file behind it - that is
+                    # exactly what a score marked missing is - and scores.path is
+                    # UNIQUE, so re-pointing a row at a path another row already
+                    # claims is an IntegrityError and a 500. Reported as a
+                    # blocked line instead, which is a sentence a person can act
+                    # on and which _apply_plan's own rule already refuses on.
+                    taken = conn.execute(
+                        "SELECT title FROM scores WHERE path = ? AND id != ?",
+                        (dest_rel, r["id"]),
+                    ).fetchone()
+                    plan.append(
+                        _plan_line(
+                            r,
+                            dest_rel,
+                            "blocked" if taken else "move",
+                            f"{taken['title']} is already at that path" if taken else None,
+                        )
+                    )
+                blocked = [line for line in plan if line["status"] == "blocked"]
+                if blocked:
+                    raise HTTPException(
+                        409,
+                        "nothing was moved. "
+                        + " ".join(f"{line['title']}: {line['reason']}" for line in blocked),
+                    )
+                if not body.dry_run:
+                    dest.parent.mkdir(parents=True, exist_ok=True)
+                    source.rename(dest)
+                    try:
+                        for line in plan:
+                            row = _score_row(conn, line["score_id"])
+                            _relink_moved_file(conn, row, line["to_path"])
+                    except Exception:
+                        dest.rename(source)
+                        raise
+    except scanner.LibraryBusy as exc:
+        raise _busy(exc) from None
+    return {
+        "dry_run": body.dry_run,
+        "applied": not body.dry_run,
+        "from_path": from_rel,
+        "to_path": to_rel,
+        "moves": plan,
+        "moved": len(plan),
+    }
+
+
+def _free_path(rel: str, conn=None, exclude_id: int | None = None) -> str:
+    """`rel`, or the first numbered variant of it that nothing occupies.
+
+    Used where refusing would strand somebody: putting a score back from the
+    trash when something else has since taken its old path. Landing beside it
+    under a distinct name is better than either overwriting (rule 3) or telling
+    a person their own file cannot come back.
+
+    "OCCUPIED" MEANS THE DISK OR THE DATABASE, and both halves are needed.
+    scores.path is UNIQUE, so a row already naming this path makes the update
+    an IntegrityError and a 500 - and a row can name a path with no file behind
+    it, which is precisely what a score marked missing is. Checking only the
+    filesystem would therefore turn "your other copy of this went missing" into
+    an unexplained server error at the moment somebody tried to undo a
+    deletion.
+    """
+    stem, suffix = PurePosixPath(rel).stem, PurePosixPath(rel).suffix
+    candidate = PurePosixPath(rel)
+
+    def taken(path: str) -> bool:
+        if _resolve_in_library(path).exists():
+            return True
+        if conn is None:
+            return False
+        row = conn.execute(
+            "SELECT id FROM scores WHERE path = ? AND id IS NOT ?", (path, exclude_id)
+        ).fetchone()
+        return row is not None
+
+    for attempt in range(1, 1000):
+        if not taken(str(candidate)):
+            return str(candidate)
+        candidate = candidate.with_name(f"{stem} ({attempt}){suffix}")
+    raise HTTPException(409, f"nothing could be put back at {rel} - a thousand names were taken")
+
+
+def _attached_counts(conn, score_id: int) -> dict:
+    """How much of somebody's own work is hanging off this score row.
+
+    Counted from the database and returned with every delete, so "nothing was
+    lost" is a number a person can read rather than a promise.
+    """
+    one = lambda sql: conn.execute(sql, (score_id,)).fetchone()[0]  # noqa: E731
+    return {
+        "practice_sessions": one(
+            "SELECT COUNT(*) FROM practice_sessions WHERE score_id = ?"
+        ),
+        "goals": one("SELECT COUNT(*) FROM practice_goals WHERE score_id = ?"),
+        "tags": one("SELECT COUNT(*) FROM score_tags WHERE score_id = ?"),
+        "transcriptions": one("SELECT COUNT(*) FROM transcriptions WHERE score_id = ?"),
+    }
+
+
+@router.delete("/scores/{score_id}", tags=[TAG_LIBRARY], response_model=ScoreDeleteOut)
+def delete_score(score_id: RowId):
+    """Delete a score: its file goes to the library's trash folder and its row
+    is marked as deleted.
+
+    THIS DESTROYS NOTHING. The file is moved, not removed, into
+    `.fermata-trash` inside the library, and the score row stays exactly where
+    it was with its practice history, goals, tags and transcription still
+    attached - the response counts each of those so an interface can say so.
+    The score leaves the library views and appears in GET /api/trash, from
+    where POST /api/trash/{id}/restore puts it back.
+
+    Destroying it takes a second, deliberate request to DELETE /api/trash/{id},
+    which states what it destroys.
+    """
+    _require_library()
+    try:
+        with scanner.hold_library_still():
+            with write_tx() as conn:
+                row = _score_row(conn, score_id)
+                if row["deleted_at"] is not None:
+                    raise HTTPException(409, "that score is already in the trash")
+                kept = _attached_counts(conn, score_id)
+                name = PurePosixPath(row["path"]).name
+                # The score id in the path is what makes a trash path unique
+                # without inventing a naming scheme: two scores called
+                # "Prelude.pdf" deleted from two folders keep their own names
+                # and cannot collide, and the folder says which row the file
+                # belongs to if anybody ever looks in there by hand.
+                trash_rel = f"{scanner.TRASH_DIR_NAME}/{score_id}/{name}"
+                trash_rel = _free_path(trash_rel)
+                source = _resolve_in_library(row["path"])
+                if source.is_file():
+                    _move_file_on_disk(source, _resolve_in_library(trash_rel))
+                conn.execute(
+                    """UPDATE scores
+                          SET path = ?, deleted_from = ?, deleted_at = datetime('now'),
+                              missing_since = NULL
+                        WHERE id = ?""",
+                    (trash_rel, row["path"], score_id),
+                )
+                # The library is smaller because somebody said so, so the mark
+                # the loss guard measures against comes down with it - see
+                # scanner.record_deliberate_shrink for what goes wrong
+                # otherwise.
+                scanner.record_deliberate_shrink(conn)
+                deleted_from = row["path"]
+                title = row["title"]
+    except scanner.LibraryBusy as exc:
+        raise _busy(exc) from None
+    return {
+        "deleted": score_id,
+        "title": title,
+        "deleted_from": deleted_from,
+        "trashed_to": trash_rel,
+        "practice_sessions_kept": kept["practice_sessions"],
+        "goals_kept": kept["goals"],
+        "tags_kept": kept["tags"],
+        "transcriptions_kept": kept["transcriptions"],
+    }
+
+
+def _deleted_row(conn, score_id: int):
+    row = _score_row(conn, score_id)
+    if row["deleted_at"] is None:
+        raise HTTPException(404, "that score is not in the trash")
+    return row
+
+
+@router.get("/trash", tags=[TAG_LIBRARY], response_model=list[ScoreOut])
+def list_trash():
+    """Scores that have been deleted and not yet destroyed, most recently
+    deleted first.
+
+    They are still whole scores - `deleted_from` says where each one came from,
+    and every session, goal, tag and transcription is still attached - which is
+    why this answers with the same shape the library does rather than a reduced
+    one.
+    """
+    conn = connect()
+    rows = conn.execute(
+        "SELECT * FROM scores WHERE deleted_at IS NOT NULL ORDER BY deleted_at DESC, id DESC"
+    ).fetchall()
+    return _with_tags(conn, rows)
+
+
+@router.post("/trash/{score_id}/restore", tags=[TAG_LIBRARY], response_model=ScoreRestoreOut)
+def restore_score(score_id: RowId):
+    """Put a deleted score back where it came from.
+
+    If something else has taken that exact path in the meantime the file lands
+    beside it under a numbered name rather than overwriting it, and
+    `restored_to` says where it actually went - see rule 3 in this section's
+    comment.
+    """
+    _require_library()
+    try:
+        with scanner.hold_library_still():
+            with write_tx() as conn:
+                row = _deleted_row(conn, score_id)
+                came_from = row["deleted_from"] or row["path"]
+                target = _free_path(came_from, conn, exclude_id=score_id)
+                source = _resolve_in_library(row["path"])
+                if not source.is_file():
+                    raise HTTPException(
+                        409,
+                        "the file for that score is no longer in Fermata's trash folder, so "
+                        "there is nothing to put back. Its practice history is still on the "
+                        "score - put the file back in your library and scan, or destroy the "
+                        "score from the trash.",
+                    )
+                _move_file_on_disk(source, _resolve_in_library(target))
+                conn.execute(
+                    "UPDATE scores SET deleted_at = NULL, deleted_from = NULL WHERE id = ?",
+                    (score_id,),
+                )
+                _relink_moved_file(conn, row, target)
+    except scanner.LibraryBusy as exc:
+        raise _busy(exc) from None
+    conn = connect()
+    return {
+        "restored": score_id,
+        "restored_from": came_from,
+        "restored_to": target,
+        "score": _with_tags(conn, [_score_row(conn, score_id)])[0],
+    }
+
+
+@router.delete("/trash/{score_id}", tags=[TAG_LIBRARY], response_model=ScorePurgeOut)
+def purge_score(score_id: RowId):
+    """Destroy a deleted score for good. THIS ONE REALLY DELETES.
+
+    What it destroys: the file, removed from the trash folder and not
+    recoverable through Fermata; the score row; its tags; and any
+    transcription, including one corrected by hand, which is real work and
+    cannot be regenerated identically.
+
+    What it keeps: every practice session and goal that named this score. The
+    hours were still spent, so those rows stay in the history recording
+    practice with no piece named (see db.py's notes on ON DELETE SET NULL). The
+    response counts both sides.
+
+    Only a score already in the trash can be destroyed, so this is always the
+    second of two deliberate steps.
+    """
+    _require_library()
+    try:
+        with scanner.hold_library_still():
+            with write_tx() as conn:
+                row = _deleted_row(conn, score_id)
+                counts = _attached_counts(conn, score_id)
+                path = _resolve_in_library(row["path"])
+                removed = None
+                if path.is_file() and scanner.in_trash(row["path"]):
+                    # Guarded on the path really being in the trash, not merely
+                    # on the row saying it is deleted: unlinking is the one
+                    # thing here with no way back, so it happens only for a file
+                    # Fermata itself put in its own trash folder.
+                    path.unlink()
+                    removed = row["path"]
+                conn.execute("DELETE FROM scores WHERE id = ?", (score_id,))
+                scanner.record_deliberate_shrink(conn)
+                title = row["title"]
+    except scanner.LibraryBusy as exc:
+        raise _busy(exc) from None
+    return {
+        "deleted": score_id,
+        "title": title,
+        "file_deleted": removed,
+        "tags_destroyed": counts["tags"],
+        "transcriptions_destroyed": counts["transcriptions"],
+        "practice_sessions_kept": counts["practice_sessions"],
+        "goals_kept": counts["goals"],
+    }

--- a/server/fermata/api.py
+++ b/server/fermata/api.py
@@ -1,3 +1,4 @@
+import errno
 import json
 import logging
 import os
@@ -143,6 +144,49 @@ def _score_row(conn, score_id: int):
     row = conn.execute("SELECT * FROM scores WHERE id = ?", (score_id,)).fetchone()
     if not row:
         raise HTTPException(404, "score not found")
+    return row
+
+
+# WHAT A DELETED SCORE MAY STILL BE ASKED FOR (#56).
+#
+# A deleted score's row is still there, deliberately: that is the whole of what
+# makes deleting recoverable. So every endpoint that takes a score id can still
+# reach one, and each of them has to have decided what to do about it. This is
+# that decision, stated once, and _live_score_row is how the routes that refuse
+# do it.
+#
+# READS ARE ALLOWED, and that is deliberate rather than an oversight. GET
+# /scores/{id}, its file, its thumbnail, its transcription and its practice
+# totals all answer for a deleted score, because the trash view is built out of
+# exactly those responses and because being able to LOOK at a score - to open
+# it, to read the transcription you spent an evening correcting - is the point
+# of a trash you can change your mind from. A trash that will not let you check
+# what is in it before you destroy it is a worse trash.
+#
+# WRITES ARE REFUSED, with 409. Every one of them means "work on this piece":
+# logging practice against it, setting a goal about it, editing its title,
+# extracting or saving a transcription. Nothing in the interface offers any of
+# them for a deleted score, so reaching one is a client's mistake or an
+# automation's, and the useful answer names the fix rather than silently
+# accepting work that will look, afterwards, like practice on a score that is
+# not in the library.
+#
+# PRACTICE ALREADY LOGGED IS UNTOUCHED BY ALL OF THIS. The history is the one
+# thing here that cannot be regenerated; it stays, it still names its piece, and
+# it still counts. What changes is only that a figure naming a deleted score now
+# SAYS the score is deleted - see practice_summary's top_scores and
+# practice.time_spent's by_score - so a dashboard can stop offering a way into
+# something that is not in the library, instead of quietly linking to it.
+def _live_score_row(conn, score_id: int, doing: str):
+    """The score row, refusing if it is in the trash. `doing` completes the
+    sentence "Fermata will not <doing> a score that is in the trash"."""
+    row = _score_row(conn, score_id)
+    if row["deleted_at"] is not None:
+        raise HTTPException(
+            409,
+            f"{row['title']} is in the trash, so Fermata will not {doing}. Put it back "
+            "from the trash first - everything already on it is still there.",
+        )
     return row
 
 
@@ -639,7 +683,7 @@ def patch_score(score_id: RowId, patch: ScorePatch):
     if patch.content_kind is not None and patch.content_kind not in VALID_KINDS:
         raise HTTPException(422, f"content_kind must be one of {sorted(VALID_KINDS)}")
     with write_tx() as conn:
-        _score_row(conn, score_id)
+        _live_score_row(conn, score_id, "change what it says")
         if patch.instrument_id is not None:
             _instrument_row(conn, patch.instrument_id)
         fields = {
@@ -817,7 +861,7 @@ def _normalise_session(
     conn, fields: dict, allow_missing_score: bool = False, check_day_window: bool = True
 ) -> dict:
     if fields.get("score_id") is not None:
-        _score_row(conn, fields["score_id"])
+        _live_score_row(conn, fields["score_id"], "log practice against it")
     try:
         return practice.normalise_session(
             recorded_on=_server_today(),
@@ -864,7 +908,7 @@ def log_practice(score_id: RowId, body: PracticeIn):
     """Log a practice session against this score, and return it alongside
     the score's recent sessions and totals."""
     with write_tx() as conn:
-        _score_row(conn, score_id)
+        _live_score_row(conn, score_id, "log practice against it")
         fields = body.model_dump()
         fields["score_id"] = score_id
         values = _normalise_session(conn, fields)
@@ -1058,8 +1102,16 @@ def practice_summary():
             WHERE p.owner = ? AND {practice.LOCAL_DATE_SQL} >= date('now', '-6 days')""",
         (DEFAULT_OWNER,),
     ).fetchone()
+    # A DELETED SCORE IS STILL COUNTED HERE, AND NOW SAYS THAT IT IS (#56).
+    # Dropping it would be the wrong fix twice over: the hours were spent, and
+    # this figure's own totals would then stop adding up to the week_seconds
+    # beside it, with nothing saying why. What was actually wrong was that a
+    # dashboard named a piece and gave a client every reason to link to it,
+    # while the library it links into no longer holds it. So the fact travels
+    # with the row instead - the same shape as `score_missing` on a session.
     top = conn.execute(
-        f"""SELECT s.id, s.title, SUM(p.seconds) AS practice_seconds
+        f"""SELECT s.id, s.title, SUM(p.seconds) AS practice_seconds,
+                   s.deleted_at IS NOT NULL AS deleted
             FROM practice_sessions p JOIN scores s ON s.id = p.score_id
             WHERE p.owner = ? AND {practice.LOCAL_DATE_SQL} >= date('now', '-6 days')
             GROUP BY p.score_id ORDER BY practice_seconds DESC LIMIT 5""",
@@ -1068,7 +1120,7 @@ def practice_summary():
     return {
         "week_seconds": week["total_seconds"],
         "week_sessions": week["session_count"],
-        "top_scores": [dict(r) for r in top],
+        "top_scores": [{**dict(r), "deleted": bool(r["deleted"])} for r in top],
     }
 
 
@@ -1163,7 +1215,7 @@ def _goal_row(conn, goal_id: int):
 
 def _normalise_goal(conn, fields: dict, allow_missing_score: bool = False) -> dict:
     if fields.get("score_id") is not None:
-        _score_row(conn, fields["score_id"])
+        _live_score_row(conn, fields["score_id"], "set a goal about it")
     try:
         return practice.normalise_goal(allow_missing_score=allow_missing_score, **fields)
     except ValueError as e:
@@ -1746,7 +1798,7 @@ def transcribe(score_id: RowId, body: TranscribeIn | None = Body(default=None)):
     comments). Only valid for pdf scores with a tab staff; an unreadable
     time signature or a non-extractable pdf is a 422."""
     conn = connect()
-    row = _score_row(conn, score_id)
+    row = _live_score_row(conn, score_id, "extract a transcription from it")
     if row["file_type"] != "pdf":
         raise HTTPException(422, "transcription is only supported for pdf scores")
     path = LIBRARY_DIR / row["path"]
@@ -1927,7 +1979,7 @@ def save_transcription(score_id: RowId, body: TranscriptionEditIn):
         raise HTTPException(
             422, f"format must be one of {sorted(VALID_TRANSCRIPTION_FORMATS)}")
     with tx() as conn:
-        _score_row(conn, score_id)
+        _live_score_row(conn, score_id, "save a transcription for it")
         conn.execute(
             """INSERT INTO transcriptions(score_id, format, content, source, updated_at)
                VALUES (?, ?, ?, 'edited', datetime('now'))
@@ -1956,7 +2008,7 @@ def delete_transcription(score_id: RowId):
     no-op, not an error - only "no transcription at all" is a 404.
     """
     with tx() as conn:
-        _score_row(conn, score_id)
+        _live_score_row(conn, score_id, "throw away its hand-corrected transcription")
         conn.execute(
             "DELETE FROM transcriptions WHERE score_id = ? AND source = 'edited'", (score_id,)
         )
@@ -2022,7 +2074,14 @@ _SAFE_SEGMENT = re.compile(r"^[^/\\]+$")
 async def upload(file: UploadFile, folder: str = "Uploads"):
     """Save a file into the library under `folder` (created if needed) and
     trigger a scan to pick it up. `folder` may not contain `..` or an
-    absolute path segment."""
+    absolute path segment.
+
+    DELIBERATELY NOT HELD against a running scan or a move, unlike the
+    library-management routes below. This only ever creates a file at a path
+    nothing claims - it never moves or removes one - so it cannot invalidate a
+    scan's listing, and holding it would refuse the second of two uploads in a
+    row for the scan the first one started. See scanner.hold_library_still for
+    the full argument and for what catches the one overlap that matters."""
     suffix = Path(file.filename or "").suffix.lower()
     if suffix not in FILE_TYPES:
         raise HTTPException(422, f"unsupported file type {suffix!r}")
@@ -2091,13 +2150,62 @@ async def upload(file: UploadFile, folder: str = "Uploads"):
 #      file "the same score".
 # ---------------------------------------------------------------------------
 
-# What a single path segment may be. No separators (those are what splits the
-# string in the first place), no empty segment, and nothing that is only dots -
-# "." and ".." are the two that escape a directory, and a segment of "..." is
-# not a name anybody meant to type either. Control characters are excluded
-# because a newline in a filename is a filename that cannot be read back out of
-# a log or a listing.
-_VALID_SEGMENT = re.compile(r"^(?!\.+$)[^/\\\x00-\x1f]+$")
+# What a single path segment may be.
+#
+# No separators (those are what splits the string in the first place), no empty
+# segment, and nothing that is only dots - "." and ".." are the two that escape
+# a directory, and a segment of "..." is not a name anybody meant to type
+# either. Control characters are excluded because a newline in a filename is a
+# filename that cannot be read back out of a log or a listing.
+#
+# AND THE CHARACTERS WINDOWS ITSELF WILL NOT TAKE, which is not tidiness and is
+# not a portability nicety - each one is a way for the text of a path to say one
+# thing and the filesystem to do another, and this whole section's guarantee is
+# that where a file goes is where the caller asked for it to go:
+#
+#   `:` IS AN NTFS ALTERNATE DATA STREAM. `evil:stream.pdf` is not a file called
+#   "evil:stream.pdf"; it is a hidden stream attached to a file called "evil".
+#   The move succeeded, the bytes went into the stream, and the content hash
+#   read back THROUGH the stream matched - so every check this code makes passed
+#   - while the library got a 0-byte "evil" the scanner cannot read, and any
+#   copy or backup that does not preserve streams drops the music silently.
+#
+#   `< > " | ? *` are refused by Win32 outright, so on Windows they are a 500
+#   from deep inside a rename, and on Linux they are a filename that cannot be
+#   copied to a Windows machine or a common network share. Refused here so the
+#   answer is the same sentence on both.
+#
+# The trailing-dot and trailing-space rule is separate and lives in
+# _reject_trailing - see there for why a regex is the wrong place for it.
+_VALID_SEGMENT = re.compile(r'^(?!\.+$)[^/\\:<>"|?*\x00-\x1f]+$')
+
+# Windows silently STRIPS a trailing dot or space from every path component -
+# `"Music."` and `"Music"` are the same directory, and `"Study .pdf"` is
+# `"Study.pdf"`. That is a divergence between what the database records and what
+# is on disk, and in one case it is a way straight through this section's
+# guarantees: `.fermata-trash.` passes the trash-folder check on its text and
+# then lands, on disk, INSIDE the trash folder. A live score would sit in the
+# folder scans skip - so it is marked missing on the next pass - and in the
+# folder docs/deployment.md tells people they may empty by hand.
+_TRAILING = " ."
+
+
+def _reject_trailing(part: str, field: str) -> None:
+    """Refuse a segment that a filesystem would quietly rename.
+
+    Not folded into _VALID_SEGMENT because the two say different things and one
+    of them needs its own sentence: the regex is about characters a name may not
+    CONTAIN, and this is about a name the filesystem will not STORE AS WRITTEN.
+    A caller who typed a trailing dot deserves to be told that rather than to
+    find their score somewhere else.
+    """
+    if part and part[-1] in _TRAILING:
+        raise HTTPException(
+            422,
+            f"{field} segment {part!r} ends in a space or a dot. Windows silently drops "
+            "those, so the folder Fermata recorded and the folder on disk would be two "
+            "different places - and one of them could be inside Fermata's own trash.",
+        )
 
 # The move dialog offers folders to move into, and a library with a deep tree
 # would otherwise hand a tablet a list thousands long. Deep enough for the
@@ -2145,7 +2253,14 @@ def _safe_parts(folder: str, field: str = "folder") -> tuple[str, ...]:
     moving a score to a folder other than the one that was asked for is not a
     smaller failure than refusing.
     """
-    raw = (folder or "").strip().replace("\\", "/")
+    # NOT .strip()ped, and that is the same rule as everything else here rather
+    # than an omission. Stripping is sanitising: "Classical " came in, a folder
+    # called "Classical" came out, and the caller was never told the two are not
+    # the same request. It is also precisely the trailing character
+    # _reject_trailing exists to refuse, so stripping first would have quietly
+    # disarmed that check for every space. An empty string is still the library
+    # root; a string that is only a space is now a refusal, which is right.
+    raw = (folder or "").replace("\\", "/")
     if raw.startswith("/") or re.match(r"^[A-Za-z]:", raw):
         raise HTTPException(422, f"{field} must be inside the library, not an absolute path")
     parts = tuple(p for p in raw.split("/") if p)
@@ -2154,8 +2269,13 @@ def _safe_parts(folder: str, field: str = "folder") -> tuple[str, ...]:
             raise HTTPException(
                 422,
                 f"{field} segment {part!r} is not a usable folder name - no separators, no "
-                "'..', and no control characters",
+                "'..', no control characters, and none of : < > \" | ? *",
             )
+        _reject_trailing(part, field)
+    # AFTER the trailing-dot rule, and that order is the whole point of the
+    # rule existing: ".fermata-trash." is not equal to ".fermata-trash", so it
+    # passes this check on its text, and Windows then drops the dot and puts the
+    # score inside the trash folder anyway.
     if parts and parts[0] == scanner.TRASH_DIR_NAME:
         raise HTTPException(
             422,
@@ -2172,13 +2292,18 @@ def _safe_filename(name: str) -> str:
     to `.txt` would leave a file the library can no longer see, which is a
     deletion wearing a rename's clothes.
     """
-    cleaned = (name or "").strip()
+    # Not stripped, for the reason _safe_parts gives: "Study.pdf " and
+    # "Study.pdf" are two different requests, and only one of them is a name
+    # Windows will actually store.
+    cleaned = name or ""
     if not cleaned or not _VALID_SEGMENT.match(cleaned):
         raise HTTPException(
             422,
-            "filename is not a usable file name - no folders, no '..', and no control "
-            "characters",
+            "filename is not a usable file name - no folders, no '..', no control "
+            "characters, and none of : < > \" | ? * (a ':' is not part of a name on "
+            "Windows at all; it opens a hidden data stream on the file before it)",
         )
+    _reject_trailing(cleaned, "filename")
     suffix = Path(cleaned).suffix.lower()
     if suffix not in FILE_TYPES:
         raise HTTPException(
@@ -2246,6 +2371,33 @@ def _location_fields(rel: str) -> tuple[str | None, str | None]:
     return meta.collection, meta.series
 
 
+def _same_file(a: Path, b: Path) -> bool:
+    """Are these two paths the same file on disk?
+
+    Asked, rather than assumed from the text of the paths, because on a
+    case-insensitive filesystem two different strings routinely name one file -
+    which is the whole of the case-only rename problem below. False when either
+    path is not there, which is the answer every caller here wants.
+    """
+    try:
+        return a.exists() and b.exists() and os.path.samefile(a, b)
+    except OSError:
+        return False
+
+
+def _fs_refused(exc: OSError) -> HTTPException:
+    """The filesystem would not take this path, said as a refusal not a crash.
+
+    The segment rules cannot know what a particular filesystem will accept: a
+    name Windows reserves outright (NUL, CON), a path over its length limit, a
+    disk that is full, a mount that went read-only. Every one of those is
+    something a person can rename or free their way around, and none of them is
+    a bug in Fermata - so they come back as a 422 carrying what the filesystem
+    actually said, the same way create_folder already answers.
+    """
+    return HTTPException(422, f"your filesystem would not accept that path: {exc}")
+
+
 def _move_file_on_disk(src: Path, dest: Path) -> None:
     """Move one file, creating the folders above it, never overwriting.
 
@@ -2256,17 +2408,45 @@ def _move_file_on_disk(src: Path, dest: Path) -> None:
     an exclusive create plus a copy plus a delete, which turns a rename into a
     read and write of the whole file for a case that needs a second process
     writing into the library at the exact moment of a move.
+
+    A DESTINATION THAT IS THE SOURCE IS NOT IN THE WAY. On NTFS - which is the
+    platform this is deployed on - "Toccata.pdf" and "toccata.pdf" are one file,
+    so correcting a score's capitalisation asks to move a file onto itself and
+    the existence check above would refuse it, blaming the score for being where
+    it is. _same_file asks the filesystem instead of the path text.
+
+    THE EXDEV FALLBACK IS NARROWED TO EXDEV, and that is a fix rather than
+    tidying. shutil.move copies and unlinks, and copying onto an existing
+    destination OVERWRITES it - so catching every OSError and falling through to
+    it turned the one case rule 3 forbids (a file already there, appearing in the
+    gap between the check and the rename, which is exactly the race an upload can
+    produce) into a silent overwrite of somebody's file.
     """
-    if dest.exists():
+    if dest.exists() and not _same_file(src, dest):
         raise HTTPException(409, f"there is already a file at {dest}")
-    dest.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        dest.parent.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        raise _fs_refused(exc) from None
     try:
         src.rename(dest)
-    except OSError:
-        # Different filesystems under one library tree (a bind mount inside a
-        # bind mount) make rename fail with EXDEV; shutil.move copies and
-        # unlinks, which is slower and works.
+        return
+    except FileExistsError:
+        # Windows' rename refuses an existing destination outright; POSIX's
+        # replaces it silently, which is why the check above exists at all.
+        raise HTTPException(409, f"there is already a file at {dest}") from None
+    except OSError as exc:
+        if exc.errno != errno.EXDEV:
+            raise _fs_refused(exc) from None
+    # Different filesystems under one library tree (a bind mount inside a bind
+    # mount). Re-checked, because the copy below would overwrite where the
+    # rename above would not.
+    if dest.exists() and not _same_file(src, dest):
+        raise HTTPException(409, f"there is already a file at {dest}")
+    try:
         shutil.move(str(src), str(dest))
+    except OSError as exc:
+        raise _fs_refused(exc) from None
 
 
 def _relink_moved_file(conn, row, dest_rel: str) -> None:
@@ -2384,7 +2564,12 @@ def _plan_move(conn, row, dest_rel: str, claimed: set[str]) -> dict:
         return _plan_line(
             row, dest_rel, "blocked", f"{taken['title']} is already at that path"
         )
-    if _resolve_in_library(dest_rel).exists():
+    # `and not _same_file(...)` is what makes correcting a score's
+    # capitalisation possible on NTFS, where "Toccata.pdf" and "toccata.pdf" are
+    # one file: without it the file in the way IS this score's own file, and the
+    # plan blocked the rename while blaming the score for existing.
+    dest = _resolve_in_library(dest_rel)
+    if dest.exists() and not _same_file(source, dest):
         return _plan_line(
             row, dest_rel, "blocked", "there is already a file at that path"
         )
@@ -2577,6 +2762,11 @@ def create_folder(body: FolderIn):
     Creating a folder that is already there is not an error - the caller asked
     to have that folder and does - but the answer says which of the two
     happened.
+
+    NOT held against a running scan, unlike every other route in this section:
+    mkdir moves nothing and removes nothing, and a scan has no opinion about an
+    empty directory. See scanner.hold_library_still for the two exemptions and
+    why each one is safe.
     """
     _require_library()
     parts = _safe_parts(body.path, "path")
@@ -2812,6 +3002,17 @@ def _tidy_trash_folder(rel: str) -> None:
         pass
 
 
+def _now(conn) -> str:
+    """One clock, UTC, in exactly the format every other timestamp here uses.
+
+    Read from SQLite rather than from Python so a value written by hand and one
+    written by a DEFAULT cannot come out in two different formats - which is
+    what would happen the first time anything compared them as text, and every
+    date in this schema is compared as text.
+    """
+    return conn.execute("SELECT datetime('now')").fetchone()[0]
+
+
 def _attached_counts(conn, score_id: int) -> dict:
     """How much of somebody's own work is hanging off this score row.
 
@@ -2861,14 +3062,28 @@ def delete_score(score_id: RowId):
                 trash_rel = f"{scanner.TRASH_DIR_NAME}/{score_id}/{name}"
                 trash_rel = _free_path(trash_rel, conn, exclude_id=score_id)
                 source = _resolve_in_library(row["path"])
-                if source.is_file():
+                file_moved = source.is_file()
+                if file_moved:
                     _move_file_on_disk(source, _resolve_in_library(trash_rel))
+                # missing_since is CARRIED when there was no file to move, and
+                # cleared when there was. A score whose file had already gone is
+                # a real thing to want out of your library - it is the case where
+                # deleting is most obviously the right answer - so this refuses
+                # nothing; but it must not then claim a file was put in the trash.
+                # `file_moved` on the response is that claim withdrawn, and the
+                # mark stays so restoring puts the score back in exactly the
+                # state it was in: present in the library, flagged as missing.
                 conn.execute(
                     """UPDATE scores
                           SET path = ?, deleted_from = ?, deleted_at = datetime('now'),
-                              missing_since = NULL
+                              missing_since = ?
                         WHERE id = ?""",
-                    (trash_rel, row["path"], score_id),
+                    (
+                        trash_rel,
+                        row["path"],
+                        None if file_moved else (row["missing_since"] or _now(conn)),
+                        score_id,
+                    ),
                 )
                 # The library is smaller because somebody said so, so the mark
                 # the loss guard measures against comes down with it - see
@@ -2883,7 +3098,9 @@ def delete_score(score_id: RowId):
         "deleted": score_id,
         "title": title,
         "deleted_from": deleted_from,
-        "trashed_to": trash_rel,
+        # null, not a path, when nothing was moved there - see `file_moved`.
+        "trashed_to": trash_rel if file_moved else None,
+        "file_moved": file_moved,
         "practice_sessions_kept": kept["practice_sessions"],
         "goals_kept": kept["goals"],
         "tags_kept": kept["tags"],
@@ -2923,6 +3140,17 @@ def restore_score(score_id: RowId):
     beside it under a numbered name rather than overwriting it, and
     `restored_to` says where it actually went - see rule 3 in this section's
     comment.
+
+    A SCORE WITH NO FILE IN THE TRASH STILL COMES BACK, and this used to be a
+    409 that stranded it. Two ways to reach that state - the score was already
+    marked missing when it was deleted, or somebody emptied the trash folder by
+    hand, which docs/deployment.md says they may - and in both the row is the
+    only thing left worth having. Refusing meant the score could never leave the
+    trash except by being destroyed, taking its tags and transcription with it,
+    which is the opposite of what a trash is for. It is restored to the library
+    marked missing instead: exactly the state a score whose file has gone is
+    supposed to be in, from which putting the file back and scanning recovers it
+    by itself. `file_restored` says which of the two happened.
     """
     _require_library()
     try:
@@ -2932,21 +3160,46 @@ def restore_score(score_id: RowId):
                 came_from = row["deleted_from"] or row["path"]
                 target = _free_path(came_from, conn, exclude_id=score_id)
                 source = _resolve_in_library(row["path"])
-                if not source.is_file():
-                    raise HTTPException(
-                        409,
-                        "the file for that score is no longer in Fermata's trash folder, so "
-                        "there is nothing to put back. Its practice history is still on the "
-                        "score - put the file back in your library and scan, or destroy the "
-                        "score from the trash.",
-                    )
-                _move_file_on_disk(source, _resolve_in_library(target))
+                file_restored = source.is_file()
                 conn.execute(
                     "UPDATE scores SET deleted_at = NULL, deleted_from = NULL WHERE id = ?",
                     (score_id,),
                 )
-                _relink_moved_file(conn, row, target)
-                _tidy_trash_folder(row["path"])
+                if not file_restored:
+                    _repoint_row(conn, score_id, target)
+                    conn.execute(
+                        "UPDATE scores SET missing_since = ? WHERE id = ? "
+                        "AND missing_since IS NULL",
+                        (_now(conn), score_id),
+                    )
+                else:
+                    _move_file_on_disk(source, _resolve_in_library(target))
+                    # THE FILESYSTEM HALF OF THE ROLLBACK, and its absence was
+                    # the one place in this section where a refusal stranded a
+                    # score rather than leaving it alone. _relink_moved_file
+                    # refuses a file whose bytes no longer match the row - the
+                    # right answer - but the file has already MOVED by then, and
+                    # write_tx only rolls back the database. So the trash listed
+                    # a score whose file was not in the trash: restoring it
+                    # refused for ever, the next scan filed the file as a brand
+                    # new historyless score, and the error told the person to
+                    # scan, which is what caused that. _apply_plan has had these
+                    # three lines from the start; this path had not.
+                    try:
+                        _relink_moved_file(conn, row, target)
+                    except Exception:
+                        try:
+                            _resolve_in_library(target).rename(source)
+                        except OSError:  # pragma: no cover - refused twice
+                            log.error(
+                                "could not put %s back in the trash at %s after a refused "
+                                "restore - the file is at the new path and the database has "
+                                "been rolled back",
+                                target,
+                                row["path"],
+                            )
+                        raise
+                    _tidy_trash_folder(row["path"])
     except scanner.LibraryBusy as exc:
         raise _busy(exc) from None
     conn = connect()
@@ -2954,6 +3207,7 @@ def restore_score(score_id: RowId):
         "restored": score_id,
         "restored_from": came_from,
         "restored_to": target,
+        "file_restored": file_restored,
         "score": _with_tags(conn, [_score_row(conn, score_id)])[0],
     }
 

--- a/server/fermata/api.py
+++ b/server/fermata/api.py
@@ -1058,7 +1058,8 @@ def list_sessions(
     conn = connect()
     filters = " AND ".join(where)
     rows = conn.execute(
-        f"""SELECT p.*, s.title AS score_title
+        f"""SELECT p.*, s.title AS score_title,
+                   s.deleted_at IS NOT NULL AS score_deleted
               FROM practice_sessions p LEFT JOIN scores s ON s.id = p.score_id
              WHERE {filters}
           ORDER BY {practice.LOCAL_DATE_SQL} DESC, p.started_at DESC, p.id DESC
@@ -2449,7 +2450,25 @@ def _move_file_on_disk(src: Path, dest: Path) -> None:
         raise _fs_refused(exc) from None
 
 
-def _relink_moved_file(conn, row, dest_rel: str) -> None:
+_MOVE_CHANGED_ADVICE = "Scan the library so Fermata re-reads it, then move the score again."
+
+# WHY THE RESTORE PATH NEEDS ITS OWN SENTENCE. The advice this refusal used to
+# give everybody - scan the library and try again - was actively harmful before
+# the rollback above existed, because the file was left at the new path and a
+# scan filed it as a brand new historyless score. With the rollback it is no
+# longer harmful, but on the restore path it is still USELESS: the file is back
+# in the trash, and scans skip the trash folder by design, so the one action the
+# message asks for provably cannot change the outcome. What is actually true
+# there is that the file in the trash is no longer the file that was deleted,
+# and a person has two real ways out.
+_RESTORE_CHANGED_ADVICE = (
+    "The file in the trash is not the one this score was deleted with - check it: put the "
+    "original back in the trash folder and restore again, or, if this score is not worth "
+    "keeping, delete it for good."
+)
+
+
+def _relink_moved_file(conn, row, dest_rel: str, advice: str = _MOVE_CHANGED_ADVICE) -> None:
     """Point the score row at where its file now is - by content, not by trust.
 
     The hash is recomputed at the destination and checked against the one the
@@ -2470,9 +2489,9 @@ def _relink_moved_file(conn, row, dest_rel: str) -> None:
     if moved_hash != row["hash"]:
         raise HTTPException(
             409,
-            "the file changed while it was being moved, so Fermata stopped rather than "
-            "attach this score's practice history and transcription to different music. "
-            "Scan the library and try again.",
+            "the file's contents are not the ones Fermata recorded for this score, so it "
+            "stopped rather than attach this score's practice history and transcription to "
+            f"different music. Nothing was changed. {advice}",
         )
     stat = dest.stat()
     _repoint_row(conn, row["id"], dest_rel, stat.st_size, stat.st_mtime)
@@ -2858,7 +2877,16 @@ def rename_folder(body: FolderRenameIn):
     dest = _resolve_in_library(to_rel)
     if not source.is_dir():
         raise HTTPException(404, f"there is no folder {from_rel} in your library")
-    if dest.exists():
+    # THE SAME EXCEPTION THE FILE PATH NEEDED, for the same reason and on the
+    # same platform: "Inbox" and "inbox" are one directory on NTFS, so fixing a
+    # folder's capitalisation asks to rename it onto itself and a bare
+    # exists() refused it - "inbox already exists", naming the folder as its own
+    # obstacle. Asking the filesystem separates the two cases a path string
+    # cannot: the same directory under another spelling (allowed - it IS the
+    # rename), and a genuinely different directory that happens to be there
+    # (still refused, because renaming onto it would merge two folders' scores
+    # into one with nothing said).
+    if dest.exists() and not _same_file(source, dest):
         raise HTTPException(409, f"{to_rel} already exists")
     prefix = from_rel + "/"
     try:
@@ -3186,7 +3214,7 @@ def restore_score(score_id: RowId):
                     # scan, which is what caused that. _apply_plan has had these
                     # three lines from the start; this path had not.
                     try:
-                        _relink_moved_file(conn, row, target)
+                        _relink_moved_file(conn, row, target, _RESTORE_CHANGED_ADVICE)
                     except Exception:
                         try:
                             _resolve_in_library(target).rename(source)

--- a/server/fermata/api_models.py
+++ b/server/fermata/api_models.py
@@ -160,6 +160,13 @@ class ScoreOut(BaseModel):
     mtime: float
     last_page: int
     missing_since: str | None
+    # Set only on a score somebody deleted (#56). `deleted_at` says when, and
+    # `deleted_from` is the library-relative path the file was at before it was
+    # moved into the trash - which is where restoring puts it back. Both null
+    # for every score in the library proper, which is the great majority of
+    # them; `path` on a deleted row names the file's location inside the trash.
+    deleted_at: str | None
+    deleted_from: str | None
     added_at: str
     instrument_id: int | None
     tags: list[str]
@@ -597,3 +604,159 @@ class ScanTriggerOut(ScanStatusOut):
 
 class UploadOut(BaseModel):
     saved: str
+
+
+# ---------------------------------------------------------------------------
+# Managing the library: moving, renaming, deleting and reorganising (#56)
+#
+# This is the one part of the API that WRITES to a person's own files, so the
+# shapes here are built around saying what happened rather than around saying
+# it worked. Every operation answers with the exact paths involved; every
+# destructive one answers with what it kept and what it destroyed, counted
+# from the database rather than assumed.
+# ---------------------------------------------------------------------------
+
+
+class MovePlanItemOut(BaseModel):
+    """One line of a move, whether or not it has happened yet.
+
+    The same shape is used for a dry run and for a move that was applied,
+    deliberately: a preview that is a different shape from the thing it
+    previews is a preview of something else. `status` is 'move' (this file
+    goes, or went, from `from_path` to `to_path`), 'unchanged' (it is already
+    where it was asked to be, and nothing will be touched) or 'blocked'
+    (something is in the way - `reason` says what, in words meant for a
+    person). A plan containing any 'blocked' line is refused as a whole rather
+    than applied in part.
+    """
+
+    score_id: int
+    title: str
+    from_path: str
+    to_path: str
+    status: str
+    reason: str | None = None
+
+
+class ScoreMoveOut(BaseModel):
+    """POST /api/scores/{id}/move: where one score's file went.
+
+    `score` is the score as it now stands - unchanged when this was a dry run,
+    which is what makes a dry run's response readable as "this is what you have
+    at the moment, and this is what would change".
+    """
+
+    dry_run: bool
+    applied: bool
+    moves: list[MovePlanItemOut]
+    score: ScoreOut
+
+
+class LibraryMoveOut(BaseModel):
+    """POST /api/library/move: a batch move, and its per-score plan.
+
+    `moved`, `unchanged` and `blocked` count the lines in `moves` by status, so
+    a caller has the headline without walking the list. On a dry run they
+    describe what WOULD happen; nothing on disk has been touched.
+    """
+
+    dry_run: bool
+    applied: bool
+    folder: str
+    moves: list[MovePlanItemOut]
+    moved: int
+    unchanged: int
+    blocked: int
+
+
+class FolderOut(BaseModel):
+    """One folder in the library tree, as the move dialog offers it.
+
+    `score_count` counts the scores whose file is directly in this folder, not
+    the ones under it - a total including subfolders would make the top-level
+    entry read as though everything were in it.
+    """
+
+    path: str
+    name: str
+    depth: int
+    score_count: int
+
+
+class FolderCreateOut(BaseModel):
+    """POST /api/library/folders. `existed` is true when the folder was
+    already there - which is not an error (asking for a folder that exists
+    leaves you with the folder you asked for) but is worth saying, so an
+    interface can tell "created" from "was already yours"."""
+
+    created: str
+    existed: bool
+
+
+class FolderRenameOut(BaseModel):
+    """POST /api/library/folders/rename: a folder moved, and every score that
+    went with it."""
+
+    dry_run: bool
+    applied: bool
+    from_path: str
+    to_path: str
+    moves: list[MovePlanItemOut]
+    moved: int
+
+
+class ScoreDeleteOut(BaseModel):
+    """DELETE /api/scores/{id}: a score moved to the trash.
+
+    The four `_kept` counts are the point of this shape. This deletion destroys
+    nothing, and the way to make that credible is to state, from the database
+    and after the fact, exactly how much is still attached to the row: the
+    practice sessions, the goals, the tags and the transcriptions. An interface
+    can then say "still holding 14 sessions" rather than "deleted (trust us)".
+    """
+
+    deleted: int
+    title: str
+    deleted_from: str
+    trashed_to: str
+    practice_sessions_kept: int
+    goals_kept: int
+    tags_kept: int
+    transcriptions_kept: int
+
+
+class ScoreRestoreOut(BaseModel):
+    """POST /api/trash/{id}/restore: a score taken back out of the trash.
+
+    `restored_to` is where the file actually ended up, which is usually where
+    it came from and is not always: something else may have taken that path
+    while the score was in the trash, in which case the file lands beside it
+    under a distinct name rather than overwriting it. Reported rather than
+    assumed, because "it is back" and "it is back where it was" are different
+    claims.
+    """
+
+    restored: int
+    restored_from: str
+    restored_to: str
+    score: ScoreOut
+
+
+class ScorePurgeOut(BaseModel):
+    """DELETE /api/trash/{id}: the destructive one.
+
+    Everything this shape reports is a thing that is now gone or a thing that
+    survived, counted before the delete ran so the numbers describe what was
+    actually there. `tags_destroyed` and `transcriptions_destroyed` cascade
+    with the row; `practice_sessions_kept` and `goals_kept` do not, because
+    the hours were still spent (see db.py's schema notes on why those two
+    references are ON DELETE SET NULL and these two are ON DELETE CASCADE).
+    """
+
+    deleted: int
+    title: str
+    file_deleted: str | None
+    tags_destroyed: int
+    transcriptions_destroyed: int
+    practice_sessions_kept: int
+    goals_kept: int

--- a/server/fermata/api_models.py
+++ b/server/fermata/api_models.py
@@ -258,6 +258,11 @@ class TopScoreOut(BaseModel):
     id: int
     title: str
     practice_seconds: int
+    # True when this score has been deleted (#56). It is still counted - the
+    # hours were spent, and dropping it would stop these figures adding up to
+    # the week beside them - but it is no longer in the library, so a client
+    # must not offer it as somewhere to go. See api.practice_summary.
+    deleted: bool
 
 
 class PracticeSummaryOut(BaseModel):
@@ -292,6 +297,8 @@ class ByScoreOut(BaseModel):
     seconds: int
     sessions: int
     last_practised: str | None
+    # Same fact, same reason as TopScoreOut.deleted - see practice.time_spent.
+    deleted: bool
 
 
 class ByActivityOut(BaseModel):
@@ -718,7 +725,12 @@ class ScoreDeleteOut(BaseModel):
     deleted: int
     title: str
     deleted_from: str
-    trashed_to: str
+    # Null when there was no file to move - a score whose file had already gone
+    # can still be deleted, and saying it was "trashed to" somewhere would be a
+    # path with nothing at it. `file_moved` is the same fact as a flag, stated
+    # so a client branches on a boolean rather than on a null.
+    trashed_to: str | None
+    file_moved: bool
     practice_sessions_kept: int
     goals_kept: int
     tags_kept: int
@@ -739,6 +751,10 @@ class ScoreRestoreOut(BaseModel):
     restored: int
     restored_from: str
     restored_to: str
+    # False when there was no file in the trash to bring back - the score
+    # returns to the library flagged as missing rather than being stranded in
+    # the trash for ever. See api.restore_score.
+    file_restored: bool
     score: ScoreOut
 
 

--- a/server/fermata/api_models.py
+++ b/server/fermata/api_models.py
@@ -226,9 +226,19 @@ class PracticeSessionOut(BaseModel):
 class PracticeSessionListOut(PracticeSessionOut):
     """A session as GET /api/practice/sessions lists it - the same fields,
     plus the piece's title joined in so a reader is not left with a bare
-    score_id (or, for a session with none, `null`)."""
+    score_id (or, for a session with none, `null`).
+
+    `score_deleted` is the same fact `top_scores` and `by_score` carry, on the
+    list that names individual sessions: the piece is in the trash. It is NOT
+    `score_missing`, which means the row itself has gone and there is no piece
+    left to name at all - a deleted score still has its title, its history and
+    a way back, and a client that conflates the two would offer to restore
+    something that cannot be restored. Both are false for a session logged
+    against no piece.
+    """
 
     score_title: str | None
+    score_deleted: bool
 
 
 class ScorePracticeOut(BaseModel):

--- a/server/fermata/config.py
+++ b/server/fermata/config.py
@@ -47,8 +47,17 @@ def ensure_dirs() -> None:
     The config folder IS created, and the difference is not arbitrary. That
     folder is Fermata's own storage - nobody mounts anything into it that
     Fermata did not put there, an empty one is a genuine first run, and there
-    is no data it could be shadowing. The library folder is the user's, and
-    Fermata only ever reads it.
+    is no data it could be shadowing. The library folder is the user's.
+
+    THAT DISTINCTION SURVIVED FERMATA LEARNING TO WRITE TO THE LIBRARY (#56),
+    and this paragraph exists because the sentence it replaces - "Fermata only
+    ever reads it" - stopped being true. Fermata now moves, renames and deletes
+    files in there when a person asks it to, which makes the reasoning above
+    stronger rather than weaker: an invented empty library is now somewhere a
+    reorganisation could be applied, not merely somewhere an index could be
+    reconciled away. What is still true, and is the rule those operations are
+    written to, is that Fermata never CREATES the library folder and never
+    writes outside it.
     """
     if not LIBRARY_DIR.is_dir():
         what = "is a file, not a folder" if LIBRARY_DIR.exists() else "is not there"

--- a/server/fermata/db.py
+++ b/server/fermata/db.py
@@ -192,6 +192,24 @@ _PRACTICE_SCHEMA = (
 # bug this column exists to prevent, reintroduced by a future migration nobody
 # would suspect. Anything added to scores from now on belongs HERE.
 #
+# deleted_at / deleted_from: what a person deleting a score through Fermata
+# leaves behind (#56). A deletion here is a MARK and a move, never a DELETE: the
+# file goes to a trash folder inside the library, `deleted_from` remembers the
+# library-relative path it came from so restoring puts it back where it was, and
+# `deleted_at` says when - which is the question actually asked of a trash
+# ("what did I throw away this afternoon?"), and one a boolean could not answer.
+# The row, and the practice history, tags, goals and transcription hanging off
+# it, stay exactly where they were, which is the whole reason this is not a
+# DELETE. `path` moves to the file's location inside the trash folder, because
+# that column has to keep naming where the bytes actually are and is UNIQUE -
+# leaving the old path on a deleted row would block a new file arriving at it.
+#
+# These two are deliberately NOT the same fact as missing_since, and the two are
+# never confused for one another. missing_since is a fact about the filesystem
+# that Fermata observed; deleted_at is a decision a person made. A missing score
+# is still in the library and says so on its card; a deleted one is in the trash
+# until it is restored or destroyed.
+#
 # missing_since: NULL means the file was there the last time a scan looked; a
 # timestamp means it was not, and says since when - which is the question
 # somebody actually asks about a row like this ("has that been gone since the
@@ -223,6 +241,8 @@ _SCORES_COLUMNS = """(
     mtime REAL NOT NULL,
     last_page INTEGER NOT NULL DEFAULT 1,
     missing_since TEXT,
+    deleted_at TEXT,
+    deleted_from TEXT,
     added_at TEXT NOT NULL DEFAULT (datetime('now'))
 )"""
 
@@ -418,7 +438,31 @@ CREATE INDEX IF NOT EXISTS idx_instruments_owner ON instruments(owner);
 # when the new schema cannot be expressed the old way. A version therefore need
 # not have a MIGRATIONS entry - SCHEMA_VERSION is stamped by init_db at the end
 # of startup regardless of which mechanism did the work.
-SCHEMA_VERSION = 4
+#
+# VERSION 5 HAS NO MIGRATIONS STEP EITHER, and is the rule above applied a
+# second time. `deleted_at` and `deleted_from` (#56) are nullable, carry no
+# foreign key and need no backfill, so as an upgrade they are only ADD COLUMNs
+# and COLUMN_ADDITIONS carries them. The stamp moves because of what the
+# PREVIOUS release does when pointed at a database this one has written.
+#
+# It does not know the columns, so it does not know a deleted score is deleted.
+# Two consequences, and the second is the one that decided this:
+#
+#   IT HANDS SOMEBODY THEIR DELETED SCORES BACK. Its scan walks the trash folder
+#   like any other, finds each deleted file at the path its row already names,
+#   and lists it in the library as an ordinary score. Somebody who deleted a
+#   score sees it return, with no statement that anything was undone.
+#
+#   AND ITS SCAN CAN ADOPT A DELETED ROW FOR A LIVE FILE. The content-hash
+#   relink picks candidates without filtering on `deleted_at`, which this
+#   release's does - so a fresh copy of a deleted score's content, arriving
+#   anywhere in the library, re-links onto the DELETED row and moves its path
+#   out of the trash. Upgrade again and that row is still marked deleted, so the
+#   file the person just added is hidden from their library and sitting in the
+#   trash view. That is this release hiding a file somebody has on disk, on the
+#   strength of a decision the older release could not see, and it is the kind
+#   of harm the stamp exists to make impossible.
+SCHEMA_VERSION = 5
 
 # Columns added to a table that had already shipped. CREATE TABLE IF NOT EXISTS
 # does nothing at all to a table that exists, so SCHEMA alone reaches only fresh
@@ -472,6 +516,12 @@ COLUMN_ADDITIONS = {
     "scores": {
         "instrument_id": "INTEGER REFERENCES instruments(id) ON DELETE SET NULL",
         "missing_since": "TEXT",
+        # #56's two, arriving the same way and for the same reasons: nullable,
+        # no foreign key, and needing no backfill, because NULL is already true
+        # of every row that exists - nothing could have been deleted through
+        # Fermata before there was a way to delete anything.
+        "deleted_at": "TEXT",
+        "deleted_from": "TEXT",
     },
 }
 
@@ -743,7 +793,8 @@ def connect() -> sqlite3.Connection:
                 "it. In Docker that is the volume mapped to /config; see "
                 "docs/deployment.md.\n"
                 "\n"
-                "Your sheet music is not affected: the library folder is only ever read."
+                "Your sheet music is not affected: Fermata has not started, so nothing has "
+                "touched your library folder."
             ) from None
         conn.execute("PRAGMA foreign_keys=ON")
         _local.conn = conn

--- a/server/fermata/practice.py
+++ b/server/fermata/practice.py
@@ -749,10 +749,17 @@ def time_spent(
     did I work on" rather than a bucket labelled "no piece" that a reader has
     to know to ignore.
     """
+    # `deleted` travels with the row (#56). A score somebody deleted is STILL
+    # listed here, because the hours were spent and dropping it would leave this
+    # breakdown not adding up to the total beside it - the same reason
+    # `scores_worked` below exists. What it must not do is read as a piece that
+    # is in the library: a client can render it as gone, and stop linking to it,
+    # only if it is told.
     by_score = conn.execute(
         f"""SELECT p.score_id, s.title,
                    SUM(p.seconds) AS seconds, COUNT(*) AS sessions,
-                   MAX({LOCAL_DATE_SQL}) AS last_practised
+                   MAX({LOCAL_DATE_SQL}) AS last_practised,
+                   s.deleted_at IS NOT NULL AS deleted
               FROM practice_sessions p JOIN scores s ON s.id = p.score_id
              WHERE p.owner = ? AND {LOCAL_DATE_SQL} BETWEEN ? AND ?
           GROUP BY p.score_id ORDER BY seconds DESC, s.title LIMIT ?""",
@@ -776,7 +783,7 @@ def time_spent(
         (owner, start, end),
     ).fetchall()
     return {
-        "by_score": [dict(r) for r in by_score],
+        "by_score": [{**dict(r), "deleted": bool(r["deleted"])} for r in by_score],
         "by_activity": [dict(r) for r in by_activity],
         "scores_worked": scores_worked,
         "by_score_truncated": scores_worked > len(by_score),

--- a/server/fermata/scanner.py
+++ b/server/fermata/scanner.py
@@ -2,6 +2,8 @@ import hashlib
 import logging
 import threading
 import time
+from contextlib import contextmanager
+from pathlib import Path
 
 from .config import FILE_TYPES, LIBRARY_DIR
 from .db import DEFAULT_OWNER, connect
@@ -52,6 +54,115 @@ _state = {
     "finished_at": None,
 }
 _state_lock = threading.Lock()
+
+# Where a deleted score's file goes, as a folder name directly under the library
+# root (#56). Inside the library rather than beside it, deliberately: the library
+# folder is very often a mount or an external drive, and a trash kept anywhere
+# else would mean every deletion copying bytes across a filesystem boundary -
+# slow, and capable of filling a small system disk with somebody's PDFs. Inside,
+# the move is a rename within one filesystem: instant, atomic, and impossible to
+# half-do.
+#
+# NAMED WITH A LEADING DOT so a file manager, a sync client and a backup tool
+# all treat it the way they treat every other application's private folder. The
+# scan skips it entirely - see _library_files - which is what stops a deleted
+# score from being re-discovered as a brand new one the moment anything scans.
+TRASH_DIR_NAME = ".fermata-trash"
+
+# True while a deliberate change to the library is being applied - a move, a
+# rename, a deletion, a restore (#56).
+#
+# WHY THIS EXISTS AT ALL, and why it is not simply left to the database. A scan
+# decides what to write from a DIRECTORY LISTING taken at its start: `files`,
+# `disk_paths`, and the set of stored paths it compares them against. A move
+# landing after that listing invalidates it in the one way the scan cannot
+# detect - the row's path is now somewhere the listing never saw, so
+# _mark_absent marks a row whose file is perfectly present, and the person's
+# score reads as missing because they moved it with the button provided for
+# moving it.
+#
+# The scanner already refuses to run two scans at once for the same reason, so
+# this is that rule extended to the other kind of writer rather than a new idea:
+# ONE thing reconciles the library at a time. It is deliberately coarse - a
+# whole-library exclusion for an operation on one file - because the alternative
+# is a scan and a mutation agreeing about which paths each may touch, which is a
+# great deal of machinery to make a scan and a click overlap by a few
+# milliseconds.
+_mutating = False
+
+
+class LibraryBusy(RuntimeError):
+    """Something else is reconciling the library right now.
+
+    Raised rather than waited out: the caller is an HTTP request with a person
+    behind it, and "a scan is running, try again in a moment" is a better answer
+    than a request that hangs for the length of a scan over a library of
+    thousands of files.
+    """
+
+
+@contextmanager
+def hold_library_still():
+    """Hold the library still for one deliberate change.
+
+    Refuses if a scan is running or another change is being applied, and makes
+    start_scan decline for as long as it is held. See the comment on `_mutating`
+    for why a change to one file excludes a scan of the whole library.
+    """
+    global _mutating
+    with _state_lock:
+        if _state["scanning"]:
+            raise LibraryBusy(
+                "a library scan is running, so Fermata will not move or delete anything "
+                "just now - a scan decides what to write from a listing taken when it "
+                "started, and a file moving underneath it would read as a file that went "
+                "missing. Wait for the scan to finish and try again."
+            )
+        if _mutating:
+            raise LibraryBusy(
+                "another change to the library is being applied right now. Wait for it to "
+                "finish and try again."
+            )
+        _mutating = True
+    try:
+        yield
+    finally:
+        with _state_lock:
+            _mutating = False
+
+
+def trash_dir(root: Path | None = None) -> Path:
+    """The trash folder for a library root.
+
+    Takes the root as an argument rather than reading LIBRARY_DIR at import
+    time, because api.py and the tests each hold their own binding of it - see
+    test_scanner.py's `library` fixture, which repoints this module's.
+    """
+    return (root if root is not None else LIBRARY_DIR) / TRASH_DIR_NAME
+
+
+def in_trash(rel: str) -> bool:
+    """Is this library-relative path inside the trash folder?"""
+    parts = Path(rel.replace("\\", "/")).parts
+    return bool(parts) and parts[0] == TRASH_DIR_NAME
+
+
+def _library_files(root: Path) -> list[Path]:
+    """Every file in the library a scan is entitled to have an opinion about.
+
+    The trash is excluded here rather than filtered out later, so that it is
+    excluded from `disk_paths` too - a deleted file counting as "on disk" would
+    make the relink treat it as a live candidate and quietly resurrect the score
+    somebody deleted.
+    """
+    return [
+        p
+        for p in root.rglob("*")
+        if p.is_file()
+        and p.suffix.lower() in FILE_TYPES
+        and not in_trash(p.relative_to(root).as_posix())
+    ]
+
 
 # WHEN A SCAN REFUSES TO BELIEVE ITSELF.
 #
@@ -139,7 +250,15 @@ def scan_status() -> dict:
         return dict(_state)
 
 
-def _hash_file(path) -> str:
+def hash_file(path) -> str:
+    """A file's content hash - the only thing in Fermata that says two files
+    are the same music.
+
+    Public because the move and restore paths in api.py check a file against
+    its score's stored hash with it (#56). That is deliberately the SAME
+    identity test _scan_file's relink uses, rather than a second one: there is
+    one answer to "is this still that score's file", and it is the bytes.
+    """
     h = hashlib.sha1()
     with open(path, "rb") as f:
         while chunk := f.read(1 << 20):
@@ -313,11 +432,7 @@ def _scan(acknowledge: str | None = None) -> None:
         )
         return
 
-    files = [
-        p
-        for p in LIBRARY_DIR.rglob("*")
-        if p.is_file() and p.suffix.lower() in FILE_TYPES
-    ]
+    files = _library_files(LIBRARY_DIR)
     # Fixed for the whole scan: lets _scan_file tell a genuinely-removed row
     # (safe to re-link on a hash match) from one whose file just hasn't been
     # visited yet in this pass.
@@ -326,7 +441,18 @@ def _scan(acknowledge: str | None = None) -> None:
         _state["total"] = len(files)
 
     # --- Decide. Reads only. ---
-    rows = conn.execute("SELECT id, path, missing_since FROM scores").fetchall()
+    #
+    # A DELETED SCORE IS NOT PART OF THIS CONVERSATION, and every query below
+    # that reaches the scores table says so. Its file is in the trash, which the
+    # walk above skipped, so counting it among the rows "believed present" would
+    # make every deletion look to the guard like a file that vanished - delete
+    # half a large library on purpose and the next scan would refuse, offering a
+    # token to acknowledge something nobody did. Deleting is not something the
+    # scan has to be talked into; it already happened, deliberately, and was
+    # recorded (#56).
+    rows = conn.execute(
+        "SELECT id, path, missing_since FROM scores WHERE deleted_at IS NULL"
+    ).fetchall()
     believed_present = [r for r in rows if r["missing_since"] is None]
     unmatched = [r for r in believed_present if r["path"] not in disk_paths]
     high_water = _read_high_water(conn)
@@ -398,7 +524,7 @@ def _mark_absent(conn, seen_paths: set, were_present: int) -> None:
     unseen = [
         row
         for row in conn.execute(
-            "SELECT id, path FROM scores WHERE missing_since IS NULL"
+            "SELECT id, path FROM scores WHERE missing_since IS NULL AND deleted_at IS NULL"
         ).fetchall()
         if row["path"] not in seen_paths
     ]
@@ -454,6 +580,30 @@ def _mark_absent(conn, seen_paths: set, were_present: int) -> None:
         )
 
 
+def record_deliberate_shrink(conn) -> int:
+    """Take the library's current size as its new high-water mark, because
+    somebody just made it smaller on purpose (#56).
+
+    THIS IS THE SAME THING AN ACKNOWLEDGEMENT DOES, and for the same reason.
+    The high-water mark is what the proportional refusal is measured against
+    (see LOSS_FRACTION), and it only ever rises by itself - so without this, a
+    person who deletes two thirds of their library through Fermata is left with
+    a mark describing a library that no longer exists, and the very next file
+    that genuinely goes missing takes the remaining count under half of it and
+    refuses a scan over one file. The refusal would be about a loss they
+    already told Fermata about, one score at a time, and confirmed by pressing
+    delete.
+
+    Returns the new mark, so a caller can say what it did rather than only do
+    it.
+    """
+    present = conn.execute(
+        "SELECT COUNT(*) FROM scores WHERE missing_since IS NULL AND deleted_at IS NULL"
+    ).fetchone()[0]
+    _write_high_water(conn, present)
+    return present
+
+
 def _record_high_water(conn, previous: int, reset: bool) -> None:
     """Remember how big this library is when it is whole.
 
@@ -463,7 +613,7 @@ def _record_high_water(conn, previous: int, reset: bool) -> None:
     subsequent scan for ever, against a library that no longer exists.
     """
     present = conn.execute(
-        "SELECT COUNT(*) FROM scores WHERE missing_since IS NULL"
+        "SELECT COUNT(*) FROM scores WHERE missing_since IS NULL AND deleted_at IS NULL"
     ).fetchone()[0]
     _write_high_water(conn, present if reset else max(previous, present))
 
@@ -492,7 +642,7 @@ def _scan_file(conn, path, rel: str, seen_paths: set, disk_paths: set) -> None:
         return
 
     file_type = FILE_TYPES[path.suffix.lower()]
-    file_hash = _hash_file(path)
+    file_hash = hash_file(path)
     pages, pdf_title, pdf_creator = (None, None, None)
     if file_type == "pdf":
         pages, pdf_title, pdf_creator = pdf_info(path)
@@ -525,10 +675,21 @@ def _scan_file(conn, path, rel: str, seen_paths: set, disk_paths: set) -> None:
         # moving together) there's no way to know which one moved, so fall back
         # to an insert and let _mark_absent record whichever one truly vanished.
         # That fallback is no longer lossy.
+        #
+        # A DELETED ROW IS NEVER A CANDIDATE (#56). Its file is in the trash by
+        # somebody's decision, and its stored path points there - so without
+        # this filter, dropping a fresh copy of that content anywhere in the
+        # library would re-link the deleted score onto it, move its path back
+        # out of the trash, and hand the person back the thing they threw away,
+        # while leaving the actual trashed file behind with nothing naming it.
+        # Restoring is an action with a button; it is not something a scan
+        # should do on somebody's behalf.
         candidates = [
             r
             for r in conn.execute(
-                "SELECT id, path, missing_since FROM scores WHERE hash = ?", (file_hash,)
+                "SELECT id, path, missing_since FROM scores"
+                " WHERE hash = ? AND deleted_at IS NULL",
+                (file_hash,),
             ).fetchall()
             if r["path"] not in disk_paths
         ]
@@ -610,7 +771,11 @@ def start_scan(acknowledge: str | None = None) -> bool:
     which is the safe way for stale consent to fail.
     """
     with _state_lock:
-        if _state["scanning"]:
+        if _state["scanning"] or _mutating:
+            # `_mutating` for the same reason `scanning` is here: one thing
+            # reconciles the library at a time. A scan starting in the middle of
+            # a move would take its directory listing while the file is at
+            # neither end of the move - see the comment on `_mutating`.
             return False
         _state["scanning"] = True
         _state["started_at"] = time.time()

--- a/server/fermata/scanner.py
+++ b/server/fermata/scanner.py
@@ -83,11 +83,31 @@ TRASH_DIR_NAME = ".fermata-trash"
 #
 # The scanner already refuses to run two scans at once for the same reason, so
 # this is that rule extended to the other kind of writer rather than a new idea:
-# ONE thing reconciles the library at a time. It is deliberately coarse - a
-# whole-library exclusion for an operation on one file - because the alternative
-# is a scan and a mutation agreeing about which paths each may touch, which is a
-# great deal of machinery to make a scan and a click overlap by a few
-# milliseconds.
+# ONE THING THAT MOVES OR REMOVES AN EXISTING FILE RUNS AT A TIME. It is
+# deliberately coarse - a whole-library exclusion for an operation on one file -
+# because the alternative is a scan and a mutation agreeing about which paths
+# each may touch, which is a great deal of machinery to make a scan and a click
+# overlap by a few milliseconds.
+#
+# WHAT IS NOT HELD, stated exactly, because "one writer at a time" is easy to
+# say and would be false as a flat claim:
+#
+#   UPLOAD IS NOT HELD, on purpose. It only ever CREATES a file at a path
+#   nothing claims; it never moves or removes one, so it cannot invalidate a
+#   scan's listing the way a move does - a scan either sees the new file and
+#   inserts a row, or does not and the upload's own scan picks it up. Holding it
+#   would also break the ordinary case rather than protect it: every upload
+#   starts a scan, so uploading two files in a row would have the second refused
+#   for the first one's scan. The one interaction that matters is an upload
+#   landing on a move's destination, and that is caught where it has to be
+#   caught anyway (a person can drop a file into the library folder with no
+#   endpoint involved at all): _move_file_on_disk refuses a destination that
+#   exists, and its rename fails rather than overwriting if the file appears in
+#   the gap after that check.
+#
+#   CREATING A FOLDER IS NOT HELD either, and needs no argument beyond stating
+#   it: mkdir moves nothing and removes nothing, and a scan does not have an
+#   opinion about an empty directory.
 _mutating = False
 
 

--- a/server/tests/test_api_docs.py
+++ b/server/tests/test_api_docs.py
@@ -290,7 +290,10 @@ def test_every_route_has_exactly_the_expected_operation_count(openapi_schema):
     hand. Update this number, deliberately, the same commit that adds or
     removes a route."""
     count = sum(1 for _ in _operations(openapi_schema))
-    assert count == 41
+    # 41 before issue #56, plus its nine: move one score, list/create folders,
+    # rename a folder, move several scores, delete a score, list the trash,
+    # restore from it, and destroy from it.
+    assert count == 50
 
 
 def test_binary_routes_do_not_advertise_a_json_content_type(openapi_schema):
@@ -374,6 +377,62 @@ def test_library_responses_match_their_models(client, insert_score):
         api_models.TagOut.model_validate(item)
     for group in client.get("/api/duplicates").json():
         api_models.DuplicateGroupOut.model_validate(group)
+
+
+def test_library_management_responses_match_their_models(client, app_env, monkeypatch, tmp_path):
+    """Issue #56's nine routes, through the same drift-guarded client.
+
+    A real file in a real throwaway library, because every one of these
+    endpoints reads or writes the filesystem - a stub row with a made-up hash
+    would be refused by the move's own content check, which is the point of
+    that check. api.py bound LIBRARY_DIR by value at import, so it is
+    repointed the way test_scanner.py's fixtures do it.
+    """
+    from fermata import config, db, scanner
+
+    root = config.LIBRARY_DIR
+    monkeypatch.setattr(api, "LIBRARY_DIR", root)
+    monkeypatch.setattr(scanner, "LIBRARY_DIR", root)
+    (root / "Inbox").mkdir(parents=True, exist_ok=True)
+    score_file = root / "Inbox" / "Study.pdf"
+    score_file.write_bytes(b"a score file")
+    stat = score_file.stat()
+
+    conn = db.connect()
+    score_id = conn.execute(
+        """INSERT INTO scores(title, collection, path, file_type, hash, size, mtime)
+           VALUES ('Study', 'Inbox', 'Inbox/Study.pdf', 'pdf', ?, ?, ?)""",
+        (scanner.hash_file(score_file), stat.st_size, stat.st_mtime),
+    ).lastrowid
+    conn.commit()
+
+    for item in client.get("/api/library/folders").json():
+        api_models.FolderOut.model_validate(item)
+    api_models.FolderCreateOut.model_validate(
+        client.post("/api/library/folders", json={"path": "Classical"}).json()
+    )
+    api_models.ScoreMoveOut.model_validate(
+        client.post(f"/api/scores/{score_id}/move", json={"folder": "Classical"}).json()
+    )
+    api_models.LibraryMoveOut.model_validate(
+        client.post(
+            "/api/library/move", json={"score_ids": [score_id], "folder": "Classical/Sor"}
+        ).json()
+    )
+    api_models.FolderRenameOut.model_validate(
+        client.post(
+            "/api/library/folders/rename",
+            json={"from_path": "Classical", "to_path": "Romantic", "dry_run": False},
+        ).json()
+    )
+    api_models.ScoreDeleteOut.model_validate(client.delete(f"/api/scores/{score_id}").json())
+    for item in client.get("/api/trash").json():
+        api_models.ScoreOut.model_validate(item)
+    api_models.ScoreRestoreOut.model_validate(
+        client.post(f"/api/trash/{score_id}/restore").json()
+    )
+    client.delete(f"/api/scores/{score_id}")
+    api_models.ScorePurgeOut.model_validate(client.delete(f"/api/trash/{score_id}").json())
 
 
 def test_practice_responses_match_their_models(client, insert_score):

--- a/server/tests/test_instruments_api.py
+++ b/server/tests/test_instruments_api.py
@@ -780,7 +780,11 @@ def test_a_column_present_without_its_foreign_key_stops_startup(app_env):
 
 def test_the_schema_version_is_stamped(app_env):
     conn = db.connect()
-    assert conn.execute("PRAGMA user_version").fetchone()[0] == db.SCHEMA_VERSION == 4
+    # 5 since issue #56 added scores.deleted_at / deleted_from - see
+    # db.SCHEMA_VERSION for why that release bumps the stamp with no
+    # migration step behind it. Pinned to a literal on purpose: reading it
+    # only from db.SCHEMA_VERSION would make this test agree with any value.
+    assert conn.execute("PRAGMA user_version").fetchone()[0] == db.SCHEMA_VERSION == 5
 
 
 def test_a_database_from_a_newer_release_stops_startup(app_env):

--- a/server/tests/test_library_management_api.py
+++ b/server/tests/test_library_management_api.py
@@ -1099,7 +1099,18 @@ def test_a_refused_restore_puts_the_file_back_in_the_trash(client, library, add_
     res = client.post(f"/api/trash/{score_id}/restore")
 
     assert res.status_code == 409
-    assert "different music" in res.json()["detail"]
+    detail = res.json()["detail"]
+    assert "different music" in detail
+    # AND IT SAYS SOMETHING THAT HELPS. The advice this refusal used to give -
+    # scan the library and try again - was what caused the stranding above
+    # while the file was left in the library; with the rollback it is merely
+    # useless here, because scans skip the trash folder by design, so the one
+    # action it asked for provably could not change the outcome. Pinned as
+    # text, because "the message is unhelpful" is not a thing any other
+    # assertion in this file can notice.
+    assert "Scan the library" not in detail
+    assert "file in the trash is not the one this score was deleted with" in detail
+    assert "delete it for good" in detail
     # THE FILE IS BACK IN THE TRASH, byte for byte as it was when the restore
     # was attempted - not left sitting in the library with nothing naming it.
     assert trash_file.read_bytes() == b"different music entirely"
@@ -1132,20 +1143,39 @@ def test_deleting_a_score_whose_file_is_already_gone_says_no_file_was_moved(
     response no longer claims a file went anywhere.
     """
     score_id = add_score("Inbox/Study.pdf")
+    # A second score that stays, purely so the scan below is an ordinary
+    # reconcile rather than an emptied library - the loss guard refuses that
+    # one outright, and rightly, since it is what an unmounted drive looks like.
+    other = add_score("Inbox/Other.pdf", content=b"other")
     client.patch(f"/api/scores/{score_id}", json={"tags": ["keep me"]})
     client.post(f"/api/scores/{score_id}/practice", json={"seconds": 900})
     (library / "Inbox/Study.pdf").unlink()
+    # Scanned first, so the row carries a REAL missing_since to be carried -
+    # the delete-time fallback (`or _now()`) would otherwise hide whether the
+    # existing mark is kept or a fresh one is stamped, and both look "not
+    # null". That distinction is the fact this asserts below: when the file went
+    # missing is when it went missing, and deleting the score is not the moment
+    # it happened.
+    scanner._scan()
+    marked_at = client.get(f"/api/scores/{score_id}").json()["missing_since"]
+    assert marked_at is not None
 
     body = client.delete(f"/api/scores/{score_id}").json()
 
     assert body["file_moved"] is False
     assert body["trashed_to"] is None
+    # CARRIED, literally - not merely non-null, and not re-stamped to now.
+    # Writing NULL here unconditionally left every other assertion in this file
+    # green, which is how a deleted-then-restored score could come back looking
+    # present when its file had been gone for a month.
+    assert client.get(f"/api/scores/{score_id}").json()["missing_since"] == marked_at
     assert body["deleted_from"] == "Inbox/Study.pdf"
     assert body["practice_sessions_kept"] == 1
     assert body["tags_kept"] == 1
     # Out of the library, in the trash, and the trash folder holds no file for
-    # it - because there was none.
-    assert paths(client) == set()
+    # it - because there was none. The score that still had a file is untouched.
+    assert paths(client) == {"Inbox/Other.pdf"}
+    assert client.get(f"/api/scores/{other}").json()["deleted_at"] is None
     assert [s["id"] for s in client.get("/api/trash").json()] == [score_id]
     assert not any((library / scanner.TRASH_DIR_NAME).rglob("*.pdf"))
 
@@ -1262,6 +1292,14 @@ def test_the_other_characters_windows_will_not_take_are_refused(client, add_scor
     res = client.post(f"/api/scores/{score_id}/move", json={"filename": bad})
 
     assert res.status_code == 422, res.text
+    # WHICH guard refused - the same correction its `:` neighbour six lines up
+    # needed, and for the same reason. Taking these characters back out of the
+    # segment rule left this test green on Windows: the name reached the
+    # filesystem, the rename failed, and F5's wrapper answered 422 too. The two
+    # are not interchangeable - on a filesystem that accepts these bytes
+    # (ext4, and so CI) nothing would have refused at all, and the status alone
+    # cannot tell that apart from a real refusal.
+    assert "is not a usable file name" in res.json()["detail"]
     assert client.get(f"/api/scores/{score_id}").json()["path"] == "Inbox/Study.pdf"
 
 
@@ -1272,13 +1310,34 @@ def test_a_filesystem_refusing_a_move_is_a_422_not_a_500(
     filesystem would not take, and the move path answered 500 for the same
     thing - a reserved name, a path over the length limit, a read-only mount, a
     disk that filled up mid-batch. The rollback was already right; only the
-    status and the message were wrong."""
+    status and the message were wrong.
+
+    BOTH filesystem calls the move makes are covered, because there are two and
+    patching one proved nothing about the other. `dest.parent.mkdir` is the
+    first thing to touch the disk, and it is the call that fails for the
+    over-length path this docstring already claims to cover - a directory
+    Windows will not create. Patching only Path.rename left the mkdir arm
+    unpinned: deleting its `except OSError` entirely kept every test green.
+    """
     score_id = add_score("Inbox/Study.pdf")
-    real_rename = Path.rename
+    real_rename, real_mkdir = Path.rename, Path.mkdir
 
     def refuse(self, target):
         raise OSError(errno.EACCES, "Access is denied")
 
+    def refuse_mkdir(self, *a, **kw):
+        raise OSError(errno.ENAMETOOLONG, "File name too long")
+
+    # The mkdir arm: the move never reaches the rename at all.
+    monkeypatch.setattr(Path, "mkdir", refuse_mkdir)
+    res = client.post(f"/api/scores/{score_id}/move", json={"folder": "Classical"})
+    assert res.status_code == 422, res.text
+    assert "would not accept that path" in res.json()["detail"]
+    monkeypatch.setattr(Path, "mkdir", real_mkdir)
+    assert (library / "Inbox/Study.pdf").read_bytes() == FIXTURE
+    assert client.get(f"/api/scores/{score_id}").json()["path"] == "Inbox/Study.pdf"
+
+    # The rename arm: the directory is made, and moving into it is refused.
     monkeypatch.setattr(Path, "rename", refuse)
     res = client.post(f"/api/scores/{score_id}/move", json={"folder": "Classical"})
 
@@ -1334,6 +1393,55 @@ def test_a_score_can_be_renamed_to_a_different_capitalisation(client, library, a
     assert res.json()["score"]["path"] == "Classical/toccata.pdf"
     assert (library / "Classical/toccata.pdf").read_bytes() == FIXTURE
     assert client.get(f"/api/scores/{score_id}").json()["id"] == score_id
+
+
+def test_a_folder_can_be_renamed_to_a_different_capitalisation(client, library, add_score):
+    """F7 again, on the half the first fix missed: rename_folder had the same
+    bare exists() check as the file path, so "Inbox" -> "inbox" answered 409
+    "inbox already exists" on NTFS - naming the folder as its own obstacle,
+    about the folder the person is standing in. The scores under it have to come
+    with it, which is the part a same-file exception must not quietly skip.
+    """
+    score_id = add_score("Inbox/Study.pdf")
+
+    # The preview is refused by the same check, so it has to pass first - a
+    # dialog that previews fine and then fails on apply is its own bug.
+    preview = client.post(
+        "/api/library/folders/rename", json={"from_path": "Inbox", "to_path": "inbox"}
+    )
+    assert preview.status_code == 200, preview.text
+
+    res = client.post(
+        "/api/library/folders/rename",
+        json={"from_path": "Inbox", "to_path": "inbox", "dry_run": False},
+    )
+
+    assert res.status_code == 200, res.text
+    assert client.get(f"/api/scores/{score_id}").json()["path"] == "inbox/Study.pdf"
+    assert (library / "inbox/Study.pdf").read_bytes() == FIXTURE
+    assert paths(client) == {"inbox/Study.pdf"}
+
+
+def test_renaming_a_folder_onto_a_different_folder_is_still_refused(client, library, add_score):
+    """The other side of that exception, and the reason it asks the filesystem
+    rather than lowercasing two strings: a folder that genuinely is a different
+    folder still blocks the rename. Merging two folders' scores into one with
+    nothing said is the outcome this refuses.
+    """
+    add_score("Inbox/Study.pdf")
+    keep = add_score("Archive/Old.pdf")
+
+    res = client.post(
+        "/api/library/folders/rename",
+        json={"from_path": "Inbox", "to_path": "Archive", "dry_run": False},
+    )
+
+    assert res.status_code == 409, res.text
+    assert "already exists" in res.json()["detail"]
+    # Neither folder moved, and the score that was already there is untouched.
+    assert paths(client) == {"Inbox/Study.pdf", "Archive/Old.pdf"}
+    assert client.get(f"/api/scores/{keep}").json()["path"] == "Archive/Old.pdf"
+    assert (library / "Archive/Old.pdf").read_bytes() == FIXTURE
 
 
 def test_a_file_is_only_in_its_own_way_when_it_really_is_its_own_file(library):
@@ -1444,6 +1552,20 @@ def test_a_deleted_score_still_counts_in_the_practice_figures_and_says_it_is_del
     assert by_score[doomed]["seconds"] == 1800
     assert by_score[doomed]["deleted"] is True
     assert by_score[kept]["deleted"] is False
+
+    # THE THIRD LIST THAT NAMES A SCORE, and the one the first pass at this
+    # missed: the sessions themselves. Fixing the two aggregates and not this
+    # left the practice page rendering a live link to a deleted score a few
+    # rows below one it had just stopped linking to.
+    sessions = client.get("/api/practice/sessions").json()["sessions"]
+    by_session = {s["score_id"]: s for s in sessions}
+    assert by_session[doomed]["score_deleted"] is True
+    assert by_session[doomed]["score_title"] is not None  # still named, still counted
+    assert by_session[doomed]["seconds"] == 1800
+    assert by_session[kept]["score_deleted"] is False
+    # Not the same fact as score_missing: the row is still there, so a client
+    # that conflated the two would call this piece gone rather than deleted.
+    assert by_session[doomed]["score_missing"] is False
 
 
 def test_an_upload_is_not_held_against_a_change_and_the_scan_it_starts_is(

--- a/server/tests/test_library_management_api.py
+++ b/server/tests/test_library_management_api.py
@@ -1,0 +1,1026 @@
+"""Moving, renaming, deleting and reorganising scores (issue #56).
+
+This is the one feature in Fermata that writes to somebody's own files, so
+these tests are not really about the endpoints. They are about the five
+promises made in api.py's own comment over this section, each of which is a
+way this feature could quietly ruin a library:
+
+  1. nothing is written outside the library folder;
+  2. deleting is a move to a trash folder, never a delete, and the row - with
+     the practice history, goals, tags and transcription hanging off it -
+     stays;
+  3. nothing is destroyed as a side effect of an organisational change: a move
+     never overwrites, and a batch is all or nothing;
+  4. a bulk operation is a dry run until somebody says otherwise;
+  5. the score row follows the file by CONTENT HASH, which is the identity test
+     the scanner already uses, so a move cannot attach one score's history to
+     another score's music.
+
+And a sixth that is not about files at all but about the scanner: a scan and a
+move must not run at once, in either order, because a scan decides what to
+write from a directory listing taken when it started.
+
+EVERYTHING IS READ BACK THROUGH THE API, never out of the database, wherever
+the claim is about what a person would see - the point of "the practice
+history survived" is that a client asking for it gets it, and a test that goes
+straight to SQL proves the row exists while proving nothing about whether the
+library shows it.
+"""
+
+import time
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from fermata import api, db, scanner, thumbs
+
+FIXTURE = b"<score-file-bytes-standing-in-for-a-pdf>"
+
+
+@pytest.fixture
+def library(app_env, tmp_path, monkeypatch):
+    """A throwaway library these endpoints will actually write into.
+
+    app_env has made tmp_path/library and pointed config at it; api.py and
+    scanner.py each bound LIBRARY_DIR by value at import, so both are repointed
+    here - the same fixture shape test_scanner.py uses, and for the same
+    reason.
+    """
+    root = tmp_path / "library"
+    monkeypatch.setattr(api, "LIBRARY_DIR", root)
+    monkeypatch.setattr(scanner, "LIBRARY_DIR", root)
+    monkeypatch.setattr(thumbs, "CACHE_DIR", tmp_path / "config" / "cache")
+    return root
+
+
+@pytest.fixture
+def client(library):
+    app = FastAPI()
+    app.include_router(api.router)
+    return TestClient(app)
+
+
+@pytest.fixture
+def add_score(library):
+    """Put a real file in the library and give it a real score row.
+
+    The row's hash is the file's actual hash, which conftest's `insert_score`
+    deliberately does not bother with - and every move here turns on that hash
+    matching, because that is how the row follows the file.
+    """
+
+    def _add(rel: str, content: bytes = FIXTURE, title: str | None = None) -> int:
+        path = library / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(content)
+        stat = path.stat()
+        conn = db.connect()
+        parts = rel.split("/")
+        cur = conn.execute(
+            """INSERT INTO scores(title, collection, path, file_type, hash, size, mtime)
+               VALUES (?, ?, ?, 'pdf', ?, ?, ?)""",
+            (
+                title or parts[-1].rsplit(".", 1)[0],
+                parts[0] if len(parts) > 1 else None,
+                rel,
+                scanner.hash_file(path),
+                stat.st_size,
+                stat.st_mtime,
+            ),
+        )
+        conn.commit()
+        return cur.lastrowid
+
+    return _add
+
+
+def _wait_for_scan(timeout: float = 10.0) -> None:
+    deadline = time.monotonic() + timeout
+    while scanner.scan_status()["scanning"]:
+        if time.monotonic() > deadline:
+            raise AssertionError("the scan did not finish")
+        time.sleep(0.02)
+
+
+def paths(client) -> set[str]:
+    return {s["path"] for s in client.get("/api/scores").json()}
+
+
+# ---------------------------------------------------------------------------
+# Moving and renaming: the file goes, and the row goes with it.
+# ---------------------------------------------------------------------------
+
+
+def test_moving_a_score_moves_the_file_and_the_row_follows_it(client, library, add_score):
+    score_id = add_score("Inbox/Study in C.pdf")
+
+    res = client.post(f"/api/scores/{score_id}/move", json={"folder": "Classical/Sor"})
+    assert res.status_code == 200, res.text
+    body = res.json()
+
+    assert body["applied"] is True
+    assert body["dry_run"] is False
+    assert [(m["from_path"], m["to_path"], m["status"]) for m in body["moves"]] == [
+        ("Inbox/Study in C.pdf", "Classical/Sor/Study in C.pdf", "move")
+    ]
+    # The file really moved - both ends of it checked, because "the new one
+    # exists" would also be true of a copy.
+    assert (library / "Classical/Sor/Study in C.pdf").read_bytes() == FIXTURE
+    assert not (library / "Inbox/Study in C.pdf").exists()
+    # And the SAME row followed it. A new row with the same title would look
+    # identical in a list and would carry none of the history.
+    assert body["score"]["id"] == score_id
+    assert body["score"]["path"] == "Classical/Sor/Study in C.pdf"
+    assert client.get(f"/api/scores/{score_id}").json()["path"] == (
+        "Classical/Sor/Study in C.pdf"
+    )
+
+
+def test_everything_hanging_off_a_moved_score_survives_the_move(client, library, add_score):
+    """The matrix issue #56 exists to protect, checked by literal value.
+
+    Every one of these is set through the API before the move and read back
+    through the API after it, so what is being asserted is what a client would
+    actually get - not that a row survived somewhere.
+    """
+    score_id = add_score("Inbox/Prelude.pdf", title="Prelude")
+
+    instrument = client.post(
+        "/api/instruments",
+        json={
+            "name": "Parlour guitar",
+            "string_count": 6,
+            "string_pitches": ["E2", "A2", "D3", "G3", "B3", "E4"],
+            "fretted": True,
+            "fret_count": 19,
+            "capo": 2,
+        },
+    ).json()
+    client.patch(
+        f"/api/scores/{score_id}",
+        json={
+            "favorite": True,
+            "last_page": 7,
+            "tags": ["wedding", "warm-up"],
+            "instrument_id": instrument["id"],
+            "composer": "Villa-Lobos",
+        },
+    )
+    logged = client.post(
+        f"/api/scores/{score_id}/practice",
+        json={"seconds": 2400, "note": "felt rough", "tempo_bpm": 92, "local_date": "2026-08-01"},
+    ).json()["session"]
+    goal = client.post(
+        "/api/practice/goals",
+        json={"scope": "score", "score_id": score_id, "target_days": 5, "intent": "to tempo"},
+    ).json()
+    client.put(
+        f"/api/scores/{score_id}/transcription",
+        json={"content": '\\title "Prelude"\n.\n:4 0.1 |'},
+    )
+
+    moved = client.post(
+        f"/api/scores/{score_id}/move",
+        json={"folder": "Classical/Villa-Lobos", "filename": "Prelude No 1.pdf"},
+    )
+    assert moved.status_code == 200, moved.text
+
+    after = client.get(f"/api/scores/{score_id}").json()
+    assert after["path"] == "Classical/Villa-Lobos/Prelude No 1.pdf"
+    # The score's own fields, by literal value.
+    assert after["favorite"] is True
+    assert after["last_page"] == 7
+    assert sorted(after["tags"]) == ["warm-up", "wedding"]
+    assert after["instrument_id"] == instrument["id"]
+    assert after["has_transcription"] is True
+    assert after["practice_seconds"] == 2400
+    assert after["last_practiced"] == "2026-08-01"
+
+    # The practice session itself, not merely its total.
+    practice = client.get(f"/api/scores/{score_id}/practice").json()
+    assert practice["session_count"] == 1
+    session = practice["sessions"][0]
+    assert session["id"] == logged["id"]
+    assert (session["seconds"], session["note"], session["tempo_bpm"]) == (
+        2400,
+        "felt rough",
+        92,
+    )
+    assert session["local_date"] == "2026-08-01"
+
+    # The goal still names the piece, and is still countable against it.
+    goals = client.get("/api/practice/goals").json()["goals"]
+    assert [g["id"] for g in goals] == [goal["id"]]
+    assert goals[0]["score_id"] == score_id
+    assert goals[0]["intent"] == "to tempo"
+    assert goals[0]["progress"]["countable"] is True
+
+    # And the transcription, by its content.
+    transcription = client.get(f"/api/scores/{score_id}/transcription").json()
+    assert transcription["content"] == '\\title "Prelude"\n.\n:4 0.1 |'
+    assert transcription["source"] == "edited"
+
+    # The file is where it was asked to go, and the old one is not there.
+    assert (library / "Classical/Villa-Lobos/Prelude No 1.pdf").read_bytes() == FIXTURE
+    assert not (library / "Inbox/Prelude.pdf").exists()
+
+
+def test_a_move_re_derives_where_a_score_is_but_not_what_it_is(client, library, add_score):
+    """`collection` and `series` follow the folders; the piece's own facts do
+    not - see api._location_fields."""
+    score_id = add_score("Inbox/Study.pdf", title="Study")
+    client.patch(
+        f"/api/scores/{score_id}",
+        json={"title": "Estudio Sencillo", "composer": "Brouwer", "source": "Patreon"},
+    )
+
+    client.post(f"/api/scores/{score_id}/move", json={"folder": "Classical/Brouwer/Estudios"})
+    after = client.get(f"/api/scores/{score_id}").json()
+
+    assert after["collection"] == "Classical"
+    assert after["series"] == "Estudios"
+    # Corrected by hand before the move, and still correct after it. Re-deriving
+    # these from the path would have made the title "Study" again.
+    assert after["title"] == "Estudio Sencillo"
+    assert after["composer"] == "Brouwer"
+    assert after["source"] == "Patreon"
+
+
+def test_renaming_a_score_renames_the_file_and_leaves_it_where_it_is(
+    client, library, add_score
+):
+    score_id = add_score("Classical/tarrega-study.pdf")
+
+    res = client.post(f"/api/scores/{score_id}/move", json={"filename": "Study in E minor.pdf"})
+
+    assert res.json()["score"]["path"] == "Classical/Study in E minor.pdf"
+    assert (library / "Classical/Study in E minor.pdf").is_file()
+    assert not (library / "Classical/tarrega-study.pdf").exists()
+
+
+def test_a_rename_must_keep_an_extension_fermata_can_read(client, add_score):
+    """Renaming a PDF to something the scanner does not pick up is a deletion
+    wearing a rename's clothes: the file stays and the library loses it."""
+    score_id = add_score("Classical/Study.pdf")
+
+    res = client.post(f"/api/scores/{score_id}/move", json={"filename": "Study.txt"})
+
+    assert res.status_code == 422
+    assert "extension" in res.json()["detail"]
+    assert client.get(f"/api/scores/{score_id}").json()["path"] == "Classical/Study.pdf"
+
+
+def test_a_dry_run_move_says_what_would_happen_and_does_none_of_it(
+    client, library, add_score
+):
+    score_id = add_score("Inbox/Study.pdf")
+
+    body = client.post(
+        f"/api/scores/{score_id}/move", json={"folder": "Classical", "dry_run": True}
+    ).json()
+
+    assert body["dry_run"] is True and body["applied"] is False
+    assert body["moves"][0]["to_path"] == "Classical/Study.pdf"
+    assert (library / "Inbox/Study.pdf").is_file()
+    assert not (library / "Classical").exists()
+    assert body["score"]["path"] == "Inbox/Study.pdf"
+
+
+def test_a_move_that_would_land_on_an_existing_file_is_refused(client, library, add_score):
+    """Rule 3: nothing is destroyed as a side effect of an organisational
+    change. The file in the way here is not even a score Fermata knows about."""
+    score_id = add_score("Inbox/Study.pdf")
+    (library / "Classical").mkdir()
+    (library / "Classical/Study.pdf").write_bytes(b"something else entirely")
+
+    res = client.post(f"/api/scores/{score_id}/move", json={"folder": "Classical"})
+
+    assert res.status_code == 409
+    assert (library / "Classical/Study.pdf").read_bytes() == b"something else entirely"
+    assert (library / "Inbox/Study.pdf").read_bytes() == FIXTURE
+    assert client.get(f"/api/scores/{score_id}").json()["path"] == "Inbox/Study.pdf"
+
+
+@pytest.mark.parametrize(
+    ("folder", "expected"),
+    [
+        ("../outside", "is not a usable folder name"),
+        ("Classical/../../outside", "is not a usable folder name"),
+        ("/etc", "not an absolute path"),
+        ("C:/Windows", "not an absolute path"),
+        (".fermata-trash", "Fermata's trash folder"),
+        (".fermata-trash/12", "Fermata's trash folder"),
+    ],
+)
+def test_a_move_out_of_the_library_folder_is_refused(
+    client, library, add_score, folder, expected
+):
+    """Issue #56 asks for this by name: refuse to write outside the configured
+    library directory, and test that. The trash is included because it is
+    Fermata's, not a folder scores may be filed into by hand - a score moved in
+    there would be invisible to the library and to the trash view alike.
+
+    WHICH GUARD REFUSED IS ASSERTED, not only that something did, and that is
+    not fussiness. There are two here - the segment rules in _safe_parts and the
+    resolved-path containment check in _resolve_in_library - and they overlap:
+    with the message unchecked, taking the segment rules out entirely left this
+    test green, because containment quietly caught every case behind it. That is
+    the shape of overlapping guard this repository has been bitten by before
+    (see scanner.py's note on why its single-pass loss test was removed), so the
+    message pins which one actually spoke. Containment has a test of its own
+    below, for the same reason in the other direction.
+    """
+    score_id = add_score("Inbox/Study.pdf")
+    outside = library.parent / "outside"
+
+    res = client.post(f"/api/scores/{score_id}/move", json={"folder": folder})
+
+    assert res.status_code == 422, res.text
+    assert expected in res.json()["detail"]
+    assert not outside.exists()
+    assert (library / "Inbox/Study.pdf").read_bytes() == FIXTURE
+    assert client.get(f"/api/scores/{score_id}").json()["path"] == "Inbox/Study.pdf"
+
+
+def test_the_containment_check_refuses_an_escaping_path_on_its_own(library):
+    """The second guard, tested where nothing else can be covering for it.
+
+    Every route builds its destination through _safe_parts first, so through
+    the API this check is unreachable - which is exactly why removing it
+    changed no test result until this one existed. It is called here directly,
+    with the kind of path _safe_parts would never let through, because it is
+    the guarantee ("nothing is written outside the library folder") rather than
+    the error message: it works on the RESOLVED path, so it is also what would
+    refuse a destination that only escapes through a symlink, which no amount
+    of inspecting the text of a path can catch.
+    """
+    from fastapi import HTTPException
+
+    (library / "Inside").mkdir()
+    assert api._resolve_in_library("Inside/Study.pdf") == library / "Inside" / "Study.pdf"
+
+    for escaping in ("../outside/Study.pdf", "Inside/../../outside/Study.pdf"):
+        with pytest.raises(HTTPException) as exc_info:
+            api._resolve_in_library(escaping)
+        assert exc_info.value.status_code == 422
+        assert "outside your library folder" in exc_info.value.detail
+
+
+def test_moving_a_file_on_disk_never_overwrites_what_is_already_there(library):
+    """The last-moment guard, tested where nothing else can be covering for it.
+
+    _plan_move already refuses a destination that exists, so through the API
+    this check is unreachable and removing it changed no test result. It exists
+    for the gap between planning and moving - something outside Fermata writing
+    into the library while a batch is being applied - and it is the reason
+    os.replace is not used here, which is a decision worth having a test
+    behind.
+    """
+    from fastapi import HTTPException
+
+    (library / "a.pdf").write_bytes(b"the one being moved")
+    (library / "b.pdf").write_bytes(b"the one already there")
+
+    with pytest.raises(HTTPException) as exc_info:
+        api._move_file_on_disk(library / "a.pdf", library / "b.pdf")
+
+    assert exc_info.value.status_code == 409
+    assert (library / "b.pdf").read_bytes() == b"the one already there"
+    assert (library / "a.pdf").read_bytes() == b"the one being moved"
+
+
+def test_a_file_that_changed_under_the_move_does_not_take_the_history_with_it(
+    client, library, add_score, monkeypatch
+):
+    """Rule 5, and the reason the move re-hashes at the destination.
+
+    The row is only re-pointed at a file whose CONTENT still matches the hash
+    the row carries - the same identity test scanner._scan_file's relink makes.
+    Here the file is replaced between being listed and being moved, which is
+    what a sync client writing into the library looks like; attaching this
+    score's practice history to whatever arrived would be silent and
+    unrecoverable.
+    """
+    score_id = add_score("Inbox/Study.pdf")
+    real_move = api._move_file_on_disk
+
+    def swap_then_move(src, dest):
+        real_move(src, dest)
+        dest.write_bytes(b"completely different music")
+
+    monkeypatch.setattr(api, "_move_file_on_disk", swap_then_move)
+
+    res = client.post(f"/api/scores/{score_id}/move", json={"folder": "Classical"})
+
+    assert res.status_code == 409
+    assert "different music" in res.json()["detail"]
+    # The row still names the file it always named, and the moved file was put
+    # back rather than left at the new path with nothing pointing at it.
+    assert client.get(f"/api/scores/{score_id}").json()["path"] == "Inbox/Study.pdf"
+    assert (library / "Inbox/Study.pdf").is_file()
+    assert not (library / "Classical/Study.pdf").exists()
+
+
+def test_a_score_whose_file_is_missing_cannot_be_moved(client, add_score):
+    score_id = add_score("Inbox/Study.pdf")
+    conn = db.connect()
+    conn.execute(
+        "UPDATE scores SET missing_since = datetime('now') WHERE id = ?", (score_id,)
+    )
+    conn.commit()
+
+    res = client.post(f"/api/scores/{score_id}/move", json={"folder": "Classical"})
+
+    assert res.status_code == 409
+    assert "cannot find this score's file" in res.json()["detail"]
+
+
+def test_a_move_with_neither_a_folder_nor_a_filename_is_refused(client, add_score):
+    score_id = add_score("Inbox/Study.pdf")
+    res = client.post(f"/api/scores/{score_id}/move", json={})
+    assert res.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# A move and a scan must not overlap, in either order.
+# ---------------------------------------------------------------------------
+
+
+def test_a_move_is_refused_while_a_scan_is_running(client, add_score, monkeypatch):
+    """A scan decides what to write from a listing taken when it started, so a
+    file moving underneath it reads as a file that went missing - see
+    scanner.hold_library_still."""
+    score_id = add_score("Inbox/Study.pdf")
+    monkeypatch.setitem(scanner._state, "scanning", True)
+
+    res = client.post(f"/api/scores/{score_id}/move", json={"folder": "Classical"})
+
+    assert res.status_code == 409
+    assert "scan is running" in res.json()["detail"]
+    assert client.get(f"/api/scores/{score_id}").json()["path"] == "Inbox/Study.pdf"
+
+
+def test_a_scan_will_not_start_while_the_library_is_being_changed(client, add_score):
+    """The other direction, which is the one that actually corrupts something:
+    a scan starting mid-move takes its listing with the file at neither end."""
+    add_score("Inbox/Study.pdf")
+
+    with scanner.hold_library_still():
+        assert scanner.start_scan() is False
+        assert client.post("/api/scan").json()["started"] is False
+
+    # And the exclusion lifts by itself.
+    assert scanner.start_scan() is True
+    _wait_for_scan()
+
+
+def test_a_second_change_is_refused_while_one_is_being_applied(client, add_score):
+    score_id = add_score("Inbox/Study.pdf")
+
+    with scanner.hold_library_still():
+        res = client.post(f"/api/scores/{score_id}/move", json={"folder": "Classical"})
+
+    assert res.status_code == 409
+    assert "another change" in res.json()["detail"]
+
+
+def test_the_next_scan_leaves_a_moved_score_exactly_as_the_move_left_it(
+    client, library, add_score
+):
+    """End to end against the real scanner: the move re-points the row itself,
+    so the scan that follows has nothing to reconcile - no relink, no mark, no
+    second row for one piece."""
+    score_id = add_score("Inbox/Study.pdf")
+    add_score("Inbox/Other.pdf", content=b"a different score entirely")
+    client.post(f"/api/scores/{score_id}/move", json={"folder": "Classical/Sor"})
+
+    scanner._scan()
+
+    status = scanner.scan_status()
+    assert (status["missing"], status["added"], status["refused"]) == (0, 0, False)
+    assert paths(client) == {"Classical/Sor/Study.pdf", "Inbox/Other.pdf"}
+    assert client.get(f"/api/scores/{score_id}").json()["missing_since"] is None
+
+
+# ---------------------------------------------------------------------------
+# Reorganising: folders, and moving several scores at once.
+# ---------------------------------------------------------------------------
+
+
+def test_a_batch_move_is_a_dry_run_unless_it_is_told_otherwise(client, library, add_score):
+    """Rule 4, and the default issue #56 asks for by name: a client that has
+    never heard of `dry_run` gets the plan, not the reorganisation."""
+    first = add_score("Inbox/One.pdf", content=b"one")
+    second = add_score("Inbox/Two.pdf", content=b"two")
+
+    body = client.post(
+        "/api/library/move", json={"score_ids": [first, second], "folder": "Classical"}
+    ).json()
+
+    assert body["dry_run"] is True and body["applied"] is False
+    assert (body["moved"], body["blocked"], body["unchanged"]) == (2, 0, 0)
+    assert {m["to_path"] for m in body["moves"]} == {
+        "Classical/One.pdf",
+        "Classical/Two.pdf",
+    }
+    assert (library / "Inbox/One.pdf").is_file()
+    assert not (library / "Classical").exists()
+
+
+def test_a_batch_move_applied_moves_every_one_of_them(client, library, add_score):
+    first = add_score("Inbox/One.pdf", content=b"one")
+    second = add_score("Inbox/Two.pdf", content=b"two")
+
+    body = client.post(
+        "/api/library/move",
+        json={"score_ids": [first, second], "folder": "Classical", "dry_run": False},
+    ).json()
+
+    assert body["applied"] is True and body["moved"] == 2
+    assert paths(client) == {"Classical/One.pdf", "Classical/Two.pdf"}
+    assert (library / "Classical/One.pdf").read_bytes() == b"one"
+    assert (library / "Classical/Two.pdf").read_bytes() == b"two"
+    assert not (library / "Inbox/One.pdf").exists()
+
+
+def test_a_batch_with_one_blocked_line_moves_nothing_at_all(client, library, add_score):
+    """Rule 3's other half: half a reorganisation is worse than none, because
+    the person then has to work out which half happened."""
+    first = add_score("Inbox/One.pdf", content=b"one")
+    second = add_score("Inbox/Two.pdf", content=b"two")
+    (library / "Classical").mkdir()
+    (library / "Classical/Two.pdf").write_bytes(b"already here")
+
+    res = client.post(
+        "/api/library/move",
+        json={"score_ids": [first, second], "folder": "Classical", "dry_run": False},
+    )
+
+    assert res.status_code == 409
+    assert "already a file at that path" in res.json()["detail"]
+    # Including the one that had nothing wrong with it.
+    assert paths(client) == {"Inbox/One.pdf", "Inbox/Two.pdf"}
+    assert (library / "Inbox/One.pdf").read_bytes() == b"one"
+    assert (library / "Classical/Two.pdf").read_bytes() == b"already here"
+
+
+def test_two_scores_that_would_collide_are_both_reported_rather_than_one_lost(
+    client, library, add_score
+):
+    """Two files with the same name in different folders, moved into one. The
+    second must not land on the first."""
+    first = add_score("Bach/Prelude.pdf", content=b"bach")
+    second = add_score("Chopin/Prelude.pdf", content=b"chopin")
+
+    body = client.post(
+        "/api/library/move", json={"score_ids": [first, second], "folder": "Favourites"}
+    ).json()
+
+    statuses = {m["score_id"]: m["status"] for m in body["moves"]}
+    assert statuses[second] == "blocked"
+    assert body["blocked"] == 1
+    reason = next(m["reason"] for m in body["moves"] if m["score_id"] == second)
+    assert "another score in this same move" in reason
+
+
+def test_a_folder_can_be_created_and_moved_into(client, library, add_score):
+    score_id = add_score("Inbox/Study.pdf")
+
+    created = client.post("/api/library/folders", json={"path": "Wedding/Processional"})
+    assert created.status_code == 200, created.text
+    assert created.json() == {"created": "Wedding/Processional", "existed": False}
+    assert (library / "Wedding/Processional").is_dir()
+
+    # Offered by the folder list even though nothing is in it yet, which is the
+    # whole point of being able to make one.
+    folders = client.get("/api/library/folders").json()
+    by_path = {f["path"]: f for f in folders}
+    assert by_path["Wedding/Processional"]["score_count"] == 0
+    assert by_path["Wedding/Processional"]["depth"] == 2
+    assert by_path["Inbox"]["score_count"] == 1
+    assert by_path[""]["name"] == "Library root"
+
+    client.post(
+        "/api/library/move",
+        json={"score_ids": [score_id], "folder": "Wedding/Processional", "dry_run": False},
+    )
+    assert client.get(f"/api/scores/{score_id}").json()["path"] == (
+        "Wedding/Processional/Study.pdf"
+    )
+    assert client.get("/api/library/folders").json()
+    assert {f["path"]: f["score_count"] for f in client.get("/api/library/folders").json()}[
+        "Wedding/Processional"
+    ] == 1
+
+
+def test_creating_a_folder_that_is_already_there_is_not_an_error(client, library):
+    (library / "Classical").mkdir()
+    res = client.post("/api/library/folders", json={"path": "Classical"})
+    assert res.json() == {"created": "Classical", "existed": True}
+
+
+def test_the_trash_folder_is_not_offered_as_a_destination(client, library, add_score):
+    score_id = add_score("Inbox/Study.pdf")
+    client.delete(f"/api/scores/{score_id}")
+
+    assert (library / scanner.TRASH_DIR_NAME).is_dir()
+    assert all(
+        not f["path"].startswith(scanner.TRASH_DIR_NAME)
+        for f in client.get("/api/library/folders").json()
+    )
+
+
+def test_renaming_a_folder_takes_its_scores_with_it(client, library, add_score):
+    first = add_score("Patreon/One.pdf", content=b"one")
+    second = add_score("Patreon/Series/Two.pdf", content=b"two")
+    client.post(f"/api/scores/{first}/practice", json={"seconds": 900})
+
+    preview = client.post(
+        "/api/library/folders/rename",
+        json={"from_path": "Patreon", "to_path": "Arrangements"},
+    ).json()
+    assert preview["dry_run"] is True and preview["applied"] is False
+    assert {m["to_path"] for m in preview["moves"]} == {
+        "Arrangements/One.pdf",
+        "Arrangements/Series/Two.pdf",
+    }
+    assert (library / "Patreon/One.pdf").is_file()
+
+    applied = client.post(
+        "/api/library/folders/rename",
+        json={"from_path": "Patreon", "to_path": "Arrangements", "dry_run": False},
+    ).json()
+    assert applied["applied"] is True and applied["moved"] == 2
+
+    assert paths(client) == {"Arrangements/One.pdf", "Arrangements/Series/Two.pdf"}
+    assert (library / "Arrangements/Series/Two.pdf").read_bytes() == b"two"
+    assert not (library / "Patreon").exists()
+    # The scores are the same scores: same ids, and the practice is still on
+    # the one that has it.
+    assert client.get(f"/api/scores/{first}").json()["practice_seconds"] == 900
+    assert client.get(f"/api/scores/{second}").json()["id"] == second
+    # The sidebar's collection follows the folder, at every depth.
+    assert {c["collection"] for c in client.get("/api/collections").json()} == {
+        "Arrangements"
+    }
+
+
+def test_a_folder_cannot_be_renamed_into_itself_or_onto_something(client, library, add_score):
+    add_score("Patreon/One.pdf")
+    (library / "Taken").mkdir()
+
+    inside = client.post(
+        "/api/library/folders/rename",
+        json={"from_path": "Patreon", "to_path": "Patreon/Deeper", "dry_run": False},
+    )
+    assert inside.status_code == 422
+    assert "inside itself" in inside.json()["detail"]
+
+    onto = client.post(
+        "/api/library/folders/rename",
+        json={"from_path": "Patreon", "to_path": "Taken", "dry_run": False},
+    )
+    assert onto.status_code == 409
+    assert (library / "Patreon/One.pdf").is_file()
+
+
+def test_renaming_a_folder_that_is_not_there_is_a_404(client):
+    res = client.post(
+        "/api/library/folders/rename",
+        json={"from_path": "Nowhere", "to_path": "Somewhere", "dry_run": False},
+    )
+    assert res.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Deleting: a move to the trash, and the second, separate step that destroys.
+# ---------------------------------------------------------------------------
+
+
+def test_deleting_a_score_moves_its_file_to_the_trash_and_keeps_the_row(
+    client, library, add_score
+):
+    score_id = add_score("Inbox/Study.pdf")
+    client.post(f"/api/scores/{score_id}/practice", json={"seconds": 1800, "note": "slow"})
+    client.patch(f"/api/scores/{score_id}", json={"tags": ["wedding"]})
+
+    res = client.delete(f"/api/scores/{score_id}")
+    assert res.status_code == 200, res.text
+    body = res.json()
+
+    assert body["deleted"] == score_id
+    assert body["deleted_from"] == "Inbox/Study.pdf"
+    assert body["trashed_to"].startswith(f"{scanner.TRASH_DIR_NAME}/{score_id}/")
+    # The counts that make "nothing was lost" a number rather than a promise.
+    assert body["practice_sessions_kept"] == 1
+    assert body["tags_kept"] == 1
+
+    # The file MOVED. It is out of the library proper and still on disk.
+    assert not (library / "Inbox/Study.pdf").exists()
+    assert (library / body["trashed_to"]).read_bytes() == FIXTURE
+    # The row is still there, still answers to its id, and still has its
+    # practice on it.
+    row = client.get(f"/api/scores/{score_id}").json()
+    assert row["deleted_at"] is not None
+    assert row["deleted_from"] == "Inbox/Study.pdf"
+    assert row["practice_seconds"] == 1800
+    assert client.get(f"/api/scores/{score_id}/practice").json()["sessions"][0]["note"] == (
+        "slow"
+    )
+
+
+def test_a_deleted_score_leaves_every_library_view_and_appears_in_the_trash(
+    client, add_score
+):
+    kept = add_score("Classical/Kept.pdf", content=b"kept")
+    doomed = add_score("Classical/Doomed.pdf", content=b"doomed")
+    client.patch(f"/api/scores/{doomed}", json={"tags": ["dross"]})
+
+    client.delete(f"/api/scores/{doomed}")
+
+    assert paths(client) == {"Classical/Kept.pdf"}
+    assert [s["id"] for s in client.get("/api/trash").json()] == [doomed]
+    # The counts the sidebar shows follow it out.
+    assert [(c["collection"], c["count"]) for c in client.get("/api/collections").json()] == [
+        ("Classical", 1)
+    ]
+    assert {t["name"]: t["count"] for t in client.get("/api/tags").json()}["dross"] == 0
+    assert client.get(f"/api/scores/{kept}").json()["deleted_at"] is None
+
+
+def test_two_identical_scores_stop_being_duplicates_when_one_is_deleted(client, add_score):
+    first = add_score("Bach/Prelude.pdf")
+    add_score("Copies/Prelude.pdf")
+    assert len(client.get("/api/duplicates").json()) == 1
+
+    client.delete(f"/api/scores/{first}")
+
+    assert client.get("/api/duplicates").json() == []
+
+
+def test_a_scan_does_not_bring_a_deleted_score_back(client, library, add_score):
+    """The relink candidate filter, which is the one that would resurrect a
+    deletion silently: the trashed file has the same content hash, and a fresh
+    copy of that content arriving in the library must become its own score
+    rather than adopting the deleted one's row."""
+    score_id = add_score("Inbox/Study.pdf")
+    client.delete(f"/api/scores/{score_id}")
+
+    (library / "Elsewhere").mkdir()
+    (library / "Elsewhere/Study.pdf").write_bytes(FIXTURE)
+    scanner._scan()
+
+    deleted = client.get(f"/api/scores/{score_id}").json()
+    assert deleted["deleted_at"] is not None
+    assert deleted["path"].startswith(scanner.TRASH_DIR_NAME)
+    assert paths(client) == {"Elsewhere/Study.pdf"}
+    assert [s["id"] for s in client.get("/api/scores").json()] != [score_id]
+
+
+def test_a_scan_does_not_take_anything_in_the_trash_for_a_score(client, library, add_score):
+    """The trash is not part of the library, and the scan's own listing is
+    where that has to be true.
+
+    Without the exclusion in scanner._library_files, anything sitting in the
+    trash folder is walked like any other file - so a file put there by hand,
+    or left behind by an interrupted purge, becomes a brand new score in the
+    library, filed under a collection called `.fermata-trash`. Deleted things
+    reappearing as new scores is the exact failure this feature must not have.
+    The reported totals are checked too: somebody watching a scan should not be
+    told their library holds files they deleted.
+    """
+    add_score("Inbox/Kept.pdf", content=b"kept")
+    trash = library / scanner.TRASH_DIR_NAME / "stray"
+    trash.mkdir(parents=True)
+    (trash / "Left behind.pdf").write_bytes(b"not a score any more")
+
+    scanner._scan()
+
+    assert paths(client) == {"Inbox/Kept.pdf"}
+    assert scanner.scan_status()["total"] == 1
+    assert all(
+        not s["path"].startswith(scanner.TRASH_DIR_NAME)
+        for s in client.get("/api/scores").json()
+    )
+
+
+def test_a_scan_does_not_mark_a_deleted_score_missing_or_refuse_over_it(
+    client, library, add_score
+):
+    """A deleted score's file is in the trash, which the scan skips - so
+    counting it among the rows believed present would make every deletion look
+    like a file that vanished."""
+    doomed = add_score("Inbox/Doomed.pdf", content=b"doomed")
+    add_score("Inbox/Kept.pdf", content=b"kept")
+    client.delete(f"/api/scores/{doomed}")
+
+    scanner._scan()
+
+    status = scanner.scan_status()
+    assert (status["missing"], status["refused"], status["added"]) == (0, False, 0)
+    assert client.get(f"/api/scores/{doomed}").json()["missing_since"] is None
+
+
+def test_deleting_most_of_a_library_does_not_make_the_next_lost_file_a_refusal(
+    client, library, add_score
+):
+    """scanner.record_deliberate_shrink, and what goes wrong without it.
+
+    The proportional guard measures what remains against the most this library
+    has ever held. That mark only rises by itself, so deleting most of a library
+    on purpose would leave it describing a library that no longer exists - and
+    the very next file that genuinely went missing would take the remaining
+    count under half of it and refuse a scan over one file, about a loss the
+    person had already confirmed twelve times by pressing delete.
+    """
+    ids = [add_score(f"Inbox/Score {n}.pdf", content=f"score {n}".encode()) for n in range(12)]
+    scanner._scan()
+    assert scanner.scan_status()["refused"] is False
+
+    for score_id in ids[:9]:
+        assert client.delete(f"/api/scores/{score_id}").status_code == 200
+
+    # And now one of the three that are left genuinely goes missing.
+    (library / "Inbox/Score 9.pdf").unlink()
+    scanner._scan()
+
+    status = scanner.scan_status()
+    assert status["refused"] is False, status["refused_reason"]
+    assert status["missing"] == 1
+
+
+def test_a_deleted_score_can_be_restored_with_everything_still_on_it(
+    client, library, add_score
+):
+    score_id = add_score("Inbox/Study.pdf")
+    client.post(f"/api/scores/{score_id}/practice", json={"seconds": 3600, "note": "good"})
+    client.patch(f"/api/scores/{score_id}", json={"tags": ["wedding"], "last_page": 4})
+    client.delete(f"/api/scores/{score_id}")
+
+    res = client.post(f"/api/trash/{score_id}/restore")
+    assert res.status_code == 200, res.text
+    body = res.json()
+
+    assert body["restored"] == score_id
+    assert body["restored_from"] == "Inbox/Study.pdf"
+    assert body["restored_to"] == "Inbox/Study.pdf"
+    assert (library / "Inbox/Study.pdf").read_bytes() == FIXTURE
+    assert not any((library / scanner.TRASH_DIR_NAME).rglob("*.pdf"))
+
+    restored = client.get(f"/api/scores/{score_id}").json()
+    assert restored["deleted_at"] is None and restored["deleted_from"] is None
+    assert restored["path"] == "Inbox/Study.pdf"
+    assert restored["practice_seconds"] == 3600
+    assert restored["tags"] == ["wedding"]
+    assert restored["last_page"] == 4
+    assert paths(client) == {"Inbox/Study.pdf"}
+    assert client.get("/api/trash").json() == []
+
+
+def test_restoring_onto_a_taken_path_lands_beside_it_rather_than_over_it(
+    client, library, add_score
+):
+    score_id = add_score("Inbox/Study.pdf")
+    client.delete(f"/api/scores/{score_id}")
+    (library / "Inbox").mkdir(exist_ok=True)
+    (library / "Inbox/Study.pdf").write_bytes(b"something else took the name")
+
+    body = client.post(f"/api/trash/{score_id}/restore").json()
+
+    assert body["restored_from"] == "Inbox/Study.pdf"
+    assert body["restored_to"] == "Inbox/Study (1).pdf"
+    assert (library / "Inbox/Study.pdf").read_bytes() == b"something else took the name"
+    assert (library / "Inbox/Study (1).pdf").read_bytes() == FIXTURE
+
+
+def test_restoring_onto_a_path_a_missing_score_still_claims_lands_beside_it(
+    client, library, add_score
+):
+    """scores.path is UNIQUE, and a row can name a path with no file behind it -
+    a score marked missing is exactly that. Checking only the filesystem before
+    putting a file back would let the update collide with that row and answer an
+    unexplained 500 at the moment somebody tried to undo a deletion."""
+    doomed = add_score("Inbox/Study.pdf", content=b"the deleted one")
+    client.delete(f"/api/scores/{doomed}")
+    # Another score claims the freed path, and then loses its file - so the path
+    # is free on disk and taken in the database.
+    other = add_score("Inbox/Study.pdf", content=b"a different arrangement")
+    (library / "Inbox/Study.pdf").unlink()
+    conn = db.connect()
+    conn.execute("UPDATE scores SET missing_since = datetime('now') WHERE id = ?", (other,))
+    conn.commit()
+
+    res = client.post(f"/api/trash/{doomed}/restore")
+
+    assert res.status_code == 200, res.text
+    assert res.json()["restored_to"] == "Inbox/Study (1).pdf"
+    assert (library / "Inbox/Study (1).pdf").read_bytes() == b"the deleted one"
+    # The other score is left exactly as it was, still marked missing.
+    assert client.get(f"/api/scores/{other}").json()["path"] == "Inbox/Study.pdf"
+
+
+def test_a_folder_rename_onto_a_path_another_score_claims_is_refused(
+    client, library, add_score
+):
+    """The same UNIQUE collision, on the route that re-points many rows at once.
+    Reported as a blocked line and refused as a whole, not raised as a 500."""
+    add_score("Patreon/One.pdf", content=b"one")
+    blocker = add_score("Arrangements/One.pdf", content=b"another one")
+    (library / "Arrangements/One.pdf").unlink()
+    (library / "Arrangements").rmdir()
+    conn = db.connect()
+    conn.execute("UPDATE scores SET missing_since = datetime('now') WHERE id = ?", (blocker,))
+    conn.commit()
+
+    res = client.post(
+        "/api/library/folders/rename",
+        json={"from_path": "Patreon", "to_path": "Arrangements", "dry_run": False},
+    )
+
+    assert res.status_code == 409, res.text
+    assert "already at that path" in res.json()["detail"]
+    assert (library / "Patreon/One.pdf").read_bytes() == b"one"
+    assert paths(client) == {"Patreon/One.pdf", "Arrangements/One.pdf"}
+
+
+def test_a_folder_name_the_filesystem_refuses_is_a_422_not_a_500(client, monkeypatch):
+    """The segment rules cannot know what a particular filesystem will accept -
+    Windows reserves CON and NUL outright, a disk can be full, a mount can be
+    read-only. Whatever it says comes back as a refusal rather than a crash."""
+
+    def refuse(*args, **kwargs):
+        raise OSError(22, "Invalid argument")
+
+    monkeypatch.setattr("pathlib.Path.mkdir", refuse)
+
+    res = client.post("/api/library/folders", json={"path": "Nope"})
+
+    assert res.status_code == 422
+    assert "would not take that folder name" in res.json()["detail"]
+
+
+def test_a_score_that_is_not_in_the_trash_cannot_be_restored_or_destroyed(
+    client, add_score
+):
+    score_id = add_score("Inbox/Study.pdf")
+
+    assert client.post(f"/api/trash/{score_id}/restore").status_code == 404
+    # The destructive route only ever acts on something already deleted, which
+    # is what makes destroying a score always the second of two steps.
+    assert client.delete(f"/api/trash/{score_id}").status_code == 404
+    assert client.get(f"/api/scores/{score_id}").json()["deleted_at"] is None
+
+
+def test_deleting_a_score_twice_is_refused_rather_than_moving_it_again(client, add_score):
+    score_id = add_score("Inbox/Study.pdf")
+    client.delete(f"/api/scores/{score_id}")
+
+    res = client.delete(f"/api/scores/{score_id}")
+
+    assert res.status_code == 409
+    assert "already in the trash" in res.json()["detail"]
+
+
+def test_destroying_a_score_from_the_trash_removes_the_file_and_the_row(
+    client, library, add_score
+):
+    score_id = add_score("Inbox/Study.pdf")
+    client.patch(f"/api/scores/{score_id}", json={"tags": ["dross"]})
+    client.put(f"/api/scores/{score_id}/transcription", json={"content": '\\title "x"\n.\n:4 0.1 |'})
+    logged = client.post(f"/api/scores/{score_id}/practice", json={"seconds": 1200}).json()
+    trashed = client.delete(f"/api/scores/{score_id}").json()
+
+    res = client.delete(f"/api/trash/{score_id}")
+    assert res.status_code == 200, res.text
+    body = res.json()
+
+    # It says what it destroyed, counted before the delete ran.
+    assert body["deleted"] == score_id
+    assert body["file_deleted"] == trashed["trashed_to"]
+    assert body["tags_destroyed"] == 1
+    assert body["transcriptions_destroyed"] == 1
+    # ...and what it kept.
+    assert body["practice_sessions_kept"] == 1
+
+    assert not (library / trashed["trashed_to"]).exists()
+    assert client.get(f"/api/scores/{score_id}").status_code == 404
+    assert client.get("/api/trash").json() == []
+    # The hours were still spent. The session survives, recording practice with
+    # no piece named - see db.py on why that reference is ON DELETE SET NULL.
+    sessions = client.get("/api/practice/sessions").json()["sessions"]
+    kept = [s for s in sessions if s["id"] == logged["session"]["id"]]
+    assert len(kept) == 1
+    assert kept[0]["seconds"] == 1200
+    assert kept[0]["score_id"] is None
+
+
+def test_deleting_is_refused_while_a_scan_is_running(client, library, add_score, monkeypatch):
+    score_id = add_score("Inbox/Study.pdf")
+    monkeypatch.setitem(scanner._state, "scanning", True)
+
+    res = client.delete(f"/api/scores/{score_id}")
+
+    assert res.status_code == 409
+    assert (library / "Inbox/Study.pdf").is_file()
+    assert client.get(f"/api/scores/{score_id}").json()["deleted_at"] is None

--- a/server/tests/test_library_management_api.py
+++ b/server/tests/test_library_management_api.py
@@ -27,7 +27,9 @@ straight to SQL proves the row exists while proving nothing about whether the
 library shows it.
 """
 
+import errno
 import time
+from pathlib import Path
 
 import pytest
 from fastapi import FastAPI
@@ -1072,6 +1074,402 @@ def test_a_folder_name_the_filesystem_refuses_is_a_422_not_a_500(client, monkeyp
 
     assert res.status_code == 422
     assert "would not take that folder name" in res.json()["detail"]
+
+
+def test_a_refused_restore_puts_the_file_back_in_the_trash(client, library, add_score):
+    """The one write path that had no filesystem rollback (adversarial review
+    F1), and the stranding it caused.
+
+    _relink_moved_file refuses a file whose bytes no longer match the row - the
+    right answer - but the file has already MOVED by then, and write_tx rolls
+    back only the database. So the trash listed a score whose file was not in
+    the trash: every later restore refused for the same reason, the next scan
+    filed the orphaned file as a brand new score with none of the history (a
+    deleted row is correctly excluded from the relink, so it could not even be
+    adopted back), and the refusal's own advice - scan and try again - was what
+    caused that.
+    """
+    score_id = add_score("Inbox/Study.pdf")
+    client.post(f"/api/scores/{score_id}/practice", json={"seconds": 1500})
+    trashed = client.delete(f"/api/scores/{score_id}").json()
+    trash_file = library / trashed["trashed_to"]
+    # Something rewrites the trashed file - a sync client, a hand edit.
+    trash_file.write_bytes(b"different music entirely")
+
+    res = client.post(f"/api/trash/{score_id}/restore")
+
+    assert res.status_code == 409
+    assert "different music" in res.json()["detail"]
+    # THE FILE IS BACK IN THE TRASH, byte for byte as it was when the restore
+    # was attempted - not left sitting in the library with nothing naming it.
+    assert trash_file.read_bytes() == b"different music entirely"
+    assert not (library / "Inbox/Study.pdf").exists()
+    # And the row is exactly as it was: still in the trash, still pointing at
+    # the trashed file, still holding the practice.
+    row = client.get(f"/api/scores/{score_id}").json()
+    assert row["path"] == trashed["trashed_to"]
+    assert row["deleted_at"] is not None
+    assert row["deleted_from"] == "Inbox/Study.pdf"
+    assert row["practice_seconds"] == 1500
+    assert [s["id"] for s in client.get("/api/trash").json()] == [score_id]
+
+    # Not stranded: put the score's own bytes back and the restore works.
+    trash_file.write_bytes(FIXTURE)
+    restored = client.post(f"/api/trash/{score_id}/restore")
+    assert restored.status_code == 200, restored.text
+    assert restored.json()["restored_to"] == "Inbox/Study.pdf"
+    assert client.get(f"/api/scores/{score_id}").json()["practice_seconds"] == 1500
+
+
+def test_deleting_a_score_whose_file_is_already_gone_says_no_file_was_moved(
+    client, library, add_score
+):
+    """Adversarial review F2. `if source.is_file()` skipped the move and the
+    response reported `trashed_to` as fact anyway - a path with nothing at it -
+    after which the score could never be restored, only destroyed, taking its
+    tags and transcription with it. It is still deleted (a score whose file has
+    gone is the case where deleting is MOST obviously the right answer), and the
+    response no longer claims a file went anywhere.
+    """
+    score_id = add_score("Inbox/Study.pdf")
+    client.patch(f"/api/scores/{score_id}", json={"tags": ["keep me"]})
+    client.post(f"/api/scores/{score_id}/practice", json={"seconds": 900})
+    (library / "Inbox/Study.pdf").unlink()
+
+    body = client.delete(f"/api/scores/{score_id}").json()
+
+    assert body["file_moved"] is False
+    assert body["trashed_to"] is None
+    assert body["deleted_from"] == "Inbox/Study.pdf"
+    assert body["practice_sessions_kept"] == 1
+    assert body["tags_kept"] == 1
+    # Out of the library, in the trash, and the trash folder holds no file for
+    # it - because there was none.
+    assert paths(client) == set()
+    assert [s["id"] for s in client.get("/api/trash").json()] == [score_id]
+    assert not any((library / scanner.TRASH_DIR_NAME).rglob("*.pdf"))
+
+
+def test_such_a_score_still_comes_back_out_of_the_trash_marked_missing(
+    client, library, add_score
+):
+    """The other half of F2: refusing to restore it was the stranding.
+
+    It returns to the library in exactly the state a score whose file has gone
+    is supposed to be in - present, flagged missing, everything still attached -
+    from which putting the file back and scanning recovers it with no further
+    action. The same path covers a trash folder somebody emptied by hand, which
+    docs/deployment.md says they may.
+    """
+    score_id = add_score("Inbox/Study.pdf")
+    client.post(f"/api/scores/{score_id}/practice", json={"seconds": 900})
+    (library / "Inbox/Study.pdf").unlink()
+    client.delete(f"/api/scores/{score_id}")
+
+    res = client.post(f"/api/trash/{score_id}/restore")
+    assert res.status_code == 200, res.text
+    body = res.json()
+
+    assert body["file_restored"] is False
+    assert body["restored_to"] == "Inbox/Study.pdf"
+    row = client.get(f"/api/scores/{score_id}").json()
+    assert row["deleted_at"] is None and row["deleted_from"] is None
+    assert row["missing_since"] is not None
+    assert row["practice_seconds"] == 900
+    assert paths(client) == {"Inbox/Study.pdf"}
+    assert client.get("/api/trash").json() == []
+
+    # ...and putting the file back really does recover it, with no action.
+    (library / "Inbox/Study.pdf").write_bytes(FIXTURE)
+    scanner._scan()
+    assert client.get(f"/api/scores/{score_id}").json()["missing_since"] is None
+
+
+def test_the_trash_folder_cannot_be_reached_by_a_trailing_dot(client, library, add_score):
+    """Adversarial review F3. Windows silently strips a trailing dot from every
+    path component, so ".fermata-trash." passes the trash-folder check on its
+    text and lands, on disk, INSIDE the trash - where scans skip it (so the
+    score is marked missing) and where docs/deployment.md tells people they may
+    delete files by hand.
+    """
+    score_id = add_score("Inbox/Study.pdf")
+
+    res = client.post(f"/api/scores/{score_id}/move", json={"folder": ".fermata-trash."})
+
+    assert res.status_code == 422, res.text
+    assert "space or a dot" in res.json()["detail"]
+    assert (library / "Inbox/Study.pdf").read_bytes() == FIXTURE
+    assert not (library / scanner.TRASH_DIR_NAME).exists()
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("folder", "Classical."),
+        ("folder", "Classical "),
+        ("folder", "Deep/Nested."),
+        ("filename", "Study.pdf."),
+        ("filename", "Study.pdf "),
+    ],
+)
+def test_a_name_the_filesystem_would_silently_rename_is_refused(
+    client, library, add_score, field, value
+):
+    """The benign half of the same rule: a trailing dot or space anywhere makes
+    the path Fermata recorded and the path on disk two different places."""
+    score_id = add_score("Inbox/Study.pdf")
+
+    res = client.post(f"/api/scores/{score_id}/move", json={field: value})
+
+    assert res.status_code == 422, res.text
+    assert "space or a dot" in res.json()["detail"]
+    assert client.get(f"/api/scores/{score_id}").json()["path"] == "Inbox/Study.pdf"
+
+
+def test_a_filename_that_opens_a_data_stream_is_refused(client, library, add_score):
+    """Adversarial review F4. "evil:stream.pdf" is not a file name on NTFS; it
+    is a hidden alternate data stream attached to a file called "evil". Every
+    check this code makes used to pass - the move succeeded, and the content
+    hash read back THROUGH the stream matched - while the library got a 0-byte
+    "evil" the scanner cannot read, and any copy that does not preserve streams
+    drops the music silently.
+    """
+    score_id = add_score("Inbox/Study.pdf")
+
+    res = client.post(f"/api/scores/{score_id}/move", json={"filename": "evil:stream.pdf"})
+
+    assert res.status_code == 422, res.text
+    # WHICH guard refused, not merely that something did. Letting ':' back into
+    # the segment rule left this test green: the name then reached the
+    # filesystem, Windows refused the rename, and F5's wrapper answered 422 with
+    # a message that also happened to contain a colon. That is the overlapping
+    # guard this file has already been bitten by twice - and here the two are
+    # not equivalent at all, because on a filesystem where ':' is an ordinary
+    # character (ext4, and so CI) nothing would have refused it at all.
+    assert "hidden data stream" in res.json()["detail"]
+    assert client.get(f"/api/scores/{score_id}").json()["path"] == "Inbox/Study.pdf"
+    assert (library / "Inbox/Study.pdf").read_bytes() == FIXTURE
+    assert not (library / "Inbox" / "evil").exists()
+    assert [p.name for p in (library / "Inbox").iterdir()] == ["Study.pdf"]
+
+
+@pytest.mark.parametrize("bad", ['a<b.pdf', 'a>b.pdf', 'a"b.pdf', "a|b.pdf", "a?b.pdf", "a*b.pdf"])
+def test_the_other_characters_windows_will_not_take_are_refused(client, add_score, bad):
+    """Refused rather than left to be a 500 from inside a rename on Windows and
+    an uncopyable filename on Linux - one answer on both."""
+    score_id = add_score("Inbox/Study.pdf")
+
+    res = client.post(f"/api/scores/{score_id}/move", json={"filename": bad})
+
+    assert res.status_code == 422, res.text
+    assert client.get(f"/api/scores/{score_id}").json()["path"] == "Inbox/Study.pdf"
+
+
+def test_a_filesystem_refusing_a_move_is_a_422_not_a_500(
+    client, library, add_score, monkeypatch
+):
+    """Adversarial review F5: create_folder answered 422 for a name the
+    filesystem would not take, and the move path answered 500 for the same
+    thing - a reserved name, a path over the length limit, a read-only mount, a
+    disk that filled up mid-batch. The rollback was already right; only the
+    status and the message were wrong."""
+    score_id = add_score("Inbox/Study.pdf")
+    real_rename = Path.rename
+
+    def refuse(self, target):
+        raise OSError(errno.EACCES, "Access is denied")
+
+    monkeypatch.setattr(Path, "rename", refuse)
+    res = client.post(f"/api/scores/{score_id}/move", json={"folder": "Classical"})
+
+    assert res.status_code == 422, res.text
+    assert "would not accept that path" in res.json()["detail"]
+    monkeypatch.setattr(Path, "rename", real_rename)
+    # Nothing moved, and the score is still usable afterwards.
+    assert (library / "Inbox/Study.pdf").read_bytes() == FIXTURE
+    assert client.get(f"/api/scores/{score_id}").json()["path"] == "Inbox/Study.pdf"
+    assert client.post(
+        f"/api/scores/{score_id}/move", json={"folder": "Classical"}
+    ).status_code == 200
+
+
+def test_the_cross_device_fallback_cannot_overwrite_what_appeared_in_the_gap(
+    client, library, add_score, monkeypatch
+):
+    """The hole the F5 fix closed on the way past.
+
+    shutil.move copies and unlinks, and copying onto an existing destination
+    OVERWRITES it - so catching every OSError and falling through to it turned
+    the one case rule 3 forbids into a silent overwrite. Simulated exactly: the
+    destination appears between the check and the rename, and the rename then
+    reports EXDEV (a bind mount inside a bind mount), which is the only error
+    the fallback is now allowed to answer.
+    """
+    score_id = add_score("Inbox/Study.pdf")
+    (library / "Classical").mkdir()
+
+    def appear_then_exdev(self, target):
+        Path(target).write_bytes(b"somebody else's file")
+        raise OSError(errno.EXDEV, "Invalid cross-device link")
+
+    monkeypatch.setattr(Path, "rename", appear_then_exdev)
+    res = client.post(f"/api/scores/{score_id}/move", json={"folder": "Classical"})
+
+    assert res.status_code == 409, res.text
+    assert (library / "Classical/Study.pdf").read_bytes() == b"somebody else's file"
+    assert (library / "Inbox/Study.pdf").read_bytes() == FIXTURE
+    assert client.get(f"/api/scores/{score_id}").json()["path"] == "Inbox/Study.pdf"
+
+
+def test_a_score_can_be_renamed_to_a_different_capitalisation(client, library, add_score):
+    """Adversarial review F7. On NTFS - the deployment platform - "Toccata.pdf"
+    and "toccata.pdf" are one file, so correcting a score's capitalisation asks
+    to move a file onto itself; the existence check refused it and blamed the
+    score for being where it is."""
+    score_id = add_score("Classical/Toccata.pdf")
+
+    res = client.post(f"/api/scores/{score_id}/move", json={"filename": "toccata.pdf"})
+
+    assert res.status_code == 200, res.text
+    assert res.json()["score"]["path"] == "Classical/toccata.pdf"
+    assert (library / "Classical/toccata.pdf").read_bytes() == FIXTURE
+    assert client.get(f"/api/scores/{score_id}").json()["id"] == score_id
+
+
+def test_a_file_is_only_in_its_own_way_when_it_really_is_its_own_file(library):
+    """_same_file asked of the filesystem, not of the path text - which is what
+    makes the case-only rename above work on a case-insensitive filesystem and
+    still refuses a genuine collision on any filesystem."""
+    (library / "a.pdf").write_bytes(b"one")
+    (library / "b.pdf").write_bytes(b"two")
+
+    assert api._same_file(library / "a.pdf", library / "a.pdf") is True
+    assert api._same_file(library / "a.pdf", library / "b.pdf") is False
+    # Not there at all is not "the same file", which is what every caller needs.
+    assert api._same_file(library / "a.pdf", library / "gone.pdf") is False
+
+
+# ---------------------------------------------------------------------------
+# What a deleted score may still be asked for (adversarial review F6).
+# ---------------------------------------------------------------------------
+
+
+def test_a_deleted_score_refuses_every_write_that_means_working_on_it(
+    client, library, add_score
+):
+    """Each of these means "work on this piece", nothing in the interface offers
+    any of them for a deleted score, and accepting one leaves practice or an
+    edit attached to something that is not in the library. Refused with 409 and
+    a sentence naming the fix - see api._live_score_row."""
+    score_id = add_score("Inbox/Study.pdf")
+    client.delete(f"/api/scores/{score_id}")
+
+    refused = {
+        "patch": client.patch(f"/api/scores/{score_id}", json={"title": "Renamed"}),
+        "practice on the score path": client.post(
+            f"/api/scores/{score_id}/practice", json={"seconds": 600}
+        ),
+        "practice on the general path": client.post(
+            "/api/practice/sessions", json={"seconds": 600, "score_id": score_id}
+        ),
+        "a goal about it": client.post(
+            "/api/practice/goals",
+            json={"scope": "score", "score_id": score_id, "target_days": 3},
+        ),
+        "transcribe": client.post(f"/api/scores/{score_id}/transcribe"),
+        "save a transcription": client.put(
+            f"/api/scores/{score_id}/transcription", json={"content": '\\title "x"\n.\n:4 0.1 |'}
+        ),
+        "throw a transcription away": client.delete(f"/api/scores/{score_id}/transcription"),
+    }
+    for what, res in refused.items():
+        assert res.status_code == 409, f"{what}: {res.status_code} {res.text}"
+        assert "in the trash" in res.json()["detail"], what
+
+    # Nothing landed: no practice, no goal, no title change.
+    assert client.get(f"/api/scores/{score_id}").json()["title"] == "Study"
+    assert client.get(f"/api/scores/{score_id}/practice").json()["session_count"] == 0
+    assert client.get("/api/practice/goals").json()["goals"] == []
+
+
+def test_a_deleted_score_can_still_be_read_and_looked_at(client, library, add_score):
+    """The other half of the same policy, and it is deliberate rather than an
+    oversight: the trash view is built out of these responses, and being able to
+    open a score - and read the transcription you spent an evening correcting -
+    before destroying it for ever is the point of a trash you can change your
+    mind from."""
+    score_id = add_score("Inbox/Study.pdf")
+    client.put(
+        f"/api/scores/{score_id}/transcription", json={"content": '\\title "kept"\n.\n:4 0.1 |'}
+    )
+    client.post(f"/api/scores/{score_id}/practice", json={"seconds": 1200})
+    client.delete(f"/api/scores/{score_id}")
+
+    assert client.get(f"/api/scores/{score_id}").status_code == 200
+    assert client.get(f"/api/scores/{score_id}/practice").json()["practice_seconds"] == 1200
+    transcription = client.get(f"/api/scores/{score_id}/transcription")
+    assert transcription.status_code == 200
+    assert transcription.json()["content"] == '\\title "kept"\n.\n:4 0.1 |'
+    served = client.get(f"/api/scores/{score_id}/file")
+    assert served.status_code == 200
+    assert served.content == FIXTURE
+
+
+def test_a_deleted_score_still_counts_in_the_practice_figures_and_says_it_is_deleted(
+    client, library, add_score
+):
+    """Practice history is sacred, so the hours stay counted and the piece stays
+    named - dropping it would leave these breakdowns not adding up to the totals
+    beside them. What was wrong is that a dashboard named a piece and gave a
+    client every reason to link to it, into a library that no longer holds it.
+    The fact travels with the row instead, the same shape as `score_missing` on
+    a session."""
+    kept = add_score("Inbox/Kept.pdf", content=b"kept")
+    doomed = add_score("Inbox/Doomed.pdf", content=b"doomed")
+    client.post(f"/api/scores/{kept}/practice", json={"seconds": 600})
+    client.post(f"/api/scores/{doomed}/practice", json={"seconds": 1800})
+    client.delete(f"/api/scores/{doomed}")
+
+    summary = client.get("/api/practice/summary").json()
+    by_id = {row["id"]: row for row in summary["top_scores"]}
+    assert by_id[doomed]["practice_seconds"] == 1800
+    assert by_id[doomed]["deleted"] is True
+    assert by_id[kept]["deleted"] is False
+    # The totals still add up, which is why the row is not simply dropped.
+    assert summary["week_seconds"] == 2400
+    assert sum(r["practice_seconds"] for r in summary["top_scores"]) == 2400
+
+    history = client.get("/api/practice/history").json()
+    by_score = {row["score_id"]: row for row in history["by_score"]}
+    assert by_score[doomed]["seconds"] == 1800
+    assert by_score[doomed]["deleted"] is True
+    assert by_score[kept]["deleted"] is False
+
+
+def test_an_upload_is_not_held_against_a_change_and_the_scan_it_starts_is(
+    client, library, add_score
+):
+    """Adversarial review F8, and the exemption stated as a test rather than
+    only as a comment.
+
+    Upload only ever CREATES a file at a path nothing claims, so it cannot
+    invalidate a scan's listing the way a move does - and holding it would
+    refuse the second of two uploads in a row for the scan the first one
+    started. What is still true while a change is being applied is that no SCAN
+    runs, which is the property the interlock is actually for.
+    """
+    with scanner.hold_library_still():
+        res = client.post(
+            "/api/upload?folder=Uploads",
+            files={"file": ("new.pdf", b"%PDF-1.4 arriving mid-move", "application/pdf")},
+        )
+        assert res.status_code == 200, res.text
+        assert res.json()["saved"].endswith("new.pdf")
+        # The scan the upload asked for was declined, so nothing walked the
+        # library while it was being changed.
+        assert scanner.scan_status()["scanning"] is False
+
+    assert (library / "Uploads/new.pdf").is_file()
 
 
 def test_a_score_that_is_not_in_the_trash_cannot_be_restored_or_destroyed(

--- a/server/tests/test_library_management_api.py
+++ b/server/tests/test_library_management_api.py
@@ -666,6 +666,120 @@ def test_renaming_a_folder_takes_its_scores_with_it(client, library, add_score):
     }
 
 
+def test_renaming_a_folder_whose_name_holds_sql_wildcards_still_finds_its_scores(
+    client, library, add_score
+):
+    """`_` is a single-character wildcard in SQL's LIKE, and this library's own
+    filenames are full of them - "Terra_s Theme" is the house style for an
+    apostrophe (see metadata._clean_stem). Escaped without an ESCAPE clause, the
+    pattern matches nothing at all, and renaming such a folder would move it on
+    disk and re-point NOT ONE score: every score in it silently marked missing
+    on the next scan, under a folder name that no longer exists.
+    """
+    first = add_score("Terra_s Theme/One.pdf", content=b"one")
+    second = add_score("Terra_s Theme/Deeper/Two.pdf", content=b"two")
+
+    body = client.post(
+        "/api/library/folders/rename",
+        json={"from_path": "Terra_s Theme", "to_path": "Terra's Theme", "dry_run": False},
+    ).json()
+
+    assert body["moved"] == 2, body
+    assert paths(client) == {"Terra's Theme/One.pdf", "Terra's Theme/Deeper/Two.pdf"}
+    assert (library / "Terra's Theme/Deeper/Two.pdf").read_bytes() == b"two"
+    assert client.get(f"/api/scores/{first}").json()["collection"] == "Terra's Theme"
+    assert client.get(f"/api/scores/{second}").json()["id"] == second
+
+    # ...and the same for the other wildcard, so the escaping is not tested for
+    # only one of the two characters it has to handle.
+    add_score("100% Guitar/Three.pdf", content=b"three")
+    percent = client.post(
+        "/api/library/folders/rename",
+        json={"from_path": "100% Guitar", "to_path": "All Guitar", "dry_run": False},
+    ).json()
+    assert percent["moved"] == 1, percent
+    assert (library / "All Guitar/Three.pdf").read_bytes() == b"three"
+
+
+def test_a_folder_rename_only_moves_the_folder_it_names(client, library, add_score):
+    """SQLite's LIKE is case-insensitive for ASCII, so the pattern that finds
+    this folder's scores also matches a differently-cased folder's - which on
+    any case-sensitive filesystem is a different folder entirely. The Python
+    prefix filter after it is what makes the answer case-SENSITIVE, and without
+    it renaming `Patreon` would re-point a score filed under `patreon` at a
+    folder its file was never in.
+    """
+    mine = add_score("Patreon/One.pdf", content=b"one")
+    conn = db.connect()
+    # A row under the other casing. Marked missing so it needs no file, which is
+    # also the only way to have both on a case-insensitive filesystem.
+    other = conn.execute(
+        """INSERT INTO scores(title, collection, path, file_type, hash, size, mtime,
+                              missing_since)
+           VALUES ('Other', 'patreon', 'patreon/Other.pdf', 'pdf', 'otherhash', 3, 0.0,
+                   datetime('now'))"""
+    ).lastrowid
+    conn.commit()
+
+    body = client.post(
+        "/api/library/folders/rename",
+        json={"from_path": "Patreon", "to_path": "Arrangements", "dry_run": False},
+    ).json()
+
+    assert body["moved"] == 1, body
+    assert client.get(f"/api/scores/{mine}").json()["path"] == "Arrangements/One.pdf"
+    assert client.get(f"/api/scores/{other}").json()["path"] == "patreon/Other.pdf"
+
+
+def test_renaming_a_folder_carries_a_score_whose_file_is_missing_along_with_it(
+    client, library, add_score
+):
+    """A score under this folder whose file is not there still has to follow the
+    rename, or it is left filed under a folder name that no longer exists - and
+    there is nothing to hash, so the content check every present score gets
+    would be a FileNotFoundError and a 500 for a perfectly ordinary tidy-up."""
+    present = add_score("Patreon/One.pdf", content=b"one")
+    absent = add_score("Patreon/Gone.pdf", content=b"gone")
+    (library / "Patreon/Gone.pdf").unlink()
+    conn = db.connect()
+    conn.execute("UPDATE scores SET missing_since = datetime('now') WHERE id = ?", (absent,))
+    conn.commit()
+
+    res = client.post(
+        "/api/library/folders/rename",
+        json={"from_path": "Patreon", "to_path": "Arrangements", "dry_run": False},
+    )
+
+    assert res.status_code == 200, res.text
+    assert res.json()["moved"] == 2
+    assert client.get(f"/api/scores/{present}").json()["path"] == "Arrangements/One.pdf"
+    gone = client.get(f"/api/scores/{absent}").json()
+    assert gone["path"] == "Arrangements/Gone.pdf"
+    # Still missing, still saying so, and its last known size is not overwritten
+    # with a figure read off a file that is not there.
+    assert gone["missing_since"] is not None
+    assert gone["size"] == len(b"gone")
+    assert gone["collection"] == "Arrangements"
+
+
+def test_the_trash_does_not_fill_up_with_empty_folders(client, library, add_score):
+    """One numbered folder per score ever deleted, left behind for ever, makes
+    the trash look like a mess somebody would be tempted to clear out by hand -
+    which is the one thing that really does lose a deleted score's file."""
+    restored = add_score("Inbox/One.pdf", content=b"one")
+    destroyed = add_score("Inbox/Two.pdf", content=b"two")
+
+    client.delete(f"/api/scores/{restored}")
+    client.delete(f"/api/scores/{destroyed}")
+    trash = library / scanner.TRASH_DIR_NAME
+    assert {p.name for p in trash.iterdir()} == {str(restored), str(destroyed)}
+
+    client.post(f"/api/trash/{restored}/restore")
+    client.delete(f"/api/trash/{destroyed}")
+
+    assert list(trash.iterdir()) == []
+
+
 def test_a_folder_cannot_be_renamed_into_itself_or_onto_something(client, library, add_score):
     add_score("Patreon/One.pdf")
     (library / "Taken").mkdir()

--- a/server/tests/test_library_management_api.py
+++ b/server/tests/test_library_management_api.py
@@ -1086,6 +1086,38 @@ def test_a_score_that_is_not_in_the_trash_cannot_be_restored_or_destroyed(
     assert client.get(f"/api/scores/{score_id}").json()["deleted_at"] is None
 
 
+def test_a_score_in_the_trash_cannot_be_moved_back_out_by_a_move(client, library, add_score):
+    """A deleted score has a perfectly good file sitting in the trash, so a move
+    would happily take it back out - leaving a file in the library that nothing
+    in the library shows (the row is still marked deleted) and a trash entry
+    whose file is not in the trash. Restoring is the only thing that takes a
+    score out of there."""
+    score_id = add_score("Inbox/Study.pdf")
+    trashed = client.delete(f"/api/scores/{score_id}").json()
+
+    previewed = client.post(
+        f"/api/scores/{score_id}/move", json={"folder": "Classical", "dry_run": True}
+    ).json()
+    assert previewed["moves"][0]["status"] == "blocked"
+    assert "in the trash" in previewed["moves"][0]["reason"]
+
+    single = client.post(f"/api/scores/{score_id}/move", json={"folder": "Classical"})
+    assert single.status_code == 409
+    assert "in the trash" in single.json()["detail"]
+
+    batch = client.post(
+        "/api/library/move",
+        json={"score_ids": [score_id], "folder": "Classical", "dry_run": False},
+    )
+    assert batch.status_code == 409
+    assert "in the trash" in batch.json()["detail"]
+
+    # Still in the trash, file and row alike.
+    assert (library / trashed["trashed_to"]).is_file()
+    assert not (library / "Classical/Study.pdf").exists()
+    assert [s["id"] for s in client.get("/api/trash").json()] == [score_id]
+
+
 def test_deleting_a_score_twice_is_refused_rather_than_moving_it_again(client, add_score):
     score_id = add_score("Inbox/Study.pdf")
     client.delete(f"/api/scores/{score_id}")

--- a/server/tests/test_practice_migration.py
+++ b/server/tests/test_practice_migration.py
@@ -309,7 +309,10 @@ def test_every_practice_session_survives_the_upgrade(upgraded, version):
 def test_the_upgrade_stamps_the_new_version(upgraded, version):
     upgraded(version)
     conn = db.connect()
-    assert conn.execute("PRAGMA user_version").fetchone()[0] == db.SCHEMA_VERSION == 4
+    # 5 since issue #56 - see db.SCHEMA_VERSION. The literal is half the
+    # point of this assertion: an upgrade landing on the version this code
+    # believes in is only interesting if that version is written down here.
+    assert conn.execute("PRAGMA user_version").fetchone()[0] == db.SCHEMA_VERSION == 5
 
 
 def test_carried_rows_are_marked_as_the_piece_practice_they_were(upgraded):
@@ -788,6 +791,6 @@ def test_a_fresh_install_needs_no_migration_and_still_lands_on_the_new_table(
         r["name"]: r["notnull"] for r in conn.execute("PRAGMA table_info(practice_sessions)")
     }
     assert notnull["score_id"] == 0
-    assert conn.execute("PRAGMA user_version").fetchone()[0] == 4
+    assert conn.execute("PRAGMA user_version").fetchone()[0] == 5
     assert conn.execute("SELECT COUNT(*) FROM practice_sessions").fetchone()[0] == 0
     db._local.conn = None

--- a/server/tests/test_scanner.py
+++ b/server/tests/test_scanner.py
@@ -1281,7 +1281,8 @@ def test_the_config_folder_is_still_ours_to_create(tmp_path, monkeypatch):
 
     The config folder is Fermata's own storage: an empty one is a genuine first
     run and there is no data it could be shadowing. The library folder is the
-    user's, and Fermata only ever reads it.
+    user's, and Fermata never creates it - which matters more since #56 gave
+    Fermata the ability to move, rename and delete files inside it, not less.
     """
     library = tmp_path / "library"
     library.mkdir()
@@ -1637,7 +1638,7 @@ def test_the_scan_survives_a_file_that_cannot_be_read_and_still_reconciles(libra
     scanner._scan()
     (library / "Classical" / "Study 0.gp").unlink()
 
-    real_stat = scanner._hash_file
+    real_stat = scanner.hash_file
 
     def explode(path):
         if path.name == "Study 1.gp":
@@ -1646,7 +1647,7 @@ def test_the_scan_survives_a_file_that_cannot_be_read_and_still_reconciles(libra
 
     import unittest.mock
 
-    with unittest.mock.patch.object(scanner, "_hash_file", explode):
+    with unittest.mock.patch.object(scanner, "hash_file", explode):
         # Force every file down the hashing path by clearing the cached stats.
         db.connect().execute("UPDATE scores SET size = -1")
         db.connect().commit()

--- a/web/src/lib/Library.svelte
+++ b/web/src/lib/Library.svelte
@@ -15,6 +15,241 @@
   let uploadInput;
   let showDuplicates = $state(false);
   let duplicates = $state([]);
+
+  // --- Managing the library (issue #56) --------------------------------------
+  //
+  // This is the only part of Fermata that writes to somebody's own files, and
+  // the interface is built around that rather than around convenience:
+  //
+  //   ORGANISE IS A MODE, not something a stray tap can start. Outside it a
+  //   card opens a score, which is what a card has always done; inside it a
+  //   card selects, and the whole grid says so. Nothing here is a drag - this
+  //   is used on a music stand, often with a tablet, and a drag that starts by
+  //   accident on a touchscreen would be a move nobody asked for.
+  //
+  //   A MOVE IS PREVIEWED BEFORE IT HAPPENS. The dialog asks the server for
+  //   the plan (its dry run) and shows every line of it - from and to - before
+  //   the button that applies it is worth pressing. The server refuses a plan
+  //   with a blocked line, and so does this.
+  //
+  //   DELETING SAYS WHAT IT KEEPS. The confirmation is not "are you sure": it
+  //   says the file goes to the library's trash and the practice history stays,
+  //   and afterwards it says how many sessions, tags and transcriptions are
+  //   still attached, counted by the server.
+  //
+  //   DESTROYING IS SOMEWHERE ELSE ENTIRELY. The only control that really
+  //   deletes lives in the trash view, needs a second press, and lists what it
+  //   will destroy first.
+  let organising = $state(false);
+  let selected = $state([]);
+  let notice = $state("");
+  let busy = $state(false);
+
+  let folders = $state([]);
+  let moveOpen = $state(false);
+  let moveError = $state("");
+  let targetFolder = $state(null);
+  let newFolderName = $state("");
+  let movePlan = $state(null);
+  let renamingFolder = $state(false);
+  let renameTo = $state("");
+  let renamePlan = $state(null);
+
+  let deleteOpen = $state(false);
+  let deleteError = $state("");
+
+  let showTrash = $state(false);
+  let trashItems = $state([]);
+  let destroyConfirmId = $state(null);
+
+  const selectedScores = $derived(scores.filter((s) => selected.includes(s.id)));
+  const blockedLines = $derived((movePlan ?? []).filter((line) => line.status === "blocked"));
+
+  function toggleSelected(score, ev) {
+    if (!organising) return;
+    ev.preventDefault();
+    ev.stopPropagation();
+    selected = selected.includes(score.id)
+      ? selected.filter((id) => id !== score.id)
+      : [...selected, score.id];
+  }
+
+  function leaveOrganising() {
+    organising = false;
+    selected = [];
+    moveOpen = false;
+    deleteOpen = false;
+  }
+
+  async function loadFolders() {
+    folders = await api.folders();
+  }
+
+  async function openMove() {
+    moveError = "";
+    movePlan = null;
+    renamingFolder = false;
+    renamePlan = null;
+    targetFolder = null;
+    newFolderName = "";
+    await loadFolders();
+    moveOpen = true;
+  }
+
+  // The preview IS the dry run - the same endpoint, the same plan shape, asked
+  // for with dry_run true. Showing a preview computed in the browser would be
+  // showing a different operation's plan and calling it this one's.
+  async function previewMove(folder) {
+    targetFolder = folder;
+    moveError = "";
+    movePlan = null;
+    try {
+      const result = await api.moveScores(selected, folder, true);
+      movePlan = result.moves;
+    } catch (err) {
+      moveError = err?.message ?? "Fermata could not work out what that would do.";
+    }
+  }
+
+  async function applyMove() {
+    if (targetFolder === null || blockedLines.length) return;
+    busy = true;
+    moveError = "";
+    try {
+      const result = await api.moveScores(selected, targetFolder, false);
+      notice = `Moved ${result.moved} score${result.moved === 1 ? "" : "s"} to ${
+        targetFolder || "the library root"
+      }.`;
+      moveOpen = false;
+      leaveOrganising();
+      await refresh();
+    } catch (err) {
+      moveError = err?.message ?? "Fermata could not move those.";
+    } finally {
+      busy = false;
+    }
+  }
+
+  async function createFolder() {
+    const name = newFolderName.trim();
+    if (!name) return;
+    moveError = "";
+    try {
+      const path = targetFolder ? `${targetFolder}/${name}` : name;
+      const created = await api.createFolder(path);
+      newFolderName = "";
+      await loadFolders();
+      await previewMove(created.created);
+    } catch (err) {
+      moveError = err?.message ?? "Fermata could not create that folder.";
+    }
+  }
+
+  async function previewFolderRename() {
+    renamePlan = null;
+    moveError = "";
+    try {
+      const result = await api.renameFolder(targetFolder, renameTo.trim(), true);
+      renamePlan = result.moves;
+    } catch (err) {
+      moveError = err?.message ?? "Fermata could not work out what that would do.";
+    }
+  }
+
+  async function applyFolderRename() {
+    busy = true;
+    moveError = "";
+    try {
+      const from = targetFolder;
+      const result = await api.renameFolder(from, renameTo.trim(), false);
+      notice = `Renamed ${from} to ${result.to_path}; ${result.moved} score${
+        result.moved === 1 ? "" : "s"
+      } moved with it.`;
+      moveOpen = false;
+      leaveOrganising();
+      await refresh();
+    } catch (err) {
+      moveError = err?.message ?? "Fermata could not rename that folder.";
+    } finally {
+      busy = false;
+    }
+  }
+
+  async function applyDelete() {
+    busy = true;
+    deleteError = "";
+    try {
+      let sessions = 0;
+      let transcriptions = 0;
+      for (const id of selected) {
+        const result = await api.deleteScore(id);
+        sessions += result.practice_sessions_kept;
+        transcriptions += result.transcriptions_kept;
+      }
+      const count = selected.length;
+      notice =
+        `Moved ${count} score${count === 1 ? "" : "s"} to the trash. ` +
+        `${sessions} practice session${sessions === 1 ? "" : "s"} and ${transcriptions} ` +
+        `transcription${transcriptions === 1 ? "" : "s"} are still attached - nothing was ` +
+        `destroyed. They are in Trash until you say otherwise.`;
+      deleteOpen = false;
+      leaveOrganising();
+      await refresh();
+    } catch (err) {
+      deleteError = err?.message ?? "Fermata could not delete those.";
+    } finally {
+      busy = false;
+    }
+  }
+
+  async function loadTrash() {
+    trashItems = await api.trash();
+  }
+
+  $effect(() => {
+    if (!showTrash) return;
+    loadTrash();
+  });
+
+  async function restore(score) {
+    busy = true;
+    try {
+      const result = await api.restoreScore(score.id);
+      notice =
+        result.restored_to === result.restored_from
+          ? `${score.title} is back at ${result.restored_to}.`
+          : `${score.title} is back, at ${result.restored_to} - something else had taken ` +
+            `${result.restored_from}, and Fermata did not overwrite it.`;
+      await loadTrash();
+      await refresh();
+    } catch (err) {
+      notice = err?.message ?? "Fermata could not put that back.";
+    } finally {
+      busy = false;
+    }
+  }
+
+  async function destroy(score) {
+    busy = true;
+    try {
+      const result = await api.destroyScore(score.id);
+      notice =
+        `${result.title} is gone for good, with ${result.tags_destroyed} tag${
+          result.tags_destroyed === 1 ? "" : "s"
+        } and ${result.transcriptions_destroyed} transcription${
+          result.transcriptions_destroyed === 1 ? "" : "s"
+        }. ${result.practice_sessions_kept} practice session${
+          result.practice_sessions_kept === 1 ? "" : "s"
+        } stayed in your history.`;
+      destroyConfirmId = null;
+      await loadTrash();
+      await refresh();
+    } catch (err) {
+      notice = err?.message ?? "Fermata could not destroy that.";
+    } finally {
+      busy = false;
+    }
+  }
   // Which build is actually running (issue #119) - fetched once, quietly, so
   // a stale deployment is diagnosable at a glance instead of by guessing from
   // which features seem to be missing. null until it arrives, which renders
@@ -173,20 +408,27 @@
     </div>
 
     <nav>
-      <button class="side-item" class:active={!collection && !favorite && !practiced && !showDuplicates} onclick={() => { collection = ""; favorite = false; practiced = ""; showDuplicates = false; }}>
+      <button class="side-item" class:active={!collection && !favorite && !practiced && !showDuplicates && !showTrash} onclick={() => { collection = ""; favorite = false; practiced = ""; showDuplicates = false; showTrash = false; }}>
         All scores
       </button>
-      <button class="side-item" class:active={favorite} onclick={() => { favorite = !favorite; showDuplicates = false; }}>
+      <button class="side-item" class:active={favorite} onclick={() => { favorite = !favorite; showDuplicates = false; showTrash = false; }}>
         ★ Favorites
       </button>
-      <button class="side-item" class:active={practiced === "recent"} onclick={() => { practiced = practiced === "recent" ? "" : "recent"; showDuplicates = false; }}>
+      <button class="side-item" class:active={practiced === "recent"} onclick={() => { practiced = practiced === "recent" ? "" : "recent"; showDuplicates = false; showTrash = false; }}>
         ◷ Recently practiced
       </button>
-      <button class="side-item" class:active={practiced === "neglected"} onclick={() => { practiced = practiced === "neglected" ? "" : "neglected"; showDuplicates = false; }}>
+      <button class="side-item" class:active={practiced === "neglected"} onclick={() => { practiced = practiced === "neglected" ? "" : "neglected"; showDuplicates = false; showTrash = false; }}>
         ⌛ Needs attention
       </button>
-      <button class="side-item" class:active={showDuplicates} onclick={() => (showDuplicates = !showDuplicates)}>
+      <button class="side-item" class:active={showDuplicates} onclick={() => { showDuplicates = !showDuplicates; showTrash = false; }}>
         ⧉ Duplicates
+      </button>
+      <!-- Deleted scores are HERE and nowhere else. They are gone from the grid
+           and from every count in this sidebar, which is what deleting has to
+           mean, and they are one press from coming back - which is what makes
+           deleting safe to offer at all (issue #56). -->
+      <button class="side-item trash-link" class:active={showTrash} onclick={() => { showTrash = !showTrash; showDuplicates = false; leaveOrganising(); }}>
+        🗑 Trash
       </button>
 
       <div class="side-label">Collections</div>
@@ -194,7 +436,7 @@
         <button
           class="side-item"
           class:active={collection === c.collection}
-          onclick={() => { collection = collection === c.collection ? "" : c.collection; showDuplicates = false; }}
+          onclick={() => { collection = collection === c.collection ? "" : c.collection; showDuplicates = false; showTrash = false; }}
         >
           {c.collection}
           <span class="count">{c.count}</span>
@@ -213,7 +455,7 @@
         <div class="side-label">Tags</div>
         <div class="tag-cloud">
           {#each tags as t}
-            <button class="chip" class:active={tag === t.name} onclick={() => { tag = tag === t.name ? "" : t.name; showDuplicates = false; }}>
+            <button class="chip" class:active={tag === t.name} onclick={() => { tag = tag === t.name ? "" : t.name; showDuplicates = false; showTrash = false; }}>
               {t.name}
             </button>
           {/each}
@@ -312,7 +554,68 @@
       </p>
     {/if}
 
-    {#if showDuplicates}
+    {#if notice}
+      <!-- What just happened to somebody's files, in their own terms and in
+           full: which scores moved where, or what a deletion kept. Dismissible
+           rather than timed - this is the receipt for a change to their
+           library, and a receipt that disappears on its own while it is being
+           read is not one. -->
+      <p class="notice" role="status">
+        {notice}
+        <button class="notice-dismiss" onclick={() => (notice = "")}>Dismiss</button>
+      </p>
+    {/if}
+
+    {#if showTrash}
+      <header>
+        <span class="result-count">{trashItems.length} in the trash</span>
+      </header>
+      <p class="trash-intro">
+        These scores have been deleted. Their files are in a trash folder inside your library
+        and their practice history, tags and transcriptions are still attached — putting one
+        back leaves it exactly as it was.
+      </p>
+      {#if !trashItems.length}
+        <p class="empty">The trash is empty.</p>
+      {:else}
+        <div class="trash-list">
+          {#each trashItems as score (score.id)}
+            <div class="trash-row">
+              <div class="trash-what">
+                <div class="trash-title">{score.title}</div>
+                <div class="trash-path">was {score.deleted_from}</div>
+                <div class="trash-kept">
+                  {Math.round(score.practice_seconds / 60)} min practised{score.tags.length
+                    ? `, ${score.tags.length} tag${score.tags.length === 1 ? "" : "s"}`
+                    : ""}{score.has_transcription ? ", transcription kept" : ""}
+                </div>
+              </div>
+              <div class="trash-actions">
+                <button class="trash-restore" disabled={busy} onclick={() => restore(score)}>
+                  Put it back
+                </button>
+                {#if destroyConfirmId === score.id}
+                  <!-- The second press. It names what it destroys and what it
+                       cannot: the file and the transcription go, the hours
+                       stay in the practice history. -->
+                  <button class="trash-destroy-confirm" disabled={busy} onclick={() => destroy(score)}>
+                    Destroy the file{score.has_transcription ? " and its transcription" : ""} —
+                    your practice history stays
+                  </button>
+                  <button class="trash-destroy-cancel" onclick={() => (destroyConfirmId = null)}>
+                    Keep it
+                  </button>
+                {:else}
+                  <button class="trash-destroy" onclick={() => (destroyConfirmId = score.id)}>
+                    Delete permanently…
+                  </button>
+                {/if}
+              </div>
+            </div>
+          {/each}
+        </div>
+      {/if}
+    {:else if showDuplicates}
       <header>
         <span class="result-count">{duplicates.length} duplicate group{duplicates.length === 1 ? "" : "s"}</span>
       </header>
@@ -341,8 +644,34 @@
             <option {value}>{label}</option>
           {/each}
         </select>
+        <button
+          class="organise-toggle"
+          class:on={organising}
+          onclick={() => (organising ? leaveOrganising() : (organising = true))}
+        >
+          {organising ? "Done organising" : "Organise"}
+        </button>
         <span class="result-count">{scores.length} score{scores.length === 1 ? "" : "s"}</span>
       </header>
+
+      {#if organising}
+        <!-- The bar only exists in organise mode, and the buttons on it only
+             do anything with something selected: a "Move" that is always
+             pressable on a page where nothing is chosen is a button that
+             either does nothing or does something surprising. -->
+        <div class="organise-bar">
+          <span class="selected-count">
+            {selected.length} selected
+          </span>
+          <button class="move-open" disabled={!selected.length} onclick={openMove}>
+            Move to folder…
+          </button>
+          <button class="delete-open" disabled={!selected.length} onclick={() => { deleteError = ""; deleteOpen = true; }}>
+            Delete…
+          </button>
+          <span class="organise-hint">Tap a score to choose it.</span>
+        </div>
+      {/if}
 
       {#if loading && !scores.length}
         <p class="empty">Loading…</p>
@@ -354,8 +683,22 @@
       {:else}
         <div class="grid">
           {#each scores as score (score.id)}
-            <a class="card" class:is-missing={score.missing_since} href={"#/score/" + score.id}>
+            <a
+              class="card"
+              class:is-missing={score.missing_since}
+              class:selectable={organising}
+              class:selected={selected.includes(score.id)}
+              href={"#/score/" + score.id}
+              onclick={(e) => toggleSelected(score, e)}
+            >
               <div class="sheet">
+                {#if organising}
+                  <!-- The whole card is the target, not a small checkbox in a
+                       corner: this is used on a stand, at arm's length, often
+                       with a tablet. The mark says which state the card is in
+                       rather than offering a second thing to hit. -->
+                  <span class="select-mark">{selected.includes(score.id) ? "✓" : ""}</span>
+                {/if}
                 {#if score.file_type === "pdf"}
                   <img src={api.thumbUrl(score.id)} alt="" loading="lazy" onerror={(e) => (e.target.style.display = "none")} />
                 {:else}
@@ -389,6 +732,145 @@
           {/each}
         </div>
       {/if}
+    {/if}
+
+    {#if moveOpen}
+      <div class="dialog-scrim">
+        <div class="dialog move" role="dialog" aria-label="Move scores">
+          <div class="dialog-head">
+            Move {selected.length} score{selected.length === 1 ? "" : "s"}
+          </div>
+          <div class="folder-list">
+            {#each folders as folder (folder.path)}
+              <button
+                class="folder-option"
+                class:chosen={targetFolder === folder.path}
+                style={`padding-left:${12 + folder.depth * 16}px`}
+                onclick={() => previewMove(folder.path)}
+              >
+                <span class="folder-name">{folder.name}</span>
+                <span class="count">{folder.score_count}</span>
+              </button>
+            {/each}
+          </div>
+
+          <div class="new-folder">
+            <input
+              class="new-folder-input"
+              type="text"
+              placeholder={targetFolder ? `New folder inside ${targetFolder}` : "New folder"}
+              bind:value={newFolderName}
+            />
+            <button class="new-folder-create" disabled={!newFolderName.trim()} onclick={createFolder}>
+              Create folder
+            </button>
+          </div>
+
+          {#if targetFolder}
+            <div class="folder-rename">
+              {#if renamingFolder}
+                <input class="folder-rename-input" type="text" bind:value={renameTo} />
+                <button
+                  class="folder-rename-preview"
+                  disabled={!renameTo.trim() || renameTo.trim() === targetFolder}
+                  onclick={previewFolderRename}
+                >
+                  Show what that would move
+                </button>
+                {#if renamePlan}
+                  <div class="rename-preview">
+                    <p class="plan-head">
+                      {renamePlan.length} score{renamePlan.length === 1 ? "" : "s"} would move
+                      with it.
+                    </p>
+                    <button class="folder-rename-apply" disabled={busy} onclick={applyFolderRename}>
+                      Rename the folder
+                    </button>
+                  </div>
+                {/if}
+              {:else}
+                <button
+                  class="folder-rename-open"
+                  onclick={() => { renamingFolder = true; renameTo = targetFolder; renamePlan = null; }}
+                >
+                  Rename “{targetFolder}” instead…
+                </button>
+              {/if}
+            </div>
+          {/if}
+
+          {#if movePlan}
+            <!-- THE PREVIEW IS THE SERVER'S OWN DRY RUN, line for line - the
+                 same request with dry_run set, so what is shown here is what
+                 would happen rather than this page's guess at it. -->
+            <div class="move-preview">
+              <p class="plan-head">This is what will happen:</p>
+              <ul>
+                {#each movePlan as line (line.score_id)}
+                  <li class="plan-line" class:blocked={line.status === "blocked"}>
+                    {#if line.status === "move"}
+                      <span class="plan-from">{line.from_path}</span> →
+                      <span class="plan-to">{line.to_path}</span>
+                    {:else if line.status === "unchanged"}
+                      <span class="plan-from">{line.from_path}</span> is already there
+                    {:else}
+                      <span class="plan-from">{line.from_path}</span> — {line.reason}
+                    {/if}
+                  </li>
+                {/each}
+              </ul>
+            </div>
+          {/if}
+
+          {#if moveError}
+            <p class="alert-error">{moveError}</p>
+          {/if}
+
+          <div class="dialog-actions">
+            <button
+              class="move-apply"
+              disabled={busy || targetFolder === null || !movePlan || blockedLines.length > 0}
+              onclick={applyMove}
+            >
+              {blockedLines.length
+                ? "Fix the problems above first"
+                : `Move ${selected.length} score${selected.length === 1 ? "" : "s"} here`}
+            </button>
+            <button class="dialog-cancel" onclick={() => (moveOpen = false)}>Cancel</button>
+          </div>
+        </div>
+      </div>
+    {/if}
+
+    {#if deleteOpen}
+      <div class="dialog-scrim">
+        <div class="dialog delete" role="dialog" aria-label="Delete scores">
+          <div class="dialog-head">
+            Delete {selected.length} score{selected.length === 1 ? "" : "s"}?
+          </div>
+          <ul class="delete-list">
+            {#each selectedScores as score (score.id)}
+              <li>{score.title} <span class="plan-from">{score.path}</span></li>
+            {/each}
+          </ul>
+          <!-- Said before the button is pressed, not after: this is the whole
+               reason deleting can be offered at a tap in a music-stand
+               interface at all. -->
+          <p class="delete-note">
+            The file moves to a trash folder inside your library. Your practice history, tags,
+            goals and any transcription stay attached, and Trash puts it all back.
+          </p>
+          {#if deleteError}
+            <p class="alert-error">{deleteError}</p>
+          {/if}
+          <div class="dialog-actions">
+            <button class="delete-apply" disabled={busy} onclick={applyDelete}>
+              Move to trash
+            </button>
+            <button class="dialog-cancel" onclick={() => (deleteOpen = false)}>Cancel</button>
+          </div>
+        </div>
+      </div>
     {/if}
   </main>
 </div>
@@ -746,6 +1228,268 @@
     color: #e8b45c;
     font-size: 13px;
     margin: 8px 0 0;
+  }
+
+  /* ---- Managing the library (issue #56) ----------------------------------
+     Everything here is sized for a music stand: the smallest target below is
+     44px tall, because the hand reaching for it is often holding a plectrum
+     and the screen is often at arm's length. */
+
+  .organise-toggle {
+    min-height: 44px;
+    padding: 0 16px;
+  }
+
+  .organise-toggle.on {
+    background: var(--brass);
+    color: #241d0f;
+    border-color: var(--brass);
+  }
+
+  .organise-bar {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 10px;
+    margin: 0 0 16px;
+    padding: 10px 14px;
+    border: 1px solid rgba(232, 180, 92, 0.4);
+    background: rgba(232, 180, 92, 0.06);
+    border-radius: 8px;
+  }
+
+  .organise-bar button {
+    min-height: 44px;
+    padding: 0 18px;
+  }
+
+  .selected-count {
+    font-family: var(--font-display);
+    font-size: 15px;
+  }
+
+  .organise-hint {
+    color: var(--ink-dim);
+    font-size: 13px;
+    margin-left: auto;
+  }
+
+  .card.selectable .sheet {
+    outline: 2px solid transparent;
+  }
+
+  .card.selected .sheet {
+    outline: 3px solid var(--brass-bright);
+    outline-offset: 2px;
+  }
+
+  .select-mark {
+    position: absolute;
+    inset: 0;
+    display: grid;
+    place-items: center;
+    font-size: 60px;
+    color: var(--brass-bright);
+    background: rgba(22, 19, 14, 0.35);
+  }
+
+  .notice {
+    border: 1px solid rgba(232, 180, 92, 0.45);
+    background: rgba(232, 180, 92, 0.07);
+    border-radius: 8px;
+    padding: 12px 14px;
+    margin: 0 0 16px;
+    color: var(--ink);
+    line-height: 1.5;
+  }
+
+  .notice-dismiss {
+    margin-left: 10px;
+    font-size: 12px;
+    padding: 4px 12px;
+  }
+
+  .dialog-scrim {
+    position: fixed;
+    inset: 0;
+    background: rgba(12, 10, 7, 0.72);
+    display: grid;
+    place-items: center;
+    z-index: 20;
+    padding: 20px;
+  }
+
+  .dialog {
+    background: var(--bg-raised);
+    border: 1px solid var(--line);
+    border-radius: 12px;
+    padding: 20px;
+    width: min(620px, 100%);
+    max-height: 88vh;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+  }
+
+  .dialog-head {
+    font-family: var(--font-display);
+    font-size: 20px;
+    color: var(--brass-bright);
+  }
+
+  .folder-list {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    max-height: 280px;
+    overflow-y: auto;
+  }
+
+  .folder-option {
+    display: flex;
+    justify-content: space-between;
+    gap: 10px;
+    text-align: left;
+    min-height: 44px;
+    align-items: center;
+    background: none;
+    border: 1px solid transparent;
+    border-radius: 8px;
+    color: var(--ink);
+  }
+
+  .folder-option:hover {
+    background: var(--surface);
+  }
+
+  .folder-option.chosen {
+    background: var(--surface);
+    border-color: var(--brass);
+    color: var(--brass-bright);
+  }
+
+  .new-folder,
+  .folder-rename,
+  .dialog-actions {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+    align-items: center;
+  }
+
+  .new-folder input,
+  .folder-rename input {
+    flex: 1;
+    min-width: 180px;
+    min-height: 44px;
+  }
+
+  .new-folder button,
+  .folder-rename button,
+  .dialog-actions button {
+    min-height: 44px;
+    padding: 0 18px;
+  }
+
+  .move-preview,
+  .rename-preview,
+  .delete-list {
+    border-top: 1px solid var(--line);
+    padding-top: 12px;
+    font-size: 13px;
+    color: var(--ink-dim);
+  }
+
+  .plan-head {
+    margin: 0 0 6px;
+    color: var(--ink);
+  }
+
+  .move-preview ul,
+  .delete-list {
+    margin: 0;
+    padding-left: 18px;
+    max-height: 200px;
+    overflow-y: auto;
+  }
+
+  .plan-line {
+    font-family: "SFMono-Regular", Consolas, Menlo, monospace;
+    font-size: 12px;
+    line-height: 1.6;
+    word-break: break-all;
+  }
+
+  .plan-line.blocked {
+    color: #e8b45c;
+  }
+
+  .plan-to {
+    color: var(--brass-bright);
+  }
+
+  .delete-note {
+    margin: 0;
+    color: var(--ink-dim);
+    font-size: 13px;
+    line-height: 1.5;
+  }
+
+  .trash-intro {
+    color: var(--ink-dim);
+    font-size: 13px;
+    line-height: 1.5;
+    margin: 0 0 16px;
+    max-width: 70ch;
+  }
+
+  .trash-list {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+
+  .trash-row {
+    display: flex;
+    justify-content: space-between;
+    gap: 14px;
+    flex-wrap: wrap;
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: 8px;
+    padding: 12px 16px;
+  }
+
+  .trash-title {
+    font-family: var(--font-display);
+    font-size: 15px;
+  }
+
+  .trash-path,
+  .trash-kept {
+    font-size: 12px;
+    color: var(--ink-dim);
+    margin-top: 2px;
+  }
+
+  .trash-actions {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+    flex-wrap: wrap;
+  }
+
+  .trash-actions button {
+    min-height: 44px;
+    padding: 0 16px;
+  }
+
+  /* Amber, not red, and only on the one control that really destroys
+     something. Everything else in this view is recoverable. */
+  .trash-destroy-confirm {
+    border-color: #e8b45c;
+    color: #e8b45c;
   }
 
   .meta {

--- a/web/src/lib/Practice.svelte
+++ b/web/src/lib/Practice.svelte
@@ -613,7 +613,18 @@
               <ul class="spent by-score">
                 {#each history.by_score as row (row.score_id)}
                   <li>
-                    <a href={"#/score/" + row.score_id}>{row.title}</a>
+                    {#if row.deleted}
+                      <!-- The hours were spent and still count, so the piece
+                           stays listed and the totals still add up - but it is
+                           in the trash, so this is not a way into it. A link
+                           here led to a score the library no longer holds
+                           (issue #56). -->
+                      <span class="deleted-piece" title="This score is in the trash. The practice still counts.">
+                        {row.title} <span class="deleted-mark">deleted</span>
+                      </span>
+                    {:else}
+                      <a href={"#/score/" + row.score_id}>{row.title}</a>
+                    {/if}
                     <span class="quiet">{formatDuration(row.seconds)}</span>
                   </li>
                 {/each}
@@ -779,6 +790,23 @@
   .quiet {
     color: var(--ink-dim);
     font-size: 13px;
+  }
+
+  /* A piece that is in the trash: still listed, still counted, and no longer
+     somewhere to go. Dimmed rather than struck through - the practice is not
+     cancelled, only the score is out of the library (issue #56). */
+  .deleted-piece {
+    color: var(--ink-dim);
+  }
+
+  .deleted-mark {
+    font-size: 11px;
+    letter-spacing: 0.04em;
+    color: #e8b45c;
+    border: 1px solid rgba(232, 180, 92, 0.5);
+    border-radius: 99px;
+    padding: 1px 7px;
+    margin-left: 4px;
   }
 
   .hint {

--- a/web/src/lib/Practice.svelte
+++ b/web/src/lib/Practice.svelte
@@ -684,7 +684,21 @@
                   {/if}
                 </span>
                 <span class="session-what" class:orphaned={session.score_missing}>
-                  {#if session.score_title}
+                  {#if session.score_title && session.score_deleted}
+                    <!-- The same treatment the by-piece list above gets, on the
+                         other list on this page that names a score. Fixing one
+                         and not the other left a live link to a deleted score
+                         two lists apart on one screen (issue #56, F6). The
+                         session itself is untouched and still counted; what it
+                         stops being is a way into a library that no longer
+                         holds the piece. -->
+                    <span
+                      class="deleted-piece"
+                      title="This score is in the trash. The practice still counts."
+                    >
+                      {session.score_title} <span class="deleted-mark">deleted</span>
+                    </span>
+                  {:else if session.score_title}
                     <a href={"#/score/" + session.score_id}>{session.score_title}</a>
                   {:else}
                     {sessionSubject(session)}

--- a/web/src/lib/api.js
+++ b/web/src/lib/api.js
@@ -137,6 +137,53 @@ export const api = {
       body: fd,
     }).then(j);
   },
+  // --- Managing the library (issue #56) ------------------------------------
+  // The one part of this API that writes to the user's own files. Two habits
+  // are baked in here rather than left to each caller: a bulk operation is
+  // asked for as a dry run first and applied as a second, separate call, and
+  // nothing here has a "force" of any kind - a refusal comes back as an
+  // ApiError with the server's own sentence in it, which is what the UI shows.
+  //
+  // `folder` may be "" (the library root), which is not the same as omitting
+  // it, so it is passed through as given rather than filtered.
+  moveScore: (id, { folder, filename, dryRun = false } = {}) =>
+    fetch(`/api/scores/${id}/move`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        ...(folder === undefined ? {} : { folder }),
+        ...(filename === undefined ? {} : { filename }),
+        dry_run: dryRun,
+      }),
+    }).then(j),
+  moveScores: (ids, folder, dryRun = true) =>
+    fetch("/api/library/move", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ score_ids: ids, folder, dry_run: dryRun }),
+    }).then(j),
+  folders: () => fetch("/api/library/folders").then(j),
+  createFolder: (path) =>
+    fetch("/api/library/folders", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ path }),
+    }).then(j),
+  renameFolder: (from, to, dryRun = true) =>
+    fetch("/api/library/folders/rename", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ from_path: from, to_path: to, dry_run: dryRun }),
+    }).then(j),
+  // Soft: the file goes to the library's trash folder and the score row - with
+  // its practice history, goals, tags and transcription - stays. The response
+  // counts each of those, which is what the confirmation shows.
+  deleteScore: (id) => fetch(`/api/scores/${id}`, { method: "DELETE" }).then(j),
+  trash: () => fetch("/api/trash").then(j),
+  restoreScore: (id) => fetch(`/api/trash/${id}/restore`, { method: "POST" }).then(j),
+  // The destructive one, and the only one. Deliberately named for what it does
+  // rather than "delete", so no caller reaches for it by accident.
+  destroyScore: (id) => fetch(`/api/trash/${id}`, { method: "DELETE" }).then(j),
   fileUrl: (id) => `/api/scores/${id}/file`,
   thumbUrl: (id) => `/api/scores/${id}/thumb`,
   transcription: (id) => fetch(`/api/scores/${id}/transcription`).then(j),

--- a/web/tests/browser/zzz-library-organise.spec.js
+++ b/web/tests/browser/zzz-library-organise.spec.js
@@ -337,10 +337,12 @@ test("practice on a deleted score still counts, and stops being a way into it", 
   });
   expect(logged.ok(), await logged.text()).toBe(true);
 
-  // While it is in the library, it is an ordinary link.
+  // While it is in the library, BOTH lists that name it are ordinary links.
   await page.goto("/#/practice");
   const row = page.locator(".by-score li", { hasText: score.title });
   await expect(row.locator("a")).toHaveAttribute("href", `#/score/${score.id}`);
+  const session = page.locator(".session-list li", { hasText: score.title });
+  await expect(session.locator("a")).toHaveAttribute("href", `#/score/${score.id}`);
 
   const deleted = await request.delete(`/api/scores/${score.id}`);
   expect(deleted.ok(), await deleted.text()).toBe(true);
@@ -353,6 +355,16 @@ test("practice on a deleted score still counts, and stops being a way into it", 
   await expect(after).toContainText("45m");
   // ...and no longer a route into a score that is not in the library.
   await expect(after.locator("a")).toHaveCount(0);
+
+  // AND THE SESSION LIST FURTHER DOWN THE SAME PAGE. Fixing the by-piece
+  // breakdown alone left this one still linking into the trash, two lists
+  // apart on one screen - which is why this asserts both rather than trusting
+  // that one flag reached every list that reads it.
+  const sessionAfter = page.locator(".session-list li", { hasText: score.title });
+  await expect(sessionAfter).toBeVisible();
+  await expect(sessionAfter.locator(".deleted-mark")).toHaveText("deleted");
+  await expect(sessionAfter).toContainText("45m");
+  await expect(sessionAfter.locator("a")).toHaveCount(0);
 });
 
 test("a batch move shows every line, and a collision is blocked rather than overwritten", async ({

--- a/web/tests/browser/zzz-library-organise.spec.js
+++ b/web/tests/browser/zzz-library-organise.spec.js
@@ -1,0 +1,376 @@
+// What a person can actually DO to their library from the library view, and
+// what they are shown while they do it (issue #56).
+//
+// WHY THIS IS A BROWSER TEST AND NOT ONLY A SERVER ONE. server/tests/
+// test_library_management_api.py proves the endpoints keep their promises. It
+// cannot prove any of those promises reached the screen - and #95's lesson,
+// recorded in zz-library-missing.spec.js next door, is that a guarantee
+// nothing renders is a guarantee nobody has. The specific things asserted
+// here are the ones that would otherwise be invisible:
+//
+//   1. the preview really is shown before a move happens, and the move that
+//      happens is the one the preview described;
+//   2. a folder can be made and renamed from the same dialog, and the scores
+//      follow it;
+//   3. deleting takes a score out of the grid and puts it in the trash, with
+//      its practice history still on it, and putting it back is one press;
+//   4. destroying takes TWO presses and says what it destroys;
+//   5. a batch move previews as a batch, and a collision is shown as a
+//      blocked line rather than silently overwriting one of the two files.
+//
+// WHY IT IS NAMED TO SORT LAST, AFTER zz-library-missing. It moves scores out
+// of Uploads/ and leaves deleted rows behind, and every other spec in this
+// suite - including zz-library-missing's own beforeEach - refuses to run
+// against a backend holding scores it did not put there. Sorting after all of
+// them is what keeps that true for them.
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { expect, test } from "@playwright/test";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const FIXTURE = path.join(here, "..", "..", "test-fixtures", "notation-only.musicxml");
+
+const libraryDir = () => {
+  const dir = process.env.FERMATA_TEST_LIBRARY_DIR;
+  if (!dir) throw new Error("FERMATA_TEST_LIBRARY_DIR is not set - see playwright.config.js");
+  return dir;
+};
+
+const SCAN_DEADLINE_MS = 30_000;
+
+/** Wait until no scan is running, then hand back the idle status. */
+async function scanSettled(request) {
+  const deadline = Date.now() + SCAN_DEADLINE_MS;
+  for (;;) {
+    const status = await (await request.get("/api/scan/status")).json();
+    if (!status.scanning) return status;
+    if (Date.now() > deadline) throw new Error("a scan never finished");
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+}
+
+/**
+ * Upload a file and wait for its score row, then wait out the scan the upload
+ * started.
+ *
+ * BOTH WAITS MATTER, and the second one is this feature's own version of the
+ * #110 lesson zz-library-missing.spec.js records. Every upload starts a scan,
+ * and a move or a delete is REFUSED while a scan is running on purpose (see
+ * scanner.hold_library_still) - so a test that clicked Move the instant the
+ * row appeared would sometimes get the refusal instead of the move, and would
+ * read as a bug in the feature rather than as a test racing the scan it
+ * started. The content is made distinct per name so the scanner's content-hash
+ * relink does not correctly treat the second upload as a rename of the first.
+ */
+async function upload(request, name, folder = "Uploads") {
+  const body = Buffer.concat([fs.readFileSync(FIXTURE), Buffer.from(`<!-- ${name} -->\n`)]);
+  const res = await request.post(`/api/upload?folder=${encodeURIComponent(folder)}`, {
+    multipart: { file: { name, mimeType: "application/xml", buffer: body } },
+  });
+  expect(res.ok(), await res.text()).toBe(true);
+  let found;
+  await expect(async () => {
+    const scores = await (await request.get("/api/scores")).json();
+    found = scores.find((s) => s.path === `${folder}/${name}`);
+    expect(found, `${name} never appeared in the library`).toBeTruthy();
+  }).toPass({ timeout: SCAN_DEADLINE_MS });
+  await scanSettled(request);
+  return found;
+}
+
+/** Everything this suite has ever put in this throwaway library, destroyed. */
+async function emptyTheLibrary(request) {
+  await scanSettled(request);
+  for (const score of await (await request.get("/api/scores")).json()) {
+    await request.delete(`/api/scores/${score.id}`);
+  }
+  for (const score of await (await request.get("/api/trash")).json()) {
+    await request.delete(`/api/trash/${score.id}`);
+  }
+}
+
+// Every folder this suite ever puts a score in. Anything else present means
+// this is not the throwaway instance, and emptyTheLibrary below must not run.
+const SUITE_FOLDERS = new Set([
+  "Uploads", // zz-library-missing.spec.js and this file's own default
+  "Bach",
+  "Chopin",
+  "Patreon",
+  "Recital",
+  "Favourites",
+  "Arrangements",
+]);
+
+test.beforeEach(async ({ request }) => {
+  // The strictest refusal in this suite, and the reason is the strongest: the
+  // helper below DESTROYS every score it can see. Nothing but a folder this
+  // suite creates may be present. Rows already marked missing are inert
+  // leftovers from zz-library-missing.spec.js, which runs before this one.
+  const existing = await (await request.get("/api/scores")).json();
+  const foreign = existing.filter(
+    (s) => !s.missing_since && !SUITE_FOLDERS.has(s.path.split("/")[0]),
+  );
+  expect(
+    foreign,
+    "refusing to run: this backend has scores in folders the suite never creates, so it is " +
+      "not the throwaway instance the suite creates - and this file empties the library",
+  ).toEqual([]);
+  await emptyTheLibrary(request);
+});
+
+test.afterAll(async ({ request }) => {
+  await emptyTheLibrary(request);
+});
+
+async function organise(page) {
+  await page.goto("/#/");
+  await page.locator(".organise-toggle").click();
+  await expect(page.locator(".organise-bar")).toBeVisible();
+}
+
+async function choose(page, score) {
+  const card = page.locator(`.card[href="#/score/${score.id}"]`);
+  await expect(card).toBeVisible();
+  await card.click();
+  await expect(card).toHaveClass(/selected/);
+}
+
+async function unchoose(page, score) {
+  const card = page.locator(`.card[href="#/score/${score.id}"]`);
+  await card.click();
+  await expect(card).not.toHaveClass(/selected/);
+}
+
+test("a move is previewed before it happens, and the move that happens is the one shown", async ({
+  page,
+  request,
+}) => {
+  const score = await upload(request, "organise-move.musicxml");
+  // Practice on it FIRST, so what survives the move is something a person put
+  // there rather than an empty row.
+  const logged = await request.post(`/api/scores/${score.id}/practice`, {
+    data: { seconds: 1800, note: "before the move" },
+  });
+  expect(logged.ok(), await logged.text()).toBe(true);
+
+  await organise(page);
+  await choose(page, score);
+  await page.locator(".move-open").click();
+
+  const dialog = page.locator(".dialog.move");
+  await expect(dialog).toBeVisible();
+  // A folder that does not exist yet, made from inside the dialog - the whole
+  // point of being able to create one is filing something into it now.
+  await dialog.locator(".new-folder-input").fill("Recital");
+  await dialog.locator(".new-folder-create").click();
+
+  // The preview: the server's own dry run, line for line. Asserted BEFORE the
+  // apply, so what follows is known to be what was shown rather than a
+  // coincidence.
+  const line = dialog.locator(".plan-line");
+  await expect(line).toHaveCount(1);
+  await expect(line).toContainText("Uploads/organise-move.musicxml");
+  await expect(line).toContainText("Recital/organise-move.musicxml");
+  // ...and nothing has moved yet.
+  expect(fs.existsSync(path.join(libraryDir(), "Uploads", "organise-move.musicxml"))).toBe(
+    true,
+  );
+
+  await dialog.locator(".move-apply").click();
+  await expect(page.locator(".dialog.move")).toHaveCount(0);
+  await expect(page.locator(".notice")).toContainText("Recital");
+
+  // The file really moved, and the SAME score followed it with its practice.
+  await expect(async () => {
+    const after = await (await request.get(`/api/scores/${score.id}`)).json();
+    expect(after.path).toBe("Recital/organise-move.musicxml");
+    expect(after.practice_seconds).toBe(1800);
+    expect(after.missing_since).toBeNull();
+  }).toPass({ timeout: SCAN_DEADLINE_MS });
+  expect(fs.existsSync(path.join(libraryDir(), "Recital", "organise-move.musicxml"))).toBe(
+    true,
+  );
+  expect(fs.existsSync(path.join(libraryDir(), "Uploads", "organise-move.musicxml"))).toBe(
+    false,
+  );
+  // And it is still in the library, under its new collection. RELOADED rather
+  // than navigated to: the page is already at "/#/", and a goto to the URL the
+  // browser is already on is a no-op, so the view under test would not change.
+  await page.reload();
+  await expect(page.locator(`.card[href="#/score/${score.id}"]`)).toBeVisible();
+  await expect(page.locator(".side-item", { hasText: "Recital" }).first()).toBeVisible();
+});
+
+test("a folder can be renamed from the same dialog, and its scores go with it", async ({
+  page,
+  request,
+}) => {
+  const score = await upload(request, "organise-rename.musicxml", "Patreon");
+
+  await organise(page);
+  await choose(page, score);
+  await page.locator(".move-open").click();
+
+  const dialog = page.locator(".dialog.move");
+  await dialog.locator(".folder-option", { hasText: "Patreon" }).click();
+  await dialog.locator(".folder-rename-open").click();
+  await dialog.locator(".folder-rename-input").fill("Arrangements");
+  await dialog.locator(".folder-rename-preview").click();
+  // Shown before it happens, like every other bulk change here.
+  await expect(dialog.locator(".rename-preview")).toContainText("1 score would move with it");
+  expect(fs.existsSync(path.join(libraryDir(), "Patreon"))).toBe(true);
+
+  await dialog.locator(".folder-rename-apply").click();
+  await expect(page.locator(".dialog.move")).toHaveCount(0);
+  await expect(page.locator(".notice")).toContainText("Arrangements");
+
+  await expect(async () => {
+    const after = await (await request.get(`/api/scores/${score.id}`)).json();
+    expect(after.path).toBe("Arrangements/organise-rename.musicxml");
+    expect(after.collection).toBe("Arrangements");
+  }).toPass({ timeout: SCAN_DEADLINE_MS });
+  expect(fs.existsSync(path.join(libraryDir(), "Patreon"))).toBe(false);
+});
+
+test("deleting a score takes it to the trash with its history, and one press brings it back", async ({
+  page,
+  request,
+}) => {
+  const score = await upload(request, "organise-delete.musicxml");
+  await request.post(`/api/scores/${score.id}/practice`, {
+    data: { seconds: 3600, note: "hours on this" },
+  });
+
+  await organise(page);
+  await choose(page, score);
+  await page.locator(".delete-open").click();
+
+  const dialog = page.locator(".dialog.delete");
+  // What it keeps, said BEFORE the button that does it.
+  await expect(dialog).toContainText("trash folder inside your library");
+  await expect(dialog).toContainText("practice history");
+  await dialog.locator(".delete-apply").click();
+
+  // Gone from the grid, and the receipt says what is still attached.
+  await expect(page.locator(`.card[href="#/score/${score.id}"]`)).toHaveCount(0);
+  await expect(page.locator(".notice")).toContainText("1 practice session");
+  await expect(page.locator(".notice")).toContainText("nothing was destroyed");
+
+  // In the trash, saying where it came from.
+  await page.locator(".trash-link").click();
+  const row = page.locator(".trash-row");
+  await expect(row).toHaveCount(1);
+  await expect(row).toContainText("Uploads/organise-delete.musicxml");
+  await expect(row).toContainText("60 min practised");
+
+  await row.locator(".trash-restore").click();
+  await expect(page.locator(".notice")).toContainText("is back at");
+  await expect(page.locator(".trash-row")).toHaveCount(0);
+
+  await expect(async () => {
+    const after = await (await request.get(`/api/scores/${score.id}`)).json();
+    expect(after.path).toBe("Uploads/organise-delete.musicxml");
+    expect(after.deleted_at).toBeNull();
+    expect(after.practice_seconds).toBe(3600);
+  }).toPass({ timeout: SCAN_DEADLINE_MS });
+  // Reloaded, not navigated: this page is already at "/#/" and showing the
+  // trash, and a goto to the URL the browser is already on would leave it
+  // there - which is exactly what this assertion must not be reading.
+  await page.reload();
+  await expect(page.locator(`.card[href="#/score/${score.id}"]`)).toBeVisible();
+});
+
+test("destroying a score takes two presses and says what it destroys", async ({
+  page,
+  request,
+}) => {
+  const score = await upload(request, "organise-destroy.musicxml");
+  const logged = await (
+    await request.post(`/api/scores/${score.id}/practice`, { data: { seconds: 600 } })
+  ).json();
+  const deleted = await request.delete(`/api/scores/${score.id}`);
+  expect(deleted.ok(), await deleted.text()).toBe(true);
+
+  await page.goto("/#/");
+  await page.locator(".trash-link").click();
+  const row = page.locator(".trash-row");
+  await expect(row).toHaveCount(1);
+
+  // The first press only reveals the second one. Nothing is destroyed by it,
+  // which is the point of there being two.
+  await row.locator(".trash-destroy").click();
+  const confirm = row.locator(".trash-destroy-confirm");
+  await expect(confirm).toContainText("your practice history stays");
+  expect((await (await request.get("/api/trash")).json()).length).toBe(1);
+
+  await confirm.click();
+  await expect(page.locator(".trash-row")).toHaveCount(0);
+  await expect(page.locator(".notice")).toContainText("gone for good");
+  await expect(page.locator(".notice")).toContainText("stayed in your history");
+
+  await expect(async () => {
+    const gone = await request.get(`/api/scores/${score.id}`);
+    expect(gone.status()).toBe(404);
+  }).toPass({ timeout: SCAN_DEADLINE_MS });
+  // The hours were still spent. THAT session - by its own id, not a matching
+  // one - is still in the history, now with no piece named.
+  const sessions = await (await request.get("/api/practice/sessions")).json();
+  const survivor = sessions.sessions.find((s) => s.id === logged.session.id);
+  expect(survivor, "the practice session went with the score").toBeTruthy();
+  expect(survivor.seconds).toBe(600);
+  expect(survivor.score_id).toBeNull();
+});
+
+test("a batch move shows every line, and a collision is blocked rather than overwritten", async ({
+  page,
+  request,
+}) => {
+  // Two scores with the SAME file name in two different folders. Moved into
+  // one folder, the second would land on the first.
+  const first = await upload(request, "clash.musicxml", "Bach");
+  const second = await upload(request, "clash.musicxml", "Chopin");
+  expect(second.id).not.toBe(first.id);
+
+  await organise(page);
+  await choose(page, first);
+  await choose(page, second);
+  await expect(page.locator(".selected-count")).toHaveText("2 selected");
+
+  await page.locator(".move-open").click();
+  const dialog = page.locator(".dialog.move");
+  await dialog.locator(".new-folder-input").fill("Favourites");
+  await dialog.locator(".new-folder-create").click();
+
+  await expect(dialog.locator(".plan-line")).toHaveCount(2);
+  await expect(dialog.locator(".plan-line.blocked")).toHaveCount(1);
+  await expect(dialog.locator(".plan-line.blocked")).toContainText("another score in this same move");
+  // ...and the move cannot be applied at all while a line is blocked: a batch
+  // is all or nothing, so the button says so rather than moving the one that
+  // would have worked.
+  const apply = dialog.locator(".move-apply");
+  await expect(apply).toBeDisabled();
+  await expect(apply).toContainText("Fix the problems above first");
+
+  // Neither file has moved.
+  expect(fs.existsSync(path.join(libraryDir(), "Bach", "clash.musicxml"))).toBe(true);
+  expect(fs.existsSync(path.join(libraryDir(), "Chopin", "clash.musicxml"))).toBe(true);
+
+  // Deselecting one leaves a plan that can be applied, and it moves exactly
+  // that one.
+  await dialog.locator(".dialog-cancel").click();
+  await unchoose(page, second);
+  await expect(page.locator(".selected-count")).toHaveText("1 selected");
+  await page.locator(".move-open").click();
+  await dialog.locator(".folder-option", { hasText: "Favourites" }).click();
+  await expect(dialog.locator(".plan-line.blocked")).toHaveCount(0);
+  await dialog.locator(".move-apply").click();
+
+  await expect(async () => {
+    const one = await (await request.get(`/api/scores/${first.id}`)).json();
+    const other = await (await request.get(`/api/scores/${second.id}`)).json();
+    expect(one.path).toBe("Favourites/clash.musicxml");
+    expect(other.path).toBe("Chopin/clash.musicxml");
+  }).toPass({ timeout: SCAN_DEADLINE_MS });
+});

--- a/web/tests/browser/zzz-library-organise.spec.js
+++ b/web/tests/browser/zzz-library-organise.spec.js
@@ -323,6 +323,38 @@ test("destroying a score takes two presses and says what it destroys", async ({
   expect(survivor.score_id).toBeNull();
 });
 
+test("practice on a deleted score still counts, and stops being a way into it", async ({
+  page,
+  request,
+}) => {
+  // Issue #56, adversarial review F6. The hours were spent, so the piece stays
+  // in the by-piece breakdown and its totals still add up - dropping it would
+  // leave that column not adding up to the total beside it. What it must stop
+  // being is a LINK, into a library that no longer holds the score.
+  const score = await upload(request, "organise-history.musicxml");
+  const logged = await request.post(`/api/scores/${score.id}/practice`, {
+    data: { seconds: 2700, note: "before it went" },
+  });
+  expect(logged.ok(), await logged.text()).toBe(true);
+
+  // While it is in the library, it is an ordinary link.
+  await page.goto("/#/practice");
+  const row = page.locator(".by-score li", { hasText: score.title });
+  await expect(row.locator("a")).toHaveAttribute("href", `#/score/${score.id}`);
+
+  const deleted = await request.delete(`/api/scores/${score.id}`);
+  expect(deleted.ok(), await deleted.text()).toBe(true);
+
+  await page.reload();
+  const after = page.locator(".by-score li", { hasText: score.title });
+  await expect(after).toBeVisible();
+  await expect(after.locator(".deleted-mark")).toHaveText("deleted");
+  // Still counted - the 45 minutes are still on the page...
+  await expect(after).toContainText("45m");
+  // ...and no longer a route into a score that is not in the library.
+  await expect(after.locator("a")).toHaveCount(0);
+});
+
 test("a batch move shows every line, and a collision is blocked rather than overwritten", async ({
   page,
   request,

--- a/web/tests/spec-floors/browser-zzz-library-organise-56-review.json
+++ b/web/tests/spec-floors/browser-zzz-library-organise-56-review.json
@@ -1,0 +1,5 @@
+{
+  "file": "tests/browser/zzz-library-organise.spec.js",
+  "count": 1,
+  "reason": "issue #56 adversarial review F6: practice logged against a score that is later deleted still counts and still shows, but stops being a link into a library that no longer holds it."
+}

--- a/web/tests/spec-floors/browser-zzz-library-organise-56.json
+++ b/web/tests/spec-floors/browser-zzz-library-organise-56.json
@@ -1,0 +1,5 @@
+{
+  "file": "tests/browser/zzz-library-organise.spec.js",
+  "count": 5,
+  "reason": "issue #56: moving, renaming a folder, deleting to the trash and restoring, destroying in two presses, and a batch move whose collision is blocked - each previewed or explained on the page before it happens."
+}


### PR DESCRIPTION
The library was read-only: the scanner read whatever folder layout existed and
nothing could be changed from the application. Managing a collection meant
leaving Fermata, moving files by hand, and waiting for a scan to catch up.

This is the first feature here that writes to a person's own files. Issue #56
says so itself — "this is the one destructive feature" — so it is built around
rules rather than around convenience, and every rule below has a test that has
been **observed to fail without it** (see Mutation testing).

Part of #56. Two of that issue's four bullets are not in here and are filed as
#171 — see [What is not in this PR](#what-is-not-in-this-pr).

## The rules, and where each one lives

**1. Nothing is written outside the library folder.** `_safe_parts` refuses a
segment that is `..`, an absolute path, a drive letter, a control character or
Fermata's own trash folder — refuses, rather than silently dropping the segment
the way `upload()` does, because a move relocates a file somebody already has.
`_resolve_in_library` then checks the **resolved** path, so a destination that
escapes only through a symlink is refused too.

**2. Deleting is a move, never a delete.** `DELETE /api/scores/{id}` moves the
file to `.fermata-trash/<id>/` inside the library and marks the row with
`deleted_at` / `deleted_from`. The practice sessions, goals, tags and
transcription stay attached, and the response *counts each of them* so an
interface can say "still holding 14 sessions" rather than "deleted (trust us)".
`DELETE /api/trash/{id}` is the one endpoint that really destroys, states what
it destroys, only ever acts on something already in the trash — and even it
keeps the practice sessions, because the hours were still spent.

**3. Nothing is destroyed as a side effect of an organisational change.** A move
onto an existing file is refused, at plan time and again at move time. A batch
with one blocked line applies none of it: half a reorganisation is worse than
none, because the person then has to work out which half.

**4. A bulk operation is a dry run until somebody says otherwise.**
`dry_run` defaults **true** on both routes that touch more than one score, so a
client that has never heard of the flag gets the plan. The response shape is
identical either way, which is what makes the preview a preview of the thing
itself — the move dialog renders the server's own dry run, line for line,
rather than a guess computed in the browser.

**5. The score row follows the file by content hash.** `_relink_moved_file`
re-hashes at the destination and requires it to match the hash the row already
carries — the same identity test `scanner._scan_file`'s relink makes, applied to
a file whose row is already known. A mismatch (a sync client rewriting the file
mid-move) is a 409 and a rollback, not a score's practice history quietly
attached to different music. There is no second notion of what makes a file
"the same score".

**6. One thing reconciles the library at a time.** A scan decides what to write
from a directory listing taken when it started, so a move landing after that
listing marks a row whose file is present. `scanner.hold_library_still()` makes
a move or a delete refuse with 409 while a scan runs, and makes `start_scan()`
decline while one is being applied — the rule the scanner already had for
overlapping scans, extended to the other kind of writer.

## What is on the surface

Nine endpoints, each with a response model, a docstring and a tag (the #19
guards). `test_every_route_has_exactly_the_expected_operation_count` moves 41 →
50.

| Endpoint | |
| --- | --- |
| `POST /api/scores/{id}/move` | Move one score's file, rename it, or both. |
| `POST /api/library/move` | Move several into one folder. Dry run by default. |
| `GET /api/library/folders` | The folder tree, for offering destinations. |
| `POST /api/library/folders` | Create a folder. |
| `POST /api/library/folders/rename` | Rename a folder, scores and all. Dry run by default. |
| `DELETE /api/scores/{id}` | Delete: file to the trash, row and history stay. |
| `GET /api/trash` | What has been deleted and not destroyed. |
| `POST /api/trash/{id}/restore` | Put it back where it came from. |
| `DELETE /api/trash/{id}` | Destroy it. The only one that really deletes. |

In the library view: an **Organise** mode (a mode, not a drag — this is used on
a music stand, often on a tablet, and a drag that starts by accident is a move
nobody asked for), a move dialog that creates and renames folders and shows the
plan before applying it, and a **Trash** view where restoring is one press and
destroying is two.

## Two decisions worth disagreeing with

**Moving re-derives `collection` and `series` and nothing else.** Those are read
off the folders and the sidebar presents them as the folder tree, so they have
to follow the file. `title`, `composer` and `source` are statements about the
music, can have been corrected by hand through `PATCH /api/scores/{id}`, and
re-deriving them from a path would undo that correction every time somebody
tidied a folder. That is why renaming a *file* and renaming a *piece* are two
different requests here.

**The schema stamp moves to 5, with no migration step behind it.** The two new
columns are ordinary `ADD COLUMN`s. The stamp moves because of what the
*previous* release does against a database this one has written: it cannot see
`deleted_at`, so its scan walks the trash, finds each deleted file at the path
its row already names, and hands somebody their deleted scores back — and its
content-hash relink, which does not filter on `deleted_at`, will adopt a
*deleted* row for a fresh live file, so upgrading again leaves a file the person
has on disk hidden in the trash view. That is the harm `SCHEMA_VERSION`'s own
comment says to bump for.

## Tests

Baselines re-derived after rebasing onto `354104a` (PR #172, the confidence-honesty cluster), by running each suite on that commit in this same worktree, with `web/node_modules` present in every run:

| | main (`af254ed`) | this branch |
| --- | --- | --- |
| `server/`, `python -m pytest -q -rs` | 855 passed, 63 skipped, 0 failed | **935 passed, 63 skipped, 0 failed** |
| `web/`, `npm run test:browser` | 332 tests: 332 passed, 0 failed | **338 tests: 338 passed, 0 failed** |

+80 server tests — 79 in `server/tests/test_library_management_api.py` and one
added to `test_api_docs.py`; +6 browser tests in
`tests/browser/zzz-library-organise.spec.js`, with two additive spec-floor
entries (`browser-zzz-library-organise-56.json`, `-56-review.json`). **No new skips**: the skip count
is unchanged in both directions.

(The 63 server skips are the pre-existing `FERMATA_TEST_LIBRARY` extraction
tests, 60 of them, plus three MusicXML-schema ones. Nothing in this change skips
conditionally.)

The everything-survives matrix is asserted **through the API, by literal value,
before and after** — `favorite`, `last_page`, the tag set, `instrument_id`, the
practice session's own id/seconds/note/tempo/local\_date, the goal's id, intent
and countability, and the transcription's content and source — because a test
that reads the database proves a row exists while proving nothing about what a
client gets.

### Mutation testing

Every invariant was broken deliberately and the named test required to go red.
48 server mutations, 48 red. The first 26:

| Mutation | Test that went red |
| --- | --- |
| hash re-link check removed | `test_a_file_that_changed_under_the_move_does_not_take_the_history_with_it` |
| move inserts a new row instead of following the score | `test_everything_hanging_off_a_moved_score_survives_the_move` |
| delete really deletes | `test_deleting_a_score_moves_its_file_to_the_trash_and_keeps_the_row`, `..._can_be_restored_...` |
| `last_page` reset by the move | `test_everything_hanging_off_a_moved_score_survives_the_move` |
| tags cleared by the move | `test_everything_hanging_off_a_moved_score_survives_the_move` |
| a deleted row is a relink candidate again | `test_a_scan_does_not_bring_a_deleted_score_back` |
| the scan walks the trash again | `test_a_scan_does_not_take_anything_in_the_trash_for_a_score` |
| a scan may start mid-move | `test_a_scan_will_not_start_while_the_library_is_being_changed` |
| a move may run mid-scan | `test_a_move_is_refused_while_a_scan_is_running`, `test_deleting_is_refused_...` |
| containment check dropped | `test_the_containment_check_refuses_an_escaping_path_on_its_own` |
| segment rules dropped | `test_a_move_out_of_the_library_folder_is_refused` |
| a move overwrites what is in its way | `test_moving_a_file_on_disk_never_overwrites_what_is_already_there` |
| a batch applies its unblocked lines | `test_a_batch_with_one_blocked_line_moves_nothing_at_all` |
| bulk move applied by default | `test_a_batch_move_is_a_dry_run_unless_it_is_told_otherwise` |
| deliberate shrink does not lower the loss mark | `test_deleting_most_of_a_library_does_not_make_the_next_lost_file_a_refusal` |
| deleted scores stay in the listing | `test_a_deleted_score_leaves_every_library_view_and_appears_in_the_trash` |
| destroying takes the practice history | `test_destroying_a_score_from_the_trash_removes_the_file_and_the_row` |
| a rename may change the extension | `test_a_rename_must_keep_an_extension_fermata_can_read` |
| `_free_path` ignores a path a row claims | `test_restoring_onto_a_path_a_missing_score_still_claims_lands_beside_it` |
| folder rename ignores a claimed destination | `test_a_folder_rename_onto_a_path_another_score_claims_is_refused` |
| a filesystem refusing a name becomes a 500 | `test_a_folder_name_the_filesystem_refuses_is_a_422_not_a_500` |
| LIKE loses its ESCAPE clause | `test_renaming_a_folder_whose_name_holds_sql_wildcards_still_finds_its_scores` |
| the Python prefix filter dropped | `test_a_folder_rename_only_moves_the_folder_it_names` |
| a missing score is hashed anyway | `test_renaming_a_folder_carries_a_score_whose_file_is_missing_along_with_it` |
| the trash keeps an empty folder per deletion | `test_the_trash_does_not_fill_up_with_empty_folders` |
| a score in the trash can be moved back out | `test_a_score_in_the_trash_cannot_be_moved_back_out_by_a_move` |

The adversarial review's eight findings added fourteen more, listed in the
section below. Plus six against the UI, each rebuilt and re-run: the preview not rendered, the
delete button destroying instead of trashing, destroying taking one press
instead of two, a blocked line no longer blocking the apply button, and a deleted piece still
being a link on the practice page. All six red.

**The first mutation pass found five guards that were green when broken**,
because a second, overlapping guard was quietly covering for each — the exact
shape `scanner.py`'s own comment records having been bitten by. Each now has a
test that pins it where nothing else can cover for it, and the
out-of-the-library test asserts *which* guard refused, not only that something
did.

**Two self-review passes after that found four more real bugs**, all in the folder
rename (second commit): a folder whose name holds an underscore moved nothing
(`_` is a LIKE wildcard and the escaping had no `ESCAPE` clause behind it — and
`Player_s Theme` is this library's own house style for an apostrophe); a
differently-cased folder's scores came along with it (SQLite's LIKE is
case-insensitive); and a score marked missing under a renamed folder was a 500,
because there is no file to hash. And a fourth (third commit): a move, on its own
or in a batch, would take a score back OUT of the trash — its file is right there
— while its row stayed marked deleted, leaving a file in the library that nothing
in the library shows.

## Manual smoke test

Run against a real `uvicorn` on **127.0.0.1:8941**, over a throwaway library at
`C:\tmp\fermata56-smoke\library` — never the live instance, never a real
library. Full transcript below; every line was produced by the script, not
transcribed by hand.

```
=== server up on http://127.0.0.1:8941 (library C:\tmp\fermata56-smoke\library) ===

--- the library it found ---
   paths: ['Inbox/Prelude.musicxml', 'Inbox/Study in C.musicxml', 'Imported/Arrangement.musicxml']

--- practice, a tag and a transcription on the score about to be moved ---
OK POST /api/scores/2/practice  -> 200   (2400s, "smoke test", 96bpm)
OK PATCH /api/scores/2          -> 200   (tags ["smoke"], favorite, last_page 5, title corrected by hand)
OK PUT  /api/scores/2/transcription -> 200

--- 1. move one score, with a dry run first ---
OK POST /api/scores/2/move (dry_run) -> 200  Inbox/Study in C.musicxml -> Classical/Sor/Study in C.musicxml
   still at Inbox/Study in C.musicxml: True          <- the dry run touched nothing
OK POST /api/scores/2/move           -> 200
   file at Classical/Sor/Estudio.musicxml: True
   old path gone: True
   same id, everything on it: {'id': 2, 'title': 'Estudio (renamed by hand)', 'collection': 'Classical',
                               'tags': ['smoke'], 'favorite': True, 'last_page': 5,
                               'practice_seconds': 2400, 'has_transcription': True}

--- 2. refusing to write outside the library ---
OK POST .../move {"folder": "../escaped"}   -> 422  folder segment '..' is not a usable folder name
OK POST .../move {"folder": "C:/Windows"}   -> 422  folder must be inside the library, not an absolute path
OK POST .../move {"folder": ".fermata-trash"} -> 422 .fermata-trash is Fermata's trash folder, not a place to put scores
   nothing outside the library: True

--- 3. a folder, a batch move (dry run by default), and a collision ---
OK POST /api/library/folders {"path": "Recital"} -> 200 {"created": "Recital", "existed": false}
OK POST /api/library/move (no dry_run sent)      -> 200 dry_run: true, applied: false
   nothing moved yet: True                            <- the default really is a dry run
OK POST /api/library/move {"dry_run": false}     -> 200 applied: true
   both in Recital: True
OK GET  /api/library/folders -> 200  (Library root, Classical, Classical/Sor, Recital, ...)

--- 4. renaming a folder takes its scores with it ---
OK POST /api/library/folders/rename (dry run) -> 200
OK POST /api/library/folders/rename           -> 200
   moved with the folder: True
   old folder gone: True
OK GET /api/collections -> [{"collection": "Classical", "count": 1}, {"collection": "Programme", "count": 2}]

--- 5. delete is a move to the trash, and it says what it kept ---
OK DELETE /api/scores/2 -> 200 {"deleted_from": "Classical/Sor/Estudio.musicxml",
                                "trashed_to": ".fermata-trash/2/Estudio.musicxml",
                                "practice_sessions_kept": 1, "tags_kept": 1, "transcriptions_kept": 1}
   file in the trash: True
   gone from the library grid: True
OK GET /api/trash -> 200  (one score, path .fermata-trash/2/Estudio.musicxml)

--- 6. a scan does not undo the deletion, or mark anything missing ---
OK POST /api/scan -> 200
   missing / added / refused: (0, 0, False)
   still deleted: True                                <- the scan skipped the trash entirely
                                                         (total went 3 -> 2, which is the library, not the trash)

--- 7. restore puts it back with everything on it ---
OK POST /api/trash/2/restore -> 200
   back at: Classical/Sor/Estudio.musicxml
   kept: {'tags': ['smoke'], 'favorite': True, 'last_page': 5,
          'practice_seconds': 2400, 'has_transcription': True}

--- 8. destroying takes a second, separate request, and keeps the hours ---
OK DELETE /api/trash/2 -> 404  "that score is not in the trash"   <- cannot destroy what was not deleted
OK DELETE /api/scores/2 -> 200
OK DELETE /api/trash/2  -> 200 {"file_deleted": ".fermata-trash/2/Estudio.musicxml",
                                "tags_destroyed": 1, "transcriptions_destroyed": 1,
                                "practice_sessions_kept": 1}
   file gone: True
OK GET /api/scores/2 -> 404
   the practice survived, with no piece named: [(2400, None, 'smoke test')]

--- 8b. the adversarial review's findings, against a real server ---
OK POST .../move {"folder": ".fermata-trash."}   -> 422  folder segment '.fermata-trash.' ends in a space or a dot
OK POST .../move {"filename": "evil:stream.pdf"} -> 422  none of : < > " | ? * (a ':' ... opens a hidden data stream)
OK POST .../move {"folder": "Classical "}        -> 422  folder segment 'Classical ' ends in a space or a dot
   nothing landed in the trash folder: True

   (F2) the score's file is removed by hand, and it is deleted anyway:
OK DELETE /api/scores/1 -> 200 {"trashed_to": null, "file_moved": false, ...}
OK POST /api/trash/1/restore -> 200 {"file_restored": false,
                                     "restored_to": "Programme/Prelude.musicxml"}
   back in the library, flagged missing: True        <- not stranded in the trash

   (F6) a deleted score refuses work, still answers reads, and still counts:
OK POST /api/scores/3/practice -> 200  (1200s, while it is still in the library)
OK DELETE /api/scores/3        -> 200  {"file_moved": true, "practice_sessions_kept": 1}
OK PATCH  /api/scores/3        -> 409  "... is in the trash, so Fermata will not change what it says"
OK POST   /api/scores/3/practice -> 409 "... will not log practice against it"
OK GET    /api/scores/3        -> 200  (reads still answer - the trash view is built on them)
OK GET /api/practice/summary   -> 200  {"week_seconds": 3600,
                                        "top_scores": [{"title": "...", "practice_seconds": 1200,
                                                        "deleted": true}]}
OK POST /api/trash/3/restore   -> 200  {"file_restored": true}

--- 9. a move refused while a scan is running ---
   (automated: test_a_move_is_refused_while_a_scan_is_running and
    test_a_scan_will_not_start_while_the_library_is_being_changed — a race this
    reliable to provoke in a test is not one to provoke by hand)

--- 10. the documented surface ---
   new paths documented: ['/api/library/folders', '/api/library/folders/rename',
                          '/api/library/move', '/api/scores/{score_id}/move',
                          '/api/trash', '/api/trash/{score_id}', '/api/trash/{score_id}/restore']
   GET /docs: 200, swagger-ui present: True

--- what is on disk at the end ---
   Programme/Arrangement.musicxml
   Programme/Prelude.musicxml

=== smoke test passed ===
```

## Adversarial review: eight findings, all addressed

The review's verdict was merge-with-nits, with two stranding bugs blocking. Both
are fixed, with the reviewer's own repros as tests. Findings in their order:

**F1 (required) — restore had no filesystem rollback.** `_relink_moved_file`
refuses a file whose bytes no longer match the row, which is right, but the file
has already moved by then and `write_tx` rolls back only the database. The trash
then listed a score whose file was not in the trash: every later restore refused
for the same reason, the next scan filed the orphan as a brand new historyless
score, and the refusal's own advice — *scan and try again* — was what caused
that. `_apply_plan` has had the three lines that fix this from the start; this
path had not. Test: the exact repro, asserting the file is back in the trash byte
for byte, the row is untouched, and a restore succeeds afterwards.

**F2 (required) — deleting a score whose file was already gone.** It reported
`trashed_to` as fact for a path with nothing at it, and the score could then
never be restored, only destroyed — taking its tags and transcription with it.
**Decision: soft-delete, honestly**, not refuse. A score whose file has gone is
the case where deleting is *most* obviously the right answer, and refusing would
have left the row stuck in the library for ever, since hard delete requires the
trash. So: `file_moved: false`, `trashed_to: null`, the missing mark carried
rather than cleared, and restore puts it back in the library flagged missing —
exactly the state it was in. That same path un-strands a trash folder somebody
emptied by hand, which `docs/deployment.md` says they may (and that page now
says what happens instead of promising it cannot be put back).

**F3 (required) — trailing-dot bypass.** `.fermata-trash.` passed the
trash-folder check on its text; Windows strips the dot and the live score lands
inside the folder scans skip. Rejected per segment now, for dots and spaces. The
`.strip()` that used to normalise a trailing space away went with it — stripping
is sanitising, and this section refuses rather than sanitises for the reason its
own docstring already gave. Two tests: the bypass, and the benign divergence.

**F4 (required) — `:` opened an NTFS alternate data stream.** Added `:` and the
rest of `< > " | ? *` to the segment rule. The test asserts *which* guard
refused, and that matters: the first version asserted only the status and stayed
green under mutation, because the name then reached the filesystem, Windows
refused the rename, and F5's new wrapper answered 422 with a message that also
contained a colon — while on ext4, where `:` is an ordinary character, nothing
would have refused it at all.

**F5 (required) — filesystem refusals were 500s on the move path** where
`create_folder` already answered 422. Wrapped the same way. Narrowing the
cross-device fallback to `EXDEV` on the way past closed a hole of its own:
`shutil.move` copies and unlinks, and copying onto an existing destination
*overwrites* it, so catching every `OSError` turned the one case rule 3 forbids
into a silent overwrite. Tested with the destination appearing in the gap.

**F6 (required) — the deleted-score matrix.** Policy decided, documented in
`api.py` and `docs/api.md`, and guarded:

- **Reads answer normally** (`GET /scores/{id}`, `/file`, `/thumb`,
  `/transcription`, `/practice`) — deliberate: the trash view is built out of
  them, and looking at a score before destroying it for ever is the point of a
  trash you can change your mind from.
- **Writes are refused with 409** — patch, practice by either route, a goal
  about it, extract/save/delete transcription. Each means "work on this piece".
- **Practice already logged is untouched and still counted.** Dropping a deleted
  score from `top_scores` or `by_score` would leave those breakdowns not adding
  up to the totals beside them. Both carry `deleted: true` instead, and the
  practice page's by-piece list now renders such a row as text with a *deleted*
  mark rather than as a link into a library that no longer holds it.

**F7 — case-only rename.** `Toccata.pdf` → `toccata.pdf` was a 409 on NTFS, the
deployment platform, blaming the score for being where it is. The check now asks
the filesystem whether the thing in the way is the score's own file
(`os.path.samefile`) instead of comparing path text.

**F8 — upload takes no hold.** Kept unheld and **documented precisely**, which
the review offered as the alternative. It only ever creates a file at a path
nothing claims, so it cannot invalidate a scan's listing the way a move does;
holding it would refuse the second of two uploads in a row for the scan the
first one started. The one overlap that matters — an upload landing on a move's
destination — is caught where it has to be caught anyway, since a person can
drop a file into the library folder with no endpoint involved. The rule is now
stated as *one thing that moves or removes an existing file at a time*, with
both exemptions (upload, create-folder) named and argued in
`scanner.hold_library_still`. A test pins the exemption and pins that no scan
runs during a change.

## Delta review: five more, and the pattern in two of them

**Two of these were the same bug as a fix already in this branch, on the half
that fix did not reach.** That is the finding worth naming.

**1. The deleted-score flag reached two lists and there are three.** The
by-piece breakdown stopped linking into the trash; the session list a few rows
below it *on the same page* did not, and `/api/practice/sessions` carried
nothing a client could have used to know. Sessions now carry `score_deleted`,
documented as the thing it is **not**: `score_missing` means the row itself has
gone and there is no piece left to name, while a deleted score keeps its title,
its history and a way back - a client conflating them would offer to restore
something that cannot be restored.

**2. The case-only rename was fixed for files and not for folders.**
`rename_folder` had the same bare `exists()`, so on NTFS `Inbox` -> `inbox`
answered *"inbox already exists"*, naming the folder as its own obstacle. Same
`_same_file` exception, and the same reason for asking the filesystem instead
of comparing lowercased strings: a genuinely different folder still refuses,
because renaming onto it would merge two folders' scores with nothing said.
Tested both ways, and the dry-run preview too - a dialog that previews fine and
then fails on apply is its own bug.

**3. Three guards nothing pinned** - each found by mutating it and watching
every test stay green:

- **delete's carried `missing_since`.** Writing `NULL` unconditionally passed
  all 77 tests. It is how a score deleted a month after its file vanished could
  come back looking present. The test now scans first, so the row carries a real
  mark, and asserts the value **literally** rather than "not null".
- **the `< > " | ? *` class.** Removing it stayed green on Windows: the name
  reached the filesystem, the rename failed, and F5's 422 wrapper answered
  anyway - the identical overlapping-guard trap its `:` neighbour six lines
  above had already been corrected for. The which-guard-spoke assertion is
  carried across. On a filesystem that accepts those bytes, nothing would have
  refused at all.
- **the `_fs_refused` arm on `dest.parent.mkdir`.** Deleting it stayed green
  because the test patched only `Path.rename`, while `mkdir` is the call that
  fails for the over-length path the test's own docstring claims to cover. Both
  arms are exercised now.

**4. The refusal that used to give harmful advice now gives useful advice.**
*"Scan the library and try again"* caused the stranding while the file was left
in the library; with the rollback it was merely **useless** on the restore path,
because scans skip the trash by design - the one action it asked for provably
could not change the outcome. The move path keeps advice true for it; the
restore path now says what is actually true there (the file in the trash is not
the one the score was deleted with) and names the two real ways out. Pinned as
text, because "this message is unhelpful" is not something another assertion can
notice.

**Mutations for this round: 8, all red** - the three previous survivors now die
alone, plus the three new guards, the restore advice, and the session row in the
UI.

### An unresolved CI failure, and what is actually known about it

Browser tests fail on this branch's rebased head, on two PDF page-turn
assertions in `practice-shortcuts.spec.js` (`.hud span` reads `1 / 2` where the
test wants `2 / 2`): `:677 ArrowRight turns the PDF page` and `:757 gig mode
... its arrow keys turn pages`. I could not settle whether this change causes
it. Rather than assert a verdict, here is the record.

**Runs:**

| Ref | Browser tests |
| --- | --- |
| `main` @ `ecbfb76` | green |
| `main` @ `ecbfb76`, re-run | green |
| `main` @ `56bc384` | **red** - the same test |
| this branch, base `af254ed` | green |
| this branch, base `ecbfb76` | **red**, **red**, green |

**Ruled out, by inspection rather than by hope:**

- These two tests are fully network-stubbed. `stubScoreApi` routes
  `**/api/scores/1` (every method, PATCH included), `/file`, `/practice`,
  `/transcription` and `/transcription/analysis`, and the spec adds its own
  `/file` override. **No server change in this PR is reachable from them.**
- The new spec sorts last (`zzz-`), so it cannot disturb shared state before
  `practice-shortcuts` runs.
- `git diff --name-only ecbfb76..HEAD` touches no PdfViewer, ScoreCompare,
  TabViewer, Viewer or `score-render` file.

**What that leaves.** The only difference these tests can see is the built
bundle: `1,686,893` bytes on `main` against `1,700,599` here, **+13.7 KB, or
+0.81%**. So either that 0.81% is enough to tip a race the spec's own comments
already describe as marginal - issue #168, whose second test is documented as
sharing the hole and only "winning the race more often" - or two reds on this
branch and one on `main` are small-sample variance. Both tests pass locally
here, in the full suite (336/336) and in isolation.

**Where this landed.** A third attempt on this branch came back green, so the tally is two red and one green here against two green and one red on `main` - the shape of one flaky test rather than a branch-specific defect. #168 has since been reopened and is under separate investigation with #165 as the prime timing suspect; attribution for this branch stays unestablished, and merging waits on that regardless. The next step that would
actually settle it is a probe PR off `ecbfb76` carrying only the web half of
this change (`Library.svelte`, `Practice.svelte`, `api.js`): red there
implicates the bundle and makes the fix this PR's job; green points at the
runner. It needs to be a PR rather than a branch, because CI only triggers on
`pull_request`.

What I have not done is edit `practice-shortcuts.spec.js` to make this go away.
Weakening another change's barrier to unblock my own is how a real defect gets
buried, and that spec is outside this change's territory.

## What is not in this PR

Two of #56's four bullets, filed as **#171** rather than left implied by a
closed issue:

- **Normalise on ingest, optionally.** A path template derived from metadata is
  a feature of its own — the template language, what to do about an empty field,
  where it is configured, and duplicate handling. Everything it needs is now in
  place (the move endpoints, their plan shape, `metadata.parse_path`) and none
  of it is wired up. #56 is explicit that it must stay opt-in, and that is a
  reason to build it deliberately rather than quickly.
- **Showing which scores have a transcription, and where each came from.** The
  association is already a fact and already on the wire (`has_transcription`);
  what is missing is that the library grid renders none of it.

So this PR does not say `Closes #56`.

## Docs

`docs/api.md` gains a section on the endpoints that write to your files and the
five rules a client can rely on; `docs/deployment.md` gains a note on the trash
folder — it counts toward disk usage, scans ignore it, and it should be backed
up with `library/` or emptied first; `README.md` gains two feature bullets. Two
comments that claimed the library folder is "only ever read" were corrected
rather than left to become quietly false.
