### PR TITLE
Fix a coda's meter read a system early (#162) and a rest read longer than its bar (#163)

### DIFF
--- a/docs/musicxml-tab-profile.md
+++ b/docs/musicxml-tab-profile.md
@@ -952,8 +952,10 @@ to tell which two dangling ends were meant to be one tie.
 of what is written — which notes are struck — and not how long anything is.
 Measured on the library this profile was developed against, adding ties left
 `bars`, `beats`, `notes`, `bars_overfull`, `bars_short` and `bars_defective`
-each exactly where they were: 10762, 83365, 99461, 1541, 4190, 5300 across
-the 293 extractable scores, unchanged to the unit.
+each exactly where they were: 10762, 83365, 99461, 1540, 4190, 5300 across
+the 293 extractable scores, unchanged to the unit. (`bars_overfull` was 1541
+when this rule landed; #163 later shortened one over-long rest, taking it to
+1540 without touching the other five, which is why it reads 1540 here.)
 
 The tie marks themselves account for as follows. The decoder matches 1534 tie
 curves across 171 of the 297 scores, which is 3068 marked ends; 2512 of those

--- a/server/fermata/tabextract.py
+++ b/server/fermata/tabextract.py
@@ -3402,6 +3402,62 @@ def _pad_voice_to_budget(tagged, budget, bar_first_x, onset_tol):
         tagged.extend(inserted)
 
 
+def _single_notatable_rest(quarters):
+    """The one (duration_code, dots) a single beat of exactly this many quarters
+    is written with, or None when no single plain-or-dotted value equals it.
+
+    Only a value a lone rest can actually carry is returned: 3.0 is a dotted
+    half, 3.5 is not any single rest and comes back None. The caller wants ONE
+    written rest, not a decomposition (which would change the bar's beat count),
+    so a length that needs two beats is declined rather than split here.
+    """
+    for code in (1, 2, 4, 8, 16, 32):
+        for dots in (0, 1, 2):
+            if abs(_beat_quarters(code, dots) - quarters) < 1e-6:
+                return code, dots
+    return None
+
+
+def _reduce_overlong_rests(voice, budget):
+    """Bring any rest in this voice whose written value alone exceeds the bar's
+    budget down to the silence the bar can still hold, in place. Returns how
+    many were reduced (issue #163).
+
+    Fires only on a rest read LONGER than the whole bar - a whole rest in 3/4,
+    a dotted-whole rest in 4/4 - which the arithmetic proves impossible without
+    any reference to the page, the same self-check issue #109 is built on. Its
+    length is replaced with the bar's budget less what the voice's other events
+    already account for, expressed as one written rest so the bar's beat count
+    does not move; the rest stays engraved silence, only shorter.
+
+    Left untouched, deliberately, in two cases. A voice whose other events
+    already fill the bar has nothing positive left for the rest to become, and
+    shrinking it to zero would drop a written beat rather than shorten one -
+    that is a rest merged into the wrong voice (a whole-measure rest sitting in
+    the same voice as the accompaniment that fills the bar), a voice-assignment
+    defect and not this over-read. A remainder no single rest can spell (3.5)
+    is declined for the same reason _single_notatable_rest declines it: two
+    beats where there was one would move the count this is careful to hold.
+    """
+    reduced = 0
+    for i, (x, code, dots, notes) in enumerate(voice):
+        if notes:
+            continue  # a sounding beat (or an unmatched-column placeholder), not a rest
+        if _beat_quarters(code, dots) <= budget + 1e-6:
+            continue
+        other = sum(_beat_quarters(c, d)
+                    for j, (_x, c, d, _n) in enumerate(voice) if j != i)
+        remaining = budget - other
+        if remaining <= 1e-6:
+            continue
+        cd = _single_notatable_rest(remaining)
+        if cd is None:
+            continue
+        voice[i] = (x, cd[0], cd[1], notes)
+        reduced += 1
+    return reduced
+
+
 def _build_measure_beats_glyph(m_cols, m_lo, m_hi, note_events, note_xs, x_tol,
                                notation_spacing, budget=None):
     """Build one measure's VOICES from glyph-decoded note/rest events on the
@@ -3437,14 +3493,16 @@ def _build_measure_beats_glyph(m_cols, m_lo, m_hi, note_events, note_xs, x_tol,
     how much of each voice is silence; without it no rests are inferred.
 
     Returns (voices, unmatched_columns, unmatched_glyph_notes,
-    unison_digits_shared): voices is a list of one or more beat lists, each a
-    list of (duration_code, dots, notes) triples in x order ready for
-    _fmt_beat; unmatched_columns is how many tab columns had no glyph note
-    within x_tol; unmatched_glyph_notes is how many decoded noteheads had no
-    fret number to match (expected to be rare - every played tab note should
-    have one); unison_digits_shared is how many were given the digit their
-    coincident twin's position was printed with instead (see
-    _share_unison_digits) - an inference, disclosed rather than silent.
+    unison_digits_shared, overlong_rests_reduced): voices is a list of one or
+    more beat lists, each a list of (duration_code, dots, notes) triples in x
+    order ready for _fmt_beat; unmatched_columns is how many tab columns had no
+    glyph note within x_tol; unmatched_glyph_notes is how many decoded
+    noteheads had no fret number to match (expected to be rare - every played
+    tab note should have one); unison_digits_shared is how many were given the
+    digit their coincident twin's position was printed with instead (see
+    _share_unison_digits) - an inference, disclosed rather than silent;
+    overlong_rests_reduced is how many rests read longer than their bar were
+    trimmed to what it can hold (issue #163, see _reduce_overlong_rests).
 
     Silence that had to be deduced from the meter is not reported here: the
     beats carry it themselves, as an InferredRest notes slot, which is what the
@@ -3511,13 +3569,28 @@ def _build_measure_beats_glyph(m_cols, m_lo, m_hi, note_events, note_xs, x_tol,
     noted = [t for t in tagged if any(notes for _x, _c, _d, notes in t)]
     live = noted if noted else [t for t in tagged if t]
 
+    # A rest glyph read at a written value its bar cannot hold beside the other
+    # events in its voice - a whole or dotted-whole rest that alone exceeds the
+    # meter (issue #163, the same family as #140's confident over-read). The
+    # silence WAS printed, so the rest stays a written beat; only its length is
+    # brought down to what the bar has room for, and disclosed as reduced. Run
+    # before padding so a voice trimmed back to its budget is not then also seen
+    # as short. A rest whose voice has no room left at all (the other events
+    # already fill the bar) cannot shrink to a positive written value and is
+    # left untouched here - see _reduce_overlong_rests.
+    overlong_rests_reduced = 0
+    if budget:
+        for t in live:
+            overlong_rests_reduced += _reduce_overlong_rests(t, budget)
+
     if len(live) > 1 and budget:
         first_x = min(t[0][0] for t in live)
         for t in live:
             _pad_voice_to_budget(t, budget, first_x, onset_tol)
 
     return ([[(code, dots, notes) for _x, code, dots, notes in t] for t in live],
-            unmatched_columns, unmatched_glyph_notes, unison_digits_shared)
+            unmatched_columns, unmatched_glyph_notes, unison_digits_shared,
+            overlong_rests_reduced)
 
 
 def _voice_mean_y(groups):
@@ -4260,7 +4333,8 @@ def _rhythm_report(counts, details, conformance=None, unread_bars=(),
                    dots_unassigned=0, dots_unassigned_no_candidate=0,
                    dots_unassigned_eliminated=0, dots_unassigned_staves=0,
                    coincident_unsplit_pairs=0, coincident_unsplit_staves=0,
-                   unison_digits_shared=0):
+                   unison_digits_shared=0, overlong_rests_reduced=0,
+                   overlong_rest_bars=()):
     """Derive the document's rhythm warnings and confidence string from the
     collected per-staff provenances - the single place that decides both, so
     they cannot drift out of step with each other or with the measure loop.
@@ -4306,6 +4380,12 @@ def _rhythm_report(counts, details, conformance=None, unread_bars=(),
     one printed for them (issue #137) - the right reading of a unison shared
     between two voices, and still an inference about which string those
     notes are on. See _share_unison_digits.
+
+    `overlong_rests_reduced` / `overlong_rest_bars` are how many rests were
+    read at a printed value longer than the whole bar and trimmed to what it
+    could hold, and the numbers of the bars they were in (issue #163, see
+    _reduce_overlong_rests). Reported like the padded-bars warning: the count
+    says how much, the bar numbers say where.
     """
     conformance = conformance or _BarConformance(0, 0, 0, 0)
     prov_bars = prov_bars or {}
@@ -4455,6 +4535,23 @@ def _rhythm_report(counts, details, conformance=None, unread_bars=(),
             "it once and the second voice's note has no number of its own. Only done inside "
             "a chord whose every other position the tablature did name, but the string and "
             "fret for those notes are inferred from the twin rather than read for them"
+        )
+
+    # A rest whose printed value alone was longer than its bar, trimmed to the
+    # silence the bar had room for (issue #163). Said out loud with its own
+    # count and bar numbers, for the same reason padded silence is: the rest
+    # WAS engraved, but its length is now this decoder's inference from the
+    # meter rather than the value the glyph read as, and a reader may want to
+    # check what was actually printed there.
+    if overlong_rests_reduced:
+        where = (f" The bars are: {_bar_list(sorted(overlong_rest_bars))}."
+                 if overlong_rest_bars else "")
+        warnings.append(
+            f"{overlong_rests_reduced} rest(s) were read at a printed value longer than the whole "
+            "bar they sit in - a length the meter cannot hold - and were shortened to the silence "
+            "the bar had room for beside the other events in their voice. The rest was engraved, "
+            "so it is kept; its duration is inferred from the time signature rather than read from "
+            f"the glyph, and may not be what the score printed.{where}"
         )
 
     # Bars that don't add up outrank how the durations were obtained: a
@@ -4957,7 +5054,23 @@ def _build_time_signature_timeline(pages_with_tab):
         # _detect_barlines. The page's drawings are memoised, so this is a
         # filter over an already-parsed content stream.
         vseg = _vertical_segments(page) if std_staves else []
+        # Which horizontal bands already have a staff on this page. Two systems
+        # printed side by side in one band - a Coda block engraved to the RIGHT
+        # of the last full system is the common case - share a `top`, so the
+        # meter printed at the right block's own start is recorded at that
+        # block's left edge, not at _SYSTEM_START_X. The sentinel means "the
+        # start of this band", which is right for the leftmost system in the
+        # band and wrong for any to its right: at -inf the right block's opening
+        # meter reaches back across the whole band in _ts_at and lands on the
+        # left system's bars, starting a Coda's meter a system early (issue
+        # #162, Answers - a courtesy 3/4 at the left system's end previews the
+        # Coda's real 3/4, and the Coda block's own 3/4 was bleeding onto the
+        # 4/4 bars beside it). std_staves is in reading order, so the first
+        # staff seen in a band is its leftmost.
+        bands_started: set = set()
         for s in std_staves:
+            leftmost_in_band = s.band not in bands_started
+            bands_started.add(s.band)
             ts, reason = glyph.decode_time_signature(page, s.top, s.bottom, s.x0, s.spacing)
             if ts is None:
                 reasons.append(reason)
@@ -4965,7 +5078,14 @@ def _build_time_signature_timeline(pages_with_tab):
                     unreadable.append(reason)
             else:
                 opening_read = opening_read or first_staff
-                _append_ts(timeline, (page_idx, s.top, _SYSTEM_START_X, ts))
+                # One staff space of reach-back absorbs the tab-vs-notation
+                # rounding on the block's first bar boundary, the same slack
+                # _mid_system_meters records a mid-system change with; the
+                # leftmost system keeps the sentinel so its own first bar, whose
+                # left boundary can land a hair left of the notation staff's, is
+                # still covered.
+                opening_x = _SYSTEM_START_X if leftmost_in_band else s.x0 - s.spacing
+                _append_ts(timeline, (page_idx, s.top, opening_x, ts))
             first_staff = False
             mid, mid_unreadable = _mid_system_meters(page, s, vseg)
             unreadable.extend(mid_unreadable)
@@ -5249,6 +5369,12 @@ def _extract(doc, pdf_path, time_signature: tuple[int, int] | None) -> Extractio
     no_stem_notes = 0
     no_stem_staves = 0
     no_stem_seen = set()
+    # Rests read longer than their bar and trimmed to what it can hold (issue
+    # #163, see _reduce_overlong_rests). A count, and the bar numbers so a
+    # reader can carry each back to the PDF the way the padded-bars warning
+    # names its own.
+    overlong_rests_reduced_total = 0
+    overlong_rest_bars = []
     # Augmentation-dot glyphs that bound to no note - a genuine anomaly (see
     # glyph.decode_note_events, dots_unassigned), summed the same way and
     # over the same de-duplicated decodes as no_stem_notes above.
@@ -5446,7 +5572,7 @@ def _extract(doc, pdf_path, time_signature: tuple[int, int] | None) -> Extractio
                 bar_ts = _ts_at(ts_timeline, page_idx, anchor_y, m_lo) or ts
                 measure_quarter_len = _measure_quarter_length(bar_ts)
                 if source.uses_glyphs:
-                    voices, unmatched_cols, unmatched_notes, shared_digits = (
+                    voices, unmatched_cols, unmatched_notes, shared_digits, overlong_reduced = (
                         _build_measure_beats_glyph(
                             m_cols, m_lo, m_hi, source.note_events, source.note_xs,
                             x_tol, std_staff.spacing, measure_quarter_len,
@@ -5455,6 +5581,9 @@ def _extract(doc, pdf_path, time_signature: tuple[int, int] | None) -> Extractio
                     unmatched_columns_glyph += unmatched_cols
                     unmatched_glyph_notes_total += unmatched_notes
                     unison_digits_shared_total += shared_digits
+                    overlong_rests_reduced_total += overlong_reduced
+                    if overlong_reduced:
+                        overlong_rest_bars.append(staff_first_bar + i)
                     if len(voices) > 1:
                         multivoice_bars += 1
                     if not voices:
@@ -5569,6 +5698,8 @@ def _extract(doc, pdf_path, time_signature: tuple[int, int] | None) -> Extractio
         coincident_unsplit_pairs=coincident_unsplit_total,
         coincident_unsplit_staves=coincident_unsplit_staves,
         unison_digits_shared=unison_digits_shared_total,
+        overlong_rests_reduced=overlong_rests_reduced_total,
+        overlong_rest_bars=tuple(sorted(overlong_rest_bars)),
     )
     warnings.extend(rhythm_warnings)
     # Font-level problems that weren't already the reason a staff degraded

--- a/server/tests/test_tabextract.py
+++ b/server/tests/test_tabextract.py
@@ -4077,11 +4077,25 @@ def test_library_wide_repeat_structure_leaves_conformance_untouched(library_root
     # needs it: a duration fix that moved this would not be a duration fix.
     assert totals["beats"] == 83365
     #                                        before #113 -> after
-    assert totals["bars_overfull"] == 1541               # 1600
+    # 1541 before #163, 1540 after: My Star (Final Fantasy XVI) bar 5 held a
+    # dotted whole rest read as six quarters in a 4/4 bar, which #163 shortens
+    # to the three quarters the bar had room for beside the quarter chord in its
+    # voice - so that voice stops being overfull. The bar stays SHORT (and so
+    # defective) because its OTHER voice was already short of the meter before
+    # this change, which is why only bars_overfull moves and bars_short /
+    # bars_defective do not. No note, beat or bar moves: a rest is neither.
+    assert totals["bars_overfull"] == 1540               # 1600 -> 1541 (#113) -> 1540 (#163)
     assert totals["bars_short"] == 4190                  # 4188
     assert totals["bars_defective"] == 5300              # 5340
     assert totals["bars_padded"] == 3603                 # 3602
-    assert totals["inferred_rest_quarters"] == 4897.875  # 4892.125
+    # 4897.875 before #162, 4899.875 after: Answers (Final Fantasy XIV
+    # Endwalker) bar 45 held one quarter in each of its two voices in a bar read
+    # a system early as 3/4. #162 puts that bar back on the running 4/4 it is
+    # printed in, so each short voice is now padded to four quarters instead of
+    # three - one extra quarter of meter-inferred silence per voice, +2.0 in
+    # total. It is padding that grew, not a rest that was read: bars_padded is
+    # unchanged because the same two voices were already being padded.
+    assert totals["inferred_rest_quarters"] == 4899.875  # 4892.125 -> 4897.875 (#113) -> 4899.875 (#162)
     # The systems still lost, named. Both are 7-line groups - a 6-line tab
     # staff ruled at 7.7pt with ONE extra full-width rule below its last
     # line, close enough to fall inside the 15.0pt cluster gap: Dynamis p1 at
@@ -4428,41 +4442,40 @@ def test_no_emitted_note_is_longer_than_the_bar_it_sits_in(library_root):
     written value rather than over dotted wholes alone, because the class is
     what matters - a whole note in a 3/4 bar would be the same defect.
 
-    TWO SITES ARE KNOWN AND NAMED rather than assumed away by a looser rule,
-    because the whole value of this check is that it does not need a page.
+    The notes of this shape are now ALL gone; one rest remains. Both were once
+    named here and both have been worked since:
 
-    Answers (Final Fantasy XIV Endwalker), bars 43 and 44: a whole note in a
-    bar read as 3/4. Read off the page, both bars are printed in 4/4 and hold
+    Answers (Final Fantasy XIV Endwalker), bars 43 and 44 held a whole note in
+    a bar read as 3/4. Read off the page, both bars are printed in 4/4 and hold
     exactly what the decoder says - a whole-note bass pedal under running
-    eighths. What is wrong is the meter, and for a reason with an owner: the
-    score's only 3/4 is a COURTESY meter, printed as the last thing on that
-    system for the Coda that follows it, and it is being applied from bar 43
-    instead of at the Coda. That is the hazard conftest's `kaine_salvation`
-    fixture already names, failing here on a different score, and it belongs
-    to the mid-system meter reader (#90/#104), not to any duration. Fixing it
-    from this side would mean loosening an arithmetic check to accommodate a
-    meter defect, which is backwards. Filed as #162; closing that one means
-    deleting these two entries from the list below.
+    eighths. What was wrong was the meter: the Coda that follows this system is
+    printed to its RIGHT in the same horizontal band, and its own opening 3/4
+    was being reached back across the band and applied from bar 43 (a courtesy
+    3/4 previewing that change also sits at the system's end, which is what made
+    it look like a mid-system change). #162 records a side-by-side block's
+    opening meter at its own left edge instead of at the band's start, so bars
+    43-45 keep the running 4/4 and only the Coda (bar 46) is 3/4 - and the whole
+    note fills its 4/4 bar exactly. That is why `impossible` is now empty.
 
-    And the RESTS, which the same issue calls out as an adjacent class and
-    which are counted separately here for exactly that reason. Two remain,
-    and they are different from each other:
+    The RESTS the same issue calls out as an adjacent class are counted
+    separately here, because a rest longer than its bar is a rest fault, not a
+    note one. One remains:
 
-      Classical-Guitar-Method-Vol1-2020, bar 16 - a whole rest alone in a 3/4
-      bar. This is #109's own named survivor, and it is LEGITIMATE
-      ENGRAVING: a whole-measure rest is drawn as a whole rest in any meter,
-      so the glyph means "this bar is silent", not "four quarters". Reading
-      it as four is a real remaining defect, with a real fix - a lone whole
-      rest should take its bar's length - which is filed as #163 and
-      deliberately not made here, because it would move the library's
-      conformance figures a second time in one change and leave neither
-      movement separable from the other.
+      Classical-Guitar-Method-Vol1-2020, bar 16 - a whole rest that reads as
+      four quarters in a 3/4 bar. Read against the page it is a LEGITIMATE
+      whole-measure rest: the melody voice is silent for the bar while the
+      tablature plays a six-eighth arpeggio. The fault is that the two are
+      flattened into one voice, where the arpeggio already fills the 3/4 bar,
+      so #163's over-read reduction (below) has no room to shrink the rest into
+      and leaves it - this is a voice-separation defect awaiting its own issue,
+      not the confident duration over-read #163 fixes. See the assertion below.
 
-      My Star (Final Fantasy XVI), bar 5 - a DOTTED whole rest, six quarters,
-      in a 4/4 bar. Not the whole-measure convention and not legitimate. It
-      predates #111/#112 (measured at #152's commit, where it is already
-      present), and is carried on #163 beside the one above so that deciding
-      whether they share a fix is somebody's job rather than nobody's.
+      My Star (Final Fantasy XVI), bar 5 held a DOTTED whole rest - six quarters
+      in a 4/4 bar, never the whole-measure convention (a plain undotted whole
+      rest) - beside a quarter chord in the same voice. That IS a confident
+      over-read of a partial rest, the family #140 also belongs to, and #163
+      shortens it to the three quarters the bar has room for, disclosed as an
+      inferred length. It is gone from the list below as a result.
     """
     type_quarters = {"breve": 8.0, "whole": 4.0, "half": 2.0, "quarter": 1.0,
                      "eighth": 0.5, "16th": 0.25, "32nd": 0.125}
@@ -4501,21 +4514,38 @@ def test_no_emitted_note_is_longer_than_the_bar_it_sits_in(library_root):
                         impossible_rests.append(where)
 
     assert scores_checked >= 250, f"only {scores_checked} scores were checked"
-    # The seventeen, and everything else of their shape. Pinned as an exact
-    # list rather than a count so a new site names itself in the failure.
-    assert impossible == [
-        ("Answers (Final Fantasy XIV Endwalker).pdf", "43", (3, 4), "whole", 0),
-        ("Answers (Final Fantasy XIV Endwalker).pdf", "44", (3, 4), "whole", 0),
-    ], (
-        "note(s) written longer than the bar they sit in, beyond the two "
-        f"disclosed in this test's docstring (score, bar, meter, type, dots): "
-        f"{impossible[:10]}"
+    # The seventeen went at #90/#104; the two on Answers went at #162, which
+    # moved that score's bars 43-44 off the courtesy 3/4 they were being read a
+    # system early in and back onto the running 4/4 a whole note fills exactly.
+    # Nothing of this shape remains, and none may come back: an emitted note
+    # longer than its bar is impossible whatever the page says, so an exact
+    # empty list here makes any new site name itself in the failure.
+    assert impossible == [], (
+        "note(s) written longer than the bar they sit in (score, bar, meter, "
+        f"type, dots): {impossible[:10]}"
         + (f" and {len(impossible) - 10} more" if len(impossible) > 10 else ""))
-    # The two disclosed rests, pinned so that they can neither multiply
-    # unnoticed nor be quietly fixed without these sentences going with them.
+    # One disclosed rest remains, pinned so it can neither multiply unnoticed
+    # nor be quietly fixed without this sentence going with it.
+    #
+    # My Star (Final Fantasy XVI) bar 5 held a DOTTED whole rest - six quarters
+    # in a 4/4 bar, never the whole-measure convention (which is a plain whole
+    # rest, undotted) - beside a quarter chord in the same voice. That is a
+    # genuine over-read of a partial rest, and #163 shortens it to the three
+    # quarters the bar has room for beside the chord, disclosed as an inferred
+    # length. It is gone from this list as a result.
+    #
+    # Classical-Guitar-Method-Vol1-2020 bar 16 stays. Read against the printed
+    # page (the Scarborough Fair setting, "She once was a true love of mine" -
+    # the last system on PDF page 84) its whole rest is a LEGITIMATE
+    # whole-measure rest: the melody voice is silent for the bar while the
+    # tablature plays a six-eighth arpeggio. The defect is that the two were flattened into one
+    # voice, where the arpeggio already fills the 3/4 bar and leaves the rest no
+    # room - a voice-separation fault, not the duration over-read #163 fixes, so
+    # #163's reduction correctly does not fire on it (shrinking it to the zero
+    # room left would drop a written beat rather than shorten one). Carried here
+    # until that separation is done under its own issue.
     assert impossible_rests == [
         ("Classical-Guitar-Method-Vol1-2020.pdf", "16", (3, 4), "whole", 0),
-        ("My Star (Final Fantasy XVI).pdf", "5", (4, 4), "whole", 1),
     ], impossible_rests
 
 


### PR DESCRIPTION
## What this changes

Two decoder-accuracy defects from the #109 self-check family, each reproduced first on current `main` and page-checked against the printed score.

### #162 — a courtesy/coda meter applied a system early (Score A)

**Score A** read bars 43-45 as **3/4** when the page prints them in **4/4** (each a whole-note bass pedal under a run of eighths — a whole note cannot sit in a 3/4 bar, which is what the self-check flagged).

Root cause, found by instrumenting the meter timeline and rendering the page: the **Coda** that follows is engraved to the **right of the last full system, in the same horizontal band** (the #152 side-by-side shape). Its own opening **3/4** was recorded in the timeline at the `_SYSTEM_START_X` sentinel (`-inf`), which in `_ts_at` reaches back across the whole band and lands on the 4/4 bars to its left. (A courtesy 3/4 previewing that change also sits at the left system's end, which is what made this look like a mid-system read — but the existing end-of-system guard correctly refuses that one; the leak was the coda block's own opening.)

**Fix:** in `_build_time_signature_timeline`, a staff that is **not the leftmost in its band** records its opening meter at its **own left edge** (`x0 - spacing`, one staff space of reach-back for tab-vs-notation rounding) instead of `-inf`. The leftmost system in each band keeps the sentinel, so every ordinary score is untouched.

Result, page-verified: bars 43-45 keep the running 4/4 (the whole note fills the bar exactly), and only the Coda (bar 46) is 3/4.

### #163 — a rest read longer than its bar (Score B)

**Score B** bar 5 held a **dotted whole rest** (six quarters) beside a quarter chord in a 4/4 voice — nine quarters written into a four-quarter bar. A dotted whole rest is never the whole-measure-rest convention (which is an undotted whole rest), so this is a genuine confident over-read of a partial rest, the family #140 also belongs to.

**Fix:** `_reduce_overlong_rests` trims any rest whose written value alone exceeds the bar's budget down to the silence the bar can hold beside the other events in its voice — here to a dotted **half** rest (three quarters), so the voice holds exactly four. It stays **one written rest** (no beat is added or lost) and is **disclosed** through a new rhythm warning naming the count and the bars: the silence was engraved, but its length is now an inference from the meter, not the value the glyph read as.

The disclosure is intentionally a **warning-family** one — a `_rhythm_report` prose warning threaded from the extract loop, of the same shape as the padded-bars / no-stem / unison-digits warnings — rather than a structured `DISCLOSURE_ROWS` counter with an `ExtractionResult` attribute. That is deliberate, not an oversight: this is printed silence whose *duration* was reduced (the rest is real and stays a written beat), which the warning channel describes well, whereas the structured `_BAR_KEYS` counters model per-bar structural facts. Left as a warning by design.

`Classical-Guitar-Method-Vol1-2020` bar 16 is deliberately **left untouched**. Rendered against the page, its plain whole rest is a *legitimate* whole-measure rest: the melody voice is silent for the bar while the tablature plays a six-eighth arpeggio. The two were flattened into one voice, where the arpeggio already fills the 3/4 bar and leaves the rest no room — a voice-separation defect, not the duration over-read this addresses (shrinking it into the zero room left would drop a written beat). Filed as a follow-up and pinned in the self-check test until then.

## Verification

- **Named sites, before/after, against the printed page** — Score A bars 43-46 and Score B bar 5 / CGM bar 16 rendered and read; decoded meters and rest durations match the ink.
- **Library-wide (all 297 PDFs, per-score musicxml hash):** exactly **two** scores change — Score A and Score B. The other **291 are byte-identical**.
- **Aggregates:** `bars`, `beats`, `notes` **unchanged** (a rest is none of them); `bars_overfull` **1541 → 1540** (Score B bar 5 stops overflowing); `inferred_rest_quarters` **+2.0** on Score A where bars 45 widen back to 4/4 and their short voices are padded one quarter further. `bars_defective`, `bars_short`, `bars_padded`, `bars_measured` unchanged.
- **Self-check pin** `test_no_emitted_note_is_longer_than_the_bar_it_sits_in`: `impossible` is now empty; `impossible_rests` loses Score B and keeps the CGM residual, both with page-checked explanations in the docstring.
- **Conformance pin** `test_library_wide_repeat_structure_leaves_conformance_untouched` updated (overfull 1540, inferred 4899.875) with the movements explained line by line.
- **kaine_salvation** courtesy-meter guard stays green.
- **Mutation-tested:** reverting the #162 fix brings back exactly Score A 43 & 44 in `impossible`; neutering `_reduce_overlong_rests` brings back Score B in `impossible_rests` and returns `bars_overfull` to 1541.
- **Full server suite green** (1060 passed; the one failure, `test_engraved_fixtures.py::test_the_summary_says_how_many_tests_skipped_for_want_of_a_library`, reproduces identically on the base commit with these files reverted — a pre-existing node_modules-skip state leak, unrelated to this change).

## Not in this PR

- **#163 residual (CGM bar 16):** the voice-separation defect above — filed as #180.
- **#91:** three distinct confidence/robustness changes (an unread stem count, a cached drawing-failure, a spacing-rhythm confidence override) plus a related bar-length-rest rounding check. Not bounded for this PR; left for its own, with the sites located in the report.

Closes #162.
