### PR TITLE
Answer how this piece is going, and refuse to draw a line through it (#57)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -132,9 +132,10 @@ A deleted score's row is still there, which is what makes deleting recoverable,
 so every endpoint that takes a score id can still reach one:
 
 - **Reads answer normally** — `GET /api/scores/{id}`, its `/file`, `/thumb`,
-  `/transcription` and `/practice`. The trash view is built out of exactly those
-  responses, and being able to look at a score before destroying it for ever is
-  the point of a trash you can change your mind from.
+  `/transcription`, `/practice` and `/practice/progress`. The trash view is
+  built out of exactly those responses, and being able to look at a score
+  before destroying it for ever is the point of a trash you can change your
+  mind from.
 - **Writes are refused with `409`** — `PATCH /api/scores/{id}`, logging practice
   against it by either route, setting a goal about it, and extracting, saving or
   deleting its transcription. Each means "work on this piece"; nothing in the
@@ -148,6 +149,9 @@ so every endpoint that takes a score id can still reach one:
   longer holds. `score_deleted` is **not** `score_missing`: the first means the
   score is in the trash and can be put back, the second means its row is gone
   and there is no piece left to name.
+  `GET /api/scores/{id}/practice/progress` answers in full for a deleted score
+  too, with `deleted: true` — refusing would be this API deciding a deletion
+  erases practice, and the hours were still spent.
 
 Deleting a score whose file has **already** gone is allowed and answers
 `file_moved: false` with `trashed_to: null` — nothing was moved, because there

--- a/docs/practice-data.md
+++ b/docs/practice-data.md
@@ -182,6 +182,16 @@ period gains one question - *was this goal realistic?* - whose answer is
 - **No verdict vocabulary.** The interface states counts - "3 of 4 planned
   days" - and stops. `web/src/lib/practice.js` owns the phrasing and carries
   the word list its tests check it against.
+- **No trend line, and no rate of improvement.** This one bites hardest on the
+  per-piece view (#57), where there is a single subject and a row of numbers
+  about it. The tempo points are stated with their days and joined in the order
+  they happened; nothing fits a line through them, reports a slope, or says a
+  piece is coming on. A piece is put down for a fortnight and picked up again
+  by design, and a direction drawn through that is a claim about somebody's
+  playing these numbers cannot support.
+- **No average rating.** Counts per rating and never a mean, for the same
+  reason a drill records counts and never a rate: a number out of five with a
+  decimal point on it is a mark rather than a fact, and it invites a colour.
 
 ## Asking questions
 
@@ -212,6 +222,41 @@ the questions rather than around the tables.
 - `GET /api/practice/history?days=&today=` - per-day totals, per-piece totals
   and per-activity totals over a window of up to a year. *Where has the time
   gone over three months.*
+- `GET /api/scores/{id}/practice/progress?days=&today=&limit=` - **how one
+  piece is going.** *Where am I with this piece.* One response, because
+  reassembling it from the general endpoints meant a client filtering the whole
+  history by `score_id` and doing the arithmetic itself - the arithmetic a
+  second reader of this API would then write again and get subtly differently.
+  It carries:
+
+  | Block | What it answers |
+  | --- | --- |
+  | `all_time` | Sessions, seconds, minutes, and the **first** and **last** practice day. The one block no window bounds. |
+  | `window` | `period_facts` scoped to this piece: every day in the window including the empty ones, and the window's totals. |
+  | `tempo` | One point per session that recorded a tempo, oldest first, with its day, its target and `reached_target`. |
+  | `modes` | Section work against run-throughs, and the sessions that said neither. |
+  | `ratings` | How many sessions got each 1-5 rating, and how many got none. Every bucket present, whether or not it was ever chosen. |
+  | `goals` | Goals scoped to **this piece** whose period touches the window, each with its progress. Never a `scope='all'` goal. |
+  | `sessions` | This piece's own sessions in the window, newest first, with their notes - and `session_total` / `sessions_truncated` beside them. |
+
+  `practised` says whether the piece has ever been practised at all, which is a
+  different fact from a window of zeros and is what lets an interface show a
+  real empty state rather than a screen of noughts. `deleted` is true for a
+  piece in the trash: it answers in full and is still counted, and only the way
+  into the library goes away. `grouped_by` names the column every figure was
+  grouped by, always `local_date` - see *Why the practice day is stored rather
+  than derived*.
+
+  On the tempo block specifically: `comparable` is false for a single point.
+  One session at a tempo is one session at a tempo, and a view that draws it as
+  a progression is inventing the thing the reader came to look for.
+  `sessions_without_tempo` is how much of the piece's practice those points say
+  nothing about. `axis_low` and `axis_high` span both the tempos and the
+  targets and exist so a chart's bounds are decided once rather than by each
+  reader separately; **they are not a personal best**, nothing states them as
+  text, and no field here compares one point to another. `latest_target` is the
+  target most recently written down, not the highest ever set - somebody who
+  decided 140 was too fast and set 110 is aiming at 110.
 - `GET /api/scores?practiced=recent|neglected` - the library's own views.
   *Which pieces have I neglected.* Windowed on the practice day, like
   everything else: the library is the view a person sees first, so it must not

--- a/server/fermata/api.py
+++ b/server/fermata/api.py
@@ -49,6 +49,7 @@ from .api_models import (
     ScoreMoveOut,
     ScoreOut,
     ScorePracticeOut,
+    ScoreProgressOut,
     ScorePurgeOut,
     ScoreRestoreOut,
     SessionDeleteOut,
@@ -3286,4 +3287,96 @@ def purge_score(score_id: RowId):
         "transcriptions_destroyed": counts["transcriptions"],
         "practice_sessions_kept": counts["practice_sessions"],
         "goals_kept": counts["goals"],
+    }
+
+
+# ---------------------------------------------------------------------------
+# HOW IS THIS PIECE GOING (#57).
+#
+# The practice page answers "how am I doing" across the library. This answers
+# the other question the issue names and treats it as a different one, because
+# it is: deciding what to practise next needs the per-piece picture as much as
+# the overall one, and the two are not slices of each other. "When did I last
+# play this" has no window; "where did the time go this quarter" has nothing
+# else.
+#
+# ONE ENDPOINT AND NOT SIX, and every figure on it computed here. A client that
+# had to fetch the sessions for one score and total them itself would be
+# writing the arithmetic this module already owns - and the second reader of
+# this surface (the planned MCP server, #31) would then write it a third time,
+# slightly differently, with nothing to say which of the three was right. See
+# issue #32's design rules: every field readable through the documented API, so
+# any future integration wraps one source of truth.
+#
+# WHAT IS NOT HERE, deliberately: no streak and no run of days, no trend line
+# through the tempo points, no average rating, and no comparison between this
+# window and any other. All four are listed under "what is deliberately absent"
+# in docs/practice-data.md and asked for by name in issue #3's own "deliberately
+# not" list. A per-piece view is where each would be most tempting and would do
+# the most damage - a piece is put down and picked up again by design, and a
+# run of days is a number that punishes exactly that.
+# ---------------------------------------------------------------------------
+
+
+@router.get(
+    "/scores/{score_id}/practice/progress",
+    tags=[TAG_PRACTICE],
+    response_model=ScoreProgressOut,
+)
+def score_practice_progress(
+    score_id: RowId,
+    days: int = practice.DEFAULT_HISTORY_DAYS,
+    today: str | None = None,
+    limit: int = practice.DEFAULT_SCORE_SESSION_LIMIT,
+):
+    """How one piece is going: its whole record, the last stretch of days a
+    piece at a time, the tempo each session was practised at, how the time
+    split between section work and run-throughs, what was written about it,
+    and any goal set about this piece.
+
+    Every figure is grouped by the practice day, which the response names in
+    `grouped_by` - see the model for what that means for a session whose day
+    was not recorded. `all_time` is the one block the window does not bound.
+
+    A piece in the trash answers this in full and says so: the practice still
+    counts, and only the way into the library goes away (#56).
+    """
+    if not 1 <= days <= practice.MAX_HISTORY_DAYS:
+        raise HTTPException(422, f"days must be between 1 and {practice.MAX_HISTORY_DAYS}")
+    if not 1 <= limit <= practice.MAX_SCORE_SESSION_LIMIT:
+        raise HTTPException(
+            422, f"limit must be between 1 and {practice.MAX_SCORE_SESSION_LIMIT}"
+        )
+    end = _today(today)
+    start = end - timedelta(days=days - 1)
+    first, last = start.isoformat(), end.isoformat()
+    conn = connect()
+    # _score_row and NOT _live_score_row: a piece in the trash still has every
+    # hour that was ever spent on it, and refusing to report them would be this
+    # application deciding a deletion erases practice - which is the one thing
+    # the whole feature is built not to do. The row says `deleted` instead.
+    row = _score_row(conn, score_id)
+    all_time = practice.score_all_time(conn, score_id)
+    listed = practice.score_sessions(conn, score_id, first, last, limit=limit)
+    return {
+        "score_id": score_id,
+        "title": row["title"],
+        "deleted": row["deleted_at"] is not None,
+        # Asked of the whole record and not of the window: a piece practised
+        # solidly last year and untouched since has been practised, and a view
+        # that greeted it with "nothing logged yet" would be wrong about the
+        # one thing this page exists to remember.
+        "practised": all_time["sessions"] > 0,
+        "start": first,
+        "end": last,
+        "grouped_by": practice.GROUPED_BY,
+        "all_time": all_time,
+        "window": practice.period_facts(conn, first, last, scope="score", score_id=score_id),
+        "tempo": practice.tempo_progression(conn, score_id, first, last),
+        "modes": practice.mode_totals(conn, score_id, first, last),
+        "ratings": practice.rating_counts(conn, score_id, first, last),
+        "goals": practice.score_goals(conn, score_id, first, last, end),
+        "sessions": listed["sessions"],
+        "session_total": listed["total"],
+        "sessions_truncated": listed["truncated"],
     }

--- a/server/fermata/api_models.py
+++ b/server/fermata/api_models.py
@@ -445,6 +445,117 @@ class PracticeReviewOut(BaseModel):
 
 
 # ---------------------------------------------------------------------------
+# Practice: one piece (#57)
+# ---------------------------------------------------------------------------
+
+
+class ScoreAllTimeOut(BaseModel):
+    """practice.score_all_time: this piece's whole record, ignoring the window
+    every other block on the response is bounded by. `first_practised` and
+    `last_practised` are practice DAYS, not timestamps - null when the piece
+    has never been practised, which is not the same as a day of zero."""
+
+    sessions: int
+    seconds: int
+    minutes: int
+    first_practised: str | None
+    last_practised: str | None
+    sessions_inferred: int
+
+
+class TempoPointOut(BaseModel):
+    """One session's tempo, as practice.tempo_progression reports it. Two
+    numbers somebody entered and the day they entered them for; nothing here
+    is fitted, smoothed or extrapolated."""
+
+    session_id: int
+    date: str
+    tempo_bpm: int
+    target_tempo_bpm: int | None
+    reached_target: bool | None
+    mode: str | None
+
+
+class TempoProgressionOut(BaseModel):
+    """practice.tempo_progression's return shape.
+
+    `axis_low` / `axis_high` are the bounds a chart of these points needs and
+    are not a personal best - see that function's docstring. `comparable` is
+    false for a single point, which is the response saying outright that there
+    is no progression here to draw. Both bounds are null when there are no
+    points at all."""
+
+    points: list[TempoPointOut]
+    count: int
+    sessions_without_tempo: int
+    axis_low: int | None
+    axis_high: int | None
+    latest_target: int | None
+    comparable: bool
+
+
+class ByModeOut(BaseModel):
+    """practice.mode_totals: section work against run-throughs, for one piece.
+    `mode` is null for the sessions that did not say which they were."""
+
+    mode: str | None
+    seconds: int
+    sessions: int
+
+
+class RatingCountOut(BaseModel):
+    rating: int
+    sessions: int
+
+
+class RatingsOut(BaseModel):
+    """practice.rating_counts: how many sessions got each 1-5 rating. Counts
+    and never a mean - see that function's docstring."""
+
+    counts: list[RatingCountOut]
+    rated: int
+    unrated: int
+
+
+class ScoreProgressOut(BaseModel):
+    """GET /api/scores/{id}/practice/progress - how one piece is going (#57).
+
+    `grouped_by` names the column every figure below was grouped and filtered
+    by, and is always practice.GROUPED_BY. It is stated rather than assumed
+    because it is the answer to a question a reader of these numbers has to
+    ask: a day here is the practiser's own calendar day where their client
+    recorded one, and the UTC day of the timestamp where it did not. See
+    `all_time.sessions_inferred` and `window.sessions_inferred` for how much of
+    each total rests on the second kind.
+
+    `deleted` is true for a piece in the trash. Its practice is still counted
+    here in full - the hours were spent - and a client must not offer it as
+    somewhere to go (#56).
+
+    `practised` is whether this piece has ever been practised at all. False
+    means every figure below is a zero about a piece nobody has played yet,
+    which is a different thing from a quiet window, and a view that cannot tell
+    them apart shows a new user a wall of noughts as though it were data."""
+
+    score_id: int
+    title: str
+    deleted: bool
+    practised: bool
+    start: str
+    end: str
+    grouped_by: str
+    all_time: ScoreAllTimeOut
+    window: PeriodFactsOut
+    tempo: TempoProgressionOut
+    modes: list[ByModeOut]
+    ratings: RatingsOut
+    goals: list[GoalOut]
+    sessions: list[PracticeSessionOut]
+    session_total: int
+    sessions_truncated: bool
+
+
+# ---------------------------------------------------------------------------
 # Transcription
 # ---------------------------------------------------------------------------
 

--- a/server/fermata/practice.py
+++ b/server/fermata/practice.py
@@ -144,6 +144,21 @@ MAX_HISTORY_DAYS = 366
 DEFAULT_SESSION_LIMIT = 100
 MAX_SESSION_LIMIT = 1_000
 
+# How many of one piece's sessions come back with its progress, and how many
+# goals about it. Both are windowed already, so these bound a window somebody
+# practised unusually hard in rather than a whole history - and both report
+# what they truncated, the way every other list here does.
+DEFAULT_SCORE_SESSION_LIMIT = 200
+MAX_SCORE_SESSION_LIMIT = 1_000
+MAX_SCORE_GOALS = 52
+
+# The column every aggregate in this module groups and filters by, named on
+# each response that carries one. A day is `local_date` where the practiser's
+# own clock recorded it and `date(started_at)` where it did not, and a reader
+# totalling by day needs to know which question was asked of the rows - see
+# LOCAL_DATE_SQL and the note above it.
+GROUPED_BY = "local_date"
+
 # The day a session belongs to, in SQL, for every query that groups or filters
 # by day. Written once because it is not a formula anyone should retype: the
 # COALESCE is what attributes a row from before local_date existed, and a query
@@ -787,4 +802,270 @@ def time_spent(
         "by_activity": [dict(r) for r in by_activity],
         "scores_worked": scores_worked,
         "by_score_truncated": scores_worked > len(by_score),
+    }
+
+
+# ---------------------------------------------------------------------------
+# ONE PIECE: how is this piece going (#57).
+#
+# Everything above answers "how am I doing" across the library. This answers
+# the other question the issue names, and says it is a different one: a person
+# deciding what to practise next needs the per-piece picture as much as the
+# overall one, and reassembling it from the general endpoints meant a client
+# filtering the whole history by score_id and doing the arithmetic itself -
+# which is the arithmetic a second reader (the planned MCP server, #31) would
+# then have to write again and get subtly differently.
+#
+# WHAT THIS DELIBERATELY DOES NOT COMPUTE, and will not:
+#
+#   No streak, and no run of days. docs/practice-data.md lists it under what
+#   is deliberately absent, and issue #3 asks for it by name in its "deliberately
+#   not" list: missing a week because of a busy job is information, not a moral
+#   failure. A per-piece view is exactly where a run of days would be most
+#   tempting and would do the most damage, since a piece is put down and picked
+#   up again by design.
+#
+#   No fitted line through the tempo points, and no rate of improvement. The
+#   points themselves are facts somebody entered; a slope drawn through three
+#   of them is this application claiming to know something it does not, which
+#   is the "without pretending to more analysis than the data supports" half of
+#   the issue. `comparable` says whether there is more than one point, so a
+#   reader can decline to draw anything rather than drawing a confident line
+#   through a single session.
+#
+#   No average rating and no accuracy. Counts per rating and never a mean, for
+#   the same reason a drill records counts and never a rate: a number out of
+#   five is a mark rather than a fact, and it invites a colour.
+# ---------------------------------------------------------------------------
+
+
+def score_all_time(conn, score_id: int, *, owner: str = DEFAULT_OWNER) -> dict:
+    """Everything ever practised on one piece, ignoring any window.
+
+    Separate from the windowed figures beside it, and named so, because "when
+    did I last play this" has no window: a piece untouched for four months
+    answers that with a date and answers "how much this quarter" with a zero,
+    and the two must not be read off each other. `first_practised` is the day
+    it entered the record, which is the only honest way to say how long
+    somebody has been working on something.
+    """
+    row = conn.execute(
+        f"""SELECT COUNT(*) AS sessions,
+                   COALESCE(SUM(p.seconds), 0) AS seconds,
+                   MIN({LOCAL_DATE_SQL}) AS first_practised,
+                   MAX({LOCAL_DATE_SQL}) AS last_practised,
+                   COALESCE(SUM(CASE WHEN p.local_date IS NULL THEN 1 ELSE 0 END), 0)
+                       AS sessions_inferred
+              FROM practice_sessions p
+             WHERE p.owner = ? AND p.score_id = ?""",
+        (owner, score_id),
+    ).fetchone()
+    seconds = row["seconds"]
+    return {
+        "sessions": row["sessions"],
+        "seconds": seconds,
+        # Floored, like every other minute figure here, so this can never
+        # claim a minute that was not practised.
+        "minutes": seconds // 60,
+        "first_practised": row["first_practised"],
+        "last_practised": row["last_practised"],
+        "sessions_inferred": row["sessions_inferred"],
+    }
+
+
+def tempo_progression(
+    conn, score_id: int, start: str, end: str, *, owner: str = DEFAULT_OWNER
+) -> dict:
+    """The tempo each session on this piece was practised at, oldest first.
+
+    THE POINTS ARE THE ANSWER. Each one is two numbers somebody entered - what
+    they played it at and what they were aiming for - and their own day. There
+    is no fitted line, no slope, no "improving", and no figure for how much
+    faster this month is than last: a tempo ladder is climbed and fallen off
+    and climbed again, and a trend drawn through that is a claim about a
+    person's playing that these numbers cannot support.
+
+    `axis_low` and `axis_high` are the chart's bounds and nothing else. They
+    span both numbers, so a target line fits on the same axis as the tempos
+    under it, and they are computed here rather than in a client because two
+    readers deriving an axis differently is two charts that disagree about the
+    same history. They are NOT a personal best: nothing states them as text,
+    and there is no field here comparing one point to another.
+
+    `comparable` is whether there is more than one point. One session at a
+    tempo is one session at a tempo - it is not a progression, and a view that
+    draws it as one is inventing the thing the reader came to look for.
+    `sessions_without_tempo` is how much of this piece's practice these points
+    say nothing about, so a sparse chart is not read as a sparse month.
+    """
+    rows = conn.execute(
+        f"""SELECT p.id AS session_id, {LOCAL_DATE_SQL} AS date,
+                   p.tempo_bpm, p.target_tempo_bpm, p.mode
+              FROM practice_sessions p
+             WHERE p.owner = ? AND p.score_id = ? AND p.tempo_bpm IS NOT NULL
+               AND {LOCAL_DATE_SQL} BETWEEN ? AND ?
+          ORDER BY date, p.started_at, p.id""",
+        (owner, score_id, start, end),
+    ).fetchall()
+    points = []
+    for r in rows:
+        tempo, target = r["tempo_bpm"], r["target_tempo_bpm"]
+        points.append(
+            {
+                "session_id": r["session_id"],
+                "date": r["date"],
+                "tempo_bpm": tempo,
+                "target_tempo_bpm": target,
+                # The same derivation session_dict makes, for the same reason:
+                # a stored answer is one that can contradict the two numbers it
+                # came from. None means one of them is missing, which is not
+                # the same as "did not reach it".
+                "reached_target": None if target is None else tempo >= target,
+                "mode": r["mode"],
+            }
+        )
+    without_tempo = conn.execute(
+        f"""SELECT COUNT(*) AS n FROM practice_sessions p
+             WHERE p.owner = ? AND p.score_id = ? AND p.tempo_bpm IS NULL
+               AND {LOCAL_DATE_SQL} BETWEEN ? AND ?""",
+        (owner, score_id, start, end),
+    ).fetchone()["n"]
+    numbers = [p["tempo_bpm"] for p in points]
+    numbers += [p["target_tempo_bpm"] for p in points if p["target_tempo_bpm"] is not None]
+    # The target most recently written down, which is what a piece is currently
+    # being worked towards. The LATEST and not the highest ever set: somebody
+    # who decided 120 was too fast and set 100 is aiming at 100, and reporting
+    # the number they abandoned would be this view arguing with them.
+    latest_target = next(
+        (p["target_tempo_bpm"] for p in reversed(points) if p["target_tempo_bpm"] is not None),
+        None,
+    )
+    return {
+        "points": points,
+        "count": len(points),
+        "sessions_without_tempo": without_tempo,
+        "axis_low": min(numbers) if numbers else None,
+        "axis_high": max(numbers) if numbers else None,
+        "latest_target": latest_target,
+        "comparable": len(points) > 1,
+    }
+
+
+def mode_totals(
+    conn, score_id: int, start: str, end: str, *, owner: str = DEFAULT_OWNER
+) -> list[dict]:
+    """Where this piece's time went between picking at a section and playing it
+    through - #32's "distinguish focused section work from full run-throughs",
+    asked of one piece.
+
+    A session that did not say which it was comes back with `mode` null rather
+    than being dropped or filed under one of the two. It is time that was
+    genuinely spent, and guessing which kind it was from whether a bar range
+    happens to be present is exactly what the stored column exists to avoid.
+    """
+    rows = conn.execute(
+        f"""SELECT p.mode, SUM(p.seconds) AS seconds, COUNT(*) AS sessions
+              FROM practice_sessions p
+             WHERE p.owner = ? AND p.score_id = ? AND {LOCAL_DATE_SQL} BETWEEN ? AND ?
+          GROUP BY p.mode
+          ORDER BY seconds DESC, p.mode IS NULL, p.mode""",
+        (owner, score_id, start, end),
+    ).fetchall()
+    return [dict(r) for r in rows]
+
+
+def rating_counts(
+    conn, score_id: int, start: str, end: str, *, owner: str = DEFAULT_OWNER
+) -> dict:
+    """How many sessions on this piece got each 1-5 rating, and how many got
+    none.
+
+    COUNTS AND NEVER A MEAN. An average rating is a mark out of five wearing a
+    decimal point, and it is the field a client would eventually colour. The
+    same rule the ear-training drill follows for its answers (see
+    docs/practice-data.md) - a rate is a grade and a count is a fact.
+
+    Every rating from 1 to 5 is present whether or not it was ever chosen. A
+    bucket somebody never used is a fact about how they rate their own
+    practice, and a list with a hole in it is one a reader has to reconstruct
+    the missing rows of before it can be drawn.
+    """
+    rows = conn.execute(
+        f"""SELECT p.rating, COUNT(*) AS sessions
+              FROM practice_sessions p
+             WHERE p.owner = ? AND p.score_id = ? AND {LOCAL_DATE_SQL} BETWEEN ? AND ?
+          GROUP BY p.rating""",
+        (owner, score_id, start, end),
+    ).fetchall()
+    counted = {r["rating"]: r["sessions"] for r in rows}
+    return {
+        "counts": [
+            {"rating": rating, "sessions": counted.get(rating, 0)}
+            for rating in range(MIN_RATING, MAX_RATING + 1)
+        ],
+        "rated": sum(n for rating, n in counted.items() if rating is not None),
+        "unrated": counted.get(None, 0),
+    }
+
+
+def score_goals(
+    conn,
+    score_id: int,
+    start: str,
+    end: str,
+    today: date,
+    *,
+    owner: str = DEFAULT_OWNER,
+    limit: int = MAX_SCORE_GOALS,
+) -> list[dict]:
+    """Goals set about this piece whose period touches the window, newest
+    first, each with its progress counted the way every other goal's is.
+
+    Scoped goals only. A goal over "any practice" is not a goal about this
+    piece even in a week when this piece was the only thing practised, and
+    listing it here would put somebody's whole-week intention on a page about
+    one score, where it reads as a target for that score alone.
+    """
+    rows = conn.execute(
+        """SELECT * FROM practice_goals
+            WHERE owner = ? AND scope = 'score' AND score_id = ?
+              AND period_end >= ? AND period_start <= ?
+         ORDER BY period_start DESC LIMIT ?""",
+        (owner, score_id, start, end, limit),
+    ).fetchall()
+    return [goal_dict(conn, r, today) for r in rows]
+
+
+def score_sessions(
+    conn,
+    score_id: int,
+    start: str,
+    end: str,
+    *,
+    owner: str = DEFAULT_OWNER,
+    limit: int = DEFAULT_SCORE_SESSION_LIMIT,
+) -> dict:
+    """This piece's own sessions in the window, newest first, with their notes.
+
+    Reports `total` and `truncated` beside the rows for the same reason
+    /practice/sessions does: a list that stops at the limit and says nothing
+    looks identical to a complete one, and a reader totalling it would report
+    less practice than there was.
+    """
+    rows = conn.execute(
+        f"""SELECT * FROM practice_sessions p
+             WHERE p.owner = ? AND p.score_id = ? AND {LOCAL_DATE_SQL} BETWEEN ? AND ?
+          ORDER BY {LOCAL_DATE_SQL} DESC, p.started_at DESC, p.id DESC
+             LIMIT ?""",
+        (owner, score_id, start, end, limit),
+    ).fetchall()
+    total = conn.execute(
+        f"""SELECT COUNT(*) AS n FROM practice_sessions p
+             WHERE p.owner = ? AND p.score_id = ? AND {LOCAL_DATE_SQL} BETWEEN ? AND ?""",
+        (owner, score_id, start, end),
+    ).fetchone()["n"]
+    return {
+        "sessions": [session_dict(r) for r in rows],
+        "total": total,
+        "truncated": total > len(rows),
     }

--- a/server/tests/test_api_docs.py
+++ b/server/tests/test_api_docs.py
@@ -292,8 +292,9 @@ def test_every_route_has_exactly_the_expected_operation_count(openapi_schema):
     count = sum(1 for _ in _operations(openapi_schema))
     # 41 before issue #56, plus its nine: move one score, list/create folders,
     # rename a folder, move several scores, delete a score, list the trash,
-    # restore from it, and destroy from it.
-    assert count == 50
+    # restore from it, and destroy from it. Plus issue #57's one: how one
+    # piece is going.
+    assert count == 51
 
 
 def test_binary_routes_do_not_advertise_a_json_content_type(openapi_schema):
@@ -456,6 +457,26 @@ def test_practice_responses_match_their_models(client, insert_score):
             f"/api/practice/sessions/{session.id}", json={"rating": 4}
         ).json()
     )
+    # Issue #57's endpoint, exercised with a session, a tempo, a mode, a
+    # rating and a goal actually present - every nested block below `progress`
+    # is empty or absent-shaped on a piece nobody has practised, and a drift
+    # guard that only ever sees empty lists cannot notice a field dropped from
+    # the objects inside them.
+    detailed = client.post(
+        f"/api/scores/{score_id}/practice",
+        json={"seconds": 900, "tempo_bpm": 90, "target_tempo_bpm": 120, "mode": "section", "rating": 4},
+    )
+    assert detailed.status_code == 200, detailed.text
+    scoped = client.post(
+        "/api/practice/goals",
+        json={"scope": "score", "score_id": score_id, "target_days": 2, "intent": "bar 34"},
+    )
+    assert scoped.status_code == 200, scoped.text
+    api_models.ScoreProgressOut.model_validate(
+        client.get(f"/api/scores/{score_id}/practice/progress").json()
+    )
+    client.delete(f"/api/practice/goals/{scoped.json()['id']}")
+
     api_models.SessionListOut.model_validate(client.get("/api/practice/sessions").json())
     api_models.PracticeSummaryOut.model_validate(client.get("/api/practice/summary").json())
     api_models.PracticeHistoryOut.model_validate(client.get("/api/practice/history").json())

--- a/server/tests/test_score_progress_api.py
+++ b/server/tests/test_score_progress_api.py
@@ -1,0 +1,694 @@
+"""GET /api/scores/{id}/practice/progress - how one piece is going (#57).
+
+Over real HTTP against a real database, like test_practice_api.py, and for the
+same reason: the window arithmetic, the `today` parameter and the 404/422
+boundaries all live in the request layer and are not exercised by calling the
+handler with keyword arguments.
+
+EVERY NUMBER HERE IS A LITERAL. Not `sum(s["seconds"] for s in sessions)`,
+which recomputes the thing under test with the same arithmetic and passes
+whatever that arithmetic does - the sessions below are constructed so the
+answer can be worked out by hand from the fixture and written down. A grouping
+that changed would have to change these constants to stay green, which is what
+makes them a test rather than a restatement.
+"""
+
+from datetime import date, timedelta
+
+import pytest
+from fastapi.testclient import TestClient
+
+from fermata import db, practice
+from fermata.main import app
+
+# Every date here is D(n): n days after an anchor 85 days back, so D(85) is
+# today and every smaller offset is a day in the past.
+#
+# Relative and not literal, for the reasons test_practice_api.py gives: a
+# session cannot be logged for a day that has not happened, and it cannot be
+# logged more than practice.MAX_BACKDATE_DAYS ago, so a fixed calendar date
+# would eventually break one rule or the other. 85 days is the anchor because
+# it leaves the whole of the default 90-day window in the past while keeping
+# every date well inside the back-dating bound.
+#
+# The window arithmetic is then checkable by eye: a window of N days ending
+# today starts at D(86 - N), so a 30-day window starts at D(56) and a 10-day
+# one at D(76).
+_TODAY = date.today()
+_ANCHOR = _TODAY - timedelta(days=85)
+
+
+def D(offset: int) -> str:
+    return (_ANCHOR + timedelta(days=offset)).isoformat()
+
+
+# The day the endpoint is asked to treat as today throughout. Passed explicitly
+# rather than left to the server's UTC date so nothing here depends on the hour
+# the suite runs at - and equal to it, because a `today` more than a day from
+# the server's own is refused (see api._today).
+TODAY = D(85)
+DAYS = 90
+
+
+@pytest.fixture
+def client(app_env, monkeypatch):
+    monkeypatch.setattr("fermata.main.scanner.start_scan", lambda: False)
+    monkeypatch.setattr("fermata.main.init_db", lambda: None)
+    with TestClient(app) as c:
+        yield c
+
+
+@pytest.fixture
+def score(client):
+    conn = db.connect()
+    cur = conn.execute(
+        """INSERT INTO scores(title, path, file_type, hash, size, mtime)
+           VALUES ('Study in C', 'Classical/Study in C.pdf', 'pdf', 'deadbeef', 1, 0.0)"""
+    )
+    conn.commit()
+    return cur.lastrowid
+
+
+@pytest.fixture
+def other_score(client):
+    conn = db.connect()
+    cur = conn.execute(
+        """INSERT INTO scores(title, path, file_type, hash, size, mtime)
+           VALUES ('To Zanarkand', 'Patreon/Zanarkand.pdf', 'pdf', 'cafebabe', 1, 0.0)"""
+    )
+    conn.commit()
+    return cur.lastrowid
+
+
+def log(client, score_id, *, day, seconds, **rest):
+    """One session on a piece. `day` is the practice day; pass day=None to log
+    a session that records none, which is the shape a row from before the
+    column existed has."""
+    body = {"seconds": seconds, "activity": "piece", "score_id": score_id, **rest}
+    if day is not None:
+        body["local_date"] = day
+    res = client.post("/api/practice/sessions", json=body)
+    assert res.status_code == 200, res.text
+    return res.json()
+
+
+def progress(client, score_id, **params):
+    query = {"days": DAYS, "today": TODAY, **params}
+    res = client.get(
+        f"/api/scores/{score_id}/practice/progress",
+        params={k: v for k, v in query.items() if v is not None},
+    )
+    assert res.status_code == 200, res.text
+    return res.json()
+
+
+def day_entry(body, day):
+    """One day out of the window's per-day list, which covers every day in the
+    window including the empty ones."""
+    found = [d for d in body["window"]["days"] if d["date"] == day]
+    assert len(found) == 1, f"{day} appears {len(found)} times in the window"
+    return found[0]
+
+
+# ---------------------------------------------------------------------------
+# The empty state: a piece nobody has played yet.
+# ---------------------------------------------------------------------------
+
+
+def test_a_piece_never_practised_says_so_rather_than_reporting_zeros(client, score):
+    """Invariant: a new user sees a real empty state, not zeros pretending to
+    be data. `practised` is the field that distinguishes "nobody has played
+    this" from "a quiet three months", and the two render differently because
+    they are different facts."""
+    body = progress(client, score)
+
+    assert body["practised"] is False
+    assert body["all_time"] == {
+        "sessions": 0,
+        "seconds": 0,
+        "minutes": 0,
+        "first_practised": None,
+        "last_practised": None,
+        "sessions_inferred": 0,
+    }
+    assert body["window"]["seconds"] == 0
+    assert body["window"]["days_practised"] == 0
+    assert body["window"]["sessions"] == 0
+    # Every day in the window is still listed, at zero - an absent day is one a
+    # reader has to infer from a gap, and this list is what a strip is drawn
+    # from whether or not anything is on it.
+    assert len(body["window"]["days"]) == DAYS
+    assert {d["seconds"] for d in body["window"]["days"]} == {0}
+    assert body["sessions"] == []
+    assert body["session_total"] == 0
+    assert body["sessions_truncated"] is False
+    assert body["goals"] == []
+    assert body["modes"] == []
+
+
+def test_a_piece_never_practised_has_no_tempo_progression_and_no_axis(client, score):
+    body = progress(client, score)["tempo"]
+    assert body["points"] == []
+    assert body["count"] == 0
+    assert body["sessions_without_tempo"] == 0
+    # Null and not zero. Zero is a tempo nobody played at; null is the absence
+    # of any number to bound an axis with, and a chart handed 0 would draw one.
+    assert body["axis_low"] is None
+    assert body["axis_high"] is None
+    assert body["latest_target"] is None
+    assert body["comparable"] is False
+
+
+def test_one_session_at_a_tempo_is_not_a_progression(client, score):
+    """Invariant: a score with one session shows no fake trend. The single
+    point is reported - it is a fact somebody entered - and `comparable` says
+    outright that there is nothing here to draw a line through."""
+    log(client, score, day=D(3), seconds=600, tempo_bpm=90, target_tempo_bpm=120)
+    tempo = progress(client, score)["tempo"]
+
+    assert tempo["count"] == 1
+    assert tempo["comparable"] is False
+    assert tempo["points"][0]["tempo_bpm"] == 90
+    assert tempo["points"][0]["reached_target"] is False
+
+
+# ---------------------------------------------------------------------------
+# The totals, over several days and against the right piece.
+# ---------------------------------------------------------------------------
+
+
+def test_totals_count_this_piece_across_days_and_ignore_every_other(
+    client, score, other_score
+):
+    # 25m + 35m on one day, 40m on another, all on `score`.
+    log(client, score, day=D(3), seconds=1500)
+    log(client, score, day=D(3), seconds=2100)
+    log(client, score, day=D(10), seconds=2400)
+    # A different piece, on a day `score` was also worked, and an hour long -
+    # so any query that forgot its score filter would be off by an obvious 3600.
+    log(client, other_score, day=D(3), seconds=3600)
+    # Practice that is not against a piece at all, on the same day.
+    res = client.post(
+        "/api/practice/sessions", json={"activity": "technique", "seconds": 1800, "local_date": D(3)}
+    )
+    assert res.status_code == 200, res.text
+
+    body = progress(client, score)
+
+    assert body["practised"] is True
+    assert body["title"] == "Study in C"
+    assert body["score_id"] == score
+    assert body["all_time"] == {
+        "sessions": 3,
+        "seconds": 6000,
+        "minutes": 100,
+        "first_practised": D(3),
+        "last_practised": D(10),
+        "sessions_inferred": 0,
+    }
+    assert body["window"]["seconds"] == 6000
+    assert body["window"]["sessions"] == 3
+    assert body["window"]["days_practised"] == 2
+    assert day_entry(body, D(3)) == {"date": D(3), "seconds": 3600, "sessions": 2, "inferred": 0}
+    assert day_entry(body, D(10)) == {"date": D(10), "seconds": 2400, "sessions": 1, "inferred": 0}
+    assert day_entry(body, D(4)) == {"date": D(4), "seconds": 0, "sessions": 0, "inferred": 0}
+    assert body["session_total"] == 3
+    assert [s["seconds"] for s in body["sessions"]] == [2400, 2100, 1500]
+
+
+def test_minutes_are_floored_and_never_claim_a_minute_that_was_not_practised(client, score):
+    log(client, score, day=D(3), seconds=119)
+    assert progress(client, score)["all_time"]["minutes"] == 1
+    assert progress(client, score)["window"]["minutes"] == 1
+
+
+def test_the_response_names_the_column_every_figure_was_grouped_by(client, score):
+    """Timezone honesty: the aggregates group by the practice day, and the
+    response says so rather than leaving a reader to assume a UTC timestamp."""
+    assert progress(client, score)["grouped_by"] == "local_date"
+    assert practice.GROUPED_BY == "local_date"
+
+
+# ---------------------------------------------------------------------------
+# The practice day, which is the practiser's own and not the server's.
+# ---------------------------------------------------------------------------
+
+
+def test_a_session_late_in_the_evening_groups_to_its_own_local_date(client, score):
+    """A session recorded at 23:30 on D(5) local time is stored with
+    started_at in UTC - which, east of Greenwich, is already D(6) - and it must
+    be counted on D(5), the day the practice happened on.
+
+    Written by forcing exactly that state: the row's stored local_date is D(5)
+    and its started_at is D(6), which is the disagreement a real evening
+    session produces and the one thing every day-based query here has to get
+    right. Asserted in both directions, because a query that grouped by the
+    timestamp would put the whole hour on D(6) and still look plausible.
+    """
+    session = log(client, score, day=D(5), seconds=1800)
+    conn = db.connect()
+    conn.execute(
+        "UPDATE practice_sessions SET started_at = ? WHERE id = ?",
+        (f"{D(6)} 03:30:00", session["id"]),
+    )
+    conn.commit()
+
+    body = progress(client, score)
+    assert day_entry(body, D(5)) == {"date": D(5), "seconds": 1800, "sessions": 1, "inferred": 0}
+    assert day_entry(body, D(6)) == {"date": D(6), "seconds": 0, "sessions": 0, "inferred": 0}
+    assert body["all_time"]["first_practised"] == D(5)
+    assert body["all_time"]["last_practised"] == D(5)
+    assert body["all_time"]["sessions_inferred"] == 0
+    assert body["sessions"][0]["local_date"] == D(5)
+    assert body["sessions"][0]["local_date_source"] == "recorded"
+
+
+def test_a_session_with_no_recorded_day_is_counted_and_marked_as_assumed(client, score):
+    """A row from before local_date existed is attributed to its UTC day - the
+    only day it ever recorded - and both the piece's whole record and the
+    window say how many of their sessions rest on one."""
+    session = log(client, score, day=None, seconds=900)
+    assert session["local_date_source"] == "utc_date"
+    conn = db.connect()
+    conn.execute(
+        "UPDATE practice_sessions SET started_at = ? WHERE id = ?",
+        (f"{D(8)} 10:00:00", session["id"]),
+    )
+    conn.commit()
+
+    body = progress(client, score)
+    assert body["all_time"]["sessions_inferred"] == 1
+    assert body["all_time"]["first_practised"] == D(8)
+    assert body["window"]["sessions_inferred"] == 1
+    assert day_entry(body, D(8)) == {"date": D(8), "seconds": 900, "sessions": 1, "inferred": 1}
+
+
+# ---------------------------------------------------------------------------
+# The window, and what sits outside it.
+# ---------------------------------------------------------------------------
+
+
+def test_practice_before_the_window_stays_in_the_whole_record_and_out_of_the_window(
+    client, score
+):
+    """"When did I last play this" has no window and "how much this stretch"
+    has nothing else, so the two blocks must disagree here - and a view reading
+    one off the other would report a piece worked on for months as untouched.
+
+    A 30-day window ending at D(85) starts at D(56), so the D(3) session is
+    outside it by 53 days and the D(70) one is inside it by 14.
+    """
+    log(client, score, day=D(3), seconds=1200)
+    log(client, score, day=D(70), seconds=600)
+
+    body = progress(client, score, days=30)
+    assert body["start"] == D(56)
+    assert body["end"] == TODAY
+    assert body["all_time"]["sessions"] == 2
+    assert body["all_time"]["seconds"] == 1800
+    assert body["all_time"]["first_practised"] == D(3)
+    assert body["practised"] is True
+    assert body["window"]["sessions"] == 1
+    assert body["window"]["seconds"] == 600
+    assert body["session_total"] == 1
+
+
+def test_a_piece_practised_only_outside_the_window_is_still_a_practised_piece(client, score):
+    """`practised` is asked of the whole record. A piece worked solidly last
+    spring and untouched since has been practised, and greeting it with the
+    empty state would be wrong about the one thing this page exists to
+    remember."""
+    log(client, score, day=D(3), seconds=1200)
+    body = progress(client, score, days=7)
+    assert body["practised"] is True
+    assert body["window"]["seconds"] == 0
+    assert body["all_time"]["last_practised"] == D(3)
+
+
+def test_the_window_boundaries_are_inclusive_on_both_ends(client, score):
+    """A 10-day window ending at TODAY = D(85) starts at D(76). A session on
+    each edge is in; one the day before the start is out."""
+    log(client, score, day=D(75), seconds=100)
+    log(client, score, day=D(76), seconds=200)
+    log(client, score, day=D(85), seconds=400)
+
+    body = progress(client, score, days=10)
+    assert body["start"] == D(76)
+    assert body["end"] == D(85)
+    assert body["window"]["seconds"] == 600
+    assert body["window"]["sessions"] == 2
+    assert body["all_time"]["seconds"] == 700
+
+
+# ---------------------------------------------------------------------------
+# Tempo, as points and never as a line.
+# ---------------------------------------------------------------------------
+
+
+def test_tempo_points_come_back_oldest_first_with_their_own_days(client, score):
+    log(client, score, day=D(20), seconds=600, tempo_bpm=100, target_tempo_bpm=120)
+    log(client, score, day=D(4), seconds=600, tempo_bpm=80, target_tempo_bpm=120)
+    log(client, score, day=D(12), seconds=600, tempo_bpm=90)
+
+    tempo = progress(client, score)["tempo"]
+    assert [(p["date"], p["tempo_bpm"]) for p in tempo["points"]] == [
+        (D(4), 80),
+        (D(12), 90),
+        (D(20), 100),
+    ]
+    assert [p["target_tempo_bpm"] for p in tempo["points"]] == [120, None, 120]
+    # None where there is no target to compare against, which is not the same
+    # as having failed to reach one.
+    assert [p["reached_target"] for p in tempo["points"]] == [False, None, False]
+    assert tempo["count"] == 3
+    assert tempo["comparable"] is True
+
+
+def test_the_tempo_axis_spans_both_the_tempos_and_the_targets(client, score):
+    """A target line has to fit on the same axis as the points under it, so
+    the bounds cover both numbers. 120 is the highest thing on the chart even
+    though nobody has played it yet."""
+    log(client, score, day=D(4), seconds=600, tempo_bpm=80, target_tempo_bpm=120)
+    log(client, score, day=D(12), seconds=600, tempo_bpm=95, target_tempo_bpm=120)
+
+    tempo = progress(client, score)["tempo"]
+    assert tempo["axis_low"] == 80
+    assert tempo["axis_high"] == 120
+
+
+def test_reaching_the_target_is_derived_from_the_two_numbers_it_comes_from(client, score):
+    log(client, score, day=D(4), seconds=600, tempo_bpm=120, target_tempo_bpm=120)
+    log(client, score, day=D(5), seconds=600, tempo_bpm=130, target_tempo_bpm=120)
+
+    tempo = progress(client, score)["tempo"]
+    assert [p["reached_target"] for p in tempo["points"]] == [True, True]
+
+
+def test_the_target_reported_is_the_latest_written_down_and_not_the_highest(client, score):
+    """Somebody who decided 140 was too fast and set 110 is aiming at 110.
+    Reporting the number they abandoned would be this view arguing with them -
+    and it would be the "best" figure this feature does not have."""
+    log(client, score, day=D(4), seconds=600, tempo_bpm=100, target_tempo_bpm=140)
+    log(client, score, day=D(20), seconds=600, tempo_bpm=100, target_tempo_bpm=110)
+
+    assert progress(client, score)["tempo"]["latest_target"] == 110
+
+
+def test_sessions_with_no_tempo_are_counted_so_a_sparse_chart_is_not_a_sparse_month(
+    client, score
+):
+    log(client, score, day=D(4), seconds=600, tempo_bpm=80)
+    log(client, score, day=D(5), seconds=600)
+    log(client, score, day=D(6), seconds=600)
+
+    tempo = progress(client, score)["tempo"]
+    assert tempo["count"] == 1
+    assert tempo["sessions_without_tempo"] == 2
+
+
+def test_tempo_points_outside_the_window_are_not_drawn_in_it(client, score):
+    log(client, score, day=D(3), seconds=600, tempo_bpm=70)
+    log(client, score, day=D(70), seconds=600, tempo_bpm=100)
+
+    tempo = progress(client, score, days=30)["tempo"]
+    assert tempo["count"] == 1
+    assert tempo["comparable"] is False
+    assert tempo["axis_low"] == 100
+    assert tempo["axis_high"] == 100
+
+
+# ---------------------------------------------------------------------------
+# Section work against run-throughs, and the ratings.
+# ---------------------------------------------------------------------------
+
+
+def test_the_time_splits_between_section_work_run_throughs_and_the_unstated(client, score):
+    log(client, score, day=D(4), seconds=600, mode="section")
+    log(client, score, day=D(5), seconds=900, mode="section")
+    log(client, score, day=D(6), seconds=1200, mode="run_through")
+    log(client, score, day=D(7), seconds=300)
+
+    modes = progress(client, score)["modes"]
+    # Ordered by time spent, and a session that did not say which it was comes
+    # back under a null mode rather than being dropped or guessed at.
+    assert modes == [
+        {"mode": "section", "seconds": 1500, "sessions": 2},
+        {"mode": "run_through", "seconds": 1200, "sessions": 1},
+        {"mode": None, "seconds": 300, "sessions": 1},
+    ]
+
+
+def test_ratings_are_counted_per_value_with_every_bucket_present(client, score):
+    log(client, score, day=D(4), seconds=600, rating=4)
+    log(client, score, day=D(5), seconds=600, rating=4)
+    log(client, score, day=D(6), seconds=600, rating=2)
+    log(client, score, day=D(7), seconds=600)
+
+    ratings = progress(client, score)["ratings"]
+    assert ratings["counts"] == [
+        {"rating": 1, "sessions": 0},
+        {"rating": 2, "sessions": 1},
+        {"rating": 3, "sessions": 0},
+        {"rating": 4, "sessions": 2},
+        {"rating": 5, "sessions": 0},
+    ]
+    assert ratings["rated"] == 3
+    assert ratings["unrated"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Goals about this piece.
+# ---------------------------------------------------------------------------
+
+
+def test_a_goal_about_this_piece_arrives_with_its_intent_and_its_progress(client, score):
+    """The #3-era intent, counted against this piece's own sessions. The goal
+    covers D(0)-D(6); two of those days were practised, for 50 minutes."""
+    made = client.post(
+        f"/api/practice/goals?today={TODAY}",
+        json={
+            "period_start": D(0),
+            "target_days": 3,
+            "target_minutes": 40,
+            "scope": "score",
+            "score_id": score,
+            "intent": "the awkward middle section",
+        },
+    )
+    assert made.status_code == 200, made.text
+    log(client, score, day=D(1), seconds=1200)
+    log(client, score, day=D(2), seconds=1800)
+
+    goals = progress(client, score)["goals"]
+    assert len(goals) == 1
+    assert goals[0]["intent"] == "the awkward middle section"
+    assert goals[0]["target_days"] == 3
+    assert goals[0]["progress"]["days_practised"] == 2
+    assert goals[0]["progress"]["minutes"] == 50
+    assert goals[0]["progress"]["met_days"] is False
+    assert goals[0]["progress"]["met_minutes"] is True
+    assert goals[0]["progress"]["met"] is False
+    assert goals[0]["progress"]["status"] == "past"
+    assert goals[0]["progress"]["countable"] is True
+
+
+def test_a_goal_over_any_practice_is_not_a_goal_about_this_piece(client, score, other_score):
+    """A whole-week intention shown on a page about one score reads as a target
+    for that score alone. Only a goal actually scoped to this piece is listed -
+    and a goal scoped to a different one is not."""
+    everything = client.post(
+        f"/api/practice/goals?today={TODAY}",
+        json={"period_start": D(0), "target_days": 5, "scope": "all"},
+    )
+    assert everything.status_code == 200, everything.text
+    elsewhere = client.post(
+        f"/api/practice/goals?today={TODAY}",
+        json={
+            "period_start": D(14),
+            "target_days": 2,
+            "scope": "score",
+            "score_id": other_score,
+        },
+    )
+    assert elsewhere.status_code == 200, elsewhere.text
+
+    assert progress(client, score)["goals"] == []
+    assert [g["score_id"] for g in progress(client, other_score)["goals"]] == [other_score]
+
+
+def test_goals_outside_the_window_are_not_listed(client, score):
+    made = client.post(
+        f"/api/practice/goals?today={TODAY}",
+        json={"period_start": D(0), "target_days": 3, "scope": "score", "score_id": score},
+    )
+    assert made.status_code == 200, made.text
+    # A 30-day window starts at D(56); the goal's period ends at D(6).
+    assert progress(client, score, days=30)["goals"] == []
+    assert len(progress(client, score, days=90)["goals"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# A piece in the trash (#56): counted, marked, and not a way back in.
+# ---------------------------------------------------------------------------
+
+
+def test_a_deleted_piece_still_reports_every_hour_and_says_it_is_deleted(
+    client, app_env, monkeypatch, tmp_path
+):
+    """Through the real delete endpoint, not by writing `deleted_at` by hand,
+    because the claim is about the policy end to end: deleting a score moves
+    the file and keeps the practice, so this view must still answer in full.
+
+    Refusing to report it would be this application deciding a deletion erases
+    practice, which is the one thing the whole feature is built not to do.
+    """
+    from fermata import api, config, scanner
+
+    root = config.LIBRARY_DIR
+    monkeypatch.setattr(api, "LIBRARY_DIR", root)
+    monkeypatch.setattr(scanner, "LIBRARY_DIR", root)
+    (root / "Inbox").mkdir(parents=True, exist_ok=True)
+    score_file = root / "Inbox" / "Study.pdf"
+    score_file.write_bytes(b"a score file")
+    stat = score_file.stat()
+    conn = db.connect()
+    score_id = conn.execute(
+        """INSERT INTO scores(title, collection, path, file_type, hash, size, mtime)
+           VALUES ('Study', 'Inbox', 'Inbox/Study.pdf', 'pdf', ?, ?, ?)""",
+        (scanner.hash_file(score_file), stat.st_size, stat.st_mtime),
+    ).lastrowid
+    conn.commit()
+
+    log(client, score_id, day=D(4), seconds=1500, tempo_bpm=90)
+    log(client, score_id, day=D(5), seconds=2100)
+
+    before = progress(client, score_id)
+    assert before["deleted"] is False
+
+    removed = client.delete(f"/api/scores/{score_id}")
+    assert removed.status_code == 200, removed.text
+    assert removed.json()["practice_sessions_kept"] == 2
+
+    after = progress(client, score_id)
+    assert after["deleted"] is True
+    assert after["title"] == "Study"
+    assert after["practised"] is True
+    # Every figure unchanged. The hours were spent; only the way into the
+    # library goes away, and that is the client's job to honour.
+    assert after["all_time"] == before["all_time"]
+    assert after["all_time"]["seconds"] == 3600
+    assert after["window"]["seconds"] == 3600
+    assert after["session_total"] == 2
+    assert after["tempo"]["count"] == 1
+
+
+# ---------------------------------------------------------------------------
+# The list, and the boundaries of what may be asked for.
+# ---------------------------------------------------------------------------
+
+
+def test_the_session_list_says_when_it_stopped_short_of_the_total(client, score):
+    """A list that stops at the limit and says nothing looks identical to a
+    complete one, and a reader totalling it would report less practice than
+    there was."""
+    for offset, seconds in ((4, 600), (5, 900), (6, 1200)):
+        log(client, score, day=D(offset), seconds=seconds)
+
+    body = progress(client, score, limit=2)
+    assert len(body["sessions"]) == 2
+    assert body["session_total"] == 3
+    assert body["sessions_truncated"] is True
+    # Newest first, so a truncated list keeps the sessions somebody is most
+    # likely to be looking for.
+    assert [s["seconds"] for s in body["sessions"]] == [1200, 900]
+    # The totals beside it are counted from every row, not from the two listed.
+    assert body["window"]["seconds"] == 2700
+    assert body["all_time"]["seconds"] == 2700
+
+
+def test_the_notes_attached_to_a_session_come_back_with_it(client, score):
+    log(
+        client,
+        score,
+        day=D(4),
+        seconds=600,
+        note="left hand shape at bar 34 still collapsing",
+        from_bar=30,
+        to_bar=38,
+        rating=3,
+        mode="section",
+    )
+    session = progress(client, score)["sessions"][0]
+    assert session["note"] == "left hand shape at bar 34 still collapsing"
+    assert session["from_bar"] == 30
+    assert session["to_bar"] == 38
+    assert session["rating"] == 3
+    assert session["mode"] == "section"
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        {"days": 0},
+        {"days": practice.MAX_HISTORY_DAYS + 1},
+        {"limit": 0},
+        {"limit": practice.MAX_SCORE_SESSION_LIMIT + 1},
+    ],
+)
+def test_a_window_or_a_limit_outside_its_bounds_is_refused(client, score, params):
+    res = client.get(
+        f"/api/scores/{score}/practice/progress",
+        params={"today": TODAY, **params},
+    )
+    assert res.status_code == 422, res.text
+
+
+def test_a_today_outside_the_window_this_instance_could_hold_is_refused(client, score):
+    res = client.get(
+        f"/api/scores/{score}/practice/progress", params={"today": "2099-01-01"}
+    )
+    assert res.status_code == 422, res.text
+    assert "today must be between" in res.json()["detail"]
+
+
+def test_an_unknown_score_is_a_404(client):
+    assert client.get("/api/scores/98765/practice/progress").status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# What this endpoint must never grow.
+# ---------------------------------------------------------------------------
+
+
+def test_nothing_on_this_response_is_a_streak_a_best_or_an_average(client, score):
+    """docs/practice-data.md lists all three under what is deliberately
+    absent, and issue #3 asks for them by name in its own "deliberately not"
+    list: missing a week because of a busy job is information, not a moral
+    failure, and a best week is the mechanism by which a good month becomes the
+    standard a bad month is measured against.
+
+    A per-piece view is where each would be most tempting - a piece is put down
+    and picked up again by design - so the guard lives here, on the field names
+    themselves, rather than in a reviewer's memory. `axis_low` and `axis_high`
+    are the chart's bounds and are deliberately not named for a record; if they
+    ever are, this test is where that argument has to be had.
+    """
+    log(client, score, day=D(4), seconds=600, tempo_bpm=90, target_tempo_bpm=120, rating=4)
+    log(client, score, day=D(5), seconds=900, tempo_bpm=100, target_tempo_bpm=120, rating=5)
+
+    forbidden = ("streak", "best", "worst", "average", "mean", "consecutive", "improv", "trend")
+    found = []
+
+    def walk(value, path=""):
+        if isinstance(value, dict):
+            for key, inner in value.items():
+                lowered = key.lower()
+                if any(word in lowered for word in forbidden):
+                    found.append(f"{path}{key}")
+                walk(inner, f"{path}{key}.")
+        elif isinstance(value, list):
+            for i, item in enumerate(value):
+                walk(item, f"{path}[{i}].")
+
+    walk(progress(client, score))
+    assert not found, f"field(s) this response must not carry: {sorted(found)}"

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -5,8 +5,14 @@
   import Practice from "./lib/Practice.svelte";
   import MetronomePage from "./lib/MetronomePage.svelte";
   import EarTraining from "./lib/EarTraining.svelte";
+  import ScoreProgress from "./lib/ScoreProgress.svelte";
 
   function parse(hash) {
+    // Checked BEFORE the bare score route, which matches a prefix: without
+    // this, #/score/7/practice opens the viewer for score 7 and the progress
+    // page is unreachable by URL.
+    const progress = hash.match(/^#\/score\/(\d+)\/practice/);
+    if (progress) return { page: "score-progress", id: Number(progress[1]) };
     const m = hash.match(/^#\/score\/(\d+)/);
     if (m) return { page: "score", id: Number(m[1]) };
     if (hash.startsWith("#/demo")) return { page: "demo" };
@@ -26,7 +32,9 @@
   });
 </script>
 
-{#if route.page === "score"}
+{#if route.page === "score-progress"}
+  <ScoreProgress id={route.id} />
+{:else if route.page === "score"}
   <Viewer id={route.id} />
 {:else if route.page === "demo"}
   <Viewer demo={true} />

--- a/web/src/lib/ScoreProgress.svelte
+++ b/web/src/lib/ScoreProgress.svelte
@@ -1,0 +1,740 @@
+<script>
+  // How is this piece going (#57).
+  //
+  // The other half of the practice page. That one answers "how am I doing"
+  // across the library; this one answers "how is THIS piece going", which the
+  // issue is explicit is a different question - deciding what to practise next
+  // needs the per-piece picture as much as the overall one.
+  //
+  // WHAT THIS PAGE OBEYS, since it is the page most tempted to break it:
+  //
+  //   Nothing here is computed. Every number on screen came off
+  //   /api/scores/{id}/practice/progress already counted. The helpers in
+  //   practice.js put a number into words and the chart helper turns a bpm
+  //   into a y coordinate; nothing between here and the server adds anything
+  //   up. That is issue #32's rule, and the reason it matters is that the same
+  //   endpoint is the contract a second reader will use.
+  //
+  //   No trend line, and no direction. A piece is put down for a fortnight and
+  //   picked up again, and an arrow through that is a claim about somebody's
+  //   playing these numbers cannot support. The tempo points are drawn with
+  //   their values printed beside them and joined so the eye can follow the
+  //   order they happened in - which is not the same as a fitted line, and the
+  //   difference is that this one goes exactly where the sessions went.
+  //
+  //   Nothing depends on a hover. This is read from a music stand, at arm's
+  //   length, in whatever light the room has - so every figure that matters is
+  //   in text at a readable size, and the charts are there to make a shape out
+  //   of numbers that are already legible without them.
+  //
+  //   Nothing is styled as an error, and there is no --danger in this file.
+  //   Same rule as Practice.svelte, and a test checks for it.
+  import { api } from "./api.js";
+  import {
+    allTimeStatement,
+    dayBars,
+    formatDuration,
+    goalStatements,
+    lastPractisedStatement,
+    localDay,
+    modeLabel,
+    periodLabel,
+    ratingStatement,
+    rangeLabel,
+    shortDate,
+    splitBars,
+    targetStatement,
+    tempoChart,
+    tempoLabel,
+    tempoStatement,
+    uncountableStatement,
+    windowStatement,
+  } from "./practice.js";
+
+  let { id } = $props();
+
+  const HISTORY_DAYS = 90;
+
+  // The browser's own date, not the server's - the same rule every other
+  // practice call follows. Read once per load; see Practice.svelte.
+  const today = localDay();
+
+  let data = $state(null);
+  let loading = $state(true);
+  let error = $state("");
+
+  async function refresh() {
+    error = "";
+    try {
+      data = await api.scoreProgress(id, HISTORY_DAYS, today);
+    } catch (e) {
+      error = e?.message ?? "Could not load this piece's practice history.";
+    } finally {
+      loading = false;
+    }
+  }
+
+  $effect(() => {
+    refresh();
+  });
+
+  // Scaled inside this window, like every other bar in this application: a bar
+  // that shrank because some other stretch was busier is a comparison drawn in
+  // pixels.
+  let windowBars = $derived(dayBars(data?.window?.days ?? []));
+  let chart = $derived(tempoChart(data?.tempo));
+  // The line through the points, in the order the sessions happened. Not a fit
+  // and not a smoothing - it passes through every point exactly, and exists so
+  // the eye can follow the order rather than to assert a direction.
+  let tempoPath = $derived(chart.points.map((p) => `${p.x},${p.y}`).join(" "));
+  let modeBars = $derived(splitBars(data?.modes ?? []));
+  let ratingBars = $derived(splitBars(data?.ratings?.counts ?? [], (r) => r.sessions));
+</script>
+
+<div class="score-progress">
+  <header>
+    <!-- Back to the library, always. The way into the SCORE is below and only
+         when there is one - a piece in the trash is still counted here and is
+         not somewhere to go (issue #56). -->
+    <a class="back" href="#/">← Library</a>
+    <h1>{data?.title ?? "Practice"}</h1>
+    {#if data?.deleted}
+      <span class="deleted-mark" title="This score is in the trash. The practice still counts."
+        >deleted</span
+      >
+    {/if}
+  </header>
+
+  <main>
+    {#if error}
+      <p class="notice" role="status">{error}</p>
+    {/if}
+
+    {#if loading}
+      <p class="quiet">Loading…</p>
+    {:else if !data}
+      <p class="quiet">
+        This piece's practice history could not be loaded, so nothing below is shown rather
+        than shown wrongly. Reload to try again.
+      </p>
+    {:else if !data.practised}
+      <!-- A piece nobody has played yet. Everything below would be a screen of
+           noughts, and a nought is not the same statement as "you have not
+           started" - the server says which this is (`practised`) rather than
+           leaving a page to guess it from a total of zero. -->
+      <section class="nothing-yet">
+        <p class="statement-text">
+          No practice logged against this piece yet. Open it and start the practice timer, and
+          this page fills in as you go — the time, the days, the tempo you played it at, and
+          whatever you wrote down.
+        </p>
+        {#if !data.deleted}
+          <p><a class="open-score" href={"#/score/" + data.score_id}>Open {data.title}</a></p>
+        {/if}
+      </section>
+    {:else}
+      <!-- ----------------------------------------------------- the record -->
+      <section class="all-time">
+        <p class="headline" data-seconds={data.all_time.seconds}>
+          {allTimeStatement(data.all_time)}
+        </p>
+        <p class="quiet last-practised">{lastPractisedStatement(data.all_time)}</p>
+        <p class="actions">
+          {#if data.deleted}
+            <span class="quiet deleted-note">
+              This score is in the trash, so there is nothing to open. Every hour above was
+              still spent and is still counted.
+            </span>
+          {:else}
+            <a class="open-score" href={"#/score/" + data.score_id}>Open {data.title}</a>
+            <a class="all-practice" href="#/practice">All your practice</a>
+          {/if}
+        </p>
+      </section>
+
+      <!-- ---------------------------------------------------- the window -->
+      <section class="window">
+        <div class="section-head">
+          <h2>The last {HISTORY_DAYS} days</h2>
+          <span class="quiet">{periodLabel(data.start, data.end)}</span>
+        </div>
+        <p class="statement-text window-total">{windowStatement(data.window, HISTORY_DAYS)}</p>
+        <!-- One bar per day the server sent, including the empty ones. A day
+             with no practice is a fact about the window and is drawn as an
+             empty bar rather than left out - a gap is something a reader has
+             to notice and then interpret. -->
+        <div class="history-strip" aria-label={`practice on this piece over ${HISTORY_DAYS} days`}>
+          {#each windowBars as bar (bar.date)}
+            <div
+              class="history-day"
+              class:has-practice={bar.seconds > 0}
+              data-day={bar.date}
+              data-seconds={bar.seconds}
+              style={`--fill:${Math.round(bar.fill * 100)}%`}
+            ></div>
+          {/each}
+        </div>
+        <div class="strip-ends quiet">
+          <span>{shortDate(data.start)}</span>
+          <span>{shortDate(data.end)}</span>
+        </div>
+      </section>
+
+      <!-- ------------------------------------------------------- tempo -->
+      <section class="tempo">
+        <div class="section-head">
+          <h2>Tempo, session by session</h2>
+        </div>
+        <p class="statement-text tempo-total">{tempoStatement(data.tempo)}</p>
+        {#if targetStatement(data.tempo)}
+          <p class="statement-text tempo-target">{targetStatement(data.tempo)}</p>
+        {/if}
+
+        {#if data.tempo.count}
+          <!-- Every value printed beside its own dot. A chart whose numbers
+               only appear on hover is a chart nobody standing at a music stand
+               can read, and these are the numbers the section is about. -->
+          <svg
+            class="tempo-chart"
+            viewBox={`0 0 ${chart.width} ${chart.height}`}
+            role="img"
+            aria-label={tempoStatement(data.tempo)}
+          >
+            {#if chart.target}
+              <line
+                class="target-line"
+                x1={chart.pad}
+                x2={chart.width - chart.pad}
+                y1={chart.target.y}
+                y2={chart.target.y}
+              />
+              <text class="target-label" x={chart.width - chart.pad} y={chart.target.y - 8}>
+                target {chart.target.bpm}
+              </text>
+            {/if}
+            {#if chart.points.length > 1}
+              <polyline class="tempo-line" points={tempoPath} />
+            {/if}
+            {#each chart.points as point (point.session_id)}
+              <circle
+                class="tempo-point"
+                class:reached={point.reached_target === true}
+                cx={point.x}
+                cy={point.y}
+                r="7"
+                data-bpm={point.tempo_bpm}
+                data-day={point.date}
+              />
+              <text class="tempo-value" x={point.x} y={point.y - 14}>{point.tempo_bpm}</text>
+            {/each}
+          </svg>
+          <ul class="tempo-days quiet">
+            {#each data.tempo.points as point (point.session_id)}
+              <li data-tempo-day={point.date}>
+                {shortDate(point.date)} · {point.tempo_bpm} bpm
+              </li>
+            {/each}
+          </ul>
+        {/if}
+      </section>
+
+      <!-- ------------------------------------------- section work vs runs -->
+      <section class="modes">
+        <div class="section-head">
+          <h2>Section work and run-throughs</h2>
+        </div>
+        {#if modeBars.length}
+          <ul class="split">
+            {#each modeBars as row (row.mode ?? "unstated")}
+              <li data-mode={row.mode ?? "unstated"}>
+                <span class="split-label">{modeLabel(row.mode)}</span>
+                <span class="split-track">
+                  <span class="split-bar" style={`width:${Math.round(row.fill * 100)}%`}></span>
+                </span>
+                <span class="split-value">{formatDuration(row.seconds)}</span>
+              </li>
+            {/each}
+          </ul>
+        {:else}
+          <p class="quiet">No practice on this piece in this window to split up.</p>
+        {/if}
+      </section>
+
+      <!-- ----------------------------------------------------- ratings -->
+      <section class="ratings">
+        <div class="section-head">
+          <h2>How it went</h2>
+          <span class="quiet">your own sense of it, session by session</span>
+        </div>
+        <p class="statement-text rating-total">{ratingStatement(data.ratings)}</p>
+        {#if data.ratings.rated}
+          <ul class="split ratings-split">
+            {#each ratingBars as row (row.rating)}
+              <li data-rating={row.rating}>
+                <span class="split-label">{row.rating}</span>
+                <span class="split-track">
+                  <span class="split-bar" style={`width:${Math.round(row.fill * 100)}%`}></span>
+                </span>
+                <span class="split-value">{row.sessions}</span>
+              </li>
+            {/each}
+          </ul>
+        {/if}
+      </section>
+
+      <!-- ------------------------------------------------------- goals -->
+      {#if data.goals.length}
+        <section class="goals">
+          <div class="section-head">
+            <h2>Goals about this piece</h2>
+          </div>
+          <ul class="goal-list">
+            {#each data.goals as goal (goal.id)}
+              <li class="goal" data-goal-week={goal.period_start}>
+                <div class="goal-head">
+                  <span class="goal-label">{periodLabel(goal.period_start, goal.period_end)}</span>
+                  {#if goal.intent}<span class="quiet goal-intent">{goal.intent}</span>{/if}
+                </div>
+                {#if uncountableStatement(goal)}
+                  <p class="statement-text uncountable">{uncountableStatement(goal)}</p>
+                {:else}
+                  <ul class="statements">
+                    {#each goalStatements(goal) as statement (statement.key)}
+                      <li class="statement" class:reached={statement.met}>
+                        <span class="tick" aria-hidden="true">{statement.met ? "✓" : ""}</span>
+                        <span class="statement-text">{statement.text}</span>
+                      </li>
+                    {/each}
+                  </ul>
+                {/if}
+                {#if goal.reflection}
+                  <p class="quiet goal-reflection">{goal.reflection}</p>
+                {/if}
+              </li>
+            {/each}
+          </ul>
+        </section>
+      {/if}
+
+      <!-- ------------------------------------------------------ sessions -->
+      <section class="sessions">
+        <div class="section-head">
+          <h2>Session by session</h2>
+          {#if data.sessions_truncated}
+            <span class="quiet truncated">
+              the most recent {data.sessions.length} of {data.session_total}
+            </span>
+          {/if}
+        </div>
+        {#if data.sessions.length}
+          <ul class="session-list">
+            {#each data.sessions as session (session.id)}
+              <li class="session" data-session={session.id}>
+                <span class="session-day">
+                  <span class="day-date">{session.local_date}</span>
+                  <!-- Whether that day was recorded or worked out from the
+                       row's UTC timestamp - the same word this application uses
+                       everywhere for a value it chose rather than read, and the
+                       same note under the list explaining it once. -->
+                  {#if session.local_date_source && session.local_date_source !== "recorded"}
+                    <span class="day-inferred">assumed</span>
+                  {/if}
+                </span>
+                <span class="session-length">{formatDuration(session.seconds)}</span>
+                <span class="quiet session-extra">
+                  {[modeLabel(session.mode), rangeLabel(session), tempoLabel(session)]
+                    .filter(Boolean)
+                    .join(" · ")}
+                </span>
+                {#if session.note}
+                  <p class="session-note">{session.note}</p>
+                {/if}
+              </li>
+            {/each}
+          </ul>
+          {#if data.sessions.some((s) => s.local_date_source && s.local_date_source !== "recorded")}
+            <p class="quiet day-note">
+              A day marked <span class="day-inferred">assumed</span> was taken from the session's
+              own timestamp rather than recorded when the practice happened.
+            </p>
+          {/if}
+        {:else}
+          <p class="quiet">
+            Nothing logged against this piece in the last {HISTORY_DAYS} days.
+          </p>
+        {/if}
+      </section>
+    {/if}
+  </main>
+</div>
+
+<style>
+  .score-progress {
+    height: 100vh;
+    display: flex;
+    flex-direction: column;
+  }
+
+  header {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    padding: 10px 16px;
+    border-bottom: 1px solid var(--line);
+    background: var(--bg-raised);
+  }
+
+  .back {
+    color: var(--ink-dim);
+    white-space: nowrap;
+  }
+
+  .back:hover {
+    color: var(--brass-bright);
+  }
+
+  header h1 {
+    font-size: 18px;
+  }
+
+  main {
+    flex: 1;
+    overflow-y: auto;
+    padding: 28px;
+    display: flex;
+    flex-direction: column;
+    gap: 34px;
+    max-width: 760px;
+  }
+
+  .section-head {
+    display: flex;
+    align-items: baseline;
+    gap: 12px;
+    margin-bottom: 12px;
+  }
+
+  h2 {
+    font-size: 16px;
+  }
+
+  .quiet {
+    color: var(--ink-dim);
+    font-size: 13px;
+  }
+
+  /* Deliberately NOT var(--danger). Nothing on this page is an error - see
+     Practice.svelte, which carries the same rule and the same test. */
+  .notice {
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-left: 3px solid var(--brass);
+    border-radius: 6px;
+    padding: 10px 14px;
+    margin: 0;
+    font-size: 14px;
+  }
+
+  .deleted-mark {
+    font-size: 11px;
+    letter-spacing: 0.04em;
+    color: #e8b45c;
+    border: 1px solid rgba(232, 180, 92, 0.5);
+    border-radius: 99px;
+    padding: 1px 7px;
+  }
+
+  /* The one number somebody came to this page for, at the size somebody
+     reading from a music stand can take in without leaning towards the
+     screen. */
+  .headline {
+    margin: 0 0 6px;
+    font-family: var(--font-display);
+    font-size: 26px;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .last-practised {
+    margin: 0 0 14px;
+  }
+
+  .actions {
+    display: flex;
+    gap: 16px;
+    align-items: baseline;
+    flex-wrap: wrap;
+    margin: 0;
+    font-size: 14px;
+  }
+
+  .statement-text {
+    font-variant-numeric: tabular-nums;
+    font-size: 15px;
+    margin: 0 0 10px;
+  }
+
+  .statements {
+    list-style: none;
+    padding: 0;
+    margin: 6px 0 0;
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+  }
+
+  /* One style for every statement, reached or not - the tick is the whole
+     difference and it is additive. Same rule as Practice.svelte. */
+  .statement {
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+    font-size: 14px;
+  }
+
+  .statement .tick {
+    width: 1em;
+    color: var(--brass-bright);
+  }
+
+  /* A no-op on purpose, and recorded as one: "the same as an unreached one" is
+     the answer, rather than an oversight for somebody to fill in with a green. */
+  .statement.reached .statement-text {
+    color: var(--ink);
+  }
+
+  /* Ninety days across the page. Each day is a column of its own so a quiet
+     fortnight is a visible gap in a texture rather than a number nobody
+     reads - and the totals above it are what actually state the figures, so
+     this never has to be measured against an axis. */
+  .history-strip {
+    display: flex;
+    align-items: flex-end;
+    gap: 1px;
+    height: 84px;
+    padding: 4px;
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: 5px;
+  }
+
+  .history-day {
+    flex: 1;
+    min-width: 2px;
+    height: var(--fill);
+    background: var(--brass);
+    border-radius: 1px 1px 0 0;
+  }
+
+  /* A day with nothing on it keeps its column and shows a floor, so the strip
+     reads as ninety days rather than as however many had practice in them. */
+  .history-day:not(.has-practice) {
+    height: 2px;
+    background: var(--line);
+  }
+
+  .strip-ends {
+    display: flex;
+    justify-content: space-between;
+    margin-top: 5px;
+  }
+
+  .tempo-chart {
+    width: 100%;
+    height: auto;
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: 5px;
+    margin: 6px 0 10px;
+  }
+
+  .tempo-line {
+    fill: none;
+    stroke: var(--brass);
+    stroke-width: 2;
+    stroke-linejoin: round;
+  }
+
+  .tempo-point {
+    fill: var(--brass);
+  }
+
+  /* A session that reached what it was aiming at is marked, and one that did
+     not is drawn exactly as it always was. Additive, like the tick on a goal:
+     something appears when a target IS reached rather than something being
+     marked when it is not. */
+  .tempo-point.reached {
+    fill: var(--brass-bright);
+    stroke: var(--brass-bright);
+    stroke-width: 4;
+  }
+
+  .tempo-value {
+    fill: var(--ink);
+    font-size: 15px;
+    font-variant-numeric: tabular-nums;
+    text-anchor: middle;
+  }
+
+  .target-line {
+    stroke: var(--ink-dim);
+    stroke-width: 1.5;
+    stroke-dasharray: 5 5;
+  }
+
+  .target-label {
+    fill: var(--ink-dim);
+    font-size: 12px;
+    text-anchor: end;
+  }
+
+  .tempo-days {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px 14px;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .split {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    font-size: 15px;
+  }
+
+  .split li {
+    display: grid;
+    grid-template-columns: 120px 1fr 80px;
+    gap: 12px;
+    align-items: center;
+  }
+
+  .split-track {
+    height: 16px;
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: 4px;
+    overflow: hidden;
+  }
+
+  .split-bar {
+    display: block;
+    height: 100%;
+    background: var(--brass);
+  }
+
+  .split-value {
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+    color: var(--ink-dim);
+  }
+
+  .ratings-split .split-label {
+    font-variant-numeric: tabular-nums;
+  }
+
+  .goal-list,
+  .session-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .goal-list {
+    gap: 14px;
+  }
+
+  .goal {
+    background: var(--bg-raised);
+    border: 1px solid var(--line);
+    border-radius: var(--radius);
+    padding: 14px 16px;
+  }
+
+  .goal-head {
+    display: flex;
+    justify-content: space-between;
+    gap: 12px;
+  }
+
+  .goal-label {
+    font-family: var(--font-display);
+    font-size: 15px;
+  }
+
+  .goal-reflection {
+    margin: 8px 0 0;
+  }
+
+  .session-list {
+    gap: 10px;
+    font-size: 14px;
+  }
+
+  .session {
+    display: grid;
+    grid-template-columns: 120px 70px 1fr;
+    gap: 10px;
+    align-items: baseline;
+    padding-bottom: 8px;
+    border-bottom: 1px solid var(--line);
+  }
+
+  .session-day,
+  .session-length {
+    color: var(--ink-dim);
+    font-size: 13px;
+    font-variant-numeric: tabular-nums;
+  }
+
+  /* "beside the date" is the whole point - without this the badge breaks onto
+     its own line the moment the track is a pixel too narrow, and a test that
+     asserts only the text cannot see that happen. */
+  .session-day {
+    white-space: nowrap;
+  }
+
+  .day-inferred {
+    font-size: 11px;
+    font-variant-numeric: normal;
+    opacity: 0.75;
+  }
+
+  .day-note {
+    margin: 12px 0 0;
+    font-size: 12px;
+  }
+
+  /* The note somebody wrote, at the size of something meant to be read rather
+     than of an annotation on a row - it is half of what a person comes back to
+     their own history for. */
+  .session-note {
+    grid-column: 2 / -1;
+    margin: 4px 0 0;
+    font-size: 14px;
+    line-height: 1.5;
+    max-width: 60ch;
+  }
+
+  .session-extra {
+    font-variant-numeric: tabular-nums;
+  }
+
+  .nothing-yet .statement-text {
+    color: var(--ink-dim);
+    max-width: 56ch;
+    line-height: 1.6;
+  }
+
+  .uncountable {
+    color: var(--ink-dim);
+    max-width: 52ch;
+  }
+</style>

--- a/web/src/lib/ScoreProgress.svelte
+++ b/web/src/lib/ScoreProgress.svelte
@@ -208,7 +208,13 @@
                 y1={chart.target.y}
                 y2={chart.target.y}
               />
-              <text class="target-label" x={chart.width - chart.pad} y={chart.target.y - 8}>
+              <!-- At the LEFT end and BELOW the line. The right end is where
+                   the newest sessions are, and on a piece that has reached its
+                   target those points sit exactly on this line with their own
+                   value printed above them - so a label there lands on top of
+                   the number it is meant to explain. Below the line, a point
+                   labelled at y-14 and this at y+14 cannot collide. -->
+              <text class="target-label" x={chart.pad} y={chart.target.y + 15}>
                 target {chart.target.bpm}
               </text>
             {/if}
@@ -225,7 +231,13 @@
                 data-bpm={point.tempo_bpm}
                 data-day={point.date}
               />
-              <text class="tempo-value" x={point.x} y={point.y - 14}>{point.tempo_bpm}</text>
+              {#if point.label}
+                <!-- Thinned when the points are packed too closely to print
+                     every one without them overlapping. Nothing is lost: the
+                     list under the chart carries every point with its day, and
+                     the most recent is always labelled here. -->
+                <text class="tempo-value" x={point.x} y={point.y - 14}>{point.tempo_bpm}</text>
+              {/if}
             {/each}
           </svg>
           <ul class="tempo-days quiet">
@@ -584,7 +596,7 @@
   .target-label {
     fill: var(--ink-dim);
     font-size: 12px;
-    text-anchor: end;
+    text-anchor: start;
   }
 
   .tempo-days {

--- a/web/src/lib/Viewer.svelte
+++ b/web/src/lib/Viewer.svelte
@@ -462,6 +462,18 @@
           >
             {practiceStart != null ? `■ ${formatElapsed(practiceElapsed)}` : "▶ Practice"}
           </button>
+          <!-- Where the time this button records ends up. Issue #57 asks for
+               this view to be reachable from the score itself as well as from
+               a place of its own, and beside the timer is where somebody asks
+               the question - "how is this one going" comes up when you have
+               just sat down with it, not while browsing a library. -->
+          <a
+            class="ghost history-link"
+            href={"#/score/" + score.id + "/practice"}
+            title="How this piece is going: the time, the days, the tempo, and your notes"
+          >
+            ◴ History
+          </a>
           <button class="ghost fav" class:on={score.favorite} onclick={toggleFavorite}>★</button>
           <button class="ghost" onclick={enterGigMode} title="Distraction-free performance view (F)">
             ⛶ Gig mode
@@ -619,6 +631,20 @@
     background: none;
     border-color: transparent;
     color: var(--ink-dim);
+  }
+
+  /* A link, not a button, because it goes somewhere - but it sits in a row of
+     buttons and has to be the same size and shape as them or the toolbar
+     develops a step in it. app.css styles `button, select, input` and an
+     anchor is none of the three, so the box it would have inherited is
+     restated here. */
+  .history-link {
+    font-family: var(--font-ui);
+    font-size: 14px;
+    border: 1px solid transparent;
+    border-radius: 8px;
+    padding: 7px 12px;
+    white-space: nowrap;
   }
 
   .ghost:hover {

--- a/web/src/lib/api.js
+++ b/web/src/lib/api.js
@@ -69,6 +69,15 @@ export const api = {
       body: JSON.stringify(body),
     }).then(j),
   practiceSummary: () => fetch("/api/practice/summary").then(j),
+  // How one piece is going (#57): its whole record, the window's per-day
+  // totals, the tempo each session was practised at, how the time split
+  // between section work and run-throughs, the sessions with their notes, and
+  // any goal set about this piece. One call, because every figure on it is
+  // counted by the server - a client totalling sessions itself would be
+  // writing arithmetic the API already owns, and getting it subtly different
+  // from whatever else reads that API next (issue #32).
+  scoreProgress: (id, days, today) =>
+    fetch(`/api/scores/${id}/practice/progress?days=${days}&today=${today}`).then(j),
   // Detail added to a session already logged. The timer stores the length the
   // moment it stops and this fills in how it went, so a stopped clock is never
   // waiting on a form and a session is never lost to an abandoned one. An

--- a/web/src/lib/practice.js
+++ b/web/src/lib/practice.js
@@ -485,6 +485,12 @@ export function splitBars(rows = [], value = (row) => row.seconds) {
  * lone dot pinned to the left edge reads as the start of a line somebody has
  * yet to draw.
  */
+// How much horizontal room a printed bpm needs before the next one crowds it.
+// Measured against the chart's own type size rather than guessed at: three
+// digits at 15px in this application's UI face come to a little under 30 units
+// in the chart's coordinate space, and this leaves a gap either side.
+const LABEL_ROOM = 34;
+
 export function tempoChart(tempo, { width = 640, height = 180, pad = 26 } = {}) {
   const points = tempo?.points ?? [];
   if (!points.length) return { points: [], target: null, width, height, pad };
@@ -497,6 +503,13 @@ export function tempoChart(tempo, { width = 640, height = 180, pad = 26 } = {}) 
   const inner = height - pad * 2;
   const y = (bpm) => (span ? pad + inner * (1 - (bpm - low) / span) : pad + inner / 2);
   const step = points.length > 1 ? (width - pad * 2) / (points.length - 1) : 0;
+  // A value is printed beside its own dot when there is room for it. Below
+  // about this much step the numbers start to sit on each other, and two
+  // figures overlapping is worse than one of them being read off the list
+  // underneath the chart - which carries every point with its day, always, and
+  // is the reason thinning these is safe rather than a loss.
+  const spacing = step > 0 ? Math.max(1, Math.ceil(LABEL_ROOM / step)) : 1;
+  const last = points.length - 1;
   return {
     width,
     height,
@@ -505,6 +518,9 @@ export function tempoChart(tempo, { width = 640, height = 180, pad = 26 } = {}) 
       ...point,
       x: points.length > 1 ? pad + step * i : width / 2,
       y: y(point.tempo_bpm),
+      // The most recent session is always labelled whatever the spacing works
+      // out to: it is the one number somebody opening this came to see.
+      label: i % spacing === 0 || i === last,
     })),
     target:
       tempo.latest_target == null

--- a/web/src/lib/practice.js
+++ b/web/src/lib/practice.js
@@ -347,6 +347,172 @@ export function rangeLabel(session) {
   return parts.join(", ");
 }
 
+// ---------------------------------------------------------------------------
+// ONE PIECE: how is this piece going (#57).
+//
+// The same rules as everything above, and one more that only bites here. A
+// page about a single piece is where a trend line is most tempting, because
+// there is one subject and a row of numbers about it - and it is where drawing
+// one would be least supported, because a piece is put down for a fortnight
+// and picked up again and that is not a decline. So:
+//
+//   Nothing below turns two numbers into a direction. No "faster than", no
+//   "up from", no arrow. The points are stated with their days and the reader
+//   draws their own conclusion, which is the only one that knows whether the
+//   fortnight was a holiday.
+//
+//   Every figure comes from the server. These functions put a number into
+//   words; not one of them computes a number the endpoint did not send. See
+//   issue #32's design rules - the arithmetic lives in one place so a second
+//   reader of that API cannot disagree with this one.
+// ---------------------------------------------------------------------------
+
+/** What this piece amounts to over the whole record, in words.
+ *
+ * Sessions and time, and never a per-session length: an average is a mark
+ * wearing a decimal point, and "your usual session is 24 minutes" is a
+ * standard a twenty-minute evening then falls short of.
+ */
+export function allTimeStatement(allTime) {
+  if (!allTime || !allTime.sessions) return "No practice logged against this piece yet";
+  const sessions = `${allTime.sessions} session${allTime.sessions === 1 ? "" : "s"}`;
+  return `${sessions}, ${formatDuration(allTime.seconds)} in total`;
+}
+
+/** When this piece was last played, and when it was first. Both are practice
+ * days rather than timestamps, and both come from the whole record rather than
+ * from whatever window is on screen - "when did I last play this" has no
+ * window, and answering it from one would call a piece untouched because the
+ * last month happened to be quiet. */
+export function lastPractisedStatement(allTime) {
+  if (!allTime || !allTime.last_practised) return "";
+  const last = `Last practised ${shortDate(allTime.last_practised)}`;
+  if (!allTime.first_practised || allTime.first_practised === allTime.last_practised) {
+    return `${last}, which is the one day it has been`;
+  }
+  return `${last}, first on ${shortDate(allTime.first_practised)}`;
+}
+
+/** What a window came to for one piece. The window's own length is named, so
+ * "nothing here" is plainly about a stretch of days rather than about the
+ * piece - which is the difference between a quiet quarter and a piece nobody
+ * has opened. */
+export function windowStatement(window, days) {
+  const span = `the last ${days} days`;
+  if (!window || !window.days_practised) return `No practice on this piece in ${span}`;
+  const total = `${formatDays(window.days_practised)}, ${formatDuration(window.seconds)} in ${span}`;
+  // The same disclosure periodStatement makes, for the same reason: a total
+  // that silently adds a recorded day to an assumed one is two kinds of day
+  // added together with nothing marking the join.
+  const inferred = window.sessions_inferred ?? 0;
+  if (!inferred) return total;
+  return `${total} (${inferred} session${inferred === 1 ? "" : "s"} on an assumed day)`;
+}
+
+/** What the tempo points do and do not amount to.
+ *
+ * A single point says so outright. This is the sentence issue #57 asks for in
+ * as many words - a week of history is a week of history, and the view should
+ * say so rather than drawing a confident trend through three points - and it
+ * is the reason the server sends `comparable` rather than leaving a client to
+ * decide how many points are enough.
+ */
+export function tempoStatement(tempo) {
+  if (!tempo || !tempo.count) return "No session on this piece wrote down a tempo";
+  const without = tempo.sessions_without_tempo ?? 0;
+  const rest = without
+    ? `, and ${without} session${without === 1 ? "" : "s"} without one`
+    : "";
+  if (!tempo.comparable) {
+    return `One session with a tempo${rest}. One session is not a progression`;
+  }
+  return `${tempo.count} sessions with a tempo${rest}`;
+}
+
+/** The tempo this piece is currently being worked towards, if any was written
+ * down. The latest target and not the highest ever set - see the server's
+ * tempo_progression for why reporting an abandoned number would be this page
+ * arguing with the person who abandoned it. */
+export function targetStatement(tempo) {
+  if (!tempo || tempo.latest_target == null) return "";
+  return `Working towards ${tempo.latest_target} bpm`;
+}
+
+/** How the work was approached, in words. A session that did not say is
+ * "Not stated" rather than being folded into either - the column exists so
+ * this is never guessed from whether a bar range happens to be present. */
+export function modeLabel(mode) {
+  return MODE_LABELS[mode] ?? "Not stated";
+}
+
+/** How many sessions on this piece carry the player's own sense of how it
+ * went. Counts, never a mean: a number out of five with a decimal point on it
+ * is a grade, and it is the figure a page would eventually colour. */
+export function ratingStatement(ratings) {
+  if (!ratings || !ratings.rated) return "No session on this piece was rated";
+  const unrated = ratings.unrated ?? 0;
+  const rated = `${ratings.rated} session${ratings.rated === 1 ? "" : "s"} rated`;
+  return unrated ? `${rated}, ${unrated} without a rating` : rated;
+}
+
+/** The bars of a split - section work against run-throughs, or the ratings -
+ * scaled against the largest bar IN THAT SPLIT.
+ *
+ * Within its own set, for the same reason dayBars is: a bar that shrinks
+ * because some other piece was worked harder is a comparison drawn in pixels.
+ */
+export function splitBars(rows = [], value = (row) => row.seconds) {
+  const most = rows.reduce((max, row) => Math.max(max, value(row) ?? 0), 0);
+  return rows.map((row) => ({
+    ...row,
+    // A floor so "a little" never renders as "nothing", and zero stays zero -
+    // a bucket nobody used is an empty bar, not a hairline that reads as one
+    // they did.
+    fill: most > 0 && (value(row) ?? 0) > 0 ? Math.max(0.06, value(row) / most) : 0,
+  }));
+}
+
+/** Where each tempo point sits in a box `width` by `height`, as plain numbers
+ * a template can put straight into an SVG.
+ *
+ * PIXELS ONLY. The axis this maps into is `axis_low` to `axis_high` as the
+ * SERVER sent them, and nothing here widens, rounds or recentres it: two
+ * readers deriving an axis differently is two charts that disagree about the
+ * same history, which is the whole reason that pair is on the response. What
+ * this function decides is entirely where a dot goes on a screen.
+ *
+ * A single point sits in the middle horizontally rather than at x=0, because a
+ * lone dot pinned to the left edge reads as the start of a line somebody has
+ * yet to draw.
+ */
+export function tempoChart(tempo, { width = 640, height = 180, pad = 26 } = {}) {
+  const points = tempo?.points ?? [];
+  if (!points.length) return { points: [], target: null, width, height, pad };
+  const low = tempo.axis_low;
+  const high = tempo.axis_high;
+  // A flat axis - every session at the same tempo, which is a real and common
+  // answer - would divide by zero and put every dot at the top. Centred
+  // instead, which is what "nothing changed" should look like.
+  const span = high > low ? high - low : 0;
+  const inner = height - pad * 2;
+  const y = (bpm) => (span ? pad + inner * (1 - (bpm - low) / span) : pad + inner / 2);
+  const step = points.length > 1 ? (width - pad * 2) / (points.length - 1) : 0;
+  return {
+    width,
+    height,
+    pad,
+    points: points.map((point, i) => ({
+      ...point,
+      x: points.length > 1 ? pad + step * i : width / 2,
+      y: y(point.tempo_bpm),
+    })),
+    target:
+      tempo.latest_target == null
+        ? null
+        : { bpm: tempo.latest_target, y: y(tempo.latest_target) },
+  };
+}
+
 /** A session's tempo, and whether a ladder run reached what it was aiming at.
  *
  * "reached 120" only when it did; when it did not, the two numbers are stated

--- a/web/tests/browser/zzzz-score-progress.spec.js
+++ b/web/tests/browser/zzzz-score-progress.spec.js
@@ -1,0 +1,381 @@
+// How is this piece going (#57), against the real backend and the real build.
+//
+// WHAT THESE PROVE THAT THE SERVER TESTS CANNOT.
+// server/tests/test_score_progress_api.py pins every figure the endpoint
+// computes, to the second. It cannot prove any of them reached the screen, and
+// #95's lesson - recorded next door in zz-library-missing.spec.js - is that a
+// guarantee nothing renders is a guarantee nobody has. So what is asserted
+// here is the seam: the numbers that are actually drawn, the empty state a new
+// piece gets INSTEAD of a screen of noughts, the sentence a single tempo point
+// gets instead of a line, and the fact that a deleted piece keeps its hours and
+// loses its link.
+//
+// AND ONE THING ONLY A BROWSER CAN CHECK AT ALL: that the tempo values are in
+// the page as text rather than in a tooltip. This is read from a music stand,
+// and a chart whose numbers appear on hover is a chart nobody standing at one
+// can read.
+//
+// WHY IT IS NAMED TO SORT LAST. It puts scores in the library, and every other
+// spec here refuses to run against a backend holding scores it did not put
+// there - including zzz-library-organise, whose own beforeEach empties the
+// library. Sorting after all of them keeps every one of those refusals true.
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { expect, test } from "@playwright/test";
+
+import { addDays, localDay } from "../../src/lib/practice.js";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const FIXTURE = path.join(here, "..", "..", "test-fixtures", "notation-only.musicxml");
+
+const SCAN_DEADLINE_MS = 30_000;
+
+const today = localDay();
+
+async function scanSettled(request) {
+  const deadline = Date.now() + SCAN_DEADLINE_MS;
+  for (;;) {
+    const status = await (await request.get("/api/scan/status")).json();
+    if (!status.scanning) return status;
+    if (Date.now() > deadline) throw new Error("a scan never finished");
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+}
+
+/** A real score in the throwaway library. Same shape as
+ * zzz-library-organise.spec.js's helper and for the same reasons: the content
+ * is made distinct per name so the scanner's content-hash relink does not
+ * treat the second upload as a rename of the first, and the scan the upload
+ * starts is waited out so a later delete is not refused for arriving during
+ * it. */
+async function upload(request, name) {
+  const body = Buffer.concat([fs.readFileSync(FIXTURE), Buffer.from(`<!-- ${name} -->\n`)]);
+  const res = await request.post("/api/upload?folder=Uploads", {
+    multipart: { file: { name, mimeType: "application/xml", buffer: body } },
+  });
+  expect(res.ok(), await res.text()).toBe(true);
+  let found;
+  await expect(async () => {
+    const scores = await (await request.get("/api/scores")).json();
+    found = scores.find((s) => s.path === `Uploads/${name}`);
+    expect(found, `${name} never appeared in the library`).toBeTruthy();
+  }).toPass({ timeout: SCAN_DEADLINE_MS });
+  await scanSettled(request);
+  return found;
+}
+
+/** One session against a piece. Awaited before anything navigates, so nothing
+ * here reads a page for state a request has not finished writing (#110). */
+async function practise(request, scoreId, body) {
+  const res = await request.post(`/api/scores/${scoreId}/practice`, { data: body });
+  expect(res.ok(), await res.text()).toBe(true);
+  return res.json();
+}
+
+async function emptyTheLibrary(request) {
+  await scanSettled(request);
+  for (const score of await (await request.get("/api/scores")).json()) {
+    await request.delete(`/api/scores/${score.id}`);
+  }
+  for (const score of await (await request.get("/api/trash")).json()) {
+    await request.delete(`/api/trash/${score.id}`);
+  }
+  const sessions = (await (await request.get("/api/practice/sessions?limit=1000")).json())
+    .sessions;
+  for (const session of sessions) await request.delete(`/api/practice/sessions/${session.id}`);
+  const goals = (await (await request.get(`/api/practice/goals?today=${today}`)).json()).goals;
+  for (const goal of goals) await request.delete(`/api/practice/goals/${goal.id}`);
+}
+
+test.beforeEach(async ({ request }) => {
+  // The same refusal every spec in this suite carries, and the same reason:
+  // the helper below destroys scores and deletes practice history, which is
+  // the one thing in this application that cannot be regenerated.
+  const existing = await (await request.get("/api/scores")).json();
+  const foreign = existing.filter((s) => !s.missing_since && !s.path.startsWith("Uploads/"));
+  expect(
+    foreign,
+    "refusing to run: this backend has scores in folders the suite never creates, so it is " +
+      "not the throwaway instance the suite creates - and this file empties the library",
+  ).toEqual([]);
+  await emptyTheLibrary(request);
+});
+
+test.afterAll(async ({ request }) => {
+  await emptyTheLibrary(request);
+});
+
+const headline = (page) => page.locator(".headline");
+const tempoTotal = (page) => page.locator(".tempo-total");
+const tempoValues = (page) => page.locator(".tempo-value");
+const tempoPoints = (page) => page.locator(".tempo-point");
+const sessions = (page) => page.locator(".session-list .session");
+
+async function open(page, scoreId) {
+  await page.goto(`/#/score/${scoreId}/practice`);
+  await expect(page.locator(".score-progress")).toBeVisible();
+}
+
+test("a piece nobody has played says so, instead of showing a screen of noughts", async ({
+  page,
+  request,
+}) => {
+  // The empty state is a different STATEMENT from a total of zero, not a
+  // prettier rendering of one - the server says which this is (`practised`)
+  // so a page never has to guess it from a nought.
+  const score = await upload(request, "progress-untouched.musicxml");
+  await open(page, score.id);
+
+  await expect(page.locator(".nothing-yet")).toBeVisible();
+  await expect(page.locator(".nothing-yet")).toContainText("No practice logged against this piece yet");
+  // Not "0 sessions", not "none in total", not an empty chart with an axis on
+  // it. None of the measuring furniture is drawn at all.
+  await expect(headline(page)).toHaveCount(0);
+  await expect(page.locator(".history-strip")).toHaveCount(0);
+  await expect(page.locator(".tempo-chart")).toHaveCount(0);
+  await expect(page.locator(".session-list")).toHaveCount(0);
+  // And there is somewhere to go from it, which is the only useful thing a
+  // page with no data can offer.
+  await expect(page.locator(".open-score")).toHaveAttribute("href", `#/score/${score.id}`);
+});
+
+test("the whole record and the window are stated separately, in words and in figures", async ({
+  page,
+  request,
+}) => {
+  const score = await upload(request, "progress-totals.musicxml");
+  await practise(request, score.id, { seconds: 1500, local_date: today });
+  await practise(request, score.id, { seconds: 2100, local_date: addDays(today, -2) });
+  await open(page, score.id);
+
+  // 25m + 35m. Pinned as the string a person reads, not as a number a test
+  // recomputed with the same arithmetic as the thing under test.
+  await expect(headline(page)).toHaveText("2 sessions, 1h in total");
+  await expect(page.locator(".window-total")).toHaveText("2 days, 1h in the last 90 days");
+  // "When did I last play this" has no window and is answered from the whole
+  // record - the two blocks are separate on purpose.
+  await expect(page.locator(".last-practised")).toContainText("Last practised");
+  // Ninety columns, one per day, including the empty ones: a day with nothing
+  // on it is a fact about the window and not a gap to be inferred.
+  await expect(page.locator(".history-strip .history-day")).toHaveCount(90);
+  await expect(
+    page.locator(`.history-strip .history-day[data-day="${today}"]`),
+  ).toHaveAttribute("data-seconds", "1500");
+  await expect(
+    page.locator(`.history-strip .history-day[data-day="${addDays(today, -1)}"]`),
+  ).toHaveAttribute("data-seconds", "0");
+});
+
+test("one session at a tempo is drawn as one session and not as a trend", async ({
+  page,
+  request,
+}) => {
+  // Issue #57's own words: the view should say so rather than drawing a
+  // confident trend through three points. Through one, even more so.
+  const score = await upload(request, "progress-one-tempo.musicxml");
+  await practise(request, score.id, {
+    seconds: 1200,
+    local_date: today,
+    tempo_bpm: 90,
+    target_tempo_bpm: 120,
+  });
+  await open(page, score.id);
+
+  await expect(tempoTotal(page)).toContainText("One session is not a progression");
+  await expect(tempoPoints(page)).toHaveCount(1);
+  // No line at all. Not a faint one, not a flat one - joining a single point
+  // to nothing is the shape a reader reads as the start of a climb.
+  await expect(page.locator(".tempo-line")).toHaveCount(0);
+  await expect(tempoValues(page)).toHaveText(["90"]);
+});
+
+test("several tempo points are drawn in the order they happened, with their values in the page", async ({
+  page,
+  request,
+}) => {
+  const score = await upload(request, "progress-tempo-ladder.musicxml");
+  // Logged newest first, so a chart that drew them in insertion order would
+  // come out backwards and this would catch it.
+  await practise(request, score.id, {
+    seconds: 900,
+    local_date: today,
+    tempo_bpm: 120,
+    target_tempo_bpm: 120,
+  });
+  await practise(request, score.id, { seconds: 900, local_date: addDays(today, -10), tempo_bpm: 100 });
+  await practise(request, score.id, { seconds: 900, local_date: addDays(today, -20), tempo_bpm: 80 });
+  await open(page, score.id);
+
+  await expect(tempoTotal(page)).toHaveText("3 sessions with a tempo");
+  // Oldest first, left to right, and every value present as TEXT - the whole
+  // point of this section on a music stand.
+  await expect(tempoValues(page)).toHaveText(["80", "100", "120"]);
+  await expect(page.locator(".tempo-line")).toHaveCount(1);
+  // The target is named beside its line, so the dashed rule is not a mystery.
+  await expect(page.locator(".tempo-target")).toHaveText("Working towards 120 bpm");
+  await expect(page.locator(".target-label")).toContainText("120");
+  // Reaching a target is marked ADDITIVELY - something appears on the one that
+  // did, rather than something being marked on the two that did not.
+  await expect(page.locator(".tempo-point.reached")).toHaveCount(1);
+  await expect(page.locator(".tempo-point.reached")).toHaveAttribute("data-bpm", "120");
+});
+
+test("the time splits between section work and run-throughs, and the unstated stays visible", async ({
+  page,
+  request,
+}) => {
+  const score = await upload(request, "progress-modes.musicxml");
+  await practise(request, score.id, { seconds: 900, local_date: today, mode: "section" });
+  await practise(request, score.id, { seconds: 300, local_date: today, mode: "run_through" });
+  await practise(request, score.id, { seconds: 120, local_date: today });
+  await open(page, score.id);
+
+  await expect(page.locator('.split li[data-mode="section"] .split-value')).toHaveText("15m");
+  await expect(page.locator('.split li[data-mode="run_through"] .split-value')).toHaveText("5m");
+  // Not dropped and not folded into either of the two - the column exists so
+  // this is never guessed from whether a bar range happens to be present.
+  await expect(page.locator('.split li[data-mode="unstated"] .split-label')).toHaveText(
+    "Not stated",
+  );
+});
+
+test("the sessions arrive with whatever was written about them", async ({ page, request }) => {
+  // Half of what somebody comes back to their own history for is the note.
+  const score = await upload(request, "progress-notes.musicxml");
+  await practise(request, score.id, {
+    seconds: 1800,
+    local_date: today,
+    note: "left hand shape at bar 34 still collapsing",
+    from_bar: 30,
+    to_bar: 38,
+    tempo_bpm: 88,
+    target_tempo_bpm: 120,
+    mode: "section",
+  });
+  await open(page, score.id);
+
+  await expect(sessions(page)).toHaveCount(1);
+  await expect(page.locator(".session-note")).toHaveText(
+    "left hand shape at bar 34 still collapsing",
+  );
+  await expect(page.locator(".session-extra")).toContainText("bars 30-38");
+  await expect(page.locator(".session-extra")).toContainText("88 bpm, aiming at 120");
+});
+
+test("a goal set about this piece appears with its intent and its counts", async ({
+  page,
+  request,
+}) => {
+  const score = await upload(request, "progress-goal.musicxml");
+  const goal = await request.post(`/api/practice/goals?today=${today}`, {
+    data: {
+      target_days: 3,
+      scope: "score",
+      score_id: score.id,
+      intent: "the awkward middle section",
+    },
+  });
+  expect(goal.ok(), await goal.text()).toBe(true);
+  await practise(request, score.id, { seconds: 1200, local_date: today });
+  await open(page, score.id);
+
+  const shown = page.locator(".goal");
+  await expect(shown).toHaveCount(1);
+  await expect(shown.locator(".goal-intent")).toHaveText("the awkward middle section");
+  // The count and nothing concluded from it: one of three, with no percentage,
+  // no grade and no "missing two".
+  await expect(shown.locator(".statement-text")).toHaveText("1 of 3 planned days");
+});
+
+test("this view is reachable from the score itself", async ({ page, request }) => {
+  // Issue #57 asks for both: reachable from the score, and a place of its own.
+  // The place of its own is the URL every other test here opens directly; this
+  // is the other half, and it is the half a person actually finds.
+  const score = await upload(request, "progress-from-viewer.musicxml");
+  await practise(request, score.id, { seconds: 600, local_date: today });
+
+  await page.goto(`/#/score/${score.id}`);
+  const link = page.locator(".history-link");
+  await expect(link).toBeVisible();
+  await link.click();
+  // Waited on through the page, not read back out of band (#110): the heading
+  // cannot be there until the route changed and the endpoint answered.
+  await expect(page.locator(".score-progress")).toBeVisible();
+  await expect(headline(page)).toHaveText("1 session, 10m in total");
+});
+
+test("a piece in the trash keeps every hour and stops being a way into the library", async ({
+  page,
+  request,
+}) => {
+  // Issue #56's policy, on the page that is entirely about one piece: the
+  // hours were spent, so they are still counted and still shown - and the
+  // piece is not in the library, so nothing here offers a way into it.
+  const score = await upload(request, "progress-deleted.musicxml");
+  await practise(request, score.id, { seconds: 2700, local_date: today, tempo_bpm: 90 });
+
+  await open(page, score.id);
+  await expect(headline(page)).toHaveText("1 session, 45m in total");
+  await expect(page.locator(`a[href="#/score/${score.id}"]`)).toHaveCount(1);
+
+  const deleted = await request.delete(`/api/scores/${score.id}`);
+  expect(deleted.ok(), await deleted.text()).toBe(true);
+
+  await page.reload();
+  await expect(page.locator(".score-progress")).toBeVisible();
+  await expect(page.locator(".deleted-mark")).toHaveText("deleted");
+  // Still counted, to the minute.
+  await expect(headline(page)).toHaveText("1 session, 45m in total");
+  await expect(sessions(page)).toHaveCount(1);
+  await expect(tempoPoints(page)).toHaveCount(1);
+  // And no route into a score the library no longer holds.
+  await expect(page.locator(`a[href="#/score/${score.id}"]`)).toHaveCount(0);
+  await expect(page.locator(".open-score")).toHaveCount(0);
+});
+
+test("nothing on this page is styled as an error", async ({ page, request }) => {
+  // The same rule Practice.svelte carries and the same reason: a target not
+  // reached is not a fault, and a page about one piece is where colouring one
+  // would be most tempting. Checked against the colour this application
+  // actually uses for a real error rather than against a name in a stylesheet.
+  const score = await upload(request, "progress-no-danger.musicxml");
+  await practise(request, score.id, {
+    seconds: 600,
+    local_date: today,
+    tempo_bpm: 80,
+    target_tempo_bpm: 120,
+    rating: 2,
+  });
+  await open(page, score.id);
+
+  const danger = await page.evaluate(() =>
+    getComputedStyle(document.documentElement).getPropertyValue("--danger").trim(),
+  );
+  expect(danger, "--danger is expected to be defined, or this test proves nothing").toBeTruthy();
+  // Through a probe, like practice.spec.js's version of this check: the
+  // variable holds a hex and every computed colour comes back as rgb(), so
+  // comparing the two directly is a test that can never go red.
+  const dangerRgb = await page.evaluate((hex) => {
+    const probe = document.createElement("span");
+    probe.style.color = hex;
+    document.body.appendChild(probe);
+    const value = getComputedStyle(probe).color;
+    probe.remove();
+    return value;
+  }, danger);
+  expect(dangerRgb).toMatch(/^rgb/);
+
+  const colours = await page.evaluate(() =>
+    [...document.querySelectorAll(".score-progress *")].map((el) => {
+      const style = getComputedStyle(el);
+      return [style.color, style.backgroundColor, style.borderColor, style.fill].join(" ");
+    }),
+  );
+  expect(colours.length, "nothing was inspected, so nothing was proved").toBeGreaterThan(20);
+  // A session that did not reach its target, and a rating of 2, are both on
+  // this page - and neither is drawn in the error colour.
+  const dangerous = colours.filter((c) => c.includes(dangerRgb));
+  expect(dangerous, "something on this page is drawn in the error colour").toEqual([]);
+});

--- a/web/tests/spec-floors/browser-zzzz-score-progress-57.json
+++ b/web/tests/spec-floors/browser-zzzz-score-progress-57.json
@@ -1,0 +1,5 @@
+{
+  "file": "tests/browser/zzzz-score-progress.spec.js",
+  "count": 10,
+  "reason": "issue #57: the per-piece practice view - the empty state a new piece gets instead of a screen of noughts, one tempo point drawn as one session rather than a trend, the tempo values present as text for a music stand, a deleted piece keeping its hours and losing its link (#56), and nothing on the page in the error colour."
+}

--- a/web/tests/spec-floors/unit-practice-57.json
+++ b/web/tests/spec-floors/unit-practice-57.json
@@ -1,0 +1,5 @@
+{
+  "file": "tests/unit/practice.spec.js",
+  "count": 10,
+  "reason": "issue #57: how one piece is going, in words - the whole record against a window, a single tempo point saying it is not a progression, ratings counted and never averaged, and the chart mapping into the axis the server sent."
+}

--- a/web/tests/spec-floors/unit-practice-57.json
+++ b/web/tests/spec-floors/unit-practice-57.json
@@ -1,5 +1,5 @@
 {
   "file": "tests/unit/practice.spec.js",
-  "count": 10,
+  "count": 11,
   "reason": "issue #57: how one piece is going, in words - the whole record against a window, a single tempo point saying it is not a progression, ratings counted and never averaged, and the chart mapping into the axis the server sent."
 }

--- a/web/tests/unit/practice.spec.js
+++ b/web/tests/unit/practice.spec.js
@@ -419,6 +419,40 @@ test("the tempo chart maps points into the axis the server sent, and nothing els
   expect(tempoChart(null).points).toEqual([]);
 });
 
+test("printed tempo values thin out when the points crowd, and the newest is always one of them", () => {
+  const points = (n) =>
+    Array.from({ length: n }, (_, i) => ({ session_id: i, tempo_bpm: 80 + i }));
+  const chart = (n, width) =>
+    tempoChart(
+      { points: points(n), axis_low: 80, axis_high: 80 + n, latest_target: null },
+      { width, height: 100, pad: 10 },
+    );
+
+  // Room for every one: 5 points across 580 units is 145 apart.
+  expect(chart(5, 600).points.every((p) => p.label)).toBe(true);
+
+  // Packed: 40 points across 580 units is under 15 apart, so three digits
+  // printed at every dot would sit on each other.
+  const crowded = chart(40, 600);
+  const labelled = crowded.points.filter((p) => p.label);
+  expect(labelled.length).toBeLessThan(40);
+  expect(labelled.length).toBeGreaterThan(0);
+  // Whatever the spacing works out to, the most recent session is labelled -
+  // it is the one number somebody opening this came to see.
+  expect(crowded.points[crowded.points.length - 1].label).toBe(true);
+  // And the ones that are labelled are far enough apart to be read.
+  const xs = labelled.map((p) => p.x);
+  for (let i = 1; i < xs.length - 1; i += 1) {
+    expect(xs[i] - xs[i - 1], "two printed values are too close together").toBeGreaterThanOrEqual(
+      34,
+    );
+  }
+  // Nothing is lost by thinning: every point is still a point, with its own
+  // value, and the list the page draws under the chart reads from these.
+  expect(crowded.points).toHaveLength(40);
+  expect(crowded.points.every((p) => Number.isFinite(p.tempo_bpm))).toBe(true);
+});
+
 test("every sentence the per-piece view produces passes the vocabulary check", () => {
   // The same list the rest of this feature is held to, applied to the phrases
   // #57 adds. A per-piece page is where "your best tempo" and "behind on this

--- a/web/tests/unit/practice.spec.js
+++ b/web/tests/unit/practice.spec.js
@@ -39,6 +39,15 @@ import {
   tempoLabel,
   timeLeftStatement,
   weekStart,
+  allTimeStatement,
+  lastPractisedStatement,
+  modeLabel,
+  ratingStatement,
+  splitBars,
+  targetStatement,
+  tempoChart,
+  tempoStatement,
+  windowStatement,
 } from "../../src/lib/practice.js";
 
 const goal = (over = {}) => ({
@@ -176,7 +185,15 @@ test("the forbidden vocabulary is matched as whole words", () => {
 // on the whole word "record", in a file whose header says the words are the
 // feature.
 const HERE = path.dirname(fileURLToPath(import.meta.url));
-const COMPONENTS = ["Practice.svelte", "Viewer.svelte", "Library.svelte"];
+const COMPONENTS = [
+  "Practice.svelte",
+  "Viewer.svelte",
+  "Library.svelte",
+  // The per-piece view (#57). A page about one piece is the one most tempting
+  // to write a verdict on - there is a single subject and a row of numbers
+  // about it - so it is the one that most needs this check.
+  "ScoreProgress.svelte",
+];
 
 // The attributes a person actually reads. Every other attribute value is
 // dropped before the check, because they are machine vocabulary and collide
@@ -201,6 +218,232 @@ test("the practice interface's own words pass the same vocabulary check", () => 
     const source = fs.readFileSync(path.join(HERE, "..", "..", "src", "lib", name), "utf8");
     const found = forbiddenWord(visibleText(source));
     expect(found, `${name} contains the word ${found}`).toBeNull();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// One piece: how is this piece going (#57).
+//
+// Same rule as everything above - the wording IS the feature - and one more
+// that only applies here. A page about a single piece is where a direction is
+// most tempting to state, so these pin that none of it does: no "faster than",
+// no "up from", no arrow, and a single tempo point saying outright that it is
+// not a progression.
+// ---------------------------------------------------------------------------
+
+const allTime = (over = {}) => ({
+  sessions: 12,
+  seconds: 12_000,
+  minutes: 200,
+  first_practised: "2026-06-03",
+  last_practised: "2026-08-14",
+  sessions_inferred: 0,
+  ...over,
+});
+
+test("what a piece amounts to over its whole record is sessions and time, never a per-session length", () => {
+  expect(allTimeStatement(allTime())).toBe("12 sessions, 3h 20m in total");
+  expect(allTimeStatement(allTime({ sessions: 1, seconds: 600 }))).toBe(
+    "1 session, 10m in total",
+  );
+  // A piece nobody has played. Said in words rather than as "0 sessions, none
+  // in total", which is a row of noughts pretending to be a measurement.
+  expect(allTimeStatement(allTime({ sessions: 0, seconds: 0 }))).toBe(
+    "No practice logged against this piece yet",
+  );
+  expect(allTimeStatement(null)).toBe("No practice logged against this piece yet");
+  // Nothing anywhere in this statement divides one number by the other. An
+  // average session length is a standard a short evening then falls short of.
+  expect(allTimeStatement(allTime())).not.toContain("per");
+});
+
+test("when a piece was last played comes from the whole record and not from a window", () => {
+  expect(lastPractisedStatement(allTime())).toBe("Last practised 14 Aug, first on 3 Jun");
+  // One day is one day, and "first on" the same date would read as two.
+  expect(lastPractisedStatement(allTime({ first_practised: "2026-08-14" }))).toBe(
+    "Last practised 14 Aug, which is the one day it has been",
+  );
+  expect(lastPractisedStatement(allTime({ last_practised: null }))).toBe("");
+  expect(lastPractisedStatement(null)).toBe("");
+});
+
+test("a window states its own length, so an empty one is about the days and not about the piece", () => {
+  expect(windowStatement({ days_practised: 8, seconds: 12_000, sessions_inferred: 0 }, 90)).toBe(
+    "8 days, 3h 20m in the last 90 days",
+  );
+  expect(windowStatement({ days_practised: 1, seconds: 600, sessions_inferred: 0 }, 30)).toBe(
+    "1 day, 10m in the last 30 days",
+  );
+  expect(windowStatement({ days_practised: 0, seconds: 0 }, 90)).toBe(
+    "No practice on this piece in the last 90 days",
+  );
+  expect(windowStatement(null, 7)).toBe("No practice on this piece in the last 7 days");
+  // The same disclosure a week's total makes: how much of it rests on a day
+  // nobody recorded.
+  expect(windowStatement({ days_practised: 2, seconds: 3600, sessions_inferred: 1 }, 90)).toBe(
+    "2 days, 1h in the last 90 days (1 session on an assumed day)",
+  );
+  expect(windowStatement({ days_practised: 2, seconds: 3600, sessions_inferred: 2 }, 90)).toBe(
+    "2 days, 1h in the last 90 days (2 sessions on an assumed day)",
+  );
+});
+
+test("one tempo point says outright that it is not a progression", () => {
+  // Issue #57 in as many words: a week of history is a week of history, and
+  // the view should say so rather than drawing a confident trend through three
+  // points. The server decides how many points are enough (`comparable`), so
+  // this and any other reader of that API cannot disagree about it.
+  expect(tempoStatement({ count: 1, comparable: false, sessions_without_tempo: 0 })).toBe(
+    "One session with a tempo. One session is not a progression",
+  );
+  expect(tempoStatement({ count: 1, comparable: false, sessions_without_tempo: 3 })).toBe(
+    "One session with a tempo, and 3 sessions without one. One session is not a progression",
+  );
+  expect(tempoStatement({ count: 4, comparable: true, sessions_without_tempo: 0 })).toBe(
+    "4 sessions with a tempo",
+  );
+  expect(tempoStatement({ count: 4, comparable: true, sessions_without_tempo: 1 })).toBe(
+    "4 sessions with a tempo, and 1 session without one",
+  );
+  expect(tempoStatement({ count: 0, comparable: false, sessions_without_tempo: 2 })).toBe(
+    "No session on this piece wrote down a tempo",
+  );
+  expect(tempoStatement(null)).toBe("No session on this piece wrote down a tempo");
+});
+
+test("the tempo target reported is the one most recently written down", () => {
+  expect(targetStatement({ latest_target: 120 })).toBe("Working towards 120 bpm");
+  expect(targetStatement({ latest_target: null })).toBe("");
+  expect(targetStatement(null)).toBe("");
+});
+
+test("a session that did not say how it was approached reads as not stated", () => {
+  expect(modeLabel("section")).toBe("Section work");
+  expect(modeLabel("run_through")).toBe("Run-through");
+  // Not folded into either, and not blank - the column exists so this is never
+  // guessed from whether a bar range happens to be present.
+  expect(modeLabel(null)).toBe("Not stated");
+  expect(modeLabel(undefined)).toBe("Not stated");
+  // A mode a newer server knows about and this build does not must not render
+  // as "undefined" beside a real one.
+  expect(modeLabel("sight_read_through")).toBe("Not stated");
+});
+
+test("ratings are counted and never averaged", () => {
+  expect(ratingStatement({ rated: 3, unrated: 1 })).toBe("3 sessions rated, 1 without a rating");
+  expect(ratingStatement({ rated: 1, unrated: 0 })).toBe("1 session rated");
+  expect(ratingStatement({ rated: 0, unrated: 4 })).toBe("No session on this piece was rated");
+  expect(ratingStatement(null)).toBe("No session on this piece was rated");
+  // No decimal point anywhere: a number out of five with one on it is a grade.
+  expect(ratingStatement({ rated: 3, unrated: 1 })).not.toMatch(/\d\.\d/);
+});
+
+test("a split's bars are scaled inside their own split and a zero stays empty", () => {
+  const bars = splitBars([
+    { mode: "section", seconds: 1500 },
+    { mode: "run_through", seconds: 750 },
+    { mode: null, seconds: 0 },
+  ]);
+  expect(bars.map((b) => b.fill)).toEqual([1, 0.5, 0]);
+  // The row's own fields survive, so a template does not have to zip two lists.
+  expect(bars[0].mode).toBe("section");
+  // A different value to scale by - the ratings count sessions, not seconds.
+  const ratings = splitBars(
+    [
+      { rating: 1, sessions: 0 },
+      { rating: 4, sessions: 2 },
+    ],
+    (r) => r.sessions,
+  );
+  expect(ratings.map((r) => r.fill)).toEqual([0, 1]);
+  // Nothing at all: no bar is full rather than every bar being full.
+  expect(splitBars([{ mode: "section", seconds: 0 }])[0].fill).toBe(0);
+  expect(splitBars([])).toEqual([]);
+  // A tiny share still shows, so "a little" never renders as "nothing".
+  expect(splitBars([{ seconds: 1000 }, { seconds: 1 }])[1].fill).toBe(0.06);
+});
+
+test("the tempo chart maps points into the axis the server sent, and nothing else", () => {
+  const chart = tempoChart(
+    {
+      points: [
+        { session_id: 1, date: "2026-06-03", tempo_bpm: 80 },
+        { session_id: 2, date: "2026-07-01", tempo_bpm: 100 },
+        { session_id: 3, date: "2026-08-14", tempo_bpm: 120 },
+      ],
+      axis_low: 80,
+      axis_high: 120,
+      latest_target: 120,
+    },
+    { width: 100, height: 100, pad: 10 },
+  );
+  // Evenly spaced across the box, first at the left pad and last at the right.
+  expect(chart.points.map((p) => p.x)).toEqual([10, 50, 90]);
+  // The axis is axis_low..axis_high exactly - not widened, rounded or
+  // recentred. Two readers deriving an axis differently is two charts that
+  // disagree about the same history.
+  expect(chart.points.map((p) => p.y)).toEqual([90, 50, 10]);
+  expect(chart.target).toEqual({ bpm: 120, y: 10 });
+
+  // Every session at the same tempo is a real answer, and dividing by a span
+  // of zero would put every dot at the top as though it were a climb.
+  const flat = tempoChart(
+    {
+      points: [
+        { session_id: 1, tempo_bpm: 90 },
+        { session_id: 2, tempo_bpm: 90 },
+      ],
+      axis_low: 90,
+      axis_high: 90,
+      latest_target: null,
+    },
+    { width: 100, height: 100, pad: 10 },
+  );
+  expect(flat.points.map((p) => p.y)).toEqual([50, 50]);
+  expect(flat.target).toBeNull();
+
+  // A lone dot sits in the middle rather than pinned to the left edge, where
+  // it reads as the start of a line somebody has yet to draw.
+  const one = tempoChart(
+    {
+      points: [{ session_id: 1, tempo_bpm: 90 }],
+      axis_low: 90,
+      axis_high: 90,
+      latest_target: null,
+    },
+    { width: 100, height: 100, pad: 10 },
+  );
+  expect(one.points[0].x).toBe(50);
+
+  expect(tempoChart({ points: [] }).points).toEqual([]);
+  expect(tempoChart(null).points).toEqual([]);
+});
+
+test("every sentence the per-piece view produces passes the vocabulary check", () => {
+  // The same list the rest of this feature is held to, applied to the phrases
+  // #57 adds. A per-piece page is where "your best tempo" and "behind on this
+  // one" would arrive if they ever did, so the guard is on the output rather
+  // than on somebody remembering the rules at the top of practice.js.
+  const sentences = [
+    allTimeStatement(allTime()),
+    allTimeStatement(allTime({ sessions: 0, seconds: 0 })),
+    lastPractisedStatement(allTime()),
+    lastPractisedStatement(allTime({ first_practised: "2026-08-14" })),
+    windowStatement({ days_practised: 8, seconds: 12_000, sessions_inferred: 1 }, 90),
+    windowStatement({ days_practised: 0, seconds: 0 }, 90),
+    tempoStatement({ count: 1, comparable: false, sessions_without_tempo: 2 }),
+    tempoStatement({ count: 5, comparable: true, sessions_without_tempo: 0 }),
+    tempoStatement({ count: 0 }),
+    targetStatement({ latest_target: 120 }),
+    ratingStatement({ rated: 3, unrated: 1 }),
+    ratingStatement({ rated: 0, unrated: 4 }),
+    modeLabel(null),
+    modeLabel("section"),
+    modeLabel("run_through"),
+  ];
+  for (const sentence of sentences) {
+    const found = forbiddenWord(sentence);
+    expect(found, `"${sentence}" contains the word ${found}`).toBeNull();
   }
 });
 


### PR DESCRIPTION
Closes #57.

The issue's own last comment narrowed what was left of it: #94 delivered the
library-wide half — where the time went, an eight-week review, the recently-
practised and neglected filters — and what remained was **per score**. "There is
a post-session panel in the viewer and practice aggregates on the score rows,
but no view that answers *how is this piece going* — total time, when it was
last practised, and the sessions with their notes, in one place reachable from
the score." That is what this is.

## One endpoint, because the arithmetic belongs in one place

`GET /api/scores/{id}/practice/progress?days=&today=&limit=`

| Block | What it answers |
| --- | --- |
| `all_time` | Sessions, seconds, minutes, and the **first** and **last** practice day. The one block no window bounds. |
| `window` | `period_facts` scoped to this piece: every day in the window including the empty ones. |
| `tempo` | One point per session that recorded a tempo, oldest first, with its day, its target and `reached_target`. |
| `modes` | Section work against run-throughs, and the sessions that said neither. |
| `ratings` | How many sessions got each 1–5 rating, and how many got none. |
| `goals` | Goals scoped to **this piece** whose period touches the window, each with its progress. |
| `sessions` | This piece's sessions in the window with their notes, plus `session_total` / `sessions_truncated`. |

Not six endpoints, and not one endpoint a client filters and totals itself. A
client doing that arithmetic would be rewriting what `practice.py` already owns,
and the next reader of this API — the MCP server #31 plans — would write it a
third time and get it subtly differently, with nothing to say which of the three
was right. That is #32's design rule: every field readable through the
documented API, so any future integration wraps one source of truth.

`grouped_by` names the column every figure was grouped by (`local_date`), and
both `all_time` and `window` report `sessions_inferred` — how much of each total
rests on a day nobody recorded.

## What it refuses to compute, and why that is a decision rather than an omission

**The brief for this work asked for streak and consistency figures. They are not
here, deliberately.** Issue #3 lists streaks under its "deliberately not":
*missing a week because of a busy job is information, not a moral failure.*
`docs/practice-data.md` says the same under what is deliberately absent, and adds
no comparison between periods and no personal best. A per-piece view is where a
run of days would be most tempting and would do the most damage — a piece is put
down and picked up again by design, and a run of days is the one number that
punishes exactly that. Building it would have meant this PR contradicting the
product rules the same feature already ships and documents. Flagged rather than
quietly complied with, since it is a real difference from what was asked for.

Also absent, for the same family of reasons: **no line fitted through the tempo
points** (the points are two numbers somebody entered; a slope through them is a
claim about their playing the data cannot support), and **no average rating** (a
number out of five with a decimal point is a mark, not a fact).

`test_nothing_on_this_response_is_a_streak_a_best_or_an_average` walks the whole
response and fails on a field named for any of them, so the argument has to be
had in that test rather than won by inattention.

Two aggregates the brief also named were **not** added, because they already
exist and duplicating them is the thing #32 argues against: per-day seconds over
a range is `GET /api/practice/history`, and per-week is `GET /api/practice/review`.

## The page

`#/score/{id}/practice`, reachable from the score itself (a **History** link
beside the practice timer, which is where the question comes up) as well as by
its own URL.

Built for a music stand: every figure that matters is text at a readable size and
nothing needs a hover. The tempo chart prints each session's bpm beside its own
dot — thinned only when the points crowd, with the most recent always printed —
and the list under it carries every point with its day regardless. The ninety-day
strip is one column per day including the empty ones, scaled inside its own
window like every other bar in this application.

Empty states are the statement and not a prettier nought: the server says whether
a piece has ever been practised (`practised`), so a new piece gets "No practice
logged against this piece yet" rather than a screen of zeros with charts drawn
around them, and a single tempo point renders as *"One session with a tempo. One
session is not a progression"* rather than as the start of a line.

A piece in the trash answers in full, is marked `deleted`, and offers no way into
a library that no longer holds it (#56).

## A rendered example

A dev instance on 127.0.0.1:8917 with a scratch library and fifteen constructed
sessions — a tempo ladder from 60 to 100 over three months, with a fortnight
away from the piece in the middle of it. What the page actually rendered:

```
15 sessions, 8h 45m in total
Last practised 28 Aug, first on 17 Jun

The last 90 days   2 Jun - 30 Aug
15 days, 8h 45m in the last 90 days
[90 day columns, one per day, empty ones included]

Tempo, session by session
15 sessions with a tempo
Working towards 100 bpm
[chart: 60 60 66 66 72 72 76 72 76 80 88 88 94 100 100, dashed target line at 100]
17 Jun · 60 bpm   19 Jun · 60 bpm   22 Jun · 66 bpm   ...   28 Aug · 100 bpm

Section work and run-throughs
Section work   5h 5m
Run-through    3h 40m

How it went
15 sessions rated
1  0    2  4    3  5    4  5    5  1

Goals about this piece
24-30 Aug          hold it at 100 for the whole piece
  2 of 4 planned days
  1h 15m of 2h 30m planned

Session by session
2026-08-28  35m  Run-through · 100 bpm, reached the 100 target
...
2026-06-22  40m  Section work · bars 30-38 · 66 bpm, aiming at 100
                 bars 30-38 are the whole problem
```

Note the eighth point: 72 after a 76, because the piece had been put down for a
fortnight. The page states it and says nothing about it, which is the whole
design.

The unpractised piece next to it in the same library rendered its empty state
with no headline, no strip, no chart and no session list — only the sentence and
a way into the score.

## How it was verified

**Server: 967 passed, 63 skipped** (60 for want of `FERMATA_TEST_LIBRARY`,
unrelated), against **935 passed / 63 skipped** re-derived on this base. 32 new,
all in `test_score_progress_api.py`, and every number in it is a literal worked
out by hand from the fixture rather than recomputed with the arithmetic under
test.

**Browser and unit: 360 passed**, against **339** re-derived on this base. 21 new
(11 unit, 10 browser), with new additive floors under `tests/spec-floors/`.

**OpenAPI guards green.** The operation count is pinned deliberately at 51, and
the #147 drift guard now exercises this endpoint with a tempo, a mode, a rating
and a goal actually present — an endpoint whose nested blocks are only ever seen
empty is one whose nested fields that guard cannot check.

**Mutation testing — every one of these was observed to fail:**

| Mutation | What went red |
| --- | --- |
| `score_all_time` groups by `date(started_at)` instead of the practice day | 4 tests, including the 23:30-local-evening one |
| `mode_totals` groups by `activity` instead of `mode` | the section-work/run-through literal test |
| `sessions_without_tempo` dropped from `TempoProgressionOut` | the #147 guard, naming `tempo.sessions_without_tempo` at its own path |
| `practised` hard-coded true | the server empty-state test **and** the browser empty-state spec |
| `comparable` becomes `len(points) > 0` | the one-session test **and** the browser "not a trend" spec |
| the endpoint uses `_live_score_row`, refusing a trashed score | the deleted-piece test |
| the page links to a deleted score | the browser "stops being a way into the library" spec |

The browser suite's own spec-floor guard was also seen to fire, mid-change, when
the floor claimed 41 and 40 ran.

## One thing deliberately not done

The practice page's by-piece list does **not** link here. #56's spec asserts that
a live row carries exactly one anchor and a trashed row carries none, and adding
a second link would either break that assertion or put a link on a deleted row —
neither of which is worth trading for a shortcut the score's own toolbar already
provides. Worth revisiting if that list is ever restructured.
