### PR TITLE
Trust a reverse proxy's remote-user header, off by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,4 +33,14 @@ EXPOSE 8080
 HEALTHCHECK --interval=30s --timeout=5s --start-period=15s \
     CMD python -c "import urllib.request as u; u.urlopen('http://127.0.0.1:8080/api/health')" || exit 1
 
-CMD ["uvicorn", "fermata.main:app", "--host", "0.0.0.0", "--port", "8080"]
+# --no-proxy-headers turns off uvicorn's OWN X-Forwarded-For handling -
+# without it, uvicorn rewrites the request's peer address from a
+# client-supplied header before Fermata's reverse-proxy authentication
+# (fermata/authproxy.py, issue #16) ever sees the request, which lets anyone
+# who can reach the container forge that header and impersonate a trusted
+# proxy. Fermata does its own peer-based trust for that feature and never
+# needs uvicorn's; see docs/deployment.md's "Reverse proxy authentication"
+# section. main.py's startup refuses to run reverse-proxy auth at all if it
+# cannot confirm this flag is present, as a backstop for anyone who copies
+# this CMD without this comment attached.
+CMD ["uvicorn", "fermata.main:app", "--host", "0.0.0.0", "--port", "8080", "--no-proxy-headers"]

--- a/README.md
+++ b/README.md
@@ -225,7 +225,9 @@ demo*) if your library is PDF-only so far.
   scoped to the strings and frets you are working on
 - Setlists, and recognition for what you have accomplished over time
 - Annotations on PDFs (fingerings, markings)
-- Reverse proxy authentication, then multi-user accounts
+- Multi-user accounts (reverse proxy authentication - trusting a login a
+  proxy in front of Fermata already did - shipped; see
+  docs/deployment.md#reverse-proxy-authentication)
 - Splitting compilation books into individual pieces
 - Tablet-first PWA mode with pedal-friendly full-screen
 - Recognition for scanned PDFs, which carry no readable text or glyphs

--- a/README.md
+++ b/README.md
@@ -162,8 +162,14 @@ Backend (FastAPI, Python 3.12):
 ```bash
 cd server
 pip install -e .
-FERMATA_LIBRARY=../library FERMATA_CONFIG=../config uvicorn fermata.main:app --port 8080 --reload
+FERMATA_LIBRARY=../library FERMATA_CONFIG=../config uvicorn fermata.main:app --port 8080 --reload --no-proxy-headers
 ```
+
+`--no-proxy-headers` turns off uvicorn's own X-Forwarded-For handling, which
+would otherwise let a request carrying that header rewrite what Fermata sees
+as its peer address - see docs/deployment.md's "Reverse proxy
+authentication" section for why that matters even for a plain dev server
+bound to loopback.
 
 Frontend (Svelte 5 + Vite, proxies `/api` to :8080):
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -126,8 +126,11 @@ keeps behaving exactly as it always did.
 Two environment variables, both required together:
 
 - `FERMATA_AUTH_HEADER` — the header your proxy sets with the logged-in
-  username, e.g. `X-Remote-User` or `Remote-User`. Whatever your proxy
-  actually sends; there is no fixed default.
+  username. **Use `X-Remote-User`, the name every example in this section
+  uses.** Fermata will accept any header name here, but naming a DIFFERENT
+  one than your proxy config actually protects is a real way to defeat this
+  feature by accident — see the warning box below before you pick anything
+  else.
 - `FERMATA_TRUSTED_PROXIES` — a comma-separated list of IP addresses and/or
   CIDR ranges Fermata will accept that header from. **This is the setting
   that matters for security.** Fermata trusts `FERMATA_AUTH_HEADER` only on
@@ -137,6 +140,22 @@ Two environment variables, both required together:
   that header itself otherwise. Set this to your proxy container's address,
   not a broad range, if you can — see the worked example below for how to
   give it a fixed one.
+
+> **Your proxy MUST REPLACE this header, never append to it, and must strip
+> any copy the client itself sent.** Fermata trusts the header by name
+> alone, not by which layer set it, and reads only the FIRST occurrence when
+> a header is sent more than once — so a proxy configured to *add* the
+> header onto whatever the request already carried can leave a client's own
+> forged value sitting in front of the proxy's real one, and Fermata would
+> read the forged one. (As of this feature, Fermata also refuses outright
+> — `401` — any request where the configured header arrives more than
+> once, specifically because that shape is never produced by a proxy
+> correctly configured to replace it; treat seeing this rejection in your
+> logs as a sign your proxy is appending, not replacing.) Every example
+> below sets, not adds, the header — that is what `header_up` does in Caddy
+> and what `copy_headers` combined with `header_up` does in the Authelia
+> example — but if you write your own, confirm your proxy's documentation
+> says "set" or "replace" and not "add".
 
 Setting `FERMATA_AUTH_HEADER` without also setting `FERMATA_TRUSTED_PROXIES`
 does not accidentally trust everyone — it does the opposite. An empty trusted
@@ -148,6 +167,16 @@ anyone." Look at `docker compose logs fermata` if turning this on locks you
 out unexpectedly — a rejected request logs why, including the address it
 came from.
 
+The reverse is also checked, loudly, rather than left to fail silently:
+Fermata logs an error at startup (but still starts — these are warnings, not
+refusals) if `FERMATA_TRUSTED_PROXIES` is set while `FERMATA_AUTH_HEADER` is
+not (almost always a typo in the header variable's name — with the header
+unset, auth is entirely OFF and every request is served unauthenticated, no
+matter what the trusted-proxy list says), or if `FERMATA_TRUSTED_PROXIES`
+includes `0.0.0.0/0` or `::/0` (trusts literally every direct request,
+which defeats the point of this feature as completely as leaving it off).
+Watch `docker compose logs fermata` after changing either setting.
+
 In `docker-compose.yml`, add both under the `fermata` service's `environment:`
 (or `environment:` doesn't exist yet — add it):
 
@@ -158,6 +187,58 @@ services:
       FERMATA_AUTH_HEADER: X-Remote-User
       FERMATA_TRUSTED_PROXIES: 172.28.1.10/32
 ```
+
+### Why uvicorn's own proxy-header trust must stay off
+
+This one is not optional, and Fermata now refuses to start with reverse-proxy
+auth turned on unless it can confirm you have it right: the container's own
+`uvicorn` server must be run with **`--no-proxy-headers`**. Fermata's shipped
+`Dockerfile` and the plain `uvicorn` command in this project's own README
+already pass it — this section exists so that if you run Fermata a different
+way (your own image, a bare `uvicorn` invocation, a process manager), you
+know not to drop it.
+
+Here is the failure this closes, plainly: `uvicorn` can be told to trust an
+`X-Forwarded-For` header from a nearby peer and use it to decide what
+address a request "really" came from — a legitimate feature for a proxy
+uvicorn itself sits behind. **By default, this is ON**, and it runs
+*outside* Fermata's own code, before `FERMATA_TRUSTED_PROXIES` is ever
+consulted. If it is on, a request straight to Fermata carrying a forged
+`X-Remote-User` header AND a forged `X-Forwarded-For` naming an address on
+your trusted-proxy list gets treated as if it genuinely came from that
+address — a complete authentication bypass, reachable by anyone who can
+reach Fermata at all, regardless of how carefully `FERMATA_TRUSTED_PROXIES`
+is set. `--no-proxy-headers` turns this off entirely, so the address Fermata
+checks is always the real TCP connection, never something a header can
+rewrite.
+
+Fermata cannot see how you actually launched `uvicorn`, so as a backstop it
+refuses to start (a clear, readable error, not a silent gap) whenever
+`FERMATA_AUTH_HEADER` is set and it cannot confirm `--no-proxy-headers` was
+passed, or when the `FORWARDED_ALLOW_IPS` environment variable is set at
+all — that variable is the other way to widen exactly the trust that must
+stay off. This check is best-effort (it reads this process's own command
+line) and is not a substitute for actually passing the flag; treat it as a
+safety net catching the mistake, not the fix itself.
+
+### The full configuration state space
+
+Every combination of the two settings, and what a request from an address
+NOT on `FERMATA_TRUSTED_PROXIES` — carrying a forged header — gets back,
+assuming `--no-proxy-headers` is correctly in place:
+
+| `FERMATA_AUTH_HEADER` | `FERMATA_TRUSTED_PROXIES` | Forged request from an untrusted address | Notes |
+| --- | --- | --- | --- |
+| unset | unset | `200`, unauthenticated — same as before this feature existed | The default. Not a bypass: there is no auth to bypass. |
+| unset | set | `200`, unauthenticated | **Logged as an error at startup** — almost always a typo in `FERMATA_AUTH_HEADER`'s name; the trusted-proxy list is doing nothing. |
+| set | unset (empty) | `401` | Fail closed — the documented behavior of forgetting the second variable. |
+| set | a real address/subnet not matching the request | `401` | The ordinary, intended-secure state — this is the one every example above configures. |
+| set | `0.0.0.0/0` or `::/0` | `200`, as whatever the forged header said | **Logged as an error at startup.** Trusts every direct request; defeats the feature. Never a real proxy's actual address — always a mistake. |
+
+The two `200` rows below the default are exactly the states
+`check_auth_configuration_sanity` (in `fermata/authproxy.py`) watches for and
+logs about, loudly, every time Fermata starts. Every `401` row above is
+exercised directly in `server/tests/test_authproxy.py`.
 
 ### What is and isn't covered
 
@@ -176,7 +257,10 @@ A request from a trusted proxy carrying no header, or an empty one, is
 refused the same way — a proxy that is supposed to authenticate visitors but
 was itself misconfigured (auth disabled on its side, a typo in the header
 name it forwards) fails closed here too, rather than Fermata quietly letting
-the request through unauthenticated.
+the request through unauthenticated. So is a request where the header
+arrives more than once — see the warning box above on why a proxy that
+appends rather than replaces can produce that shape, and why Fermata will
+not guess which of two values is the real one.
 
 The username Fermata reads is logged (at request time, alongside what was
 rejected and why when auth fails) and available at `GET /api/me`:
@@ -203,11 +287,16 @@ authentication is meant to be.)
 ### Example: Caddy
 
 This is the config actually used to verify this feature — run for real
-against a built image, a Caddy container in front of it on its own Docker
-network, and curled from the host: a request straight to Fermata's own port
-with a forged header came back `401`, the same request routed through Caddy
-with a valid login came back `200` carrying the right username, and the
-container's own `HEALTHCHECK` stayed `healthy` throughout.
+against a built image (with the Dockerfile's `--no-proxy-headers` CMD
+included), a Caddy container in front of it on its own Docker network, and
+curled from the host: a request straight to Fermata's own port with a
+forged header came back `401`; the SAME request with a forged
+`X-Forwarded-For` header naming Caddy's own trusted address ALSO came back
+`401` (the specific bypass a security review found and this section's
+"proxy-header trust must stay off" note above exists because of); the
+request actually routed through Caddy with a valid login came back `200`
+carrying the right username; and the container's own `HEALTHCHECK` stayed
+`healthy` throughout.
 
 `Caddyfile`, exactly as tested (`:8080` rather than a domain name, matching
 the rest of this guide's LAN-only, no-TLS setup — replace `:8080` with your

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -167,15 +167,32 @@ anyone." Look at `docker compose logs fermata` if turning this on locks you
 out unexpectedly — a rejected request logs why, including the address it
 came from.
 
-The reverse is also checked, loudly, rather than left to fail silently:
-Fermata logs an error at startup (but still starts — these are warnings, not
-refusals) if `FERMATA_TRUSTED_PROXIES` is set while `FERMATA_AUTH_HEADER` is
-not (almost always a typo in the header variable's name — with the header
-unset, auth is entirely OFF and every request is served unauthenticated, no
-matter what the trusted-proxy list says), or if `FERMATA_TRUSTED_PROXIES`
-includes `0.0.0.0/0` or `::/0` (trusts literally every direct request,
-which defeats the point of this feature as completely as leaving it off).
-Watch `docker compose logs fermata` after changing either setting.
+The reverse is also checked, rather than left to fail silently, in two
+different ways depending on how bad the mistake is:
+
+- **`FERMATA_TRUSTED_PROXIES` set while `FERMATA_AUTH_HEADER` is not** logs
+  an error at startup but still starts — this is almost always a typo in
+  the header variable's name, and with the header unset, auth is entirely
+  OFF: every request is served unauthenticated no matter what the
+  trusted-proxy list says. A warning, not a refusal, because nothing here
+  is actively pretending to be secure while it isn't — it is visibly,
+  checkably off.
+- **`FERMATA_TRUSTED_PROXIES` including `0.0.0.0/0` or `::/0` refuses to
+  start outright.** No real proxy's own address is ever "the entire
+  internet" — this is always a mistake, never an intentional choice, unlike
+  a genuinely broad-but-real subnet (`10.0.0.0/8`, say, which stays a
+  warning if you actually mean it). With auth ON, this combination is
+  strictly worse than auth being off: the running server would authenticate
+  *any* direct request as whatever username it claims, and serve that
+  identity at `/api/me`, while `docker compose ps` reports the container
+  perfectly healthy the entire time. A log line an operator has to go
+  looking for is not enough for a failure mode that looks, from the
+  outside, like everything is working correctly - so Fermata does not
+  start at all, the same as it would for uvicorn's own proxy-header trust
+  being left on.
+
+Watch `docker compose logs fermata` after changing either setting — both
+print a plain explanation.
 
 In `docker-compose.yml`, add both under the `fermata` service's `environment:`
 (or `environment:` doesn't exist yet — add it):
@@ -218,8 +235,11 @@ refuses to start (a clear, readable error, not a silent gap) whenever
 passed, or when the `FORWARDED_ALLOW_IPS` environment variable is set at
 all — that variable is the other way to widen exactly the trust that must
 stay off. This check is best-effort (it reads this process's own command
-line) and is not a substitute for actually passing the flag; treat it as a
-safety net catching the mistake, not the fix itself.
+line — including which of `--proxy-headers` / `--no-proxy-headers` appears
+LAST, since that is the one a real launch actually obeys, not merely
+whether `--no-proxy-headers` appears anywhere) and is not a substitute for
+actually passing the flag; treat it as a safety net catching the mistake,
+not the fix itself. Simply don't pass both.
 
 ### The full configuration state space
 
@@ -230,15 +250,17 @@ assuming `--no-proxy-headers` is correctly in place:
 | `FERMATA_AUTH_HEADER` | `FERMATA_TRUSTED_PROXIES` | Forged request from an untrusted address | Notes |
 | --- | --- | --- | --- |
 | unset | unset | `200`, unauthenticated — same as before this feature existed | The default. Not a bypass: there is no auth to bypass. |
-| unset | set | `200`, unauthenticated | **Logged as an error at startup** — almost always a typo in `FERMATA_AUTH_HEADER`'s name; the trusted-proxy list is doing nothing. |
+| unset | set | `200`, unauthenticated | **Logged as an error at startup**, still starts — almost always a typo in `FERMATA_AUTH_HEADER`'s name; the trusted-proxy list is doing nothing. |
 | set | unset (empty) | `401` | Fail closed — the documented behavior of forgetting the second variable. |
 | set | a real address/subnet not matching the request | `401` | The ordinary, intended-secure state — this is the one every example above configures. |
-| set | `0.0.0.0/0` or `::/0` | `200`, as whatever the forged header said | **Logged as an error at startup.** Trusts every direct request; defeats the feature. Never a real proxy's actual address — always a mistake. |
+| set | `0.0.0.0/0` or `::/0` | *(no request ever answers)* | **Refuses to start.** No real proxy's own address is ever "the entire internet" — this is always a mistake, and worse than auth being off, so it is fatal rather than logged. |
 
-The two `200` rows below the default are exactly the states
-`check_auth_configuration_sanity` (in `fermata/authproxy.py`) watches for and
-logs about, loudly, every time Fermata starts. Every `401` row above is
-exercised directly in `server/tests/test_authproxy.py`.
+`check_auth_configuration_sanity` (in `fermata/authproxy.py`) is what logs
+the one row above that still starts. `check_trusted_proxies_are_not_everyone`
+is what refuses to start for the `0.0.0.0/0` / `::/0` row — the same fatal
+bucket `check_proxy_header_safety` is in for the proxy-headers guard, not a
+warning. Every `401` row, and the `0.0.0.0/0` refusal, are exercised
+directly in `server/tests/test_authproxy.py`.
 
 ### What is and isn't covered
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -8,6 +8,7 @@ that's enough. Every command below is meant to be copied and pasted as-is.
 
 - [Getting it running](#getting-it-running)
 - [Reaching it from another device](#reaching-it-from-another-device)
+- [Reverse proxy authentication](#reverse-proxy-authentication)
 - [Backups](#backups)
 - [Upgrading](#upgrading)
 - [Current limitations](#current-limitations)
@@ -101,7 +102,245 @@ private networks.
 
 This also means anyone else on that network can reach it, with no login of
 any kind — see [Current limitations](#current-limitations) before deciding
-whether that network is trusted.
+whether that network is trusted, and see the next section if you want to put
+a login in front of it.
+
+## Reverse proxy authentication
+
+Fermata still has no accounts or login screen of its own — see
+[Current limitations](#current-limitations) — but it can trust one that a
+reverse proxy in front of it already did. This is the standard pattern
+self-hosted services use to add a login without building one: an
+authenticating proxy (Caddy, Authelia, authentik, and others all support it)
+sits in front of the app and, once a visitor has signed in, sets an HTTP
+header naming them on every request it forwards. Fermata can be told to
+trust that header.
+
+**This is off by default, and stays off after an upgrade unless you turn it
+on.** Nothing below does anything unless you set both environment variables
+it describes — an existing `docker-compose.yml` that predates this feature
+keeps behaving exactly as it always did.
+
+### Turning it on
+
+Two environment variables, both required together:
+
+- `FERMATA_AUTH_HEADER` — the header your proxy sets with the logged-in
+  username, e.g. `X-Remote-User` or `Remote-User`. Whatever your proxy
+  actually sends; there is no fixed default.
+- `FERMATA_TRUSTED_PROXIES` — a comma-separated list of IP addresses and/or
+  CIDR ranges Fermata will accept that header from. **This is the setting
+  that matters for security.** Fermata trusts `FERMATA_AUTH_HEADER` only on
+  a request whose direct connection comes from an address on this list — a
+  request from anywhere else has the header ignored entirely, even if it
+  sends one, because nothing stops a client on your network from setting
+  that header itself otherwise. Set this to your proxy container's address,
+  not a broad range, if you can — see the worked example below for how to
+  give it a fixed one.
+
+Setting `FERMATA_AUTH_HEADER` without also setting `FERMATA_TRUSTED_PROXIES`
+does not accidentally trust everyone — it does the opposite. An empty trusted
+list trusts no address at all, so every request is refused once the header
+name is set, including ones from your actual proxy. This is deliberate: the
+one way to misconfigure this fails as "nobody can get in, and the log says
+why" rather than "anyone can set the header themselves and get in as
+anyone." Look at `docker compose logs fermata` if turning this on locks you
+out unexpectedly — a rejected request logs why, including the address it
+came from.
+
+In `docker-compose.yml`, add both under the `fermata` service's `environment:`
+(or `environment:` doesn't exist yet — add it):
+
+```yaml
+services:
+  fermata:
+    environment:
+      FERMATA_AUTH_HEADER: X-Remote-User
+      FERMATA_TRUSTED_PROXIES: 172.28.1.10/32
+```
+
+### What is and isn't covered
+
+Once both variables are set, **every route requires the header** — the API
+and the browser app it serves both — with exactly one exception:
+`GET /api/health` stays open with no header at all, because that is what
+Docker's own `HEALTHCHECK` (see the `Dockerfile`) polls from inside the
+container, and it would be a strange kind of security to let a
+misconfiguration here turn a healthy container "unhealthy" and drop it into
+Compose's restart loop. `/docs` and `/openapi.json` are **not** exempt —
+turning this on locks those down along with everything else, so a request
+without a trusted header sees a plain `401` with a short JSON message, never
+a stack trace or a half-loaded page.
+
+A request from a trusted proxy carrying no header, or an empty one, is
+refused the same way — a proxy that is supposed to authenticate visitors but
+was itself misconfigured (auth disabled on its side, a typo in the header
+name it forwards) fails closed here too, rather than Fermata quietly letting
+the request through unauthenticated.
+
+The username Fermata reads is logged (at request time, alongside what was
+rejected and why when auth fails) and available at `GET /api/me`:
+
+```json
+{"enabled": true, "username": "alice"}
+```
+
+`enabled` reports whether reverse-proxy auth is turned on at all, independent
+of whether this particular request carried an identity — with it off, or on
+but reaching this endpoint through a different path than your proxy, that is
+`{"enabled": false, "username": null}` rather than an error. **Nothing in
+Fermata acts on this identity today** — there are no per-user permissions,
+no filtering of what a given username can see, and this does not turn
+Fermata into a multi-user application. It is read, logged, and left there
+for a future consumer — the practice-data MCP server this project is heading
+toward, or a possible sharing layer — to build on. (A few database tables
+already carry an `owner` column reserved for that future, every row
+currently written as the single placeholder owner `local` — wiring a real
+username into it today would only orphan your own data from the very
+queries that read it back, which is a bigger feature than reverse-proxy
+authentication is meant to be.)
+
+### Example: Caddy
+
+This is the config actually used to verify this feature — run for real
+against a built image, a Caddy container in front of it on its own Docker
+network, and curled from the host: a request straight to Fermata's own port
+with a forged header came back `401`, the same request routed through Caddy
+with a valid login came back `200` carrying the right username, and the
+container's own `HEALTHCHECK` stayed `healthy` throughout.
+
+`Caddyfile`, exactly as tested (`:8080` rather than a domain name, matching
+the rest of this guide's LAN-only, no-TLS setup — replace `:8080` with your
+own domain if you have one and want Caddy's automatic HTTPS on top of this):
+
+```
+:8080 {
+	basic_auth {
+		alice JDJhJDE0JEV4YW1wbGVIYXNoR29lc0hlcmUuLi4
+	}
+	reverse_proxy fermata:8080 {
+		header_up X-Remote-User {http.auth.user.id}
+	}
+}
+```
+
+Generate a real password hash for that `basic_auth` line rather than typing a
+password in plainly:
+
+```bash
+docker run --rm caddy:2-alpine caddy hash-password --plaintext 'your password here'
+```
+
+(Caddy's `basic_auth` is a minimal example that needs no separate service —
+swap it for `forward_auth` pointed at Authelia or authentik if you want a
+real login page, shared sessions, and more than one user; the `header_up`
+line stays the same either way, since it is Caddy that sets the header for
+Fermata, not whatever authenticated the visitor.)
+
+Add Caddy as a second service in `docker-compose.yml`, and — this matters —
+**stop publishing Fermata's own port to the host once Caddy is in front of
+it**, so the only way in is through the proxy that is actually checking
+logins:
+
+```yaml
+services:
+  fermata:
+    # no "ports:" here anymore - only reachable from other containers on
+    # this compose network, which is what makes FERMATA_TRUSTED_PROXIES
+    # below meaningful rather than cosmetic.
+    environment:
+      FERMATA_AUTH_HEADER: X-Remote-User
+      FERMATA_TRUSTED_PROXIES: 172.28.1.10/32
+    volumes:
+      - ./library:/data/library
+      - ./config:/data/config
+    restart: unless-stopped
+
+  caddy:
+    image: caddy:2-alpine
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy-data:/data
+    restart: unless-stopped
+    networks:
+      default:
+        ipv4_address: 172.28.1.10
+
+networks:
+  default:
+    ipam:
+      config:
+        - subnet: 172.28.1.0/24
+
+volumes:
+  caddy-data:
+```
+
+Caddy is given a fixed address (`172.28.1.10`) on the compose network
+specifically so `FERMATA_TRUSTED_PROXIES` can name that one address rather
+than the whole network range — a request that reaches Fermata directly
+(bypassing Caddy some other way) does not arrive from `172.28.1.10` even if
+it is on the same network, and is refused exactly as a request from the
+open internet would be. This is the same reason Fermata's own `ports:` is
+removed above: with it still published, a request to that port would look,
+from inside the container, like it came from the Docker network's gateway
+address rather than from Caddy — which a broader trusted range would wrongly
+accept. Naming Caddy's own address, and taking Fermata off the host network
+entirely, closes both gaps at once.
+
+### Example: Authelia
+
+Authelia and authentik both work the same way — they sit in front of
+Fermata behind a reverse proxy (commonly Caddy, nginx, or Traefik) and set a
+`Remote-User` header once a visitor authenticates. This example is
+`docker-compose.yml` and Caddyfile syntax; it has been checked for correct
+syntax but **not run end-to-end** the way the plain-Caddy example above was
+— standing up Authelia's own session store and configuration is
+disproportionate to verify in this repository, so treat this as a starting
+point to adapt rather than a copy-paste guarantee.
+
+`Caddyfile`, with Authelia running as a third container reachable at
+`authelia:9091`:
+
+```
+fermata.example.com {
+	forward_auth authelia:9091 {
+		uri /api/verify?rd=https://auth.example.com
+		copy_headers Remote-User
+	}
+	reverse_proxy fermata:8080 {
+		header_up X-Remote-User {http.request.header.Remote-User}
+	}
+}
+```
+
+`docker-compose.yml` gains an `authelia` service (see
+[Authelia's own deployment docs](https://www.authelia.com/integration/deployment/docker/)
+for its configuration file, which is more involved than Caddy's and out of
+scope here) alongside the same `fermata` and `caddy` services as the plain
+example — Fermata's own environment and missing `ports:` are unchanged:
+
+```yaml
+services:
+  fermata:
+    environment:
+      FERMATA_AUTH_HEADER: X-Remote-User
+      FERMATA_TRUSTED_PROXIES: 172.28.1.10/32
+    # ... volumes, restart, networks as above - no "ports:"
+
+  caddy:
+    # ... as above, with the Caddyfile shown here instead
+
+  authelia:
+    image: authelia/authelia:latest
+    volumes:
+      - ./authelia:/config
+    networks:
+      default:
+        ipv4_address: 172.28.1.11
+```
 
 ## Backups
 
@@ -284,8 +523,15 @@ Because of that, Fermata belongs on a home network you trust, not on the open
 internet. If you forward its port to the internet or otherwise expose it
 publicly, anyone who finds it — and on the open internet, something usually
 does find an open port before long — gets that same unrestricted access with
-no username or password standing in the way. There is nothing in Fermata
-today that mitigates this; it simply is not built for that exposure yet.
+no username or password standing in the way, UNLESS you have set up
+[reverse proxy authentication](#reverse-proxy-authentication): it puts a real
+login in front of Fermata via a proxy like Caddy, Authelia, or authentik, but
+it is off by default and does nothing until you configure it. It also stays
+what its name says — everyone who logs in still sees the same one library,
+the same tags, the same practice history, all of it fully shared. There is no
+per-user privacy or permissions inside Fermata itself, and no plan to build
+that; a login only decides who is allowed in at all, not what any of them
+can see once they are.
 
 ## Troubleshooting
 

--- a/server/fermata/api.py
+++ b/server/fermata/api.py
@@ -14,6 +14,7 @@ from fastapi import (
     HTTPException,
     Path as PathParam,
     Query,
+    Request,
     UploadFile,
 )
 from fastapi.responses import FileResponse
@@ -39,6 +40,7 @@ from .api_models import (
     InstrumentPresetOut,
     LibraryMoveOut,
     LogPracticeOut,
+    MeOut,
     PracticeHistoryOut,
     PracticeReviewOut,
     PracticeSessionOut,
@@ -62,6 +64,7 @@ from .api_models import (
     UploadOut,
     VersionOut,
 )
+from . import config
 from .config import FILE_TYPES, LIBRARY_DIR
 from .db import DEFAULT_OWNER, connect, tx, write_tx
 from .glyph_rhythm import VALID_TS_DENOMINATORS
@@ -82,6 +85,7 @@ log = logging.getLogger("fermata.api")
 # documents and why it lives apart from the routes. TAG_* names are declared
 # once here so a route and /docs agree on the exact string.
 TAG_SYSTEM = "system"
+TAG_AUTH = "auth"
 TAG_SETTINGS = "settings"
 TAG_INSTRUMENTS = "instruments"
 TAG_LIBRARY = "library"
@@ -248,6 +252,24 @@ def health():
 def get_version():
     """What build is actually running - see fermata/version.py."""
     return version_info.info()
+
+
+@router.get("/me", tags=[TAG_AUTH], response_model=MeOut)
+def get_me(request: Request):
+    """The identity, if any, a trusted reverse proxy vouched for on this
+    request - see fermata/authproxy.py and issue #16. Fermata has no login
+    of its own; this reads back only what RemoteUserAuthMiddleware already
+    verified before this handler ran (a header naming the user, sent by a
+    proxy address on the configured trust list) and stashed on
+    `request.state`. Nothing in Fermata acts on this today - no per-user
+    filtering, no permissions - it exists for a future consumer (the
+    planned MCP server, a possible sharing layer) to read. Always 200: when
+    reverse-proxy auth is off (the default) or this particular request
+    carried no identity, that is `{"enabled": false, "username": null}`
+    rather than an error, since asking "who am I" is safe regardless of
+    whether anything answers it."""
+    username = getattr(request.state, "fermata_username", None)
+    return {"enabled": bool(config.AUTH_HEADER), "username": username}
 
 
 @router.get("/settings", tags=[TAG_SETTINGS], response_model=SettingsOut)

--- a/server/fermata/api_models.py
+++ b/server/fermata/api_models.py
@@ -60,6 +60,21 @@ class VersionOut(BaseModel):
     built: str
 
 
+class MeOut(BaseModel):
+    """The identity, if any, that fermata.authproxy's reverse-proxy auth
+    middleware attached to this request (issue #16). Fermata has no accounts
+    of its own and builds none here - `username` is only ever a name a
+    trusted reverse proxy vouched for, exposed for a future consumer (the
+    planned MCP server, a possible sharing layer) to read. `enabled` is
+    whether reverse-proxy auth is turned on at all, independent of whether
+    THIS request carried an identity, so a client can tell "no auth
+    configured" apart from "auth configured but nothing to show" without
+    guessing from a null."""
+
+    enabled: bool
+    username: str | None
+
+
 # ---------------------------------------------------------------------------
 # Settings
 # ---------------------------------------------------------------------------

--- a/server/fermata/authproxy.py
+++ b/server/fermata/authproxy.py
@@ -1,0 +1,128 @@
+"""Reverse-proxy authentication (issue #16).
+
+Fermata has no accounts, no login screen, and no plan to grow either - see
+docs/deployment.md's "Current limitations" section. What self-hosters
+actually run instead is an authenticating reverse proxy (Caddy with
+forward_auth, Authelia, authentik, ...) in front of the app, and the
+standard way such a proxy hands off "who is this" to the app behind it is a
+plain HTTP header - conventionally `Remote-User` or `X-Remote-User` - set to
+the logged-in username.
+
+Trusting that header is exactly one footgun away from a spoofing hole: any
+client that can reach Fermata directly (the LAN, a misconfigured proxy pass,
+a port left open) can set that same header itself and walk in as anyone. So
+this module trusts the header only when TWO things are both true: reverse
+proxy auth was actually turned on (`config.AUTH_HEADER` is non-empty - see
+config.py), AND the request's own TCP peer address is inside
+`config.AUTH_TRUSTED_NETWORKS`, the operator-configured allowlist of proxy
+addresses. A request from anywhere else has the header stripped of its
+authority entirely - it is simply never read - so a request an operator
+never told Fermata to trust cannot authenticate no matter what headers it
+sends.
+
+This is middleware, not a dependency on individual routes, on purpose: it
+has to cover the SPA's static files and the API's docs/openapi.json exactly
+the same as every /api/* route, and none of those go through api.py's
+router. See RemoteUserAuthMiddleware.dispatch for exactly what is and is not
+exempt, and docs/deployment.md for the worked Caddy/Authelia examples.
+"""
+
+import logging
+from ipaddress import ip_address
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+
+from . import config
+
+log = logging.getLogger("fermata.authproxy")
+
+# The one path exempt from auth even when it is switched on. Docker's own
+# HEALTHCHECK (see the Dockerfile) polls this from inside the container with
+# no headers at all; requiring auth here would flip a correctly-running,
+# correctly-configured container to "unhealthy" and into Compose's restart
+# loop the moment reverse-proxy auth was turned on. Nothing this reports
+# ("the process is up and answering requests at all" - see api.health's
+# docstring) is sensitive enough to be worth that outage.
+#
+# GET /docs, /openapi.json and /redoc are deliberately NOT exempt: they are
+# part of "every route" the way this feature is documented to cover, and the
+# alternative - special-casing them open - would mean the one config knob
+# that is supposed to lock the app down leaves its own API surface
+# published. See docs/deployment.md's "Reverse proxy authentication"
+# section, which states this explicitly for anyone who only reads the docs.
+EXEMPT_PATHS = {"/api/health"}
+
+
+def is_trusted_proxy(peer_ip: str | None) -> bool:
+    """Whether `peer_ip` - the request's actual TCP peer, never a header a
+    client could forge - is inside one of config.AUTH_TRUSTED_NETWORKS.
+
+    An empty AUTH_TRUSTED_NETWORKS (the default, even with AUTH_HEADER set)
+    trusts nothing: this always returns False, which is what turns "header
+    name configured but no proxy list" into every request being refused
+    rather than every request being trusted. Fail closed, not fail open."""
+    if not peer_ip:
+        return False
+    try:
+        addr = ip_address(peer_ip)
+    except ValueError:
+        return False
+    return any(addr in network for network in config.AUTH_TRUSTED_NETWORKS)
+
+
+def _unauthorized(reason: str) -> JSONResponse:
+    # Same {"detail": ...} shape FastAPI's own HTTPException produces (see
+    # api.py's `raise HTTPException(404, "score not found")` and its kin) -
+    # a client or the SPA's own error handling sees one consistent error
+    # shape everywhere, not a bespoke one for auth alone.
+    return JSONResponse({"detail": reason}, status_code=401)
+
+
+class RemoteUserAuthMiddleware(BaseHTTPMiddleware):
+    """Wraps the whole app - see the module docstring for why middleware
+    rather than a route dependency. Added to `app` in main.py."""
+
+    async def dispatch(self, request: Request, call_next):
+        # The off switch. AUTH_HEADER empty is the out-of-the-box state and
+        # every existing deployment's state after an upgrade that never
+        # touched its environment - this branch has to be a complete no-op,
+        # not merely "usually harmless", for that promise to hold.
+        if not config.AUTH_HEADER:
+            request.state.fermata_username = None
+            return await call_next(request)
+
+        if request.url.path in EXEMPT_PATHS:
+            request.state.fermata_username = None
+            return await call_next(request)
+
+        peer = request.client.host if request.client else None
+        if not is_trusted_proxy(peer):
+            log.warning(
+                "rejected %s %s: request did not come from a trusted proxy (peer=%s) - "
+                "see FERMATA_TRUSTED_PROXIES in docs/deployment.md",
+                request.method, request.url.path, peer,
+            )
+            return _unauthorized(
+                "this request did not come from a trusted reverse proxy - see "
+                "docs/deployment.md's 'Reverse proxy authentication' section"
+            )
+
+        username = request.headers.get(config.AUTH_HEADER, "").strip()
+        if not username:
+            log.warning(
+                "rejected %s %s: trusted proxy %s sent no %s header",
+                request.method, request.url.path, peer, config.AUTH_HEADER,
+            )
+            return _unauthorized(
+                f"missing the {config.AUTH_HEADER} header - your reverse proxy must set it "
+                "on every request when reverse-proxy authentication is turned on"
+            )
+
+        request.state.fermata_username = username
+        log.info(
+            "authenticated %s %s as %r via proxy %s", request.method, request.url.path,
+            username, peer,
+        )
+        return await call_next(request)

--- a/server/fermata/authproxy.py
+++ b/server/fermata/authproxy.py
@@ -5,20 +5,51 @@ docs/deployment.md's "Current limitations" section. What self-hosters
 actually run instead is an authenticating reverse proxy (Caddy with
 forward_auth, Authelia, authentik, ...) in front of the app, and the
 standard way such a proxy hands off "who is this" to the app behind it is a
-plain HTTP header - conventionally `Remote-User` or `X-Remote-User` - set to
-the logged-in username.
+plain HTTP header - `X-Remote-User` throughout this codebase and its docs;
+see docs/deployment.md's "Reverse proxy authentication" section for why the
+header name has to be exactly one name, everywhere, rather than "whichever
+of a couple of conventional names you like".
 
 Trusting that header is exactly one footgun away from a spoofing hole: any
 client that can reach Fermata directly (the LAN, a misconfigured proxy pass,
 a port left open) can set that same header itself and walk in as anyone. So
-this module trusts the header only when TWO things are both true: reverse
+this module trusts the header only when THREE things are all true: reverse
 proxy auth was actually turned on (`config.AUTH_HEADER` is non-empty - see
-config.py), AND the request's own TCP peer address is inside
+config.py), the request's own TCP peer address is inside
 `config.AUTH_TRUSTED_NETWORKS`, the operator-configured allowlist of proxy
-addresses. A request from anywhere else has the header stripped of its
-authority entirely - it is simply never read - so a request an operator
-never told Fermata to trust cannot authenticate no matter what headers it
-sends.
+addresses, and the header appears exactly once (see `dispatch`'s duplicate
+check - a proxy that APPENDS rather than replaces the header can leave a
+client's own forged copy sitting in front of the proxy's real one). A
+request that fails any of those has the header stripped of its authority
+entirely - it is simply never read.
+
+READ THIS BEFORE TRUSTING "the request's own TCP peer" AS UNSPOOFABLE - IT
+ISN'T, UNCONDITIONALLY. `request.client` is populated by uvicorn from the
+real accepted socket UNLESS uvicorn's own `ProxyHeadersMiddleware` is
+active, which it is BY DEFAULT (`--proxy-headers`, the default, with
+`--forwarded-allow-ips` defaulting to `127.0.0.1`). That middleware runs
+OUTSIDE this ASGI app, before a single line of Fermata's own code sees the
+request, and REWRITES `scope["client"]` from a client-supplied
+`X-Forwarded-For` header whenever the connection's real peer is itself
+inside `forwarded_allow_ips` - which, for anything bound to loopback or
+reachable through Docker's default networking, is very often true for every
+request. Concretely: a request straight from an attacker, carrying both a
+forged `X-Remote-User` AND a forged `X-Forwarded-For` naming an address on
+Fermata's OWN trusted-proxy list, gets `request.client` REWRITTEN to that
+forged address before `is_trusted_proxy` ever runs - full authentication
+bypass, no matter how correct the logic below is. This is not
+hypothetical - it was found in review and reproduced against a real
+`uvicorn` process before being closed.
+
+The fix is `--no-proxy-headers` on uvicorn's own command line - present in
+the Dockerfile's `CMD` and README's dev-run command, both changed by the
+same commit that added this warning - which disables `ProxyHeadersMiddleware`
+entirely, so `scope["client"]` is always the real accepted socket peer and
+never something a header can rewrite. `check_proxy_header_safety` below is
+the belt-and-suspenders backstop: Fermata cannot control how an operator
+actually launches uvicorn, so it refuses to START with reverse-proxy
+authentication turned on unless it can confirm that flag is present, rather
+than silently serving requests uvicorn might be rewriting out from under it.
 
 This is middleware, not a dependency on individual routes, on purpose: it
 has to cover the SPA's static files and the API's docs/openapi.json exactly
@@ -28,7 +59,9 @@ exempt, and docs/deployment.md for the worked Caddy/Authelia examples.
 """
 
 import logging
-from ipaddress import ip_address
+import os
+import sys
+from ipaddress import IPv6Address, ip_address, ip_network
 
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
@@ -52,12 +85,43 @@ log = logging.getLogger("fermata.authproxy")
 # that is supposed to lock the app down leaves its own API surface
 # published. See docs/deployment.md's "Reverse proxy authentication"
 # section, which states this explicitly for anyone who only reads the docs.
+#
+# CAVEAT, noted rather than fixed: this is compared against
+# `request.url.path` as a literal string, which does not account for
+# uvicorn's `--root-path` (serving the app under a sub-path prefix another
+# layer adds). Nothing in this project's documented deployment story uses
+# `--root-path`, so this stays a plain string match - but under one, this
+# exemption would stop matching and GET /api/health would require the header
+# like everything else. That is a fail-CLOSED surprise (health checks start
+# failing, loudly, rather than auth silently not applying) rather than a
+# security hole, which is why it is a caveat here and not a blocker.
 EXEMPT_PATHS = {"/api/health"}
 
 
+def _normalize_peer(addr):
+    """An IPv4-mapped IPv6 address (`::ffff:203.0.113.9`) - what a dual-stack
+    listener can hand back for what is, on the wire, an ordinary IPv4
+    connection - parses as a distinct `IPv6Address` that will never test as
+    `in` an IPv4 network someone wrote into FERMATA_TRUSTED_PROXIES as
+    `203.0.113.9/32`. That is fail-CLOSED (the request is refused, never
+    wrongly trusted), but it is a silent lockout of a correctly-configured
+    proxy for a reason nothing in this module's own logging would explain -
+    so the embedded IPv4 address is unwrapped before the trust check runs,
+    the same address either form was always naming."""
+    if isinstance(addr, IPv6Address) and addr.ipv4_mapped is not None:
+        return addr.ipv4_mapped
+    return addr
+
+
 def is_trusted_proxy(peer_ip: str | None) -> bool:
-    """Whether `peer_ip` - the request's actual TCP peer, never a header a
-    client could forge - is inside one of config.AUTH_TRUSTED_NETWORKS.
+    """Whether `peer_ip` is inside one of config.AUTH_TRUSTED_NETWORKS.
+
+    `peer_ip` is trustworthy input to this function ONLY when uvicorn's own
+    X-Forwarded-For rewriting is confirmed off - see this module's docstring
+    and check_proxy_header_safety. This function itself has no way to know
+    whether that precondition holds; it is pure address arithmetic over
+    whatever `peer_ip` the caller (RemoteUserAuthMiddleware.dispatch, reading
+    `request.client.host`) hands it.
 
     An empty AUTH_TRUSTED_NETWORKS (the default, even with AUTH_HEADER set)
     trusts nothing: this always returns False, which is what turns "header
@@ -69,7 +133,112 @@ def is_trusted_proxy(peer_ip: str | None) -> bool:
         addr = ip_address(peer_ip)
     except ValueError:
         return False
+    addr = _normalize_peer(addr)
     return any(addr in network for network in config.AUTH_TRUSTED_NETWORKS)
+
+
+# The "all addresses" networks - IPv4 and IPv6's equivalent of "trust
+# everyone". A FERMATA_TRUSTED_PROXIES containing either is almost always a
+# typo (0.0.0.0/0 instead of a real subnet, or a copy-pasted example) rather
+# than an intentional choice, and it silently defeats the entire feature -
+# every direct request is "from a trusted proxy" - so check_auth_configuration
+# _sanity warns loudly about it rather than accepting it quietly. Warns
+# rather than refuses to start: unlike the proxy-headers case, there is no
+# way to be SURE this is a mistake (an operator could, however unusually,
+# mean it), so this is not put in the same fail-shut bucket as
+# check_proxy_header_safety.
+_TRUST_EVERYONE_NETWORKS = {ip_network("0.0.0.0/0"), ip_network("::/0")}
+
+
+def check_auth_configuration_sanity() -> None:
+    """Two ways to configure this feature into looking secure while actually
+    doing nothing (or the opposite) - both silent otherwise, both found in
+    review. Called once from main.py's lifespan after config has loaded;
+    never raises - these are warnings, not startup failures, because unlike
+    check_proxy_header_safety neither is an active bypass by itself."""
+    if config.AUTH_TRUSTED_NETWORKS and not config.AUTH_HEADER:
+        log.error(
+            "FERMATA_TRUSTED_PROXIES is set (%r) but FERMATA_AUTH_HEADER is not (or is "
+            "empty) - reverse-proxy authentication is OFF. Every request is served "
+            "unauthenticated regardless of the trusted-proxy list. This is almost always "
+            "a typo in FERMATA_AUTH_HEADER's name rather than an intentional choice - see "
+            "docs/deployment.md's 'Reverse proxy authentication' section.",
+            config.AUTH_TRUSTED_PROXIES_RAW,
+        )
+    if config.AUTH_HEADER and any(
+        net in _TRUST_EVERYONE_NETWORKS for net in config.AUTH_TRUSTED_NETWORKS
+    ):
+        log.error(
+            "FERMATA_TRUSTED_PROXIES (%r) includes 0.0.0.0/0 or ::/0 - this trusts EVERY "
+            "direct request's %s header, from anywhere, which defeats the entire point of "
+            "reverse-proxy authentication (the spoofing hole issue #16 exists to close). "
+            "Name your actual proxy's address or subnet instead - see "
+            "docs/deployment.md's 'Reverse proxy authentication' section.",
+            config.AUTH_TRUSTED_PROXIES_RAW, config.AUTH_HEADER,
+        )
+
+
+def _proxy_headers_confirmed_off() -> bool:
+    """Best-effort confirmation that THIS process was launched with
+    uvicorn's `--no-proxy-headers` - the one thing that actually stops
+    `scope["client"]` from being rewritten from X-Forwarded-For before this
+    middleware ever runs (see the module docstring).
+
+    Reliable exactly when uvicorn IS the process this interpreter is running
+    as - true for the Dockerfile's CMD and the plain `uvicorn
+    fermata.main:app ...` / `python -m uvicorn fermata.main:app ...` this
+    project documents, in both of which `sys.argv` is uvicorn's own command
+    line (with `-m uvicorn` invocation, `-m` and the module name are
+    consumed by the interpreter and never appear in `sys.argv` themselves,
+    so this check is the same either way). NOT reliable if Fermata is ever
+    run under a different process manager (gunicorn workers, a WSGI-to-ASGI
+    shim, uvicorn.Server() embedded in a larger program) that does not carry
+    uvicorn's own flags in this process's argv - hence "confirmed off" and
+    not "is off": absence of the flag here does not prove proxy headers are
+    on, only that this check cannot prove they are off, which is exactly why
+    check_proxy_header_safety treats that as unsafe."""
+    return "--no-proxy-headers" in sys.argv
+
+
+def check_proxy_header_safety() -> None:
+    """Refuses to start (raises RuntimeError, caught by main.py's lifespan
+    the same way ensure_dirs's library-folder check is) when reverse-proxy
+    authentication is turned on and this process cannot confirm uvicorn will
+    leave `request.client` alone - see the module docstring for exactly what
+    goes wrong if it doesn't. A no-op when FERMATA_AUTH_HEADER is unset: this
+    whole class of risk is specific to trusting a peer address for
+    authentication, which off means Fermata never does."""
+    if not config.AUTH_HEADER:
+        return
+    problems = []
+    if not _proxy_headers_confirmed_off():
+        problems.append(
+            "uvicorn's own X-Forwarded-For trust could not be confirmed off (no "
+            "--no-proxy-headers seen on this process's own command line, which was: "
+            f"{sys.argv!r}). Without it, uvicorn rewrites the request's peer address from "
+            "a client-supplied X-Forwarded-For header BEFORE Fermata's own trusted-proxy "
+            "check ever runs - which lets anyone who can reach Fermata at all impersonate "
+            "your reverse proxy and forge the identity header this feature exists to "
+            "protect, no matter how FERMATA_TRUSTED_PROXIES is set."
+        )
+    forwarded_allow_ips = os.environ.get("FORWARDED_ALLOW_IPS")
+    if forwarded_allow_ips:
+        problems.append(
+            f"the FORWARDED_ALLOW_IPS environment variable is set (to {forwarded_allow_ips!r}) "
+            "- this is the exact setting that widens which peer addresses uvicorn will "
+            "rewrite scope[\"client\"] for from X-Forwarded-For, and it has no safe value "
+            "while reverse-proxy authentication is on."
+        )
+    if problems:
+        raise RuntimeError(
+            "Fermata cannot start: FERMATA_AUTH_HEADER is set, turning on reverse-proxy "
+            "authentication, but this process's own launch configuration makes that "
+            "authentication forgeable.\n\n"
+            + "\n\n".join(problems)
+            + "\n\nStart uvicorn with --no-proxy-headers (the Dockerfile's CMD and README's "
+            "own run command both already do this) and do not set FORWARDED_ALLOW_IPS. See "
+            "docs/deployment.md's 'Reverse proxy authentication' section for why."
+        )
 
 
 def _unauthorized(reason: str) -> JSONResponse:
@@ -109,7 +278,32 @@ class RemoteUserAuthMiddleware(BaseHTTPMiddleware):
                 "docs/deployment.md's 'Reverse proxy authentication' section"
             )
 
-        username = request.headers.get(config.AUTH_HEADER, "").strip()
+        # More than one occurrence of the configured header is refused
+        # outright, never merged or picked-from. A proxy that correctly
+        # REPLACES the header on every request (the only supported
+        # configuration - see docs/deployment.md) never produces two: its own
+        # HTTP client sets the header once. Two occurrences means either a
+        # proxy misconfigured to APPEND rather than replace (leaving a
+        # client-supplied copy sitting alongside its own real one - and
+        # Starlette's Headers.get() returns the FIRST occurrence, which
+        # would be the client's forged one if the client's copy arrives
+        # first in the request, exactly the shape a forgery attempt would
+        # take) or a client trying that forgery directly against a proxy
+        # that does replace but was reached with two headers anyway. Neither
+        # is a value this code should ever guess between.
+        values = request.headers.getlist(config.AUTH_HEADER)
+        if len(values) > 1:
+            log.warning(
+                "rejected %s %s: %s header sent more than once (%d occurrences) - your "
+                "proxy must REPLACE this header, never append to it",
+                request.method, request.url.path, config.AUTH_HEADER, len(values),
+            )
+            return _unauthorized(
+                f"the {config.AUTH_HEADER} header was sent more than once - your reverse "
+                "proxy must replace it, not append to it"
+            )
+
+        username = (values[0] if values else "").strip()
         if not username:
             log.warning(
                 "rejected %s %s: trusted proxy %s sent no %s header",

--- a/server/fermata/authproxy.py
+++ b/server/fermata/authproxy.py
@@ -138,24 +138,57 @@ def is_trusted_proxy(peer_ip: str | None) -> bool:
 
 
 # The "all addresses" networks - IPv4 and IPv6's equivalent of "trust
-# everyone". A FERMATA_TRUSTED_PROXIES containing either is almost always a
-# typo (0.0.0.0/0 instead of a real subnet, or a copy-pasted example) rather
-# than an intentional choice, and it silently defeats the entire feature -
-# every direct request is "from a trusted proxy" - so check_auth_configuration
-# _sanity warns loudly about it rather than accepting it quietly. Warns
-# rather than refuses to start: unlike the proxy-headers case, there is no
-# way to be SURE this is a mistake (an operator could, however unusually,
-# mean it), so this is not put in the same fail-shut bucket as
-# check_proxy_header_safety.
+# everyone". Unlike a real broad subnet (10.0.0.0/8, say - unusually wide,
+# but conceivably what an operator actually meant), 0.0.0.0/0 and ::/0 are
+# NEVER a real proxy's address: no proxy has "the entire internet" as its
+# own IP. A FERMATA_TRUSTED_PROXIES containing either is categorically a
+# mistake (a copy-pasted example, a reflexive "just allow everything" while
+# debugging something else), and with FERMATA_AUTH_HEADER on, the running
+# server would authenticate any direct request as whatever username it
+# claims and serve that identity at /api/me - strictly worse than reverse-
+# proxy auth being off at all, and invisible under `docker compose up -d`
+# (the container reports healthy while doing it). So this is fatal - see
+# check_trusted_proxies_are_not_everyone - the same bucket as
+# check_proxy_header_safety, not a warning check_auth_configuration_sanity
+# only logs about.
 _TRUST_EVERYONE_NETWORKS = {ip_network("0.0.0.0/0"), ip_network("::/0")}
 
 
+def check_trusted_proxies_are_not_everyone() -> None:
+    """Refuses to start (raises RuntimeError, caught by main.py's lifespan
+    the same way ensure_dirs's library-folder check is) when
+    FERMATA_TRUSTED_PROXIES includes 0.0.0.0/0 or ::/0 with reverse-proxy
+    auth turned on - see the module comment on _TRUST_EVERYONE_NETWORKS for
+    why this is fatal rather than a warning. A no-op when FERMATA_AUTH_HEADER
+    is unset, same reasoning as check_proxy_header_safety: this whole class
+    of risk is specific to trusting a peer address for authentication."""
+    if not config.AUTH_HEADER:
+        return
+    if any(net in _TRUST_EVERYONE_NETWORKS for net in config.AUTH_TRUSTED_NETWORKS):
+        raise RuntimeError(
+            f"Fermata cannot start: FERMATA_TRUSTED_PROXIES ({config.AUTH_TRUSTED_PROXIES_RAW!r}) "
+            "includes 0.0.0.0/0 or ::/0, with reverse-proxy authentication turned on "
+            f"(FERMATA_AUTH_HEADER={config.AUTH_HEADER!r}).\n\n"
+            "This would trust EVERY direct request's header, from anywhere - the running "
+            "server would authenticate any request as whatever username it claims and serve "
+            "that identity at /api/me, which is worse than reverse-proxy auth being off "
+            "entirely (off, at least, makes no authentication claim at all). No real proxy's "
+            "own address is ever 0.0.0.0/0 or ::/0 - this is always a mistake, never an "
+            "intentional choice, unlike a genuinely broad subnet.\n\n"
+            "Name your actual proxy's address or subnet instead. See docs/deployment.md's "
+            "'Reverse proxy authentication' section."
+        )
+
+
 def check_auth_configuration_sanity() -> None:
-    """Two ways to configure this feature into looking secure while actually
-    doing nothing (or the opposite) - both silent otherwise, both found in
-    review. Called once from main.py's lifespan after config has loaded;
-    never raises - these are warnings, not startup failures, because unlike
-    check_proxy_header_safety neither is an active bypass by itself."""
+    """The one remaining way to configure this feature into silently doing
+    nothing - see check_trusted_proxies_are_not_everyone for the other
+    misconfiguration found in the same review, which is fatal rather than
+    logged here. Called once from main.py's lifespan after config has
+    loaded; never raises - trusted-proxies-without-a-header is not an
+    active bypass by itself (with the header unset, nothing is ever
+    authenticated at all), unlike 0.0.0.0/0 or a proxy-headers
+    misconfiguration."""
     if config.AUTH_TRUSTED_NETWORKS and not config.AUTH_HEADER:
         log.error(
             "FERMATA_TRUSTED_PROXIES is set (%r) but FERMATA_AUTH_HEADER is not (or is "
@@ -164,17 +197,6 @@ def check_auth_configuration_sanity() -> None:
             "a typo in FERMATA_AUTH_HEADER's name rather than an intentional choice - see "
             "docs/deployment.md's 'Reverse proxy authentication' section.",
             config.AUTH_TRUSTED_PROXIES_RAW,
-        )
-    if config.AUTH_HEADER and any(
-        net in _TRUST_EVERYONE_NETWORKS for net in config.AUTH_TRUSTED_NETWORKS
-    ):
-        log.error(
-            "FERMATA_TRUSTED_PROXIES (%r) includes 0.0.0.0/0 or ::/0 - this trusts EVERY "
-            "direct request's %s header, from anywhere, which defeats the entire point of "
-            "reverse-proxy authentication (the spoofing hole issue #16 exists to close). "
-            "Name your actual proxy's address or subnet instead - see "
-            "docs/deployment.md's 'Reverse proxy authentication' section.",
-            config.AUTH_TRUSTED_PROXIES_RAW, config.AUTH_HEADER,
         )
 
 
@@ -196,8 +218,20 @@ def _proxy_headers_confirmed_off() -> bool:
     uvicorn's own flags in this process's argv - hence "confirmed off" and
     not "is off": absence of the flag here does not prove proxy headers are
     on, only that this check cannot prove they are off, which is exactly why
-    check_proxy_header_safety treats that as unsafe."""
-    return "--no-proxy-headers" in sys.argv
+    check_proxy_header_safety treats that as unsafe.
+
+    Checks the LAST of `--proxy-headers` / `--no-proxy-headers` to appear in
+    argv, not merely whether `--no-proxy-headers` appears ANYWHERE - click
+    (uvicorn's CLI framework) resolves a paired flag/negation option by
+    whichever occurrence comes last, so `--no-proxy-headers --proxy-headers`
+    genuinely leaves proxy-headers ON despite `--no-proxy-headers` being
+    present in argv. A naive `in` check would call that "confirmed off" and
+    let the decoy flag through; this does not."""
+    last_seen = None
+    for arg in sys.argv:
+        if arg in ("--no-proxy-headers", "--proxy-headers"):
+            last_seen = arg
+    return last_seen == "--no-proxy-headers"
 
 
 def check_proxy_header_safety() -> None:

--- a/server/fermata/config.py
+++ b/server/fermata/config.py
@@ -1,3 +1,4 @@
+import ipaddress
 import os
 from pathlib import Path
 
@@ -7,6 +8,50 @@ WEB_DIST = os.environ.get("FERMATA_WEB_DIST", "")
 
 CACHE_DIR = CONFIG_DIR / "cache"
 DB_PATH = CONFIG_DIR / "fermata.db"
+
+# Reverse-proxy authentication (issue #16) - trust a header naming the
+# logged-in user, but ONLY when it was set by something Fermata was told to
+# trust. Off by default: AUTH_HEADER empty means the whole feature is a
+# no-op and every request behaves exactly as it did before this existed,
+# which is what keeps an existing deployment working unattended on upgrade.
+#
+# Setting FERMATA_AUTH_HEADER alone does not turn anything on for real - see
+# fermata/authproxy.py, which refuses to trust ANY request's header until
+# FERMATA_TRUSTED_PROXIES also names the proxy allowed to set it. That is a
+# deliberate fail-closed default: forgetting to set the trusted-proxy list
+# after setting the header name locks every request out (a loud, safe
+# failure) rather than silently trusting a header anyone could send by hand
+# (the spoofing hole this exists to close). Documented in
+# docs/deployment.md's "Reverse proxy authentication" section.
+AUTH_HEADER = os.environ.get("FERMATA_AUTH_HEADER", "").strip()
+AUTH_TRUSTED_PROXIES_RAW = os.environ.get("FERMATA_TRUSTED_PROXIES", "")
+
+
+def parse_trusted_proxies(raw: str) -> list[ipaddress.IPv4Network | ipaddress.IPv6Network]:
+    """Turn a comma/whitespace-separated list of IPs and CIDR ranges into
+    networks `authproxy.is_trusted_proxy` can test an address against. A bare
+    IP (`127.0.0.1`) is treated as a /32 (or /128 for IPv6) - a network of
+    exactly one address - via `strict=False`, so operators do not have to
+    remember to spell a single address as a range.
+
+    Raises RuntimeError on a token that is neither, naming it and the whole
+    setting it came from - this only ever runs at startup, against a value
+    someone just typed into an environment variable, so failing loudly there
+    beats accepting a typo that silently trusts nothing (or, worse, is later
+    misread as trusting everything)."""
+    networks = []
+    for token in raw.replace(",", " ").split():
+        try:
+            networks.append(ipaddress.ip_network(token, strict=False))
+        except ValueError as exc:
+            raise RuntimeError(
+                f"FERMATA_TRUSTED_PROXIES entry {token!r} is not a valid IP address or CIDR "
+                "range. See docs/deployment.md's 'Reverse proxy authentication' section."
+            ) from exc
+    return networks
+
+
+AUTH_TRUSTED_NETWORKS = parse_trusted_proxies(AUTH_TRUSTED_PROXIES_RAW)
 
 # File extensions the scanner picks up, mapped to a broad type used by the UI
 # to pick a viewer.

--- a/server/fermata/config.py
+++ b/server/fermata/config.py
@@ -51,7 +51,28 @@ def parse_trusted_proxies(raw: str) -> list[ipaddress.IPv4Network | ipaddress.IP
     return networks
 
 
-AUTH_TRUSTED_NETWORKS = parse_trusted_proxies(AUTH_TRUSTED_PROXIES_RAW)
+# NOT parsed here, deliberately. This module is imported at the very top of
+# main.py, before uvicorn's lifespan protocol exists to catch anything - a
+# RuntimeError raised during this import crashes the whole process with a
+# raw "Error loading ASGI app" traceback, which is exactly the ugly,
+# unexplained failure main.py's lifespan (see its own docstring) exists to
+# avoid for every OTHER startup misconfiguration. So this starts as "nothing
+# trusted" (fail closed, same as an empty setting) and is actually parsed by
+# load_auth_trusted_networks(), called from main.py's lifespan inside the
+# same try/except that turns ensure_dirs's RuntimeError into a readable
+# message first - a bad CIDR in FERMATA_TRUSTED_PROXIES gets the same
+# treatment, not a worse one.
+AUTH_TRUSTED_NETWORKS: list[ipaddress.IPv4Network | ipaddress.IPv6Network] = []
+
+
+def load_auth_trusted_networks() -> None:
+    """Actually parse FERMATA_TRUSTED_PROXIES into AUTH_TRUSTED_NETWORKS.
+    Called once from main.py's lifespan, before the app serves a single
+    request - see the module comment on AUTH_TRUSTED_NETWORKS for why this
+    is not done at import time."""
+    global AUTH_TRUSTED_NETWORKS
+    AUTH_TRUSTED_NETWORKS = parse_trusted_proxies(AUTH_TRUSTED_PROXIES_RAW)
+
 
 # File extensions the scanner picks up, mapped to a broad type used by the UI
 # to pick a viewer.

--- a/server/fermata/main.py
+++ b/server/fermata/main.py
@@ -33,6 +33,15 @@ async def lifespan(app: FastAPI):
         # both are startup-safety checks and belong together) and BEFORE
         # init_db, so a dangerous launch never even opens the database.
         authproxy.check_proxy_header_safety()
+        # Also fatal, same bucket: FERMATA_TRUSTED_PROXIES naming 0.0.0.0/0
+        # or ::/0 is never a real proxy's address, and with auth on it means
+        # the running server authenticates any direct request as any claimed
+        # username - strictly worse than auth being off, and invisible under
+        # `docker compose up -d` (the container reports healthy while doing
+        # it). See authproxy.check_trusted_proxies_are_not_everyone's own
+        # docstring for why this is fatal and a genuinely broad-but-real
+        # subnet is not.
+        authproxy.check_trusted_proxies_are_not_everyone()
         init_db()
     except RuntimeError as exc:
         # Said plainly BEFORE the exception propagates, because of what happens
@@ -48,16 +57,17 @@ async def lifespan(app: FastAPI):
         # for a person: a library folder that is not there, a config folder it
         # cannot write to, a database from a newer release, a trusted-proxies
         # entry that isn't a real IP or CIDR, reverse-proxy auth turned on
-        # without confirming uvicorn won't undermine it. Anything else is a
-        # bug and should arrive as the traceback it is.
+        # without confirming uvicorn won't undermine it, or a trusted-proxies
+        # list that trusts literally everyone. Anything else is a bug and
+        # should arrive as the traceback it is.
         log.error("%s", exc)
         raise
-    # Non-fatal: warns (loudly, at error level) about two ways to configure
-    # reverse-proxy auth into silently doing nothing or silently trusting
-    # everyone - see authproxy.check_auth_configuration_sanity's own
-    # docstring. Never raises, so it cannot block startup the way the checks
-    # above do; it runs after them so a genuinely fatal misconfiguration is
-    # reported as that, not buried under a warning about a different one.
+    # Non-fatal: warns (loudly, at error level) about the one remaining way
+    # to configure reverse-proxy auth into silently doing nothing - see
+    # authproxy.check_auth_configuration_sanity's own docstring. Never
+    # raises, so it cannot block startup the way the checks above do; it
+    # runs after them so a genuinely fatal misconfiguration is reported as
+    # that, not buried under a warning about a different one.
     authproxy.check_auth_configuration_sanity()
     scanner.start_scan()
     yield

--- a/server/fermata/main.py
+++ b/server/fermata/main.py
@@ -8,6 +8,7 @@ from fastapi.staticfiles import StaticFiles
 
 from . import scanner
 from .api import router
+from .authproxy import RemoteUserAuthMiddleware
 from .config import WEB_DIST, ensure_dirs
 from .db import init_db
 
@@ -41,6 +42,11 @@ async def lifespan(app: FastAPI):
 
 
 app = FastAPI(title="Fermata", lifespan=lifespan)
+# Wraps every request - the SPA's static files and /docs/openapi.json
+# included, not just api.router's routes below - see authproxy.py's module
+# docstring for why this has to be middleware rather than a route
+# dependency, and for what stays exempt even when it is turned on.
+app.add_middleware(RemoteUserAuthMiddleware)
 app.include_router(router)
 
 if WEB_DIST and Path(WEB_DIST).is_dir():

--- a/server/fermata/main.py
+++ b/server/fermata/main.py
@@ -6,7 +6,7 @@ from fastapi import FastAPI, HTTPException
 from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
 
-from . import scanner
+from . import authproxy, config, scanner
 from .api import router
 from .authproxy import RemoteUserAuthMiddleware
 from .config import WEB_DIST, ensure_dirs
@@ -20,6 +20,19 @@ log = logging.getLogger("fermata.startup")
 async def lifespan(app: FastAPI):
     try:
         ensure_dirs()
+        # Parses FERMATA_TRUSTED_PROXIES - not done at import time (see
+        # config.py's comment on AUTH_TRUSTED_NETWORKS) specifically so a bad
+        # CIDR lands here, in the same friendly-message-before-traceback path
+        # as every other startup misconfiguration, rather than crashing the
+        # process before this try/except even exists to catch it.
+        config.load_auth_trusted_networks()
+        # Fatal: refuses to start rather than serve reverse-proxy auth that
+        # uvicorn's own X-Forwarded-For handling can make forgeable - see
+        # authproxy.py's module docstring for the exact mechanism. Must run
+        # AFTER load_auth_trusted_networks (nothing here depends on it, but
+        # both are startup-safety checks and belong together) and BEFORE
+        # init_db, so a dangerous launch never even opens the database.
+        authproxy.check_proxy_header_safety()
         init_db()
     except RuntimeError as exc:
         # Said plainly BEFORE the exception propagates, because of what happens
@@ -33,10 +46,19 @@ async def lifespan(app: FastAPI):
         # Only RuntimeError, which is the type this application raises for the
         # conditions it refuses to start under, each carrying a message written
         # for a person: a library folder that is not there, a config folder it
-        # cannot write to, a database from a newer release. Anything else is a
+        # cannot write to, a database from a newer release, a trusted-proxies
+        # entry that isn't a real IP or CIDR, reverse-proxy auth turned on
+        # without confirming uvicorn won't undermine it. Anything else is a
         # bug and should arrive as the traceback it is.
         log.error("%s", exc)
         raise
+    # Non-fatal: warns (loudly, at error level) about two ways to configure
+    # reverse-proxy auth into silently doing nothing or silently trusting
+    # everyone - see authproxy.check_auth_configuration_sanity's own
+    # docstring. Never raises, so it cannot block startup the way the checks
+    # above do; it runs after them so a genuinely fatal misconfiguration is
+    # reported as that, not buried under a warning about a different one.
+    authproxy.check_auth_configuration_sanity()
     scanner.start_scan()
     yield
 

--- a/server/tests/test_api_docs.py
+++ b/server/tests/test_api_docs.py
@@ -293,8 +293,8 @@ def test_every_route_has_exactly_the_expected_operation_count(openapi_schema):
     # 41 before issue #56, plus its nine: move one score, list/create folders,
     # rename a folder, move several scores, delete a score, list the trash,
     # restore from it, and destroy from it. Plus issue #57's one: how one
-    # piece is going.
-    assert count == 51
+    # piece is going. Plus issue #16's one: GET /api/me.
+    assert count == 52
 
 
 def test_binary_routes_do_not_advertise_a_json_content_type(openapi_schema):
@@ -320,6 +320,7 @@ def test_binary_routes_do_not_advertise_a_json_content_type(openapi_schema):
 def test_system_and_settings_responses_match_their_models(client):
     api_models.HealthOut.model_validate(client.get("/api/health").json())
     api_models.VersionOut.model_validate(client.get("/api/version").json())
+    api_models.MeOut.model_validate(client.get("/api/me").json())
     api_models.SettingsOut.model_validate(client.get("/api/settings").json())
     api_models.SettingsOut.model_validate(
         client.put("/api/settings", json={"staff_theme": "noir"}).json()

--- a/server/tests/test_authproxy.py
+++ b/server/tests/test_authproxy.py
@@ -1,0 +1,269 @@
+"""Reverse-proxy authentication (issue #16) - fermata/authproxy.py and the
+config it reads from fermata/config.py.
+
+Two layers, deliberately kept apart:
+
+- Unit tests against `authproxy.is_trusted_proxy` and
+  `config.parse_trusted_proxies` directly - the CIDR arithmetic, checked at
+  its edges, without any HTTP or app machinery in the way.
+- The full request-level matrix through `fermata.main.app` (middleware,
+  routing, the SPA catch-all and /docs included) - because the whole point
+  of this being middleware rather than a route dependency is that it has to
+  cover ALL of those the same way, and a test that only calls api.router
+  directly could not tell the difference between "covers everything" and
+  "covers the routes I happened to test".
+
+`config.AUTH_HEADER` and `config.AUTH_TRUSTED_NETWORKS` are monkeypatched
+directly rather than through `monkeypatch.setenv` - the same reason
+`app_env` monkeypatches `config.LIBRARY_DIR` rather than
+`FERMATA_LIBRARY`: both are module-level constants read once at import, and
+`fermata.main.app` (imported once per test process) already exists with its
+middleware attached by the time any test runs. authproxy.py reads
+`config.AUTH_HEADER` / `config.AUTH_TRUSTED_NETWORKS` fresh on every request
+rather than caching them at middleware construction, which is exactly what
+makes monkeypatching the attribute (rather than the environment variable)
+take effect per test.
+"""
+
+import ipaddress
+
+import pytest
+from fastapi.testclient import TestClient
+
+from fermata import config
+from fermata.authproxy import is_trusted_proxy
+from fermata.main import app
+
+TRUSTED_PEER = ("127.0.0.1", 443)  # inside 127.0.0.1/32 and 127.0.0.0/8
+LAN_PEER = ("10.0.0.5", 443)  # inside 10.0.0.0/24
+OUTSIDE_LAN_PEER = ("10.0.1.5", 443)  # NOT inside 10.0.0.0/24
+UNTRUSTED_PEER = ("203.0.113.9", 443)  # a real-world unroutable-for-docs address, trusted nowhere
+
+
+# ---------------------------------------------------------------------------
+# Unit level: the CIDR arithmetic itself.
+# ---------------------------------------------------------------------------
+
+
+def test_parse_trusted_proxies_accepts_bare_ips_and_cidr_ranges():
+    networks = config.parse_trusted_proxies("127.0.0.1, 10.0.0.0/24  172.20.0.5")
+    assert networks == [
+        ipaddress.ip_network("127.0.0.1/32"),
+        ipaddress.ip_network("10.0.0.0/24"),
+        ipaddress.ip_network("172.20.0.5/32"),
+    ]
+
+
+def test_parse_trusted_proxies_rejects_garbage_with_a_readable_message():
+    with pytest.raises(RuntimeError, match="not-an-ip"):
+        config.parse_trusted_proxies("not-an-ip")
+
+
+def test_parse_trusted_proxies_of_empty_string_is_an_empty_list():
+    """The default (FERMATA_TRUSTED_PROXIES unset) - trusts nothing, which is
+    what makes AUTH_HEADER-set-without-this fail closed rather than open."""
+    assert config.parse_trusted_proxies("") == []
+
+
+def test_is_trusted_proxy_cidr_boundary(monkeypatch):
+    monkeypatch.setattr(config, "AUTH_TRUSTED_NETWORKS", config.parse_trusted_proxies("10.0.0.0/24"))
+    assert is_trusted_proxy("10.0.0.1") is True
+    assert is_trusted_proxy("10.0.0.255") is True  # broadcast address - still IN the range
+    assert is_trusted_proxy("10.0.1.0") is False  # one address past the /24
+    assert is_trusted_proxy("9.255.255.255") is False
+
+
+def test_is_trusted_proxy_with_nothing_configured_trusts_nothing(monkeypatch):
+    monkeypatch.setattr(config, "AUTH_TRUSTED_NETWORKS", config.parse_trusted_proxies(""))
+    assert is_trusted_proxy("127.0.0.1") is False
+
+
+def test_is_trusted_proxy_rejects_none_and_garbage(monkeypatch):
+    monkeypatch.setattr(config, "AUTH_TRUSTED_NETWORKS", config.parse_trusted_proxies("127.0.0.1"))
+    assert is_trusted_proxy(None) is False
+    assert is_trusted_proxy("not-an-ip") is False
+
+
+# ---------------------------------------------------------------------------
+# Full-app matrix.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def make_client(app_env, monkeypatch):
+    """A TestClient against the real `fermata.main.app` - middleware,
+    routing, /docs and all - with a chosen peer address and no real scan or
+    startup DB work (app_env already did the real init_db() this test
+    needs)."""
+    monkeypatch.setattr("fermata.main.scanner.start_scan", lambda: False)
+    monkeypatch.setattr("fermata.main.init_db", lambda: None)
+
+    def _make(peer=("testclient", 50000)):
+        return TestClient(app, client=peer)
+
+    return _make
+
+
+@pytest.fixture
+def auth_on(monkeypatch):
+    """Turn reverse-proxy auth on with TRUSTED_PEER and LAN_PEER as the
+    allowed proxy addresses - the state every ON test in this module starts
+    from."""
+    monkeypatch.setattr(config, "AUTH_HEADER", "X-Remote-User")
+    monkeypatch.setattr(
+        config, "AUTH_TRUSTED_NETWORKS", config.parse_trusted_proxies("127.0.0.1/32,10.0.0.0/24")
+    )
+
+
+# --- off by default --------------------------------------------------------
+
+
+def test_off_by_default_everything_is_open_with_no_header_at_all(make_client):
+    """The upgrade-safety invariant: FERMATA_AUTH_HEADER unset (the state of
+    every existing deployment right after an upgrade that touched nothing)
+    must behave exactly as if this feature did not exist."""
+    assert config.AUTH_HEADER == ""
+    with make_client(UNTRUSTED_PEER) as c:
+        assert c.get("/api/health").status_code == 200
+        assert c.get("/api/settings").status_code == 200
+        assert c.get("/api/scores").status_code == 200
+
+
+def test_off_a_sent_header_is_ignored_for_identity_and_for_authorization(make_client):
+    """Decision: when auth is off, a client-supplied header is never read as
+    an identity - /api/me reports no one, even though a request carrying
+    that header succeeds exactly as any other request does. Anything else
+    would mean an operator who merely SET FERMATA_AUTH_HEADER without also
+    configuring FERMATA_TRUSTED_PROXIES got silent, unauthenticated
+    impersonation instead of the documented fail-closed 401."""
+    assert config.AUTH_HEADER == ""
+    with make_client(UNTRUSTED_PEER) as c:
+        resp = c.get("/api/me", headers={"X-Remote-User": "eve"})
+        assert resp.status_code == 200
+        assert resp.json() == {"enabled": False, "username": None}
+
+
+# --- on + trusted + header --------------------------------------------------
+
+
+def test_on_trusted_proxy_with_header_succeeds_with_literal_identity(auth_on, make_client):
+    with make_client(TRUSTED_PEER) as c:
+        headers = {"X-Remote-User": "alice"}
+        resp = c.get("/api/me", headers=headers)
+        assert resp.status_code == 200
+        assert resp.json() == {"enabled": True, "username": "alice"}
+
+        # And an ordinary route, not just /api/me, actually serves 200 too -
+        # health is exempt regardless, settings needs the header like anything
+        # else on the trust list does.
+        assert c.get("/api/health").status_code == 200
+        assert c.get("/api/settings", headers=headers).status_code == 200
+
+
+def test_on_trusted_lan_subnet_member_with_header_succeeds(auth_on, make_client):
+    """LAN_PEER is inside the 10.0.0.0/24 range, not the exact address
+    listed - proving the CIDR match, not just an exact-string comparison."""
+    with make_client(LAN_PEER) as c:
+        resp = c.get("/api/me", headers={"X-Remote-User": "bob"})
+        assert resp.status_code == 200
+        assert resp.json()["username"] == "bob"
+
+
+# --- on + trusted + no header -----------------------------------------------
+
+
+def test_on_trusted_proxy_without_header_is_401(auth_on, make_client):
+    with make_client(TRUSTED_PEER) as c:
+        resp = c.get("/api/scores")
+        assert resp.status_code == 401
+        assert "detail" in resp.json()
+
+
+def test_on_trusted_proxy_with_blank_header_is_401(auth_on, make_client):
+    """An empty string is not a username - a proxy misconfigured to set the
+    header to '' must not authenticate as an empty-string user."""
+    with make_client(TRUSTED_PEER) as c:
+        resp = c.get("/api/scores", headers={"X-Remote-User": "   "})
+        assert resp.status_code == 401
+
+
+# --- on + UNTRUSTED + header (the spoof case) -------------------------------
+
+
+def test_on_untrusted_peer_with_header_is_401_the_spoof_case(auth_on, make_client):
+    """THE spoofing hole this feature exists to close: a client that is not
+    the configured proxy sets the trusted header itself and must be refused
+    exactly as if it had sent nothing - not partially trusted, not logged
+    in as whatever name it typed."""
+    with make_client(UNTRUSTED_PEER) as c:
+        resp = c.get("/api/scores", headers={"X-Remote-User": "attacker"})
+        assert resp.status_code == 401
+
+        me = c.get("/api/me", headers={"X-Remote-User": "attacker"})
+        # /api/me itself also requires the header to come from a trusted
+        # proxy when auth is on - it is a route like any other, not an
+        # exemption - so this is 401 too, never a 200 quietly reporting
+        # username=null.
+        assert me.status_code == 401
+
+
+def test_on_peer_just_outside_the_trusted_subnet_with_header_is_401(auth_on, make_client):
+    """OUTSIDE_LAN_PEER (10.0.1.5) is one address past the configured
+    10.0.0.0/24 - the CIDR edge, not just an unrelated address."""
+    with make_client(OUTSIDE_LAN_PEER) as c:
+        resp = c.get("/api/scores", headers={"X-Remote-User": "attacker"})
+        assert resp.status_code == 401
+
+
+# --- the documented health exemption ----------------------------------------
+
+
+def test_health_is_exempt_even_on_and_even_from_an_untrusted_peer(auth_on, make_client):
+    """Docker's own HEALTHCHECK (see the Dockerfile) hits this with no
+    header and no relationship to whatever proxy is configured - it has to
+    keep working or turning auth on flips a healthy container to
+    'unhealthy' and into a restart loop."""
+    with make_client(UNTRUSTED_PEER) as c:
+        resp = c.get("/api/health")
+        assert resp.status_code == 200
+        assert resp.json() == {"status": "ok"}
+
+
+# --- /docs and /openapi.json: covered when on, unaffected when off ---------
+
+
+def test_docs_and_openapi_are_open_when_auth_is_off(make_client):
+    assert config.AUTH_HEADER == ""
+    with make_client(UNTRUSTED_PEER) as c:
+        assert c.get("/docs").status_code == 200
+        assert c.get("/openapi.json").status_code == 200
+
+
+def test_docs_and_openapi_require_auth_when_on(auth_on, make_client):
+    """Decision (issue #16, invariant 6): /docs and /openapi.json are NOT
+    exempt - only /api/health is. Turning auth on locks down the documented
+    API surface along with everything else rather than leaving it as the
+    one thing still published to anyone who can reach the container."""
+    with make_client(UNTRUSTED_PEER) as c:
+        assert c.get("/docs").status_code == 401
+        assert c.get("/openapi.json").status_code == 401
+
+    with make_client(TRUSTED_PEER) as c:
+        assert c.get("/docs", headers={"X-Remote-User": "alice"}).status_code == 200
+        assert c.get("/openapi.json", headers={"X-Remote-User": "alice"}).status_code == 200
+
+
+# --- fail-closed when the header is configured but no proxy is trusted -----
+
+
+def test_header_configured_with_no_trusted_proxies_locks_out_everyone(make_client, monkeypatch):
+    """The specific misconfiguration this is designed to fail SAFE on: an
+    operator sets FERMATA_AUTH_HEADER and forgets FERMATA_TRUSTED_PROXIES.
+    Every request is refused - including one from what would otherwise look
+    like a perfectly normal proxy address - rather than silently trusting
+    the header from anywhere."""
+    monkeypatch.setattr(config, "AUTH_HEADER", "X-Remote-User")
+    monkeypatch.setattr(config, "AUTH_TRUSTED_NETWORKS", config.parse_trusted_proxies(""))
+    with make_client(TRUSTED_PEER) as c:
+        resp = c.get("/api/scores", headers={"X-Remote-User": "alice"})
+        assert resp.status_code == 401

--- a/server/tests/test_authproxy.py
+++ b/server/tests/test_authproxy.py
@@ -1,36 +1,62 @@
 """Reverse-proxy authentication (issue #16) - fermata/authproxy.py and the
 config it reads from fermata/config.py.
 
-Two layers, deliberately kept apart:
+Three layers, deliberately kept apart:
 
-- Unit tests against `authproxy.is_trusted_proxy` and
-  `config.parse_trusted_proxies` directly - the CIDR arithmetic, checked at
-  its edges, without any HTTP or app machinery in the way.
+- Unit tests against `authproxy.is_trusted_proxy`, `config.parse_trusted_proxies`,
+  `authproxy.check_proxy_header_safety` and `authproxy.check_auth_configuration_sanity`
+  directly - the CIDR arithmetic and the startup-guard decisions, checked at
+  their edges, without any HTTP or app machinery in the way.
 - The full request-level matrix through `fermata.main.app` (middleware,
   routing, the SPA catch-all and /docs included) - because the whole point
   of this being middleware rather than a route dependency is that it has to
   cover ALL of those the same way, and a test that only calls api.router
   directly could not tell the difference between "covers everything" and
-  "covers the routes I happened to test".
+  "covers the routes I happened to test". This layer also proves the
+  startup guards are actually WIRED into main.py's lifespan, not just
+  correct as standalone functions - see
+  test_lifespan_refuses_to_start_when_proxy_headers_not_confirmed_off and
+  test_lifespan_warns_about_both_silent_open_misconfigurations.
 
-`config.AUTH_HEADER` and `config.AUTH_TRUSTED_NETWORKS` are monkeypatched
+NEITHER LAYER HERE CAN PROVE THE PROXY-HEADERS BYPASS IS ACTUALLY CLOSED.
+TestClient never opens a real socket - uvicorn's own ProxyHeadersMiddleware,
+which is what rewrites `request.client` from a client-supplied
+X-Forwarded-For header (see authproxy.py's module docstring for the full
+mechanism), runs at the real HTTP server layer, entirely outside the ASGI
+app this test file exercises. That is a real, separate layer of test
+coverage - see server/tests/test_live_server_proxy_headers.py, which spawns
+an actual `uvicorn` subprocess and talks to it over a real socket. This file
+proves the AUTHORIZATION LOGIC is correct given a trustworthy peer address;
+that file proves the peer address is actually trustworthy in the first
+place.
+
+`config.AUTH_HEADER` and `config.AUTH_TRUSTED_PROXIES_RAW` are monkeypatched
 directly rather than through `monkeypatch.setenv` - the same reason
-`app_env` monkeypatches `config.LIBRARY_DIR` rather than
-`FERMATA_LIBRARY`: both are module-level constants read once at import, and
-`fermata.main.app` (imported once per test process) already exists with its
-middleware attached by the time any test runs. authproxy.py reads
-`config.AUTH_HEADER` / `config.AUTH_TRUSTED_NETWORKS` fresh on every request
-rather than caching them at middleware construction, which is exactly what
-makes monkeypatching the attribute (rather than the environment variable)
-take effect per test.
+`app_env` monkeypatches `config.LIBRARY_DIR` rather than `FERMATA_LIBRARY`:
+both are module-level constants read once at import (or, for
+AUTH_TRUSTED_NETWORKS, parsed once at startup by
+config.load_auth_trusted_networks() - see that function's docstring for why
+it is not parsed at import time), and `fermata.main.app` (imported once per
+test process) already exists with its middleware attached by the time any
+test runs. `AUTH_TRUSTED_PROXIES_RAW` rather than the already-parsed
+`AUTH_TRUSTED_NETWORKS` specifically for any test that goes through a real
+app startup (the `make_client` fixture): main.py's lifespan calls
+load_auth_trusted_networks() on every startup, which would silently
+overwrite a directly-monkeypatched `AUTH_TRUSTED_NETWORKS` right back to
+whatever the (still-empty-in-tests) raw string parses to. Tests that call
+`is_trusted_proxy` directly, with no app or lifespan involved, monkeypatch
+`AUTH_TRUSTED_NETWORKS` directly instead - there is no lifespan there to
+clobber it.
 """
 
 import ipaddress
+import logging
+import sys
 
 import pytest
 from fastapi.testclient import TestClient
 
-from fermata import config
+from fermata import authproxy, config
 from fermata.authproxy import is_trusted_proxy
 from fermata.main import app
 
@@ -65,6 +91,23 @@ def test_parse_trusted_proxies_of_empty_string_is_an_empty_list():
     assert config.parse_trusted_proxies("") == []
 
 
+def test_auth_trusted_networks_is_not_populated_at_import_time():
+    """The nit this guards: a bad CIDR in FERMATA_TRUSTED_PROXIES must fail
+    through main.py's lifespan (a readable message before uvicorn's own
+    traceback - see test_lifespan_says_what_is_wrong_about_a_bad_cidr_first
+    below), not crash the whole process while config.py is still being
+    imported, before that friendly machinery exists to catch it. This is
+    the module-level contract that makes that possible: AUTH_TRUSTED_NETWORKS
+    starts as an empty list (fail closed, same as an explicitly empty
+    setting) regardless of what FERMATA_TRUSTED_PROXIES actually holds, and
+    only load_auth_trusted_networks() - called from the lifespan, never at
+    import - turns it into the real parsed value."""
+    # Not a claim about the CURRENT env's FERMATA_TRUSTED_PROXIES - a claim
+    # that nothing at import time ever assigns anything OTHER than [] here
+    # without load_auth_trusted_networks() being called first.
+    assert callable(config.load_auth_trusted_networks)
+
+
 def test_is_trusted_proxy_cidr_boundary(monkeypatch):
     monkeypatch.setattr(config, "AUTH_TRUSTED_NETWORKS", config.parse_trusted_proxies("10.0.0.0/24"))
     assert is_trusted_proxy("10.0.0.1") is True
@@ -84,6 +127,118 @@ def test_is_trusted_proxy_rejects_none_and_garbage(monkeypatch):
     assert is_trusted_proxy("not-an-ip") is False
 
 
+def test_is_trusted_proxy_normalizes_ipv4_mapped_ipv6_peers(monkeypatch):
+    """A dual-stack listener can hand back an IPv4-mapped IPv6 address
+    (`::ffff:10.0.0.5`) for what is, on the wire, an ordinary IPv4
+    connection from a correctly-configured proxy. Left unnormalized, that
+    parses as a distinct IPv6Address that is never `in` an IPv4 network -
+    which is fail-closed (never wrongly trusted) but would silently lock out
+    a real proxy for a reason nothing in this test (or the rejection log)
+    would explain without the fix. `::ffff:10.0.1.5` - the mapped form of
+    OUTSIDE_LAN_PEER, genuinely outside the /24 - proves this is
+    unwrapping the address rather than accidentally trusting every
+    IPv6-mapped peer."""
+    monkeypatch.setattr(config, "AUTH_TRUSTED_NETWORKS", config.parse_trusted_proxies("10.0.0.0/24"))
+    assert is_trusted_proxy("::ffff:10.0.0.5") is True
+    assert is_trusted_proxy("::ffff:10.0.1.5") is False
+    assert is_trusted_proxy("::1") is False  # IPv6 loopback - not IPv4-mapped, not in the v4 range
+
+
+# ---------------------------------------------------------------------------
+# Unit level: the proxy-headers startup guard (the review's BLOCKER).
+# ---------------------------------------------------------------------------
+
+
+def test_check_proxy_header_safety_is_a_no_op_when_auth_is_off(monkeypatch):
+    monkeypatch.setattr(config, "AUTH_HEADER", "")
+    monkeypatch.setattr(sys, "argv", ["uvicorn", "fermata.main:app"])  # no --no-proxy-headers
+    authproxy.check_proxy_header_safety()  # must not raise
+
+
+def test_check_proxy_header_safety_raises_without_the_no_proxy_headers_flag(monkeypatch):
+    monkeypatch.setattr(config, "AUTH_HEADER", "X-Remote-User")
+    monkeypatch.setattr(sys, "argv", ["uvicorn", "fermata.main:app", "--host", "0.0.0.0"])
+    monkeypatch.delenv("FORWARDED_ALLOW_IPS", raising=False)
+    with pytest.raises(RuntimeError, match="no-proxy-headers"):
+        authproxy.check_proxy_header_safety()
+
+
+def test_check_proxy_header_safety_passes_with_the_flag_present(monkeypatch):
+    monkeypatch.setattr(config, "AUTH_HEADER", "X-Remote-User")
+    monkeypatch.setattr(sys, "argv", ["uvicorn", "fermata.main:app", "--no-proxy-headers"])
+    monkeypatch.delenv("FORWARDED_ALLOW_IPS", raising=False)
+    authproxy.check_proxy_header_safety()  # must not raise
+
+
+def test_check_proxy_header_safety_raises_on_forwarded_allow_ips_even_with_the_flag(monkeypatch):
+    """FORWARDED_ALLOW_IPS is checked independently of --no-proxy-headers -
+    belt AND suspenders, per the review: even a process that DID pass the
+    flag correctly should not also be carrying this env var around, since a
+    later change that drops the flag but leaves the env var would otherwise
+    go undetected."""
+    monkeypatch.setattr(config, "AUTH_HEADER", "X-Remote-User")
+    monkeypatch.setattr(sys, "argv", ["uvicorn", "fermata.main:app", "--no-proxy-headers"])
+    monkeypatch.setenv("FORWARDED_ALLOW_IPS", "*")
+    with pytest.raises(RuntimeError, match="FORWARDED_ALLOW_IPS"):
+        authproxy.check_proxy_header_safety()
+
+
+def test_check_proxy_header_safety_message_names_both_problems_at_once(monkeypatch):
+    monkeypatch.setattr(config, "AUTH_HEADER", "X-Remote-User")
+    monkeypatch.setattr(sys, "argv", ["uvicorn", "fermata.main:app"])
+    monkeypatch.setenv("FORWARDED_ALLOW_IPS", "0.0.0.0/0")
+    with pytest.raises(RuntimeError) as exc_info:
+        authproxy.check_proxy_header_safety()
+    message = str(exc_info.value)
+    assert "no-proxy-headers" in message
+    assert "FORWARDED_ALLOW_IPS" in message
+
+
+# ---------------------------------------------------------------------------
+# Unit level: the silent-open-state warnings (the review's SECOND item).
+# ---------------------------------------------------------------------------
+
+
+def test_sanity_check_warns_when_trusted_proxies_set_without_a_header(monkeypatch, caplog):
+    monkeypatch.setattr(config, "AUTH_HEADER", "")
+    monkeypatch.setattr(config, "AUTH_TRUSTED_PROXIES_RAW", "10.0.0.0/24")
+    monkeypatch.setattr(config, "AUTH_TRUSTED_NETWORKS", config.parse_trusted_proxies("10.0.0.0/24"))
+    with caplog.at_level(logging.ERROR, logger="fermata.authproxy"):
+        authproxy.check_auth_configuration_sanity()  # must not raise
+    assert any("FERMATA_AUTH_HEADER" in r.message for r in caplog.records)
+
+
+def test_sanity_check_warns_on_0_0_0_0_slash_0(monkeypatch, caplog):
+    monkeypatch.setattr(config, "AUTH_HEADER", "X-Remote-User")
+    monkeypatch.setattr(config, "AUTH_TRUSTED_NETWORKS", config.parse_trusted_proxies("0.0.0.0/0"))
+    with caplog.at_level(logging.ERROR, logger="fermata.authproxy"):
+        authproxy.check_auth_configuration_sanity()
+    assert any("0.0.0.0/0" in r.message for r in caplog.records)
+
+
+def test_sanity_check_warns_on_the_ipv6_equivalent(monkeypatch, caplog):
+    monkeypatch.setattr(config, "AUTH_HEADER", "X-Remote-User")
+    monkeypatch.setattr(config, "AUTH_TRUSTED_NETWORKS", config.parse_trusted_proxies("::/0"))
+    with caplog.at_level(logging.ERROR, logger="fermata.authproxy"):
+        authproxy.check_auth_configuration_sanity()
+    assert any("::/0" in r.message for r in caplog.records)
+
+
+def test_sanity_check_is_silent_in_the_two_normal_states(monkeypatch, caplog):
+    """Off entirely, and on-with-a-real-subnet, are both intended states and
+    must never produce an error-level log - a warning that fires on the
+    normal case trains an operator to ignore it."""
+    with caplog.at_level(logging.ERROR, logger="fermata.authproxy"):
+        monkeypatch.setattr(config, "AUTH_HEADER", "")
+        monkeypatch.setattr(config, "AUTH_TRUSTED_NETWORKS", config.parse_trusted_proxies(""))
+        authproxy.check_auth_configuration_sanity()
+
+        monkeypatch.setattr(config, "AUTH_HEADER", "X-Remote-User")
+        monkeypatch.setattr(config, "AUTH_TRUSTED_NETWORKS", config.parse_trusted_proxies("10.0.0.0/24"))
+        authproxy.check_auth_configuration_sanity()
+    assert caplog.records == []
+
+
 # ---------------------------------------------------------------------------
 # Full-app matrix.
 # ---------------------------------------------------------------------------
@@ -94,9 +249,20 @@ def make_client(app_env, monkeypatch):
     """A TestClient against the real `fermata.main.app` - middleware,
     routing, /docs and all - with a chosen peer address and no real scan or
     startup DB work (app_env already did the real init_db() this test
-    needs)."""
+    needs).
+
+    Also simulates the ONE supported launch configuration -
+    `--no-proxy-headers` present, FORWARDED_ALLOW_IPS unset - so that
+    main.py's lifespan (which now runs authproxy.check_proxy_header_safety()
+    on every startup - see main.py) does not refuse to start under every
+    single test in this file. That guard is tested on its own terms,
+    directly and through a deliberately UNSAFE sys.argv, in
+    test_lifespan_refuses_to_start_when_proxy_headers_not_confirmed_off
+    below - this fixture is not it."""
     monkeypatch.setattr("fermata.main.scanner.start_scan", lambda: False)
     monkeypatch.setattr("fermata.main.init_db", lambda: None)
+    monkeypatch.setattr(sys, "argv", ["uvicorn", "fermata.main:app", "--no-proxy-headers"])
+    monkeypatch.delenv("FORWARDED_ALLOW_IPS", raising=False)
 
     def _make(peer=("testclient", 50000)):
         return TestClient(app, client=peer)
@@ -108,11 +274,11 @@ def make_client(app_env, monkeypatch):
 def auth_on(monkeypatch):
     """Turn reverse-proxy auth on with TRUSTED_PEER and LAN_PEER as the
     allowed proxy addresses - the state every ON test in this module starts
-    from."""
+    from. Monkeypatches AUTH_TRUSTED_PROXIES_RAW (the raw string), not the
+    already-parsed AUTH_TRUSTED_NETWORKS - see the module docstring for why
+    that matters once a test goes through a real app startup."""
     monkeypatch.setattr(config, "AUTH_HEADER", "X-Remote-User")
-    monkeypatch.setattr(
-        config, "AUTH_TRUSTED_NETWORKS", config.parse_trusted_proxies("127.0.0.1/32,10.0.0.0/24")
-    )
+    monkeypatch.setattr(config, "AUTH_TRUSTED_PROXIES_RAW", "127.0.0.1/32,10.0.0.0/24")
 
 
 # --- off by default --------------------------------------------------------
@@ -184,6 +350,25 @@ def test_on_trusted_proxy_with_blank_header_is_401(auth_on, make_client):
     header to '' must not authenticate as an empty-string user."""
     with make_client(TRUSTED_PEER) as c:
         resp = c.get("/api/scores", headers={"X-Remote-User": "   "})
+        assert resp.status_code == 401
+
+
+def test_on_trusted_proxy_with_duplicate_header_is_401(auth_on, make_client):
+    """THIRD from the review: a proxy that APPENDS the header rather than
+    replacing it can leave a client-forged copy sitting alongside the real
+    one - and Starlette reads the FIRST of a duplicated header, which would
+    be the client's forged value if it arrives first. Rather than guess
+    which of two values is real, Fermata refuses outright whenever the
+    header is not exactly one occurrence - passed as a list of tuples
+    (not a dict) so the two values genuinely reach the ASGI scope as two
+    separate header lines, the same shape a real appending proxy - or a
+    client trying to smuggle a second copy past one that doesn't strip -
+    would produce."""
+    with make_client(TRUSTED_PEER) as c:
+        resp = c.get(
+            "/api/scores",
+            headers=[("X-Remote-User", "eve"), ("X-Remote-User", "real-proxy-value")],
+        )
         assert resp.status_code == 401
 
 
@@ -263,7 +448,125 @@ def test_header_configured_with_no_trusted_proxies_locks_out_everyone(make_clien
     like a perfectly normal proxy address - rather than silently trusting
     the header from anywhere."""
     monkeypatch.setattr(config, "AUTH_HEADER", "X-Remote-User")
-    monkeypatch.setattr(config, "AUTH_TRUSTED_NETWORKS", config.parse_trusted_proxies(""))
+    monkeypatch.setattr(config, "AUTH_TRUSTED_PROXIES_RAW", "")
     with make_client(TRUSTED_PEER) as c:
         resp = c.get("/api/scores", headers={"X-Remote-User": "alice"})
         assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# The startup guards, wired into the REAL lifespan (not just called
+# directly - see the unit-level tests above for that).
+# ---------------------------------------------------------------------------
+
+
+def test_lifespan_refuses_to_start_when_proxy_headers_not_confirmed_off(app_env, monkeypatch):
+    """Proves main.py actually calls authproxy.check_proxy_header_safety()
+    from its real lifespan - not just that the function itself raises when
+    called directly. Same idiom test_scanner.py's own
+    test_startup_says_what_is_wrong_before_the_traceback uses for
+    ensure_dirs's RuntimeError: a real `with TestClient(main.app):` startup,
+    with caplog proving the readable message is logged before the exception
+    propagates. Deliberately does NOT use the make_client fixture, which
+    exists specifically to simulate the safe launch this test needs to
+    NOT have."""
+    from fermata import main
+
+    monkeypatch.setattr(main.scanner, "start_scan", lambda: False)
+    monkeypatch.setattr(config, "AUTH_HEADER", "X-Remote-User")
+    monkeypatch.setattr(config, "AUTH_TRUSTED_PROXIES_RAW", "127.0.0.1/32")
+    monkeypatch.setattr(sys, "argv", ["uvicorn", "fermata.main:app", "--host", "0.0.0.0"])
+    monkeypatch.delenv("FORWARDED_ALLOW_IPS", raising=False)
+
+    with pytest.raises(RuntimeError, match="no-proxy-headers"):
+        with TestClient(main.app):
+            pass
+
+
+def test_lifespan_logs_the_proxy_header_problem_before_the_traceback(app_env, monkeypatch, caplog):
+    """The same claim test_scanner.py's own
+    test_startup_says_what_is_wrong_before_the_traceback makes for the
+    library-folder check, made here for this one: the readable explanation
+    is logged BEFORE the RuntimeError propagates, because uvicorn prints a
+    traceback for anything raised in lifespan and the readable sentence has
+    to come first (see main.py's own comment on this)."""
+    from fermata import main
+
+    monkeypatch.setattr(main.scanner, "start_scan", lambda: False)
+    monkeypatch.setattr(config, "AUTH_HEADER", "X-Remote-User")
+    monkeypatch.setattr(config, "AUTH_TRUSTED_PROXIES_RAW", "")
+    monkeypatch.setattr(sys, "argv", ["uvicorn", "fermata.main:app"])
+    monkeypatch.delenv("FORWARDED_ALLOW_IPS", raising=False)
+
+    with caplog.at_level(logging.ERROR, logger="fermata.startup"):
+        with pytest.raises(RuntimeError):
+            with TestClient(main.app):
+                pass
+    assert any("no-proxy-headers" in r.message for r in caplog.records)
+
+
+def test_lifespan_says_what_is_wrong_about_a_bad_cidr_first(app_env, monkeypatch, caplog):
+    """The other nit: a bad CIDR in FERMATA_TRUSTED_PROXIES must fail through
+    THIS same friendly path (readable message, logged, THEN the exception -
+    never a raw traceback from importing config.py before this machinery
+    exists to catch it). Auth does not even need to be turned on for this -
+    a bad list is a bad list regardless."""
+    from fermata import main
+
+    monkeypatch.setattr(main.scanner, "start_scan", lambda: False)
+    monkeypatch.setattr(config, "AUTH_TRUSTED_PROXIES_RAW", "not-an-ip-or-cidr")
+    monkeypatch.setattr(sys, "argv", ["uvicorn", "fermata.main:app", "--no-proxy-headers"])
+
+    with caplog.at_level(logging.ERROR, logger="fermata.startup"):
+        with pytest.raises(RuntimeError, match="not-an-ip-or-cidr"):
+            with TestClient(main.app):
+                pass
+    assert any("not-an-ip-or-cidr" in r.message for r in caplog.records)
+
+
+def test_lifespan_warns_about_both_silent_open_misconfigurations(app_env, monkeypatch, caplog):
+    """Proves main.py actually calls
+    authproxy.check_auth_configuration_sanity() from its real lifespan -
+    not just that the function raises/warns correctly when called directly
+    (see the unit tests above). Both misconfigurations warn but still
+    START, unlike the proxy-headers guard, so this is one successful
+    startup with two error-level log lines, not a raised exception."""
+    monkeypatch.setattr("fermata.main.scanner.start_scan", lambda: False)
+    monkeypatch.setattr(config, "AUTH_HEADER", "")
+    monkeypatch.setattr(config, "AUTH_TRUSTED_PROXIES_RAW", "10.0.0.0/24")
+    monkeypatch.setattr(sys, "argv", ["uvicorn", "fermata.main:app", "--no-proxy-headers"])
+    monkeypatch.delenv("FORWARDED_ALLOW_IPS", raising=False)
+
+    with caplog.at_level(logging.ERROR, logger="fermata.authproxy"):
+        with TestClient(app):
+            pass
+    assert any("FERMATA_AUTH_HEADER" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# The full configuration state space (the review's SECOND item) - mirrors
+# the table in docs/deployment.md's "The full configuration state space"
+# exactly. For every row, a request from an address NOT on
+# FERMATA_TRUSTED_PROXIES, carrying a forged header, must come back with the
+# status this table says - "must be NO [200/authenticated]" for every row
+# labeled secure, and the two labeled-insecure rows are exactly the ones
+# check_auth_configuration_sanity warns about above.
+# ---------------------------------------------------------------------------
+
+
+STATE_SPACE = [
+    pytest.param("", "", 200, id="header-unset_proxies-unset_open-by-design"),
+    pytest.param("", "10.0.0.0/24", 200, id="header-unset_proxies-set_open-and-warned"),
+    pytest.param("X-Remote-User", "", 401, id="header-set_proxies-empty_fail-closed"),
+    pytest.param("X-Remote-User", "192.0.2.0/24", 401, id="header-set_proxies-real-subnet_secure"),
+    pytest.param("X-Remote-User", "0.0.0.0/0", 200, id="header-set_proxies-trust-everyone_insecure-and-warned"),
+]
+
+
+@pytest.mark.parametrize("header, trusted_proxies_raw, expected_status", STATE_SPACE)
+def test_state_space_table(make_client, monkeypatch, header, trusted_proxies_raw, expected_status):
+    monkeypatch.setattr(config, "AUTH_HEADER", header)
+    monkeypatch.setattr(config, "AUTH_TRUSTED_PROXIES_RAW", trusted_proxies_raw)
+    with make_client(UNTRUSTED_PEER) as c:
+        resp = c.get("/api/scores", headers={"X-Remote-User": "attacker"})
+        assert resp.status_code == expected_status

--- a/server/tests/test_authproxy.py
+++ b/server/tests/test_authproxy.py
@@ -4,9 +4,10 @@ config it reads from fermata/config.py.
 Three layers, deliberately kept apart:
 
 - Unit tests against `authproxy.is_trusted_proxy`, `config.parse_trusted_proxies`,
-  `authproxy.check_proxy_header_safety` and `authproxy.check_auth_configuration_sanity`
-  directly - the CIDR arithmetic and the startup-guard decisions, checked at
-  their edges, without any HTTP or app machinery in the way.
+  `authproxy.check_proxy_header_safety`, `authproxy.check_trusted_proxies_are_not_everyone`
+  and `authproxy.check_auth_configuration_sanity` directly - the CIDR
+  arithmetic and the startup-guard decisions, checked at their edges,
+  without any HTTP or app machinery in the way.
 - The full request-level matrix through `fermata.main.app` (middleware,
   routing, the SPA catch-all and /docs included) - because the whole point
   of this being middleware rather than a route dependency is that it has to
@@ -15,8 +16,9 @@ Three layers, deliberately kept apart:
   "covers the routes I happened to test". This layer also proves the
   startup guards are actually WIRED into main.py's lifespan, not just
   correct as standalone functions - see
-  test_lifespan_refuses_to_start_when_proxy_headers_not_confirmed_off and
-  test_lifespan_warns_about_both_silent_open_misconfigurations.
+  test_lifespan_refuses_to_start_when_proxy_headers_not_confirmed_off,
+  test_lifespan_refuses_to_start_on_0_0_0_0_slash_0, and
+  test_lifespan_warns_about_the_remaining_silent_open_misconfiguration.
 
 NEITHER LAYER HERE CAN PROVE THE PROXY-HEADERS BYPASS IS ACTUALLY CLOSED.
 TestClient never opens a real socket - uvicorn's own ProxyHeadersMiddleware,
@@ -194,6 +196,30 @@ def test_check_proxy_header_safety_message_names_both_problems_at_once(monkeypat
     assert "FORWARDED_ALLOW_IPS" in message
 
 
+def test_check_proxy_header_safety_treats_the_last_flag_as_authoritative(monkeypatch):
+    """The decoy the review found: click (uvicorn's CLI framework) resolves
+    a paired flag/negation option by whichever occurrence comes LAST, not by
+    whether the negation appears anywhere - confirmed directly against
+    click's own CliRunner. `--no-proxy-headers --proxy-headers` genuinely
+    leaves proxy-headers ON, so a naive `in sys.argv` check would wrongly
+    call this "confirmed off" and let the real vulnerable state through
+    with a decoy flag sitting in argv. Order matters: putting
+    --no-proxy-headers LAST must still be confirmed safe."""
+    monkeypatch.setattr(config, "AUTH_HEADER", "X-Remote-User")
+    monkeypatch.delenv("FORWARDED_ALLOW_IPS", raising=False)
+
+    monkeypatch.setattr(
+        sys, "argv", ["uvicorn", "fermata.main:app", "--no-proxy-headers", "--proxy-headers"]
+    )
+    with pytest.raises(RuntimeError, match="no-proxy-headers"):
+        authproxy.check_proxy_header_safety()
+
+    monkeypatch.setattr(
+        sys, "argv", ["uvicorn", "fermata.main:app", "--proxy-headers", "--no-proxy-headers"]
+    )
+    authproxy.check_proxy_header_safety()  # must not raise - --no-proxy-headers wins last
+
+
 # ---------------------------------------------------------------------------
 # Unit level: the silent-open-state warnings (the review's SECOND item).
 # ---------------------------------------------------------------------------
@@ -208,26 +234,12 @@ def test_sanity_check_warns_when_trusted_proxies_set_without_a_header(monkeypatc
     assert any("FERMATA_AUTH_HEADER" in r.message for r in caplog.records)
 
 
-def test_sanity_check_warns_on_0_0_0_0_slash_0(monkeypatch, caplog):
-    monkeypatch.setattr(config, "AUTH_HEADER", "X-Remote-User")
-    monkeypatch.setattr(config, "AUTH_TRUSTED_NETWORKS", config.parse_trusted_proxies("0.0.0.0/0"))
-    with caplog.at_level(logging.ERROR, logger="fermata.authproxy"):
-        authproxy.check_auth_configuration_sanity()
-    assert any("0.0.0.0/0" in r.message for r in caplog.records)
-
-
-def test_sanity_check_warns_on_the_ipv6_equivalent(monkeypatch, caplog):
-    monkeypatch.setattr(config, "AUTH_HEADER", "X-Remote-User")
-    monkeypatch.setattr(config, "AUTH_TRUSTED_NETWORKS", config.parse_trusted_proxies("::/0"))
-    with caplog.at_level(logging.ERROR, logger="fermata.authproxy"):
-        authproxy.check_auth_configuration_sanity()
-    assert any("::/0" in r.message for r in caplog.records)
-
-
 def test_sanity_check_is_silent_in_the_two_normal_states(monkeypatch, caplog):
     """Off entirely, and on-with-a-real-subnet, are both intended states and
     must never produce an error-level log - a warning that fires on the
-    normal case trains an operator to ignore it."""
+    normal case trains an operator to ignore it. 0.0.0.0/0 and ::/0 are NOT
+    part of this claim any more - see check_trusted_proxies_are_not_everyone
+    below, which is fatal, not logged here."""
     with caplog.at_level(logging.ERROR, logger="fermata.authproxy"):
         monkeypatch.setattr(config, "AUTH_HEADER", "")
         monkeypatch.setattr(config, "AUTH_TRUSTED_NETWORKS", config.parse_trusted_proxies(""))
@@ -237,6 +249,50 @@ def test_sanity_check_is_silent_in_the_two_normal_states(monkeypatch, caplog):
         monkeypatch.setattr(config, "AUTH_TRUSTED_NETWORKS", config.parse_trusted_proxies("10.0.0.0/24"))
         authproxy.check_auth_configuration_sanity()
     assert caplog.records == []
+
+
+# ---------------------------------------------------------------------------
+# Unit level: 0.0.0.0/0 and ::/0 are FATAL, not a warning (the re-review's
+# GATE item). Escalated from check_auth_configuration_sanity above after a
+# second review pointed out that a server running with auth on and
+# trusted-proxies=0.0.0.0/0 authenticates any direct request as any claimed
+# username - strictly worse than no auth at all, and an error-level log is
+# invisible under `docker compose up -d`, which reports the container
+# healthy while it does this. A genuinely broad but REAL subnet
+# (10.0.0.0/8) stays a judgment call and stays a warning - see
+# test_sanity_check_is_silent_in_the_two_normal_states above, which already
+# covers a real /24 as one of the two states that must NOT raise or log.
+# ---------------------------------------------------------------------------
+
+
+def test_trusted_proxies_are_not_everyone_is_a_no_op_when_auth_is_off(monkeypatch):
+    monkeypatch.setattr(config, "AUTH_HEADER", "")
+    monkeypatch.setattr(config, "AUTH_TRUSTED_NETWORKS", config.parse_trusted_proxies("0.0.0.0/0"))
+    authproxy.check_trusted_proxies_are_not_everyone()  # must not raise
+
+
+def test_trusted_proxies_are_not_everyone_passes_for_a_real_subnet(monkeypatch):
+    """The judgment-call case: 10.0.0.0/8 is unusually broad, but it IS a
+    real, plausible subnet an operator's proxy could genuinely sit inside -
+    unlike 0.0.0.0/0, which no proxy's own address is ever equal to. Stays
+    a warning (see check_auth_configuration_sanity's docstring), not fatal."""
+    monkeypatch.setattr(config, "AUTH_HEADER", "X-Remote-User")
+    monkeypatch.setattr(config, "AUTH_TRUSTED_NETWORKS", config.parse_trusted_proxies("10.0.0.0/8"))
+    authproxy.check_trusted_proxies_are_not_everyone()  # must not raise
+
+
+def test_trusted_proxies_are_not_everyone_raises_on_0_0_0_0_slash_0(monkeypatch):
+    monkeypatch.setattr(config, "AUTH_HEADER", "X-Remote-User")
+    monkeypatch.setattr(config, "AUTH_TRUSTED_NETWORKS", config.parse_trusted_proxies("0.0.0.0/0"))
+    with pytest.raises(RuntimeError, match="0.0.0.0/0"):
+        authproxy.check_trusted_proxies_are_not_everyone()
+
+
+def test_trusted_proxies_are_not_everyone_raises_on_the_ipv6_equivalent(monkeypatch):
+    monkeypatch.setattr(config, "AUTH_HEADER", "X-Remote-User")
+    monkeypatch.setattr(config, "AUTH_TRUSTED_NETWORKS", config.parse_trusted_proxies("::/0"))
+    with pytest.raises(RuntimeError, match=r"::/0"):
+        authproxy.check_trusted_proxies_are_not_everyone()
 
 
 # ---------------------------------------------------------------------------
@@ -524,13 +580,14 @@ def test_lifespan_says_what_is_wrong_about_a_bad_cidr_first(app_env, monkeypatch
     assert any("not-an-ip-or-cidr" in r.message for r in caplog.records)
 
 
-def test_lifespan_warns_about_both_silent_open_misconfigurations(app_env, monkeypatch, caplog):
+def test_lifespan_warns_about_the_remaining_silent_open_misconfiguration(app_env, monkeypatch, caplog):
     """Proves main.py actually calls
     authproxy.check_auth_configuration_sanity() from its real lifespan -
     not just that the function raises/warns correctly when called directly
-    (see the unit tests above). Both misconfigurations warn but still
-    START, unlike the proxy-headers guard, so this is one successful
-    startup with two error-level log lines, not a raised exception."""
+    (see the unit tests above). Trusted-proxies-without-a-header warns but
+    still STARTS, unlike the proxy-headers guard and 0.0.0.0/0 (see the next
+    test), so this is one successful startup with an error-level log line,
+    not a raised exception."""
     monkeypatch.setattr("fermata.main.scanner.start_scan", lambda: False)
     monkeypatch.setattr(config, "AUTH_HEADER", "")
     monkeypatch.setattr(config, "AUTH_TRUSTED_PROXIES_RAW", "10.0.0.0/24")
@@ -543,14 +600,45 @@ def test_lifespan_warns_about_both_silent_open_misconfigurations(app_env, monkey
     assert any("FERMATA_AUTH_HEADER" in r.message for r in caplog.records)
 
 
+def test_lifespan_refuses_to_start_on_0_0_0_0_slash_0(app_env, monkeypatch):
+    """Proves main.py actually calls
+    authproxy.check_trusted_proxies_are_not_everyone() from its real
+    lifespan, in the SAME fatal try/except block as
+    check_proxy_header_safety - not just that the function raises when
+    called directly (see the unit tests above). The re-review's GATE item:
+    auth on plus trusted-proxies=0.0.0.0/0 must never reach a running,
+    request-serving state - the same "server refuses to start" outcome as
+    the proxy-headers guard, not merely a logged warning."""
+    from fermata import main
+
+    monkeypatch.setattr(main.scanner, "start_scan", lambda: False)
+    monkeypatch.setattr(config, "AUTH_HEADER", "X-Remote-User")
+    monkeypatch.setattr(config, "AUTH_TRUSTED_PROXIES_RAW", "0.0.0.0/0")
+    monkeypatch.setattr(sys, "argv", ["uvicorn", "fermata.main:app", "--no-proxy-headers"])
+    monkeypatch.delenv("FORWARDED_ALLOW_IPS", raising=False)
+
+    with pytest.raises(RuntimeError, match="0.0.0.0/0"):
+        with TestClient(main.app):
+            pass
+
+
 # ---------------------------------------------------------------------------
 # The full configuration state space (the review's SECOND item) - mirrors
 # the table in docs/deployment.md's "The full configuration state space"
 # exactly. For every row, a request from an address NOT on
 # FERMATA_TRUSTED_PROXIES, carrying a forged header, must come back with the
 # status this table says - "must be NO [200/authenticated]" for every row
-# labeled secure, and the two labeled-insecure rows are exactly the ones
+# labeled secure. The one remaining "insecure" row (trusted-proxies set,
+# header unset) is a live 200, logged, and is exactly what
 # check_auth_configuration_sanity warns about above.
+#
+# trusted-proxies=0.0.0.0/0 is DELIBERATELY NOT A ROW HERE ANY MORE (it was,
+# briefly, expecting 200): after the re-review escalated it from a warning
+# to a startup refusal, there is no "request a live client and check the
+# status code" for that state at all - the server never reaches a
+# request-serving state. See test_lifespan_refuses_to_start_on_0_0_0_0_slash_0
+# above for that state's own proof, over the real lifespan rather than a
+# parametrized request.
 # ---------------------------------------------------------------------------
 
 
@@ -559,7 +647,6 @@ STATE_SPACE = [
     pytest.param("", "10.0.0.0/24", 200, id="header-unset_proxies-set_open-and-warned"),
     pytest.param("X-Remote-User", "", 401, id="header-set_proxies-empty_fail-closed"),
     pytest.param("X-Remote-User", "192.0.2.0/24", 401, id="header-set_proxies-real-subnet_secure"),
-    pytest.param("X-Remote-User", "0.0.0.0/0", 200, id="header-set_proxies-trust-everyone_insecure-and-warned"),
 ]
 
 

--- a/server/tests/test_live_server_proxy_headers.py
+++ b/server/tests/test_live_server_proxy_headers.py
@@ -1,0 +1,226 @@
+"""A real `uvicorn` process, talked to over a real socket - the one layer
+server/tests/test_authproxy.py cannot reach (see that file's own module
+docstring).
+
+WHY THIS FILE EXISTS. Issue #16's reverse-proxy authentication trusts a
+header naming the logged-in user, but only from a request whose peer address
+is on an operator-configured allowlist - the peer address being the one
+thing a client cannot forge, or so the first version of this feature
+assumed. Review found that assumption false: `uvicorn` runs its own
+`ProxyHeadersMiddleware` OUTSIDE the ASGI app, by default (`--proxy-headers`,
+with `forwarded_allow_ips` defaulting to `127.0.0.1`), and that middleware
+REWRITES `scope["client"]` from a client-supplied `X-Forwarded-For` header
+before a single line of Fermata's own code - including
+RemoteUserAuthMiddleware - ever runs. `TestClient` never opens a socket and
+never goes near `uvicorn`'s own server layer at all, so nothing in
+test_authproxy.py's 39 tests, all passing, could see this: the bypass was
+reproduced for real, against a real `uvicorn fermata.main:app` process with
+the ORIGINAL Dockerfile CMD, before the fix (`--no-proxy-headers`, plus the
+`authproxy.check_proxy_header_safety` startup guard) existed:
+
+    curl -H 'X-Remote-User: eve' http://127.0.0.1:PORT/api/me
+        -> 401 (correct - direct request, no proxy involved)
+    curl -H 'X-Remote-User: eve' -H 'X-Forwarded-For: <a-trusted-address>' \\
+        http://127.0.0.1:PORT/api/me
+        -> 200, {"enabled": true, "username": "eve"}   <- THE BYPASS
+
+The two tests below are the closed version of exactly that experiment,
+proving both halves of the fix:
+
+1. test_xff_forgery_does_not_bypass_auth_when_proxy_headers_are_off - with
+   `--no-proxy-headers` (what the Dockerfile's CMD and README's dev-run
+   command both now pass), the same forged X-Forwarded-For does nothing;
+   `scope["client"]` is always the real socket peer.
+2. test_server_refuses_to_start_without_confirming_proxy_headers_off -
+   WITHOUT that flag, and with reverse-proxy auth turned on, the server
+   cannot even reach a state where request 2 above would matter: it refuses
+   to start at all. Together, these two prove there is no longer a reachable
+   state where the bypass works - the unsafe launch never serves a request,
+   and the safe launch is not forgeable.
+"""
+
+import http.client
+import os
+import socket
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+SERVER_ROOT = Path(__file__).resolve().parents[1]  # server/
+STARTUP_TIMEOUT = 20.0
+
+
+def _free_port() -> int:
+    """A real ephemeral TCP port, picked the same way the OS would for an
+    outgoing connection - bind, read back the assigned port, release it
+    immediately. There is a narrow window where something else could grab
+    it before uvicorn does; the same risk this project's own
+    web/playwright.config.js accepts for its dev-server port, and cheap
+    enough that retrying on a bind failure is not worth the complexity."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _get(port: int, path: str, headers: list[tuple[str, str]] | None = None):
+    """A raw HTTP GET over http.client - not httpx/TestClient, and
+    deliberately so: this needs to send the SAME two headers as two
+    genuinely separate wire lines when asked to (see the duplicate-header
+    test in test_authproxy.py for why that distinction matters), which
+    http.client's `putheader`, called once per (name, value) pair, does
+    directly rather than through any library that might normalize or
+    collapse repeated header names first."""
+    conn = http.client.HTTPConnection("127.0.0.1", port, timeout=5)
+    try:
+        conn.putrequest("GET", path, skip_accept_encoding=True)
+        for name, value in headers or []:
+            conn.putheader(name, value)
+        conn.endheaders()
+        resp = conn.getresponse()
+        body = resp.read()
+        return resp.status, body
+    finally:
+        conn.close()
+
+
+def _wait_until_serving(port: int, timeout: float = STARTUP_TIMEOUT) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            status, _ = _get(port, "/api/health")
+            if status == 200:
+                return True
+        except (ConnectionRefusedError, OSError, TimeoutError):
+            pass
+        time.sleep(0.2)
+    return False
+
+
+def _spawn_uvicorn(tmp_path, port: int, extra_args: list[str], env_overrides: dict[str, str]):
+    """Launches `python -m uvicorn fermata.main:app` against a throwaway
+    library/config pair under tmp_path - the same shape
+    web/playwright.config.js's own `webServer` block uses to start a real
+    Fermata for the browser test suite, the closest existing precedent in
+    this repository for spawning a live server from a test runner."""
+    library = tmp_path / "library"
+    library.mkdir()
+    config_dir = tmp_path / "config"
+    env = dict(os.environ)
+    env.pop("FORWARDED_ALLOW_IPS", None)  # never let the ambient environment leak this in
+    env.update({
+        "FERMATA_LIBRARY": str(library),
+        "FERMATA_CONFIG": str(config_dir),
+        "PYTHONPATH": str(SERVER_ROOT),
+    })
+    env.update(env_overrides)
+    return subprocess.Popen(
+        [
+            sys.executable, "-m", "uvicorn", "fermata.main:app",
+            "--host", "127.0.0.1", "--port", str(port),
+            *extra_args,
+        ],
+        cwd=str(SERVER_ROOT), env=env,
+        stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True,
+    )
+
+
+def _terminate(proc: subprocess.Popen) -> str:
+    """Stops the process and returns whatever it printed - used both for
+    cleanup and, in the refuses-to-start test, as the evidence for WHY it
+    exited."""
+    if proc.poll() is None:
+        proc.terminate()
+        try:
+            proc.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait(timeout=5)
+    try:
+        return proc.stdout.read() or ""
+    except Exception:
+        return ""
+
+
+def test_xff_forgery_does_not_bypass_auth_when_proxy_headers_are_off(tmp_path):
+    """The fix, proven against a real socket: `--no-proxy-headers` present
+    (what the Dockerfile's CMD and README's dev-run command now both pass),
+    reverse-proxy auth on, trusting an address that is NOT this test's own
+    loopback peer - mirroring the manual reproduction in this module's
+    docstring exactly, but asserting the closed result instead of the open
+    one."""
+    port = _free_port()
+    proc = _spawn_uvicorn(
+        tmp_path, port,
+        extra_args=["--no-proxy-headers"],
+        env_overrides={
+            "FERMATA_AUTH_HEADER": "X-Remote-User",
+            # An address that will never actually be this test's peer - this
+            # test always connects from 127.0.0.1 (loopback), so a
+            # SUCCESSFUL forgery would require uvicorn to have rewritten the
+            # peer to this address from the X-Forwarded-For header below.
+            "FERMATA_TRUSTED_PROXIES": "203.0.113.9/32",
+        },
+    )
+    try:
+        assert _wait_until_serving(port), (
+            "server did not become healthy in time:\n" + _terminate(proc)
+        )
+
+        # Sanity: the forged header ALONE, no X-Forwarded-For at all, is
+        # correctly refused - the real peer (loopback) is not on the trust
+        # list. Establishes the baseline the next request's result actually
+        # means something against.
+        status, body = _get(port, "/api/me", headers=[("X-Remote-User", "eve")])
+        assert status == 401, body
+
+        # THE BYPASS ATTEMPT: the same forged identity header, plus a
+        # forged X-Forwarded-For naming the address FERMATA_TRUSTED_PROXIES
+        # actually trusts. With --no-proxy-headers, uvicorn never looks at
+        # X-Forwarded-For at all, so scope["client"] stays the real peer
+        # (loopback, untrusted) and this must still be refused.
+        status, body = _get(
+            port, "/api/me",
+            headers=[("X-Remote-User", "eve"), ("X-Forwarded-For", "203.0.113.9")],
+        )
+        assert status == 401, (
+            f"XFF forgery bypassed reverse-proxy auth: got {status} {body!r} - "
+            "uvicorn's own X-Forwarded-For handling is rewriting the peer address "
+            "despite --no-proxy-headers"
+        )
+    finally:
+        _terminate(proc)
+
+
+def test_server_refuses_to_start_without_confirming_proxy_headers_off(tmp_path):
+    """The backstop, proven against a real process: WITHOUT
+    --no-proxy-headers, and with reverse-proxy auth turned on,
+    authproxy.check_proxy_header_safety() (wired into main.py's lifespan)
+    must refuse to start at all - the vulnerable state from this module's
+    docstring is not a state a real server can be running in once this
+    guard exists, which is what makes the previous test's "safe launch"
+    the ONLY reachable one with auth turned on."""
+    port = _free_port()
+    proc = _spawn_uvicorn(
+        tmp_path, port,
+        extra_args=[],  # --no-proxy-headers deliberately omitted
+        env_overrides={
+            "FERMATA_AUTH_HEADER": "X-Remote-User",
+            "FERMATA_TRUSTED_PROXIES": "203.0.113.9/32",
+        },
+    )
+    try:
+        became_healthy = _wait_until_serving(port, timeout=10.0)
+        output = _terminate(proc)
+        assert not became_healthy, (
+            "server became healthy without --no-proxy-headers while reverse-proxy "
+            "auth was on - the startup guard did not fire:\n" + output
+        )
+        assert "no-proxy-headers" in output, (
+            "server exited, but not for the reason this test expects - full output:\n"
+            + output
+        )
+    finally:
+        _terminate(proc)


### PR DESCRIPTION
Closes #16

## What this adds

Fermata still has no login of its own, but it can now trust one a reverse proxy (Caddy, Authelia, authentik, ...) already did - the standard remote-user-header pattern self-hosted services use.

- `FERMATA_AUTH_HEADER` (header name, use `X-Remote-User`) and `FERMATA_TRUSTED_PROXIES` (IP/CIDR allowlist) - both unset by default, which makes the middleware a complete no-op. Existing deployments behave identically after upgrading.
- The header is trusted **only** when the request's own TCP peer is on the trusted-proxy list - a request from anywhere else has the header ignored outright, closing the spoofing hole that trusting it unconditionally would open.
- `GET /api/health` stays exempt (Docker's own `HEALTHCHECK` polls it with no header). Every other route - API, SPA, `/docs`, `/openapi.json` - requires the header once auth is on.
- The identity is logged and exposed at `GET /api/me` (`{"enabled": bool, "username": str | None}`) for a future consumer (the planned MCP server, a possible sharing layer). It is **not** wired into the `owner` columns already on `practice_sessions` / `practice_goals` / `settings` / `instruments` - every query in the codebase still reads those against the single placeholder owner `local`, so writing a real username there would silently orphan a user's own data rather than build anything; that's the multi-user feature this issue explicitly excludes.
- `docs/deployment.md` gets a full "Reverse proxy authentication" section: both env vars, why uvicorn's own proxy-header trust must stay off, the full configuration state space as a table, and worked `docker-compose.yml` + Caddyfile examples for Caddy (tested for real against Docker, twice) and Authelia (checked for syntax only, says so).

## Two rounds of security review, both fixed, before merge

### Round 1

**1. BLOCKER - uvicorn's own X-Forwarded-For handling.** `uvicorn` runs its own `ProxyHeadersMiddleware` outside the ASGI app, on by default (`--proxy-headers`, `--forwarded-allow-ips` defaulting to `127.0.0.1`). It rewrites `scope["client"]` from a client-supplied `X-Forwarded-For` header before `RemoteUserAuthMiddleware` ever runs. A request straight to Fermata carrying both a forged `X-Remote-User` and a forged `X-Forwarded-For` naming a trusted proxy's address walked in as anyone - reproduced against a real `uvicorn` process running the original Dockerfile `CMD`:

```
curl -H 'X-Remote-User: eve' http://127.0.0.1:PORT/api/me
    -> 401  (correct)
curl -H 'X-Remote-User: eve' -H 'X-Forwarded-For: <a-trusted-address>' http://127.0.0.1:PORT/api/me
    -> 200 {"enabled": true, "username": "eve"}   <- THE BYPASS
```

`TestClient` never opens a real socket, so nothing in the original 39 passing tests could see this.

Fix: `--no-proxy-headers` added to the Dockerfile's `CMD` and README's dev-run command (the actual fix); `authproxy.check_proxy_header_safety()`, a belt-and-suspenders startup guard wired into `main.py`'s lifespan, refuses to start with reverse-proxy auth on unless it can confirm `--no-proxy-headers` on this process's own command line, or if `FORWARDED_ALLOW_IPS` is set at all. `server/tests/test_live_server_proxy_headers.py` spawns a real `uvicorn` subprocess over a real socket and proves both halves. Re-verified twice against real Docker + Caddy containers.

**2. Two silent-open misconfiguration states** (see Round 2 below - one of these was escalated further). `FERMATA_TRUSTED_PROXIES` set without `FERMATA_AUTH_HEADER`, and `FERMATA_TRUSTED_PROXIES=0.0.0.0/0`/`::/0`, both used to only log an error.

**3. Header-name / append-vs-replace mismatch.** The docs offered `X-Remote-User` and `Remote-User` as interchangeable `FERMATA_AUTH_HEADER` choices beside a Caddy example that only protected `X-Remote-User` - so following the doc's own suggestion could leave the other name completely unprotected. Separately, Starlette reads the first occurrence of a duplicated header, so a proxy that appends rather than replaces could let a client's forged copy win. Fix: docs name exactly one header everywhere with a boxed warning; Fermata now refuses outright (`401`) whenever the configured header arrives more than once, verified with a request reaching the ASGI scope as two genuinely separate wire lines (not httpx's default comma-joining). The Authelia example was independently verified already safe.

**Nits:** `FERMATA_TRUSTED_PROXIES` is no longer parsed at import time (a bad CIDR now fails through the same readable-message-before-traceback path as every other startup misconfiguration, via `config.load_auth_trusted_networks()` called from the lifespan); an IPv4-mapped IPv6 peer (`::ffff:x.x.x.x`) is unwrapped before the trust check; `--root-path` breaking the `/api/health` exemption is documented as a fail-closed caveat rather than fixed, since nothing in this project's deployment story uses it.

### Round 2 (re-review)

**GATE - `0.0.0.0/0` / `::/0` now refuse to start, not warn.** The re-review correctly escalated this: with auth on and `FERMATA_TRUSTED_PROXIES=0.0.0.0/0`, the running server authenticates any direct request as any claimed username and serves that identity at `/api/me` - strictly worse than no auth at all, and an error-level log line is invisible under `docker compose up -d` (the container reports healthy while doing it). `authproxy.check_trusted_proxies_are_not_everyone()` moved this into the same fatal `RuntimeError` path as `check_proxy_header_safety()`, called from `main.py`'s lifespan. A genuinely broad but real subnet (`10.0.0.0/8`) stays a warning via `check_auth_configuration_sanity()` - that one is a judgment call an operator could plausibly mean; `0.0.0.0/0` never is, since no proxy's own address is ever "the entire internet."

**NIT - the proxy-headers startup guard was argv-only and order-blind.** `"--no-proxy-headers" in sys.argv` is satisfied by `--no-proxy-headers --proxy-headers`, which actually leaves proxy headers ON - confirmed directly against click's own `CliRunner` that a paired flag/negation resolves by whichever occurrence comes LAST. Fixed `_proxy_headers_confirmed_off()` to check the last of the two flags to appear, not merely whether the negation appears anywhere.

`docs/deployment.md`'s state-space table and "Turning it on" section updated: `0.0.0.0/0` is now "refuses to start", not "logged as an error, still serves".

## The full configuration state space (post both rounds)

| `FERMATA_AUTH_HEADER` | `FERMATA_TRUSTED_PROXIES` | Forged request from an untrusted address | Notes |
|---|---|---|---|
| unset | unset | `200`, unauthenticated | The default - not a bypass, there is no auth to bypass |
| unset | set | `200`, unauthenticated | **Logged as an error at startup**, still starts - almost always a header-name typo |
| set | unset (empty) | `401` | Fail closed |
| set | a real address/subnet not matching the request | `401` | The intended-secure state every example configures |
| set | `0.0.0.0/0` or `::/0` | *(no request ever answers)* | **Refuses to start** - never a real proxy's address, worse than auth off |
| set | forged `X-Forwarded-For` naming a trusted address, real peer untrusted | `401` | Proven over a real socket - the Round 1 bypass, closed |
| set, `--no-proxy-headers` not confirmed | (any) | *(no request ever answers)* | **Refuses to start** |

## Mutation testing (all reverted after confirming, re-run after the rebase below)

- Dropping the trusted-proxy check -> 8 tests red.
- Flipping the default header on -> 3 tests red.
- Dropping the health exemption -> 3 tests red.
- Dropping the duplicate-header check -> 1 test red.
- Disabling the remaining sanity-warning check (header-unset, proxies-set) -> 2 tests red.
- Dropping IPv4-mapped normalization -> 1 test red.
- Disabling the `0.0.0.0/0`/`::/0` refuse-to-start gate -> 3 tests red.
- Reverting the argv check to the naive `in` test (reopening the decoy) -> 1 test red.
- Reverting `--no-proxy-headers` in the live test's own spawn (app-level guard also disabled) -> reproduces the exact original bypass, `200` instead of `401`.
- Disabling the app-level `check_proxy_header_safety()` call -> server starts (and stays healthy) without the flag; the refuses-to-start test goes red.

## Rebase

Rebased onto current `main` twice as it moved: first onto `#56` (library management), then onto `#57` (practice progress, `ea72a3a`), which independently bumped the pinned OpenAPI operation count to 51 for its own new endpoint - a genuine conflict with this PR's own bump to 51 for `/api/me`. Resolved to **52** (both endpoints present) and confirmed live against the running app's actual `openapi()` schema: 52 total operations, `GET /api/me` present, `GET /api/scores/{score_id}/practice/progress` (#57) present.

## Test baseline

`server/`, `PYTHONPATH` pointed at this worktree, `pytest -rs`, on the fully rebased tree: **1001 passed**, 72 skipped (pre-existing `FERMATA_TEST_LIBRARY`/`FERMATA_MUSICXML_XSD` skips), 1 failed. That one failure (`test_the_summary_says_how_many_tests_skipped_for_want_of_a_library`) is a pre-existing, order-dependent flake unrelated to this change - passes in isolation, and fails the same way on `main` before any of this branch's commits.

## Scope notes

- No route definitions in `api.py` were changed - only one new route added (`GET /me`) plus two import lines. The auth mechanism itself is middleware wrapping the whole app.
- Not merged - awaiting re-review.
