### PR TITLE
Build an interactive fretboard neck, and fret to note on it (#25, #27)

### DIFF
--- a/docs/practice-data.md
+++ b/docs/practice-data.md
@@ -410,6 +410,13 @@ its `note` - the same as every other activity - so a reader of the practice
 page is not left with a blank line; the structured record lives here instead
 of being the only place the time was spent.
 
+**Counts, never a rate.** There is no accuracy percentage anywhere a query
+over `trainer_attempts` could produce one, and no column or view counts a
+run of consecutive `correct` rows - the same rule the rest of this document
+holds to (no streaks, no best week, no average rating). A `correct = 0` row
+is a fact worth finding, not a mark against anyone; a query is free to count
+right and wrong separately and never free to divide one by the other.
+
 ### Asking questions
 
 - `POST /api/trainer/attempts` - log one answered question.

--- a/docs/practice-data.md
+++ b/docs/practice-data.md
@@ -356,34 +356,80 @@ There is no down direction. A database written by a newer release is refused
 outright at startup rather than written to blind; restoring a backup is the way
 back. See the Backups section of [deployment.md](deployment.md).
 
+## Trainer attempts
+
+The per-attempt table this section spent a long time refusing to guess at.
+*Hear a note, name it* (issue #61) was the first trainer and deliberately did
+not get one - one exercise was not enough to know whether the unit was a
+position, an interval, or a pitch, and designing a table around the first
+would have been the same guess this section was written against. *Fret to
+note* (issue #27) is the second, and it decided: the unit is one QUESTION, and
+every question - whichever direction a fretboard drill asks it in - reduces to
+two facts, a note being tested and a note the answer named.
+
+One table, `trainer_attempts`, independent of `practice_sessions`:
+
+| Column | Meaning |
+| --- | --- |
+| `id` | Stable for the life of the row. |
+| `owner` | `'local'`, same as everywhere else. |
+| `session_id` | The `practice_sessions` row logging the surrounding drill's TIME, when there is one yet - `NULL` otherwise. See below for why that is the ordinary case, not an edge one. |
+| `drill` | Which exercise asked it. `'fret_to_note'` today; a second fretboard drill (#26, #29) widens this, not a migration. |
+| `direction` | `position_to_note` (shown a position, asked for its note) or `note_to_position` (shown a note, asked to find a position). |
+| `target_string`, `target_fret` | The position a question NAMED - set only on `position_to_note`, where there is one. A note prompt has no single expected position (most notes sound in several places), so these stay `NULL` on `note_to_position`. |
+| `target_note` | The note being tested, always set. |
+| `given_string`, `given_fret` | The position a TAP answered with - set only on `note_to_position`. `NULL` on `position_to_note`, where the answer was a note choice and no position was touched. |
+| `given_note` | The note the answer actually named, always set. On `note_to_position` this is the note that SOUNDS at the tapped position, worked out from the instrument's own tuning by the client that drew the neck - never from what the player meant to tap, the same rule ear_training's question-from-what-sounded already applies one layer up. |
+| `correct` | `given_note = target_note`. Computed server-side from the two note fields, unconditionally, the same rule for both directions - never accepted from a client. |
+| `response_ms` | How long the question took, informational. |
+| `created_at` | When the row was written. |
+
+**Why exactly one of the two position pairs is ever populated, decided by
+`direction`.** A position-to-note question has a target position and a chosen
+note for an answer; a note-to-position question has a target note and a
+tapped position for an answer. Trying to force both directions into the same
+"target position, given position" shape would leave a `note_to_position` row
+inventing a target position it never had, or a `position_to_note` row
+inventing a tapped position that was never touched.
+
+**Why `session_id` is usually `NULL`, and that is not a gap.** An attempt is
+written the moment a question is answered - mid-drill, typically well before
+the practice_sessions row that will carry the drill's total TIME even exists
+(that one is written when the drill stops, the same as every other activity).
+Linking every attempt to a session was never the point; querying "which
+positions get missed" is, and that needs no session_id at all - see the
+endpoints below. `ON DELETE SET NULL`, for the same reason `score_id` is on
+`practice_sessions`: deleting the session that logged a drill's time is not a
+reason to forget that a question was asked and answered.
+
+**Structured and queryable (issue #32), not a JSON blob and not a free-text
+note.** "Which positions am I weak on" is `WHERE correct = 0 GROUP BY
+target_string, target_fret`, not something parsed out of a sentence. The
+drill's own `practice_sessions` row still carries a human-readable summary in
+its `note` - the same as every other activity - so a reader of the practice
+page is not left with a blank line; the structured record lives here instead
+of being the only place the time was spent.
+
+### Asking questions
+
+- `POST /api/trainer/attempts` - log one answered question.
+- `GET /api/trainer/attempts?drill=&direction=&correct=&session_id=&limit=` -
+  the raw, queryable record, newest first, with `total` and `truncated`
+  beside it like every other list here. A client asking "which positions am I
+  weak on" filters `correct=false` and groups the results itself, rather than
+  this API keeping a bespoke aggregate endpoint in step with every future
+  drill's own idea of what a weak spot is.
+
 ## What is not here yet
 
-- **Per-attempt trainer results** - which positions or intervals were missed,
-  and response times. That belongs beside the trainer that produces it, and
-  inventing its shape before one exists would be guessing. What the `activity`
-  vocabulary guarantees is that when a trainer arrives, the time it accounts
-  for lands in the same history and the same goals as everything else.
-
-  One now has. *Hear a note, name it* (`web/src/lib/EarTraining.svelte`) writes
-  one ordinary session with `activity = 'ear_training'`, and everything it knows
-  beyond the time goes in the `note`: how many notes were asked, how many were
-  named as heard, and the range they were drawn from. Nothing about the drill is
-  special-cased anywhere - it shows on the practice page and counts towards a
-  goal exactly as a piece does, which was the whole point of there being one
-  session table.
-
-  That is deliberately still not a per-attempt schema. One exercise is not
-  enough to know what such a table needs: the second and third - fret-to-note,
-  chord recognition - are what should decide whether the unit is a position, an
-  interval, or a pitch, and designing it around the first would be the same
-  guess this section was written to avoid. What the note already proves is that
-  a drill's time and a drill's counts can live here without one.
-
-  Note that a drill records **counts and never a rate**. There is no accuracy
-  percentage in the note, on the page, or anywhere a query could produce one,
-  for the same reason there is no best week: a number out of a hundred is a mark
-  rather than a fact, and it invites a colour. Nothing counts consecutive
-  correct answers either.
+- **Interval or chord-recognition attempt shapes.** `trainer_attempts` is
+  drill-agnostic in its schema (a `drill` column, not a table per exercise),
+  but a chord drill's own idea of "which chord, which voicing" has not been
+  built against it yet, and inventing that shape before that trainer exists
+  would be the same guess this section spent a long time avoiding for
+  fret-to-note. Fret-to-note's `position_to_note`/`note_to_position` split is
+  a real answer for a single-note drill; a chord is a different unit, and #26
+  or #29 gets to decide whether it fits the same table or needs its own.
 - **Key, tempo and difficulty per score** - musical metadata about the piece
   rather than about the practice.
 - **Achievements** - looking back at what has been accomplished, where a goal

--- a/server/fermata/api.py
+++ b/server/fermata/api.py
@@ -24,7 +24,7 @@ from fastapi import (
 from fastapi.responses import FileResponse, Response
 from pydantic import BaseModel, Field, StrictInt
 
-from . import instruments, practice, scanner
+from . import instruments, practice, scanner, trainer
 from . import version as version_info
 from .api_models import (
     ByActivityOut,
@@ -63,6 +63,8 @@ from .api_models import (
     SessionListOut,
     SettingsOut,
     TagOut,
+    TrainerAttemptListOut,
+    TrainerAttemptOut,
     TranscribeResultOut,
     TranscriptionAnalysisOut,
     TranscriptionOut,
@@ -98,6 +100,7 @@ TAG_PRACTICE = "practice"
 TAG_TRANSCRIPTION = "transcription"
 TAG_SCAN = "scan"
 TAG_PORTABILITY = "portability"
+TAG_TRAINER = "trainer"
 
 # SQLite's INTEGER is 64-bit, and handing the driver anything wider raises
 # OverflowError from inside the query - a 500 for what is only ever a row that
@@ -4147,3 +4150,135 @@ async def import_library(file: UploadFile, dry_run: bool = True):
                 pass
         raise
     return {"dry_run": False, **result}
+
+
+# ---------------------------------------------------------------------------
+# Trainer: per-attempt fretboard drill results (issue #27)
+# ---------------------------------------------------------------------------
+
+
+class TrainerAttemptIn(BaseModel):
+    """One question from a fretboard drill, as answered.
+
+    `session_id` is optional and, in the ordinary case, absent: an attempt is
+    written the moment a question is answered, which is normally well before
+    the drill stops and the practice_sessions row that carries its total
+    TIME is written - see trainer.py's module docstring. A client that
+    already has one (a session opened up front) may still pass it.
+
+    `correct` is deliberately not a field here at all - see
+    trainer.normalise_attempt for why it is always computed from
+    target_note/given_note server-side rather than accepted from a caller.
+    """
+
+    session_id: Count | None = Field(default=None, ge=1, le=SQLITE_MAX_INTEGER)
+    drill: str
+    direction: str
+    target_string: Count | None = None
+    target_fret: Count | None = None
+    target_note: str
+    given_string: Count | None = None
+    given_fret: Count | None = None
+    given_note: str
+    response_ms: Count | None = None
+
+
+_ATTEMPT_COLUMNS = (
+    "session_id",
+    "drill",
+    "direction",
+    "target_string",
+    "target_fret",
+    "target_note",
+    "given_string",
+    "given_fret",
+    "given_note",
+    "correct",
+    "response_ms",
+)
+
+
+@router.post("/trainer/attempts", tags=[TAG_TRAINER], response_model=TrainerAttemptOut)
+def log_trainer_attempt(body: TrainerAttemptIn):
+    """Record one question from a fretboard drill: what was asked, what was
+    answered, and whether the two agree.
+
+    Structured, not a free-text note (issue #32) - so "which positions get
+    missed" is a query over this table rather than something parsed out of a
+    session's note the way ear_training's counts are. `correct` in the
+    response is what this endpoint computed, never what the request claimed.
+    """
+    with write_tx() as conn:
+        if body.session_id is not None:
+            _session_row(conn, body.session_id)
+        try:
+            values = trainer.normalise_attempt(**{
+                k: v for k, v in body.model_dump().items() if k != "session_id"
+            })
+        except ValueError as e:
+            raise HTTPException(422, str(e)) from None
+        values["session_id"] = body.session_id
+        columns = ", ".join(_ATTEMPT_COLUMNS)
+        placeholders = ", ".join("?" * len(_ATTEMPT_COLUMNS))
+        row = conn.execute(
+            f"""INSERT INTO trainer_attempts(owner, {columns})
+                VALUES (?, {placeholders})
+                RETURNING *""",
+            [DEFAULT_OWNER, *(values[c] for c in _ATTEMPT_COLUMNS)],
+        ).fetchone()
+        return trainer.attempt_dict(row)
+
+
+@router.get("/trainer/attempts", tags=[TAG_TRAINER], response_model=TrainerAttemptListOut)
+def list_trainer_attempts(
+    drill: str = "",
+    direction: str = "",
+    correct: bool | None = None,
+    session_id: Annotated[int | None, Query(ge=1, le=SQLITE_MAX_INTEGER)] = None,
+    limit: int = practice.DEFAULT_SESSION_LIMIT,
+):
+    """The raw record of every question a fretboard drill has asked, newest
+    first - filterable by drill, direction, whether it was answered
+    correctly, or which session it belongs to.
+
+    This is the queryable half of issue #32's promise: a client asking "which
+    positions am I weak on" filters `correct=false` and groups the results by
+    `target_string`/`target_fret` itself, rather than needing a bespoke
+    aggregate endpoint this application would have to keep in step with every
+    future drill's own idea of what a weak spot is.
+    """
+    if not 1 <= limit <= practice.MAX_SESSION_LIMIT:
+        raise HTTPException(422, f"limit must be between 1 and {practice.MAX_SESSION_LIMIT}")
+    if drill and drill not in trainer.DRILLS:
+        raise HTTPException(422, f"drill must be one of {list(trainer.DRILLS)}")
+    if direction and direction not in trainer.DIRECTIONS:
+        raise HTTPException(422, f"direction must be one of {list(trainer.DIRECTIONS)}")
+    where = ["owner = ?"]
+    params: list = [DEFAULT_OWNER]
+    if drill:
+        where.append("drill = ?")
+        params.append(drill)
+    if direction:
+        where.append("direction = ?")
+        params.append(direction)
+    if correct is not None:
+        where.append("correct = ?")
+        params.append(1 if correct else 0)
+    if session_id is not None:
+        where.append("session_id = ?")
+        params.append(session_id)
+    filters = " AND ".join(where)
+    conn = connect()
+    rows = conn.execute(
+        f"""SELECT * FROM trainer_attempts WHERE {filters}
+             ORDER BY created_at DESC, id DESC LIMIT ?""",
+        [*params, limit],
+    ).fetchall()
+    total = conn.execute(
+        f"SELECT COUNT(*) AS n FROM trainer_attempts WHERE {filters}", params
+    ).fetchone()["n"]
+    return {
+        "attempts": [trainer.attempt_dict(r) for r in rows],
+        "total": total,
+        "truncated": total > len(rows),
+    }

--- a/server/fermata/api_models.py
+++ b/server/fermata/api_models.py
@@ -969,3 +969,44 @@ class ImportOut(BaseModel):
     practice_sessions_imported: int
     practice_goals_imported: int
     settings_imported: int
+
+
+# ---------------------------------------------------------------------------
+# Trainer: per-attempt fretboard drill results (issue #27)
+# ---------------------------------------------------------------------------
+
+
+class TrainerAttemptOut(BaseModel):
+    """One question from a fretboard drill, as trainer.attempt_dict presents
+    it - the stored row verbatim, plus `correct` as a real bool.
+
+    Exactly one of (target_string, target_fret) or (given_string, given_fret)
+    is non-null, decided by `direction` - see trainer.py's module docstring
+    for why a position-to-note question has no given position and a
+    note-to-position one has no single target position.
+    """
+
+    id: int
+    owner: str
+    session_id: int | None
+    drill: str
+    direction: str
+    target_string: int | None
+    target_fret: int | None
+    target_note: str
+    given_string: int | None
+    given_fret: int | None
+    given_note: str
+    correct: bool
+    response_ms: int | None
+    created_at: str
+
+
+class TrainerAttemptListOut(BaseModel):
+    """GET /api/trainer/attempts: the raw, queryable record - which positions
+    and which notes get missed is a WHERE clause over this, not something a
+    reader has to parse out of a session's note."""
+
+    attempts: list[TrainerAttemptOut]
+    total: int
+    truncated: bool

--- a/server/fermata/db.py
+++ b/server/fermata/db.py
@@ -176,6 +176,87 @@ _PRACTICE_SCHEMA = (
     + "".join(f"{statement};\n" for statement in _PRACTICE_GOALS_INDEXES)
 )
 
+# One row per QUESTION a fretboard drill asked - the per-attempt detail
+# docs/practice-data.md's "What is not here yet" section always said would
+# wait for a second trainer to decide its shape (issue #32). Issue #27, fret
+# to note, is that second trainer, and this is the shape it decided on: not a
+# JSON blob and not a free-text note, because "which positions are missed" has
+# to be a WHERE clause, not a thing a client parses out of a sentence.
+#
+# WHY ONE 'correct' RULE COVERS BOTH DIRECTIONS OF THE DRILL. A question is
+# asked one of two ways - shown a position and asked for its note, or shown a
+# note and asked to find a position that sounds it - and the two look like
+# they would need two different ways of grading. They do not: every attempt
+# stores `target_note` (the note being tested) and `given_note` (the note the
+# answer actually named), and `correct` is `given_note = target_note`,
+# unconditionally, computed here rather than trusted from the client. For the
+# position-to-note direction `given_note` is literally the note the player
+# picked. For the note-to-position direction `given_note` is the note that
+# SOUNDS at the position they tapped, worked out from the instrument's tuning
+# by the same client that drew the neck - see web/src/lib/trainer/neck.js's
+# noteAt. That mirrors ear-training.js's own rule ("the question is built from
+# what was SOUNDED, never from what was asked for"): the server does not need
+# to know a tuning to grade an attempt, only to compare two notes it was told.
+#
+# target_string/target_fret are the position a question NAMED, and are NULL
+# on the note-to-position direction: a note prompt has no single expected
+# position, since most notes sound in several places, so there is nothing
+# there to record as "the" target position - only which note was asked for.
+# given_string/given_fret are the position a TAP answered with, and are NULL
+# on the position-to-note direction, where the answer was a note choice and no
+# position was ever touched. Exactly one of the two position pairs is
+# populated, decided by `direction`.
+#
+# `drill` is a free second axis on purpose, alongside `direction`: fret to
+# note is the first trainer to write here, and is not assumed to be the last
+# fretboard exercise this table will ever hold (#26, #29). Widening the
+# CHECK in trainer.py's DRILLS is how a second one arrives; the table itself
+# needs no migration for that.
+#
+# ON DELETE SET NULL on session_id, for the same reason score_id is on
+# practice_sessions: an attempt is a fact about a question that was answered,
+# and deleting the practice_sessions row that logged the surrounding drill's
+# TIME (see api.log_session, activity='fretboard') does not undo the
+# answering. session_id is nullable in the other direction too - an attempt is
+# written the moment it is answered, mid-drill, before the session row that
+# will eventually carry the drill's total time even exists, so most attempts
+# are never linked to one at all. Querying "how did this session go" was
+# never the point; querying "which positions get missed" is, and that needs
+# no session_id at all.
+_TRAINER_ATTEMPTS_COLUMNS = """(
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    owner TEXT NOT NULL DEFAULT 'local',
+    session_id INTEGER REFERENCES practice_sessions(id) ON DELETE SET NULL,
+    drill TEXT NOT NULL,
+    direction TEXT NOT NULL,
+    target_string INTEGER,
+    target_fret INTEGER,
+    target_note TEXT NOT NULL,
+    given_string INTEGER,
+    given_fret INTEGER,
+    given_note TEXT NOT NULL,
+    correct INTEGER NOT NULL,
+    response_ms INTEGER,
+    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+)"""
+
+_TRAINER_SCHEMA = (
+    "CREATE TABLE IF NOT EXISTS trainer_attempts " + _TRAINER_ATTEMPTS_COLUMNS + ";\n"
+    + "CREATE INDEX IF NOT EXISTS idx_trainer_attempts_owner_drill"
+    " ON trainer_attempts(owner, drill, created_at);\n"
+    + "CREATE INDEX IF NOT EXISTS idx_trainer_attempts_session"
+    " ON trainer_attempts(session_id);\n"
+    # The index a "which positions get missed" query actually needs: every
+    # attempt this drill's position-to-note direction wrote, grouped by the
+    # position it was about. Left off target_note/correct because SQLite can
+    # apply those as a filter over this index's own rows without a second
+    # lookup - narrowing the indexed columns to what the WHERE and GROUP BY
+    # need is what keeps this from scanning a whole drill's history to find
+    # one string's weak frets.
+    + "CREATE INDEX IF NOT EXISTS idx_trainer_attempts_target"
+    " ON trainer_attempts(owner, drill, target_string, target_fret);\n"
+)
+
 
 # The scores table's columns, written once, for the same reason
 # _PRACTICE_SESSIONS_COLUMNS is: SCHEMA builds the table from it, and any future
@@ -394,7 +475,7 @@ CREATE TABLE IF NOT EXISTS instruments (
     updated_at TEXT NOT NULL DEFAULT (datetime('now'))
 );
 CREATE INDEX IF NOT EXISTS idx_instruments_owner ON instruments(owner);
-""" + _PRACTICE_SCHEMA
+""" + _PRACTICE_SCHEMA + _TRAINER_SCHEMA
 
 # The schema this code expects. Stamped into PRAGMA user_version once a startup
 # has finished bringing a database up to date.

--- a/server/fermata/trainer.py
+++ b/server/fermata/trainer.py
@@ -1,0 +1,182 @@
+"""Per-attempt results from a fretboard drill (issue #27, building on the neck
+component of issue #25) - structured rows, not a free-text note.
+
+docs/practice-data.md has always said the per-attempt schema would wait for a
+second trainer to decide what the unit is: a position, an interval, a pitch.
+Fret to note is that second trainer (ear training, the first, still logs only
+a `note` string - see EarTraining.svelte). What it decided: the unit is one
+QUESTION, and every question - whichever direction it was asked in - reduces
+to the same two facts, a note being tested and a note the answer named. See
+db.py's own comment on trainer_attempts for why that lets one `correct` rule
+cover both directions without this module ever needing to know a tuning.
+
+Nothing here is a session. `practice_sessions` still carries the drill's
+TIME, exactly the way ear_training does (api.log_session, activity
+'fretboard') - this module only validates and stores the per-question detail
+that sits beside it. See api.py's /trainer/attempts routes for where the two
+meet.
+"""
+
+from typing import Any
+
+# The one drill that writes here today. A widened tuple, not a migration, is
+# how a second one (#26, #29) arrives - the table itself is drill-agnostic
+# already (db.py's _TRAINER_ATTEMPTS_COLUMNS).
+DRILLS = ("fret_to_note",)
+
+# Which way the question ran. 'position_to_note': a position was shown, a
+# note was named. 'note_to_position': a note was named, a position was
+# tapped. See the module docstring for why both reduce to the same grading
+# rule.
+DIRECTIONS = ("position_to_note", "note_to_position")
+
+# The twelve pitch classes an attempt may name - one sharp OR flat per class,
+# never both, and never an octave. This is character-for-character the table
+# web/src/lib/trainer/neck.js's pitchClass spells (which is itself derived
+# from pitch.js's spellMidi, so the two cannot drift into different
+# spellings for the same MIDI note without a test somewhere failing to
+# notice). Fixing the set here, rather than accepting any string a client
+# calls a note, is what keeps "which notes get missed" a GROUP BY instead of
+# a query that first has to fold "Db" and "C#" together.
+PITCH_CLASSES = ("C", "C#", "D", "Eb", "E", "F", "F#", "G", "Ab", "A", "Bb", "B")
+
+# Generous bounds on a position, wide enough for anything instruments.py
+# would accept (MIN/MAX_STRINGS is 1-24, MIN/MAX_FRETS is 1-36) plus fret 0
+# for an open string, without importing that module just to restate its two
+# numbers - a trainer attempt is checked against the QUESTION it answered,
+# never against a live instrument row, so there is no definition here to stay
+# in lockstep with.
+MIN_STRING_NUMBER = 1
+MAX_STRING_NUMBER = 24
+MIN_FRET = 0
+MAX_FRET = 36
+
+# How long a response may claim to have taken. Milliseconds, optional, and
+# purely informational - nothing here computes from it - so the bound exists
+# only to catch a units mistake (a value in seconds, or a timestamp) rather
+# than to mean anything about how fast is fast. Ten minutes is far longer
+# than anyone deliberating one fretboard question.
+MAX_RESPONSE_MS = 10 * 60 * 1000
+
+
+def _position(string_value, fret_value, *, string_field: str, fret_field: str):
+    """A (string, fret) pair, both present or both absent. Raises ValueError
+    naming whichever field is the problem.
+
+    Never ONE of the two: a position with a string but no fret, or the
+    reverse, is not a partial position, it is not a position - and letting
+    one arrive alone would mean some rows answer "was a position given" with
+    a value that depends on which column happens to be non-null.
+    """
+    if string_value is None and fret_value is None:
+        return None, None
+    if string_value is None or fret_value is None:
+        raise ValueError(f"{string_field} and {fret_field} must both be given, or neither")
+    if isinstance(string_value, bool) or not isinstance(string_value, int):
+        raise ValueError(f"{string_field} must be a whole number")
+    if isinstance(fret_value, bool) or not isinstance(fret_value, int):
+        raise ValueError(f"{fret_field} must be a whole number")
+    if not MIN_STRING_NUMBER <= string_value <= MAX_STRING_NUMBER:
+        raise ValueError(
+            f"{string_field} must be between {MIN_STRING_NUMBER} and {MAX_STRING_NUMBER}"
+        )
+    if not MIN_FRET <= fret_value <= MAX_FRET:
+        raise ValueError(f"{fret_field} must be between {MIN_FRET} and {MAX_FRET}")
+    return string_value, fret_value
+
+
+def _note(value, field: str) -> str:
+    if value not in PITCH_CLASSES:
+        raise ValueError(f"{field} must be one of {list(PITCH_CLASSES)}")
+    return value
+
+
+def normalise_attempt(
+    *,
+    drill,
+    direction,
+    target_string=None,
+    target_fret=None,
+    target_note,
+    given_string=None,
+    given_fret=None,
+    given_note,
+    response_ms=None,
+) -> dict[str, Any]:
+    """Check one attempt and return the row to store, `correct` included.
+
+    Raises ValueError with a message meant for a person. `correct` is
+    computed here and is NEVER accepted from a caller - see the module
+    docstring for why `given_note == target_note` is the whole of the rule,
+    the same rule regardless of which direction the question was asked in.
+    """
+    if drill not in DRILLS:
+        raise ValueError(f"drill must be one of {list(DRILLS)}")
+    if direction not in DIRECTIONS:
+        raise ValueError(f"direction must be one of {list(DIRECTIONS)}")
+
+    target_string, target_fret = _position(
+        target_string, target_fret, string_field="target_string", fret_field="target_fret"
+    )
+    given_string, given_fret = _position(
+        given_string, given_fret, string_field="given_string", fret_field="given_fret"
+    )
+    target_note = _note(target_note, "target_note")
+    given_note = _note(given_note, "given_note")
+
+    if direction == "position_to_note":
+        # The question NAMED a position; the answer named a note. A tap on
+        # the neck answers the other direction, not this one.
+        if target_string is None:
+            raise ValueError(
+                "position_to_note needs target_string and target_fret - the position asked about"
+            )
+        if given_string is not None:
+            raise ValueError(
+                "position_to_note is answered with a note, not a tapped position - "
+                "given_string/given_fret must be omitted"
+            )
+    else:
+        # note_to_position: the question named a note only. There is no
+        # single target position to record - see db.py's comment on why
+        # target_string/target_fret stay NULL here - and the answer must be
+        # an actual tap, not a note choice.
+        if target_string is not None:
+            raise ValueError(
+                "note_to_position has no single target position - "
+                "target_string/target_fret must be omitted"
+            )
+        if given_string is None:
+            raise ValueError(
+                "note_to_position is answered by tapping a position - "
+                "given_string and given_fret are required"
+            )
+
+    if response_ms is not None:
+        if isinstance(response_ms, bool) or not isinstance(response_ms, int):
+            raise ValueError("response_ms must be a whole number")
+        if not 0 <= response_ms <= MAX_RESPONSE_MS:
+            raise ValueError(f"response_ms must be between 0 and {MAX_RESPONSE_MS}")
+
+    return {
+        "drill": drill,
+        "direction": direction,
+        "target_string": target_string,
+        "target_fret": target_fret,
+        "target_note": target_note,
+        "given_string": given_string,
+        "given_fret": given_fret,
+        "given_note": given_note,
+        # The one place this row's verdict is decided. Not stored from
+        # anywhere else and not trusted from a request body.
+        "correct": given_note == target_note,
+        "response_ms": response_ms,
+    }
+
+
+def attempt_dict(row) -> dict:
+    """One attempt as the API presents it - the stored row, with `correct`
+    turned back into a real bool (SQLite hands integers back)."""
+    d = dict(row)
+    d["correct"] = bool(d["correct"])
+    return d

--- a/server/tests/test_api_docs.py
+++ b/server/tests/test_api_docs.py
@@ -298,8 +298,9 @@ def test_every_route_has_exactly_the_expected_operation_count(openapi_schema):
     # rename a folder, move several scores, delete a score, list the trash,
     # restore from it, and destroy from it. Plus issue #57's one: how one
     # piece is going. Plus issue #16's one: GET /api/me. Plus issue #58's two:
-    # export the library to an archive, import one back.
-    assert count == 54
+    # export the library to an archive, import one back. Plus issue #27's
+    # two: log a fretboard drill attempt, and list them.
+    assert count == 56
 
 
 def test_binary_routes_do_not_advertise_a_json_content_type(openapi_schema):
@@ -601,6 +602,31 @@ def test_transcription_model_stays_in_sync_with_api_pys_bar_key_tuples():
     extra = actual - expected
     assert not missing, f"api_models.TranscriptionOut is missing field(s) for: {sorted(missing)}"
     assert not extra, f"api_models.TranscriptionOut has field(s) no longer in api.py's tuples: {sorted(extra)}"
+
+
+def test_trainer_responses_match_their_models(client):
+    """Issue #27's two routes, through the drift-guarded client - proves both
+    that TrainerAttemptOut/TrainerAttemptListOut describe the real response
+    shape and (claim 5) that every key the handler actually computed reaches
+    the wire, which a bare model_validate() on the response alone could
+    never catch."""
+    logged = client.post(
+        "/api/trainer/attempts",
+        json={
+            "drill": "fret_to_note",
+            "direction": "position_to_note",
+            "target_string": 6,
+            "target_fret": 3,
+            "target_note": "G",
+            "given_note": "G",
+        },
+    )
+    assert logged.status_code == 200, logged.text
+    api_models.TrainerAttemptOut.model_validate(logged.json())
+
+    api_models.TrainerAttemptListOut.model_validate(
+        client.get("/api/trainer/attempts").json()
+    )
 
 
 def test_scan_and_upload_responses_match_their_models(client, monkeypatch):

--- a/server/tests/test_trainer_api.py
+++ b/server/tests/test_trainer_api.py
@@ -1,0 +1,344 @@
+"""Per-attempt fretboard drill results (issue #27): trainer.normalise_attempt
+directly, and the two /api/trainer/attempts routes end to end.
+
+Structured rows, not a free-text note - issue #32's promise for this second
+trainer - so the tests below are literal-value assertions on a stored row and
+a real round trip through the API, not a shape check alone. See #146: a field
+that validates against its model is not the same claim as a field that
+actually reaches the wire with the value that was stored.
+"""
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from fermata import api, db, trainer
+
+# ---------------------------------------------------------------- trainer.py, directly
+
+
+def make(**overrides):
+    base = dict(
+        drill="fret_to_note",
+        direction="position_to_note",
+        target_string=6,
+        target_fret=3,
+        target_note="G",
+        given_note="G",
+    )
+    return {**base, **overrides}
+
+
+def test_a_matching_answer_is_correct():
+    row = trainer.normalise_attempt(**make())
+    assert row["correct"] is True
+
+
+def test_a_mismatched_answer_is_incorrect():
+    row = trainer.normalise_attempt(**make(given_note="F#"))
+    assert row["correct"] is False
+
+
+def test_correct_is_computed_and_cannot_be_smuggled_in():
+    """normalise_attempt's signature has no `correct` parameter at all - a
+    caller cannot pass one through and have it accepted, honest or not."""
+    import inspect
+
+    assert "correct" not in inspect.signature(trainer.normalise_attempt).parameters
+
+
+def test_note_to_position_direction_computes_correctness_the_same_way():
+    """The other direction: no target position, an answer given as a tapped
+    position's note rather than a chosen one. Same rule, same field."""
+    row = trainer.normalise_attempt(
+        drill="fret_to_note",
+        direction="note_to_position",
+        target_note="C",
+        given_string=5,
+        given_fret=3,
+        given_note="C",
+    )
+    assert row["correct"] is True
+    assert row["target_string"] is None
+    assert row["target_fret"] is None
+
+
+def test_position_to_note_rejects_a_given_position():
+    with pytest.raises(ValueError, match="given_string/given_fret must be omitted"):
+        trainer.normalise_attempt(**make(given_string=1, given_fret=0))
+
+
+def test_position_to_note_requires_a_target_position():
+    with pytest.raises(ValueError, match="target_string and target_fret"):
+        trainer.normalise_attempt(**make(target_string=None, target_fret=None))
+
+
+def test_note_to_position_rejects_a_target_position():
+    with pytest.raises(ValueError, match="target_string/target_fret must be omitted"):
+        trainer.normalise_attempt(
+            drill="fret_to_note",
+            direction="note_to_position",
+            target_string=6,
+            target_fret=0,
+            target_note="E",
+            given_string=6,
+            given_fret=0,
+            given_note="E",
+        )
+
+
+def test_note_to_position_requires_a_given_position():
+    with pytest.raises(ValueError, match="given_string and given_fret are required"):
+        trainer.normalise_attempt(
+            drill="fret_to_note", direction="note_to_position", target_note="E", given_note="E"
+        )
+
+
+def test_a_position_needs_both_halves():
+    with pytest.raises(ValueError, match="must both be given, or neither"):
+        trainer.normalise_attempt(**make(target_fret=None))
+
+
+@pytest.mark.parametrize("field", ["target_note", "given_note"])
+def test_only_the_twelve_canonical_pitch_classes_are_accepted(field):
+    """Db is not accepted alongside C# - one spelling per pitch class, the
+    same twelve pitch.js's spellMidi (and neck.js's pitchClass) produce, so
+    "which notes get missed" is a GROUP BY rather than a query that first has
+    to fold synonyms together. See trainer.py's PITCH_CLASSES."""
+    with pytest.raises(ValueError, match="target_note|given_note"):
+        trainer.normalise_attempt(**make(**{field: "Db"}))
+
+
+def test_an_octave_is_rejected_not_silently_stripped():
+    with pytest.raises(ValueError):
+        trainer.normalise_attempt(**make(target_note="G3"))
+
+
+@pytest.mark.parametrize("drill", ["fret_to_note", "FRET_TO_NOTE", "chords", ""])
+def test_drill_must_be_a_known_one(drill):
+    if drill == "fret_to_note":
+        trainer.normalise_attempt(**make(drill=drill))  # does not raise
+    else:
+        with pytest.raises(ValueError, match="drill must be one of"):
+            trainer.normalise_attempt(**make(drill=drill))
+
+
+def test_string_number_bounds():
+    with pytest.raises(ValueError, match="target_string"):
+        trainer.normalise_attempt(**make(target_string=0))
+    with pytest.raises(ValueError, match="target_string"):
+        trainer.normalise_attempt(**make(target_string=25))
+
+
+def test_fret_bounds():
+    with pytest.raises(ValueError, match="target_fret"):
+        trainer.normalise_attempt(**make(target_fret=-1))
+    with pytest.raises(ValueError, match="target_fret"):
+        trainer.normalise_attempt(**make(target_fret=37))
+    # An open string is fret 0, and is accepted.
+    row = trainer.normalise_attempt(**make(target_fret=0, given_note="F#"))
+    assert row["target_fret"] == 0
+
+
+def test_response_ms_bounds():
+    row = trainer.normalise_attempt(**make(response_ms=1500))
+    assert row["response_ms"] == 1500
+    with pytest.raises(ValueError, match="response_ms"):
+        trainer.normalise_attempt(**make(response_ms=-1))
+    with pytest.raises(ValueError, match="response_ms"):
+        trainer.normalise_attempt(**make(response_ms=trainer.MAX_RESPONSE_MS + 1))
+
+
+# ---------------------------------------------------------------------------
+# The API, end to end
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def client(app_env):
+    app = FastAPI()
+    app.include_router(api.router)
+    return TestClient(app)
+
+
+def test_logging_an_attempt_stores_the_row_and_returns_it(client):
+    resp = client.post(
+        "/api/trainer/attempts",
+        json={
+            "drill": "fret_to_note",
+            "direction": "position_to_note",
+            "target_string": 6,
+            "target_fret": 3,
+            "target_note": "G",
+            "given_note": "F#",
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    # Literal-value assertions on the response - not just "it validates".
+    assert body["drill"] == "fret_to_note"
+    assert body["direction"] == "position_to_note"
+    assert body["target_string"] == 6
+    assert body["target_fret"] == 3
+    assert body["target_note"] == "G"
+    assert body["given_note"] == "F#"
+    assert body["given_string"] is None
+    assert body["given_fret"] is None
+    assert body["correct"] is False
+    assert body["owner"] == "local"
+    assert body["session_id"] is None
+    assert isinstance(body["id"], int)
+    assert body["created_at"]
+
+    # And the field ROUND-TRIPS: what a fresh read of the same row says is
+    # exactly what the write returned (#146's lesson, applied here rather
+    # than only trusted from the write's own response).
+    conn = db.connect()
+    row = dict(conn.execute("SELECT * FROM trainer_attempts WHERE id = ?", (body["id"],)).fetchone())
+    assert row["target_note"] == "G"
+    assert row["given_note"] == "F#"
+    assert row["correct"] == 0  # SQLite's storage of False
+
+    fetched = client.get("/api/trainer/attempts?limit=10").json()["attempts"][0]
+    assert fetched["id"] == body["id"]
+    assert fetched["correct"] is False
+    assert fetched["target_note"] == "G"
+    assert fetched["given_note"] == "F#"
+
+
+def test_a_correct_answer_round_trips_true(client):
+    resp = client.post(
+        "/api/trainer/attempts",
+        json={
+            "drill": "fret_to_note",
+            "direction": "position_to_note",
+            "target_string": 1,
+            "target_fret": 0,
+            "target_note": "E",
+            "given_note": "E",
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["correct"] is True
+    listed = client.get("/api/trainer/attempts?correct=true").json()
+    assert listed["total"] == 1
+    assert listed["attempts"][0]["id"] == resp.json()["id"]
+    assert client.get("/api/trainer/attempts?correct=false").json()["total"] == 0
+
+
+def test_a_bad_body_is_refused_with_422_naming_the_problem(client):
+    resp = client.post(
+        "/api/trainer/attempts",
+        json={
+            "drill": "fret_to_note",
+            "direction": "position_to_note",
+            "target_string": 6,
+            "target_fret": 3,
+            "target_note": "H",  # not a pitch class
+            "given_note": "G",
+        },
+    )
+    assert resp.status_code == 422
+    assert "target_note" in resp.json()["detail"]
+
+
+def test_an_unknown_session_id_is_refused(client):
+    resp = client.post(
+        "/api/trainer/attempts",
+        json={
+            "session_id": 99999,
+            "drill": "fret_to_note",
+            "direction": "position_to_note",
+            "target_string": 6,
+            "target_fret": 3,
+            "target_note": "G",
+            "given_note": "G",
+        },
+    )
+    assert resp.status_code == 404
+
+
+def test_an_attempt_can_be_linked_to_a_real_session(client):
+    session = client.post(
+        "/api/practice/sessions", json={"seconds": 120, "activity": "fretboard"}
+    ).json()
+    resp = client.post(
+        "/api/trainer/attempts",
+        json={
+            "session_id": session["id"],
+            "drill": "fret_to_note",
+            "direction": "position_to_note",
+            "target_string": 6,
+            "target_fret": 0,
+            "target_note": "E",
+            "given_note": "E",
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["session_id"] == session["id"]
+    assert client.get(f"/api/trainer/attempts?session_id={session['id']}").json()["total"] == 1
+
+    # Deleting the session keeps the attempt - the question was still asked
+    # and answered - and only unlinks it, mirroring practice_sessions'
+    # score_id ON DELETE SET NULL.
+    client.delete(f"/api/practice/sessions/{session['id']}")
+    still_there = client.get("/api/trainer/attempts").json()
+    assert still_there["total"] == 1
+    assert still_there["attempts"][0]["session_id"] is None
+
+
+def test_listing_filters_by_drill_and_direction(client):
+    for direction in ("position_to_note", "note_to_position"):
+        body = (
+            {
+                "drill": "fret_to_note",
+                "direction": direction,
+                "target_string": 3,
+                "target_fret": 2,
+                "target_note": "A",
+                "given_note": "A",
+            }
+            if direction == "position_to_note"
+            else {
+                "drill": "fret_to_note",
+                "direction": direction,
+                "target_note": "A",
+                "given_string": 3,
+                "given_fret": 2,
+                "given_note": "A",
+            }
+        )
+        assert client.post("/api/trainer/attempts", json=body).status_code == 200
+
+    assert client.get("/api/trainer/attempts").json()["total"] == 2
+    assert (
+        client.get("/api/trainer/attempts?direction=position_to_note").json()["total"] == 1
+    )
+    assert (
+        client.get("/api/trainer/attempts?direction=note_to_position").json()["total"] == 1
+    )
+    assert client.get("/api/trainer/attempts?drill=fret_to_note").json()["total"] == 2
+
+
+def test_an_unknown_filter_value_is_refused(client):
+    assert client.get("/api/trainer/attempts?drill=chords").status_code == 422
+    assert client.get("/api/trainer/attempts?direction=sideways").status_code == 422
+
+
+def test_truncation_is_reported_honestly(client):
+    for fret in range(3):
+        client.post(
+            "/api/trainer/attempts",
+            json={
+                "drill": "fret_to_note",
+                "direction": "position_to_note",
+                "target_string": 6,
+                "target_fret": fret,
+                "target_note": "E",
+                "given_note": "E",
+            },
+        )
+    listed = client.get("/api/trainer/attempts?limit=2").json()
+    assert listed["total"] == 3
+    assert len(listed["attempts"]) == 2
+    assert listed["truncated"] is True

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -6,6 +6,7 @@
   import MetronomePage from "./lib/MetronomePage.svelte";
   import EarTraining from "./lib/EarTraining.svelte";
   import ScoreProgress from "./lib/ScoreProgress.svelte";
+  import FretToNote from "./lib/trainer/FretToNote.svelte";
 
   function parse(hash) {
     // Checked BEFORE the bare score route, which matches a prefix: without
@@ -20,6 +21,7 @@
     if (hash.startsWith("#/practice")) return { page: "practice" };
     if (hash.startsWith("#/metronome")) return { page: "metronome" };
     if (hash.startsWith("#/ear-training")) return { page: "ear-training" };
+    if (hash.startsWith("#/fretboard")) return { page: "fretboard" };
     return { page: "library" };
   }
 
@@ -46,6 +48,8 @@
   <MetronomePage />
 {:else if route.page === "ear-training"}
   <EarTraining />
+{:else if route.page === "fretboard"}
+  <FretToNote />
 {:else}
   <Library />
 {/if}

--- a/web/src/lib/Library.svelte
+++ b/web/src/lib/Library.svelte
@@ -479,6 +479,7 @@
       <a class="demo-link practice-link" href="#/practice">◴ Practice &amp; goals</a>
       <a class="demo-link" href="#/metronome">♩ Metronome</a>
       <a class="demo-link ear-training-link" href="#/ear-training">♪ Hear a note, name it</a>
+      <a class="demo-link fretboard-link" href="#/fretboard">▤ Fret to note</a>
       <a class="demo-link" href="#/demo">Notation/tab demo →</a>
       <a class="demo-link" href="#/settings">⚙ Settings</a>
     </div>

--- a/web/src/lib/api.js
+++ b/web/src/lib/api.js
@@ -238,6 +238,22 @@ export const api = {
       body: JSON.stringify(body),
     }).then(j),
   deleteInstrument: (id) => fetch(`/api/instruments/${id}`, { method: "DELETE" }).then(j),
+  // Structured, per-question fretboard drill results (issue #27, #32) - one
+  // row per answered question, independent of the practice_sessions row the
+  // drill's own TIME is logged against (see fret-to-note.js's module
+  // docstring for why the two are separate calls).
+  logTrainerAttempt: (body) =>
+    fetch("/api/trainer/attempts", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }).then(j),
+  trainerAttempts: (params = {}) => {
+    const q = new URLSearchParams(
+      Object.fromEntries(Object.entries(params).filter(([, v]) => v != null && v !== "")),
+    );
+    return fetch(`/api/trainer/attempts?${q}`).then(j);
+  },
   version: () => fetch("/api/version").then(j),
   settings: () => fetch("/api/settings").then(j),
   putSettings: (values) =>

--- a/web/src/lib/trainer/FretToNote.svelte
+++ b/web/src/lib/trainer/FretToNote.svelte
@@ -22,7 +22,7 @@
 
   import { api } from "../api.js";
   import { getInstruments, loadInstruments } from "../instruments.svelte.js";
-  import { formatDuration, localDay } from "../practice.js";
+  import { localDay } from "../practice.js";
   import Neck from "./Neck.svelte";
   import {
     DEFAULT_FRET_COUNT,
@@ -37,12 +37,10 @@
     attemptPayload,
     checkPositionAnswer,
     checkTapAnswer,
-    directionLabel,
     loggedStatement,
     pickQuestion,
     progressStatement,
     scopeIsAskable,
-    scopeLabel,
     sessionNote,
   } from "./fret-to-note.js";
 

--- a/web/src/lib/trainer/FretToNote.svelte
+++ b/web/src/lib/trainer/FretToNote.svelte
@@ -1,0 +1,730 @@
+<script>
+  // Fret to note, both directions (issue #27) - the first drill built on the
+  // neck component (#25). A real drill loop: prompt, answer, feedback, next.
+  //
+  // WHAT MAKES THIS ONE HONEST, following EarTraining.svelte's own lead:
+  //
+  //   Nothing here grades anybody. Two counts, stated - no percentage, no
+  //   streak. A wrong answer is the practice, not a shortfall: the position
+  //   or the note is stated plainly either way, in the same place and the
+  //   same style. See fret-to-note.js's answerStatement and the tone rules
+  //   at the top of that file.
+  //
+  //   The tapped position (not the note a player MEANT to tap) decides a
+  //   note-to-position answer - mirrors ear-training.js's own rule that the
+  //   question is built from what actually happened, not from intent.
+  //
+  //   Every question is a structured row (POST /api/trainer/attempts), not
+  //   only a count folded into the session's note - issue #32's promise for
+  //   this drill. The session logged at the end still carries a human-
+  //   readable summary in its own `note`, the same as every other activity.
+  import { onDestroy } from "svelte";
+
+  import { api } from "../api.js";
+  import { getInstruments, loadInstruments } from "../instruments.svelte.js";
+  import { formatDuration, localDay } from "../practice.js";
+  import Neck from "./Neck.svelte";
+  import {
+    DEFAULT_FRET_COUNT,
+    PITCH_CLASSES,
+    fretCountFromInstrument,
+    stringsFromInstrument,
+  } from "./neck.js";
+  import {
+    NOTE_TO_POSITION,
+    POSITION_TO_NOTE,
+    answerStatement,
+    attemptPayload,
+    checkPositionAnswer,
+    checkTapAnswer,
+    directionLabel,
+    loggedStatement,
+    pickQuestion,
+    progressStatement,
+    scopeIsAskable,
+    scopeLabel,
+    sessionNote,
+  } from "./fret-to-note.js";
+
+  const instruments = getInstruments();
+
+  $effect(() => {
+    loadInstruments();
+  });
+
+  // Which instrument's tuning to draw the neck from: "" is the standard
+  // six-string fallback, otherwise an instrument's id as a string. Adopted
+  // automatically only when exactly one instrument is defined - the same
+  // rule EarTraining.svelte follows and for the same reason: with more than
+  // one, which is in somebody's hands is not knowable, so guessing would be
+  // worse than a plain default that says what it is.
+  let source = $state("");
+  let sourceSettled = false;
+  $effect(() => {
+    if (!instruments.loaded || sourceSettled) return;
+    sourceSettled = true;
+    if (instruments.list.length === 1) source = String(instruments.list[0].id);
+  });
+
+  const instrument = $derived(instruments.list.find((i) => String(i.id) === source) ?? null);
+  const strings = $derived(stringsFromInstrument(instrument));
+  const fretCount = $derived(fretCountFromInstrument(instrument));
+
+  let direction = $state(POSITION_TO_NOTE);
+
+  // Scope: which strings and which frets a question may be drawn from. Both
+  // default to "everything the current tuning offers" and stay there until a
+  // person touches the controls - see the two effects below - which is what
+  // lets a fret-range default follow a newly picked instrument's own fret
+  // count rather than freezing at whatever the six-string fallback offered.
+  let customizedStrings = false;
+  let selectedStrings = $state([]);
+  $effect(() => {
+    if (customizedStrings) return;
+    selectedStrings = strings.map((s) => s.number);
+  });
+
+  let customizedFretRange = false;
+  let startFret = $state(0);
+  let endFret = $state(DEFAULT_FRET_COUNT);
+  $effect(() => {
+    if (customizedFretRange) return;
+    startFret = 0;
+    endFret = fretCount;
+  });
+
+  function toggleString(number) {
+    customizedStrings = true;
+    if (selectedStrings.includes(number)) {
+      // At least one string must stay selected - an empty list does not mean
+      // "nothing asked", it means "no filter at all" (see fret-to-note.js's
+      // scopePositions), so silently allowing zero would make the last
+      // string's checkbox appear to narrow the drill to nothing while
+      // actually widening it back to everything.
+      if (selectedStrings.length <= 1) return;
+      selectedStrings = selectedStrings.filter((n) => n !== number);
+    } else {
+      selectedStrings = [...selectedStrings, number];
+    }
+  }
+
+  function setStartFret(value) {
+    customizedFretRange = true;
+    startFret = Number(value);
+  }
+
+  function setEndFret(value) {
+    customizedFretRange = true;
+    endFret = Number(value);
+  }
+
+  const scope = $derived({ startFret, endFret, stringNumbers: selectedStrings });
+  const askable = $derived(scopeIsAskable(strings, scope));
+
+  let running = $state(false);
+  let asked = $state(0);
+  let correctCount = $state(0);
+  // { question, given, correct }. `given` is null until answered - see
+  // chooseNote/tapPosition. `question.string`/`.fret` are set only for a
+  // position-to-note question; `question.note` is always set.
+  let round = $state(null);
+  let questionStartedAt = 0;
+  let attemptLogFailures = $state(0);
+
+  let startedAt = 0;
+  let logged = $state(null);
+  let logError = $state("");
+  let logging = $state(false);
+  let unlogged = $state(null);
+
+  function elapsed() {
+    return Math.max(1, Math.round((Date.now() - startedAt) / 1000));
+  }
+
+  function drillNote() {
+    return sessionNote({ asked, correct: correctCount, direction, strings, scope });
+  }
+
+  function nextQuestion() {
+    const previous = round?.question ?? null;
+    const question = pickQuestion(strings, scope, direction, previous);
+    round = question ? { question, given: null, correct: null } : null;
+    questionStartedAt = Date.now();
+  }
+
+  async function recordAttempt(question, given, correct) {
+    const responseMs = Math.max(0, Date.now() - questionStartedAt);
+    try {
+      await api.logTrainerAttempt(attemptPayload({ question, given, responseMs }));
+    } catch {
+      // Best-effort: the drill's own counts (asked/correctCount, already
+      // updated) and its session log are the record that must not be lost.
+      // A failed per-question POST is noted quietly rather than interrupting
+      // the loop a person is mid-question in.
+      attemptLogFailures += 1;
+    }
+  }
+
+  function chooseNote(note) {
+    if (!round || round.given != null || round.question.direction !== POSITION_TO_NOTE) return;
+    const correct = checkPositionAnswer(round.question, note);
+    const given = { note };
+    round = { ...round, given, correct };
+    asked += 1;
+    if (correct) correctCount += 1;
+    recordAttempt(round.question, given, correct);
+  }
+
+  function tapPosition(stringNumber, fret) {
+    if (!round || round.given != null || round.question.direction !== NOTE_TO_POSITION) return;
+    const { correct, note } = checkTapAnswer(strings, round.question, stringNumber, fret);
+    const given = { string: stringNumber, fret, note };
+    round = { ...round, given, correct };
+    asked += 1;
+    if (correct) correctCount += 1;
+    recordAttempt(round.question, given, correct);
+  }
+
+  function neckMarkers() {
+    if (!round) return [];
+    const { question, given, correct } = round;
+    if (question.direction === POSITION_TO_NOTE) {
+      const kind = given == null ? "target" : correct ? "correct" : "incorrect";
+      return [{ string: question.string, fret: question.fret, kind }];
+    }
+    if (given == null) return [];
+    return [{ string: given.string, fret: given.fret, kind: correct ? "correct" : "incorrect" }];
+  }
+
+  // Once a note-to-position question is answered, every OTHER place that
+  // note sounds is revealed too - the neck's own "highlight a note across
+  // the neck" primitive (Neck.svelte's highlightNote prop), reused rather
+  // than this component recomputing positions by hand. This is what
+  // "reveal the answer" (issue #27) means on this direction: not only right
+  // or wrong, but where the note actually is.
+  const highlightNote = $derived(
+    round?.question?.direction === NOTE_TO_POSITION && round.given != null
+      ? round.question.note
+      : null,
+  );
+
+  const neckInteractive = $derived(
+    running && round != null && round.given == null && direction === NOTE_TO_POSITION,
+  );
+
+  function start() {
+    if (!askable) return;
+    running = true;
+    startedAt = Date.now();
+    asked = 0;
+    correctCount = 0;
+    attemptLogFailures = 0;
+    logged = null;
+    logError = "";
+    unlogged = null;
+    nextQuestion();
+  }
+
+  async function stopAndLog() {
+    if (!running) return;
+    const seconds = elapsed();
+    const totalAsked = asked;
+    running = false;
+    round = null;
+    // Nothing was ever asked, so nothing was practised - a start immediately
+    // stopped is a mis-click, not a session worth a row.
+    if (!totalAsked) return;
+    await send(seconds);
+  }
+
+  async function send(seconds) {
+    logging = true;
+    logError = "";
+    try {
+      const session = await api.logSession({
+        activity: "fretboard",
+        seconds,
+        local_date: localDay(),
+        note: drillNote(),
+      });
+      logged = { seconds: session?.seconds ?? seconds, id: session?.id ?? null };
+      unlogged = null;
+    } catch (e) {
+      logError = e?.message || "That practice could not be logged.";
+      unlogged = seconds;
+    } finally {
+      logging = false;
+    }
+  }
+
+  function retryLog() {
+    if (unlogged == null) return;
+    send(unlogged);
+  }
+
+  // Leaving mid-drill still logs the practice - see EarTraining.svelte's
+  // identical teardown and the comment there on why: a hash route change
+  // unmounts this component, and practice history cannot be regenerated.
+  onDestroy(() => {
+    if (!running || asked < 1) return;
+    api
+      .logSession({
+        activity: "fretboard",
+        seconds: elapsed(),
+        local_date: localDay(),
+        note: drillNote(),
+      })
+      .catch(() => {});
+  });
+</script>
+
+<div class="page">
+  <header>
+    <a class="back" href="#/">← Library</a>
+    <h1>Fret to note</h1>
+  </header>
+
+  <main>
+    <section
+      class="drill"
+      data-running={running ? "1" : "0"}
+      data-asked={asked}
+      data-correct={correctCount}
+      data-direction={direction}
+      data-askable={askable ? "1" : "0"}
+      data-question-note={round?.question?.note ?? ""}
+      data-question-string={round?.question?.string ?? ""}
+      data-question-fret={round?.question?.fret ?? ""}
+      data-given-note={round?.given?.note ?? ""}
+      data-attempt-log-failures={attemptLogFailures}
+    >
+      <p class="hint">
+        Shown a position, name its note - or shown a note, tap where it lives on the neck. Both
+        directions are different skills, so pick the one to practise.
+      </p>
+
+      <!-- ------------------------------------------------------ direction -->
+      <div class="row direction-row" role="group" aria-label="Direction">
+        <button
+          class="direction-choice"
+          class:active={direction === POSITION_TO_NOTE}
+          disabled={running}
+          onclick={() => (direction = POSITION_TO_NOTE)}
+        >
+          Position → note
+        </button>
+        <button
+          class="direction-choice"
+          class:active={direction === NOTE_TO_POSITION}
+          disabled={running}
+          onclick={() => (direction = NOTE_TO_POSITION)}
+        >
+          Note → position
+        </button>
+      </div>
+
+      <!-- ------------------------------------------------------ source & scope -->
+      <div class="row scope-row">
+        <label>
+          <span>Tuning</span>
+          <select class="scope-source" bind:value={source} disabled={running}>
+            <option value="">Standard guitar</option>
+            {#each instruments.list as owned (owned.id)}
+              <option value={String(owned.id)}>{owned.name}</option>
+            {/each}
+          </select>
+        </label>
+        <label>
+          <span>Frets</span>
+          <select
+            class="scope-start-fret"
+            value={startFret}
+            disabled={running}
+            onchange={(e) => setStartFret(e.currentTarget.value)}
+          >
+            {#each Array.from({ length: fretCount + 1 }, (_, f) => f) as f (f)}
+              <option value={f}>{f}</option>
+            {/each}
+          </select>
+          <span>to</span>
+          <select
+            class="scope-end-fret"
+            value={endFret}
+            disabled={running}
+            onchange={(e) => setEndFret(e.currentTarget.value)}
+          >
+            {#each Array.from({ length: fretCount + 1 }, (_, f) => f) as f (f)}
+              <option value={f}>{f}</option>
+            {/each}
+          </select>
+        </label>
+      </div>
+
+      <div class="row strings-row" role="group" aria-label="Strings">
+        {#each [...strings].sort((a, b) => b.number - a.number) as string (string.number)}
+          <button
+            class="string-choice"
+            class:active={selectedStrings.includes(string.number)}
+            disabled={running}
+            onclick={() => toggleString(string.number)}
+          >
+            {string.number}
+          </button>
+        {/each}
+      </div>
+
+      {#if instruments.error}
+        <p class="notice instruments-error">
+          {instruments.error} The drill below uses the standard guitar instead.
+        </p>
+      {/if}
+
+      {#if !askable}
+        <p class="statement narrow-scope">
+          Nothing is selected to ask about - choose at least one fret in range.
+        </p>
+      {/if}
+
+      <!-- ------------------------------------------------------- the drill -->
+      {#if running && round}
+        <p class="statement progress">{progressStatement({ asked, correct: correctCount })}</p>
+
+        {#if direction === NOTE_TO_POSITION}
+          <p class="statement prompt">
+            Find <strong>{round.question.note}</strong> on the neck.
+          </p>
+        {:else}
+          <p class="statement prompt">Name the highlighted note.</p>
+        {/if}
+
+        <Neck
+          {strings}
+          {fretCount}
+          startFret={0}
+          markers={neckMarkers()}
+          highlightNote={highlightNote}
+          interactive={neckInteractive}
+          onTap={tapPosition}
+        />
+
+        <div class="statement-slot" role="status" aria-live="polite">
+          {#if round.given != null}
+            <p class="statement answer-statement">
+              {answerStatement(round.question, round.given, round.correct)}
+            </p>
+          {/if}
+        </div>
+
+        {#if direction === POSITION_TO_NOTE}
+          <ul class="choices">
+            {#each PITCH_CLASSES as note (note)}
+              <li>
+                <button
+                  class="choice"
+                  class:correct={round.given != null && note === round.question.note}
+                  class:picked={round.given?.note === note && note !== round.question.note}
+                  data-note={note}
+                  disabled={round.given != null}
+                  onclick={() => chooseNote(note)}
+                >
+                  {note}
+                </button>
+              </li>
+            {/each}
+          </ul>
+        {/if}
+
+        <div class="row controls">
+          {#if round.given != null}
+            <button class="primary next-question" onclick={nextQuestion}>Next question</button>
+          {/if}
+          <button class="ghost stop-drill" onclick={stopAndLog} disabled={logging}>
+            {logging ? "Logging…" : "Stop and log this practice"}
+          </button>
+        </div>
+      {:else if running && !round}
+        <p class="statement narrow-scope">
+          Nothing is selected to ask about - choose at least one fret in range.
+        </p>
+        <div class="row controls">
+          <button class="ghost stop-drill" onclick={stopAndLog} disabled={logging}>
+            {logging ? "Logging…" : "Stop"}
+          </button>
+        </div>
+      {:else}
+        {#if askable}
+          <div class="row controls">
+            <button class="primary start-drill" onclick={start}>Start</button>
+          </div>
+        {/if}
+
+        {#if logged}
+          <p class="statement logged">
+            {loggedStatement(logged.seconds)}
+            {progressStatement({ asked, correct: correctCount })}
+            <a href="#/practice">Practice &amp; goals →</a>
+          </p>
+        {/if}
+
+        {#if logError}
+          <p class="notice log-error">
+            {logError}
+            <button class="retry-log" onclick={retryLog} disabled={logging}>
+              {logging ? "Trying…" : "Try again"}
+            </button>
+          </p>
+        {/if}
+      {/if}
+    </section>
+
+    <p class="quiet footnote">
+      The time you spend here is logged as fretboard practice, in the same history as everything
+      else. Every question is also kept on its own, so which positions and which notes need more
+      time is something you can look back on - not only a count for the session it happened in.
+    </p>
+  </main>
+</div>
+
+<style>
+  .page {
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+  }
+
+  header {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    padding: 14px 20px;
+    border-bottom: 1px solid var(--line);
+  }
+
+  h1 {
+    margin: 0;
+    font-size: 18px;
+    font-weight: 600;
+  }
+
+  .back {
+    color: var(--ink-dim);
+    font-size: 14px;
+  }
+
+  .back:hover {
+    color: var(--brass);
+  }
+
+  main {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 20px;
+    padding: 32px 20px 48px;
+  }
+
+  .drill {
+    width: 100%;
+    max-width: 720px;
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+    padding: 22px;
+    background: var(--bg-raised);
+    border: 1px solid var(--line);
+    border-radius: var(--radius);
+  }
+
+  .hint,
+  .quiet {
+    margin: 0;
+    color: var(--ink-dim);
+    font-size: 13px;
+    line-height: 1.5;
+  }
+
+  .row {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    flex-wrap: wrap;
+  }
+
+  .scope-row label {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 14px;
+  }
+
+  select {
+    background: var(--surface);
+    color: var(--ink);
+    border: 1px solid var(--line);
+    border-radius: 6px;
+    padding: 5px 8px;
+    font: inherit;
+    font-size: 14px;
+  }
+
+  /* Big touch targets throughout - this app's tablet-at-a-music-stand rule
+     (issue #25/#119): every tappable control here is at least 44px tall. */
+  .direction-choice,
+  .string-choice,
+  .choice,
+  button {
+    min-height: 44px;
+  }
+
+  .direction-choice,
+  .string-choice {
+    background: var(--surface);
+    color: var(--ink);
+    border: 1px solid var(--line);
+    border-radius: var(--radius);
+    padding: 10px 16px;
+    font: inherit;
+    font-size: 15px;
+    cursor: pointer;
+  }
+
+  .string-choice {
+    min-width: 44px;
+    padding: 10px 0;
+    text-align: center;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .direction-choice.active,
+  .string-choice.active {
+    border-color: var(--brass);
+    color: var(--brass-bright);
+  }
+
+  .direction-choice:disabled,
+  .string-choice:disabled {
+    opacity: 0.55;
+    cursor: default;
+  }
+
+  .statement {
+    margin: 0;
+    font-size: 15px;
+    color: var(--ink);
+    line-height: 1.5;
+  }
+
+  .statement-slot {
+    min-height: 30px;
+    display: flex;
+    align-items: center;
+  }
+
+  .choices {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 10px;
+  }
+
+  .choice {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 14px 6px;
+    background: var(--surface);
+    color: var(--ink);
+    border: 1px solid var(--line);
+    border-radius: var(--radius);
+    font: inherit;
+    font-size: 18px;
+    font-variant-numeric: tabular-nums;
+    cursor: pointer;
+  }
+
+  .choice:hover:enabled {
+    border-color: var(--brass);
+  }
+
+  .choice:disabled {
+    opacity: 1;
+    cursor: default;
+  }
+
+  .choice.correct {
+    border-color: var(--brass);
+    color: var(--brass-bright);
+  }
+
+  /* NOT --danger - see Neck.svelte's identical rule for the same marker
+     kind. A wrong choice is shown as picked, in this app's ordinary "not the
+     thing" ink, never in the colour reserved for a fault. */
+  .choice.picked {
+    border-color: var(--ink-dim);
+  }
+
+  button {
+    background: var(--surface);
+    color: var(--ink);
+    border: 1px solid var(--line);
+    border-radius: 6px;
+    padding: 8px 14px;
+    font: inherit;
+    font-size: 14px;
+    cursor: pointer;
+  }
+
+  button:hover:enabled {
+    border-color: var(--brass);
+  }
+
+  button:disabled {
+    opacity: 0.55;
+    cursor: default;
+  }
+
+  button.primary {
+    background: var(--brass);
+    border-color: var(--brass);
+    color: #1a1509;
+    font-weight: 600;
+  }
+
+  button.ghost {
+    background: none;
+    color: var(--ink-dim);
+  }
+
+  .notice {
+    margin: 0;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    flex-wrap: wrap;
+    font-size: 14px;
+    color: var(--ink);
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: 6px;
+    padding: 8px 12px;
+  }
+
+  .logged a {
+    color: var(--brass);
+  }
+
+  .footnote {
+    max-width: 52ch;
+    text-align: center;
+  }
+
+  @media (min-width: 640px) {
+    .choices {
+      grid-template-columns: repeat(6, minmax(0, 1fr));
+    }
+  }
+</style>

--- a/web/src/lib/trainer/Neck.svelte
+++ b/web/src/lib/trainer/Neck.svelte
@@ -1,0 +1,358 @@
+<script>
+  // The interactive fretboard (issue #25) - a reusable, hand-rolled SVG
+  // component every fretboard trainer (#26, #27, #29) draws on. It is a pure
+  // display component with no game logic and no server calls of its own,
+  // same as this app's other primitives (Metronome, the tab renderer): what
+  // note sounds where, and which position was tapped, are the whole of what
+  // it knows.
+  //
+  // PROPS, chosen for reuse rather than for the one drill that exists today:
+  //
+  //   strings       [{ number, midi }], in ANY order - see neck.js's
+  //                 stringsFromInstrument for how a caller gets one from a
+  //                 saved instrument or the standard-guitar fallback. Sorted
+  //                 here by number, ascending, so string 1 (the highest
+  //                 pitch) always draws at the TOP - the same convention
+  //                 server/fermata/musicxml.py documents ("string 1 is
+  //                 assigned to the top tab line").
+  //   fretCount     how many frets to draw.
+  //   startFret     the lowest fret drawn - lets a drill scope itself to a
+  //                 range (issue #27's "particular strings, a fret range")
+  //                 without this component knowing anything about scoping.
+  //   markers       [{ string, fret, kind }], kind one of 'target',
+  //                 'correct', 'incorrect', 'hint' - explicit overlays a
+  //                 caller places, keyed by position.
+  //   highlightNote a pitch class ("C#") to mark, as 'hint', at EVERY
+  //                 position that sounds it - "highlight a note across the
+  //                 neck" as a built-in feature rather than something every
+  //                 caller recomputes from neck.js's positionsForNote by
+  //                 hand. An explicit marker at the same position always
+  //                 wins (see markerFor), so a caller's own correct/incorrect
+  //                 mark is never overwritten by this.
+  //   showLabels    show every position's note name, not only marked ones -
+  //                 a reference/explore mode. A drill leaves this false so
+  //                 the labels cannot give an unanswered question away; only
+  //                 its own markers reveal anything.
+  //   interactive   whether a tap fires onTap at all.
+  //   onTap         (stringNumber, fret, note) => void, called on a tap of a
+  //                 playable position. Not called for a tap on a string
+  //                 number this component was not given, or a fret beyond
+  //                 MIDI's range - see neck.js's noteAt.
+  //
+  // GEOMETRY is plain SVG in a viewBox, scaled to whatever width the caller's
+  // layout gives it (width: 100%, height: auto) - see the styles below for
+  // how that stays legible and touch-target-sized down to tablet width
+  // without a break-point, which issue #25 asks for directly.
+  import { DEFAULT_FRET_COUNT, inlayDots, noteAt, pitchClass, posKey } from "./neck.js";
+
+  let {
+    strings = [],
+    fretCount = DEFAULT_FRET_COUNT,
+    startFret = 0,
+    markers = [],
+    highlightNote = null,
+    showLabels = false,
+    interactive = false,
+    onTap = null,
+  } = $props();
+
+  const sorted = $derived([...strings].sort((a, b) => a.number - b.number));
+
+  // ---- geometry, in SVG user units -----------------------------------------
+  const NUT_GAP = 44; // space left of the nut wire, for open-string markers
+  const FRET_WIDTH = 62;
+  const STRING_GAP = 34;
+  const MARGIN = 22;
+  const DOT_R = 5;
+  const MARKER_R = 14;
+
+  const width = $derived(NUT_GAP + Math.max(1, fretCount) * FRET_WIDTH + MARGIN);
+  const height = $derived(MARGIN * 2 + Math.max(0, sorted.length - 1) * STRING_GAP);
+
+  function stringY(index) {
+    return MARGIN + index * STRING_GAP;
+  }
+
+  function fretWireX(fret) {
+    return NUT_GAP + fret * FRET_WIDTH;
+  }
+
+  function positionX(fret) {
+    return fret === 0 ? NUT_GAP / 2 : NUT_GAP + (fret - 0.5) * FRET_WIDTH;
+  }
+
+  const fretWires = $derived(
+    Array.from({ length: Math.max(1, fretCount) + 1 }, (_, i) => i),
+  );
+
+  const drawnFrets = $derived(
+    Array.from(
+      { length: Math.max(0, fretCount - Math.max(0, startFret) + 1) },
+      (_, i) => Math.max(0, startFret) + i,
+    ),
+  );
+
+  const dotFrets = $derived(drawnFrets.filter((f) => f > 0 && inlayDots(f) > 0));
+
+  // markers, keyed by position - the last one wins if a caller ever passes
+  // two for the same spot, which is a caller error but should not crash.
+  const explicit = $derived(
+    new Map((markers ?? []).map((m) => [posKey(m.string, m.fret), m.kind])),
+  );
+
+  const highlighted = $derived(
+    highlightNote
+      ? new Set(
+          sorted.flatMap((s) =>
+            drawnFrets
+              .filter((fret) => {
+                const midi = noteAt(sorted, s.number, fret);
+                return midi != null && pitchClass(midi) === highlightNote;
+              })
+              .map((fret) => posKey(s.number, fret)),
+          ),
+        )
+      : new Set(),
+  );
+
+  function markerFor(stringNumber, fret) {
+    const key = posKey(stringNumber, fret);
+    // Explicit markers always win over the auto-highlight - a caller's own
+    // correct/incorrect mark on the position that was just answered must not
+    // be swallowed by a highlightNote covering the same spot.
+    return explicit.get(key) ?? (highlighted.has(key) ? "hint" : null);
+  }
+
+  function tap(stringNumber, fret, note) {
+    if (!interactive || typeof onTap !== "function") return;
+    onTap(stringNumber, fret, note);
+  }
+</script>
+
+<div class="neck" data-string-count={sorted.length} data-fret-count={fretCount}>
+  <svg viewBox={`0 0 ${width} ${height}`} role="img" aria-label="Fretboard">
+    <!-- the fingerboard itself -->
+    <rect
+      class="board"
+      x={NUT_GAP}
+      y={MARGIN - STRING_GAP / 2}
+      width={Math.max(1, fretCount) * FRET_WIDTH}
+      height={Math.max(0, sorted.length - 1) * STRING_GAP + STRING_GAP}
+    />
+
+    <!-- inlay dots, centred vertically (or symmetric around centre for a
+         double dot at 12/24) -->
+    {#each dotFrets as fret (fret)}
+      {#if inlayDots(fret) === 1}
+        <circle
+          class="inlay"
+          cx={positionX(fret)}
+          cy={MARGIN + (Math.max(0, sorted.length - 1) * STRING_GAP) / 2}
+          r={DOT_R}
+        />
+      {:else}
+        <circle class="inlay" cx={positionX(fret)} cy={MARGIN + STRING_GAP * 0.9} r={DOT_R} />
+        <circle
+          class="inlay"
+          cx={positionX(fret)}
+          cy={MARGIN + Math.max(0, sorted.length - 1) * STRING_GAP - STRING_GAP * 0.9}
+          r={DOT_R}
+        />
+      {/if}
+    {/each}
+
+    <!-- fret wires; the nut (fret 0) drawn thicker -->
+    {#each fretWires as fret (fret)}
+      <line
+        class="wire"
+        class:nut={fret === 0}
+        x1={fretWireX(fret)}
+        x2={fretWireX(fret)}
+        y1={MARGIN - STRING_GAP / 2}
+        y2={MARGIN + Math.max(0, sorted.length - 1) * STRING_GAP + STRING_GAP / 2}
+      />
+    {/each}
+
+    <!-- strings -->
+    {#each sorted as string, i (string.number)}
+      <line
+        class="string"
+        x1={NUT_GAP - 6}
+        x2={fretWireX(Math.max(1, fretCount))}
+        y1={stringY(i)}
+        y2={stringY(i)}
+      />
+      <text class="string-label" x={4} y={stringY(i) + 4}>{string.number}</text>
+    {/each}
+
+    <!-- positions: one tappable target per (string, drawn fret) -->
+    {#each sorted as string, i (string.number)}
+      {#each drawnFrets as fret (fret)}
+        {@const midi = noteAt(sorted, string.number, fret)}
+        {#if midi != null}
+          {@const note = pitchClass(midi)}
+          {@const kind = markerFor(string.number, fret)}
+          <!-- role is static ("button", not conditional on `interactive`) so
+               the compiler can see this is genuinely a button - a role that
+               only sometimes applies is what triggered
+               a11y_no_noninteractive_tabindex here. tabindex still varies:
+               -1 pulls a non-interactive neck (the ordinary case while a
+               position-to-note question is showing) out of tab order
+               entirely, so a display-only fretboard is not 400 tab stops. -->
+          <g
+            class="position"
+            class:interactive
+            data-string={string.number}
+            data-fret={fret}
+            data-note={note}
+            data-marker={kind ?? ""}
+            role="button"
+            aria-label={`String ${string.number}, fret ${fret}`}
+            aria-disabled={!interactive}
+            tabindex={interactive ? 0 : -1}
+            onclick={() => tap(string.number, fret, note)}
+            onkeydown={(e) => {
+              if (interactive && (e.key === "Enter" || e.key === " ")) {
+                e.preventDefault();
+                tap(string.number, fret, note);
+              }
+            }}
+          >
+            <!-- a large, invisible hit area - the touch target is bigger
+                 than what is drawn, per this app's tablet-at-a-music-stand
+                 sizing (issue #25's "big touch targets"). -->
+            <circle class="hit" cx={positionX(fret)} cy={stringY(i)} r={MARKER_R + 8} />
+            {#if kind}
+              <circle class="mark {kind}" cx={positionX(fret)} cy={stringY(i)} r={MARKER_R} />
+            {/if}
+            <!-- Never shown for a bare 'target' marker - that marker names
+                 the position a position-to-note question is ASKING about,
+                 and printing the note on it would answer the question for
+                 free. Every other kind is either revealed already
+                 (correct/incorrect/hint) or explicitly requested
+                 (showLabels). -->
+            {#if showLabels || (kind && kind !== "target")}
+              <text class="note-label {kind ?? ''}" x={positionX(fret)} y={stringY(i) + 4}
+                >{note}</text
+              >
+            {/if}
+          </g>
+        {/if}
+      {/each}
+    {/each}
+  </svg>
+</div>
+
+<style>
+  .neck {
+    width: 100%;
+  }
+
+  svg {
+    display: block;
+    width: 100%;
+    height: auto;
+  }
+
+  .board {
+    fill: var(--surface);
+    stroke: var(--line);
+  }
+
+  .wire {
+    stroke: var(--ink-dim);
+    stroke-width: 1.5;
+  }
+
+  .wire.nut {
+    stroke: var(--ink);
+    stroke-width: 4;
+  }
+
+  .string {
+    stroke: var(--ink-dim);
+    stroke-width: 1.5;
+  }
+
+  .string-label {
+    fill: var(--ink-dim);
+    font-size: 11px;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .inlay {
+    fill: var(--line);
+  }
+
+  .position.interactive {
+    cursor: pointer;
+  }
+
+  .hit {
+    fill: transparent;
+    /* No stroke: this is a touch target, not a drawn element - see the
+       markers below for what is actually visible. */
+  }
+
+  .position.interactive:focus-visible .hit {
+    fill: none;
+    stroke: var(--brass);
+    stroke-width: 2;
+  }
+
+  .mark {
+    stroke-width: 2;
+  }
+
+  /* The question being asked right now - waiting for an answer. Brass, like
+     everything this app already uses for "here" (the metronome's beat, the
+     current page). Not yet a verdict. */
+  .mark.target {
+    fill: var(--bg-raised);
+    stroke: var(--brass-bright);
+    stroke-width: 3;
+  }
+
+  .mark.correct {
+    fill: var(--brass);
+    stroke: var(--brass-bright);
+  }
+
+  /* Deliberately NOT --danger. A wrong answer here is information, the same
+     rule ear-training.js and practice.js apply throughout this application -
+     see FretToNote.svelte's own note. Marked so it can be told apart from a
+     correct one, in the same muted ink the rest of this page uses for "not
+     the thing", never in the colour this app reserves for a fault. */
+  .mark.incorrect {
+    fill: var(--bg-raised);
+    stroke: var(--ink-dim);
+  }
+
+  /* A revealed position that was not itself tapped - part of the answer,
+     shown after the fact, or a highlighted note. Quiet on purpose: this is
+     not something to answer, only to notice. */
+  .mark.hint {
+    fill: var(--line);
+    stroke: var(--ink-dim);
+    stroke-width: 1.5;
+  }
+
+  .note-label {
+    fill: var(--ink);
+    font-size: 12px;
+    font-weight: 600;
+    text-anchor: middle;
+    pointer-events: none;
+    font-variant-numeric: tabular-nums;
+  }
+
+  /* Dark text on the brass fill 'correct' uses - the same pairing
+     button.primary uses elsewhere in this application. */
+  .note-label.correct {
+    fill: #1a1509;
+  }
+
+  .note-label.target {
+    fill: var(--brass-bright);
+  }
+</style>

--- a/web/src/lib/trainer/fret-to-note.js
+++ b/web/src/lib/trainer/fret-to-note.js
@@ -1,0 +1,184 @@
+// Fret to note, both directions (issue #27) - the first drill built on the
+// neck component (#25). Show a position, name its note; or name a note, find
+// a position that sounds it.
+//
+// No runes and no browser - the pattern is ear-training.js's, for the same
+// reason: which question gets asked and how the answer is worded is worth
+// getting right on its own, testable without a page.
+//
+// THE TONE RULES ARE practice.js's, same as ear-training.js, and bind the
+// same way here: a wrong answer is the practice, not a shortfall. No
+// accuracy percentage, no streak, no verdict word - only counts, stated.
+// tests/unit/fret-to-note.spec.js checks every string this module produces
+// against practice.js's own FORBIDDEN_WORDS list.
+//
+// STRUCTURED RESULTS, NOT A FREE-TEXT NOTE (issue #32). Unlike ear-training,
+// which still logs its counts into the session's `note` (docs/practice-
+// data.md says as much, deliberately, until a second trainer existed to
+// decide otherwise), every question this drill asks is ALSO posted as one
+// row to POST /api/trainer/attempts - see attemptPayload. The practice
+// session this drill logs still carries the drill's own summary in its note,
+// the same as every other activity, so a reader of the practice page is not
+// left with a blank line; the STRUCTURED, QUERYABLE record lives in
+// trainer_attempts instead of being the only place time was spent.
+import { countOrNone, formatDuration } from "../practice.js";
+import { DEFAULT_FRET_COUNT, noteAt, pitchClass, positions as neckPositions } from "./neck.js";
+
+export const POSITION_TO_NOTE = "position_to_note";
+export const NOTE_TO_POSITION = "note_to_position";
+export const DIRECTIONS = [POSITION_TO_NOTE, NOTE_TO_POSITION];
+
+export const DRILL = "fret_to_note";
+
+/** Every position a scope actually allows: `strings` narrowed to
+ * `scope.stringNumbers` (all of them when omitted or empty) and
+ * `scope.startFret`..`scope.endFret`. The one place both pickQuestion and
+ * the "can this even be asked" check draw positions from. */
+export function scopePositions(strings, scope = {}) {
+  const start = Math.max(0, Number(scope.startFret ?? 0));
+  const end = Number(scope.endFret ?? DEFAULT_FRET_COUNT);
+  const allowed = Array.isArray(scope.stringNumbers) && scope.stringNumbers.length
+    ? new Set(scope.stringNumbers)
+    : null;
+  return neckPositions(strings, start, end).filter((p) => !allowed || allowed.has(p.string));
+}
+
+/** Whether a scope has anything to ask about at all - reachable through the
+ * ordinary interface the moment every string is deselected, or a fret range
+ * is narrowed to nothing. */
+export function scopeIsAskable(strings, scope) {
+  return scopePositions(strings, scope).length > 0;
+}
+
+/** "Strings 1, 2, frets 0-5" - the scope, named. Every string is not stated
+ * (it is the ordinary case); a narrowed set is. */
+export function scopeLabel(strings, scope = {}) {
+  const start = Math.max(0, Number(scope.startFret ?? 0));
+  const end = Number(scope.endFret ?? DEFAULT_FRET_COUNT);
+  const all = (strings ?? []).map((s) => s.number).sort((a, b) => a - b);
+  const selected = Array.isArray(scope.stringNumbers) && scope.stringNumbers.length
+    ? [...scope.stringNumbers].sort((a, b) => a - b)
+    : all;
+  const parts = [];
+  if (selected.length !== all.length) {
+    parts.push(`string${selected.length === 1 ? "" : "s"} ${selected.join(", ")}`);
+  }
+  parts.push(`frets ${start}-${end}`);
+  return parts.join(", ");
+}
+
+/** How the direction reads in a sentence. */
+export function directionLabel(direction) {
+  return direction === NOTE_TO_POSITION ? "note to position" : "position to note";
+}
+
+/** The next question: a position (position-to-note) or a note
+ * (note-to-position), drawn uniformly from what the scope allows. Never
+ * repeats the position/note just asked, the same rule pickTarget in
+ * ear-training.js follows and for the same reason - a repeat reads as the
+ * drill having failed to advance. Null when the scope has nothing to ask. */
+export function pickQuestion(strings, scope, direction, previous = null, rand = Math.random) {
+  const pool = scopePositions(strings, scope);
+  if (!pool.length) return null;
+
+  if (direction === POSITION_TO_NOTE) {
+    const eligible = previous
+      ? pool.filter((p) => !(p.string === previous.string && p.fret === previous.fret))
+      : pool;
+    const from = eligible.length ? eligible : pool;
+    const picked = from[Math.min(from.length - 1, Math.floor(rand() * from.length))];
+    return { direction, string: picked.string, fret: picked.fret, note: picked.note };
+  }
+
+  const notes = [...new Set(pool.map((p) => p.note))];
+  const eligible = previous ? notes.filter((n) => n !== previous.note) : notes;
+  const from = eligible.length ? eligible : notes;
+  const note = from[Math.min(from.length - 1, Math.floor(rand() * from.length))];
+  return { direction, note, string: null, fret: null };
+}
+
+/** position-to-note: was the chosen note the one asked about. */
+export function checkPositionAnswer(question, chosenNote) {
+  return chosenNote === question.note;
+}
+
+/** note-to-position: the note that SOUNDS at the tapped position, worked out
+ * from the instrument's own tuning - never from what the player meant to
+ * tap - and whether it is the one that was asked for. Mirrors ear-
+ * training.js's own rule ("the question is built from what was SOUNDED"):
+ * the tapped position is the ground truth, and the note it produces is what
+ * gets graded and what gets sent to the server (see attemptPayload). */
+export function checkTapAnswer(strings, question, tappedString, tappedFret) {
+  const midi = noteAt(strings, tappedString, tappedFret);
+  if (midi == null) return { correct: false, note: null };
+  const note = pitchClass(midi);
+  return { correct: note === question.note, note };
+}
+
+/** The structured row to POST to /api/trainer/attempts for one answered
+ * question - issue #32's promise, kept per-question rather than folded into
+ * the session's free-text note. `given.note` must already be resolved (via
+ * checkPositionAnswer's chosen note, or checkTapAnswer's `note`) - this
+ * function does no grading of its own, matching db.py/trainer.py's own rule
+ * that `correct` is computed once, server-side, from target_note vs
+ * given_note. */
+export function attemptPayload({ sessionId = null, question, given, responseMs = null }) {
+  const base = {
+    session_id: sessionId,
+    drill: DRILL,
+    direction: question.direction,
+    response_ms: responseMs ?? null,
+  };
+  if (question.direction === POSITION_TO_NOTE) {
+    return {
+      ...base,
+      target_string: question.string,
+      target_fret: question.fret,
+      target_note: question.note,
+      given_note: given.note,
+    };
+  }
+  return {
+    ...base,
+    target_note: question.note,
+    given_string: given.string,
+    given_fret: given.fret,
+    given_note: given.note,
+  };
+}
+
+/** What to say about the answer just given - the note either way, and which
+ * position when a tap was involved. No verdict word: the fact stated is what
+ * teaches, same rule as ear-training's roundStatement. */
+export function answerStatement(question, given, correct) {
+  if (question.direction === POSITION_TO_NOTE) {
+    const at = `String ${question.string}, fret ${question.fret} is ${question.note}.`;
+    return correct ? at : `${at} You named ${given.note}.`;
+  }
+  const at = `String ${given.string}, fret ${given.fret} is ${given.note}.`;
+  return correct ? at : `${at} ${question.note} is elsewhere on the neck.`;
+}
+
+/** How the drill has gone so far. Two counts, nothing else - no percentage,
+ * no streak. Matches ear-training.js's progressStatement in shape. */
+export function progressStatement({ asked = 0, correct = 0 } = {}) {
+  const total = Math.max(0, Math.floor(Number(asked) || 0));
+  if (!total) return "Nothing asked yet.";
+  const questions = total === 1 ? "1 question" : `${total} questions`;
+  return `${questions}, ${countOrNone(correct)} answered correctly.`;
+}
+
+/** What goes in the practice session's free-text `note` - a human-readable
+ * summary beside the structured per-question rows this drill also writes
+ * (see attemptPayload and the module docstring on why both exist). */
+export function sessionNote({ asked = 0, correct = 0, direction, strings, scope } = {}) {
+  return `Fret to note, ${directionLabel(direction)}. ${progressStatement({ asked, correct })} ${scopeLabel(
+    strings,
+    scope,
+  )}.`;
+}
+
+/** What was logged, said back once the drill has stopped. */
+export function loggedStatement(seconds) {
+  return `${formatDuration(seconds)} of fretboard practice is in your practice history.`;
+}

--- a/web/src/lib/trainer/neck.js
+++ b/web/src/lib/trainer/neck.js
@@ -1,0 +1,155 @@
+// The neck: pure geometry and note arithmetic for the interactive fretboard
+// (issue #25) - the shared foundation every fretboard trainer (#26, #27, #29)
+// builds on.
+//
+// No runes and no browser, for the same reason pitch.js and ear-training.js
+// have none: the part of this worth getting right is arithmetic - which note
+// sounds at a string and a fret - and arithmetic is what a unit test can hold
+// to account without a page. Neck.svelte draws what this computes; it adds no
+// note-naming or position logic of its own.
+//
+// READS TUNING FROM THE INSTRUMENT, NOT A HARDCODED SIX STRINGS. An
+// instrument definition (server/fermata/instruments.py, loaded here through
+// instruments.svelte.js) already carries exactly what a neck needs: how many
+// strings, what each is tuned to, and how many frets. stringsFromInstrument
+// reads that - a seven-string guitar or a dropped tuning draws its own real
+// strings - and falls back to a plain standard six-string guitar only when
+// there is no instrument to read from at all (defaultStrings), which is a
+// starting point rather than an assumption. An UNFRETTED instrument (a
+// violin) has no frets and is deliberately not offered a neck at all; see
+// stringsFromInstrument's own comment.
+import { MAX_MIDI, MIN_MIDI, pitchMidi, spellMidi } from "../pitch.js";
+
+export const MIN_FRETS = 1;
+
+// The default when nothing else is known: standard guitar, EADGBE. Matches
+// server/fermata/instruments.py's "guitar-standard" preset exactly, and is
+// used only by defaultStrings/defaultFretCount below - anywhere an
+// instrument is available, its own tuning is read instead.
+const STANDARD_TUNING_PITCHES = ["E2", "A2", "D3", "G3", "B3", "E4"];
+export const DEFAULT_FRET_COUNT = 12;
+
+/** Standard six-string guitar strings, numbered 6 (low E) to 1 (high e) - the
+ * STRING ORDER convention instruments.py documents, applied to a tuning that
+ * exists independently of any saved instrument. The one hardcoded tuning in
+ * this module, and only a fallback - see the module docstring. */
+export function defaultStrings() {
+  return STANDARD_TUNING_PITCHES.map((pitch, index) => ({
+    number: STANDARD_TUNING_PITCHES.length - index,
+    midi: pitchMidi(pitch),
+  }));
+}
+
+/** The strings to draw a neck from: an instrument's own, when it has some to
+ * give, or the standard six-string fallback.
+ *
+ * Reads `instrument.strings` - the shape instruments.svelte.js's saved rows
+ * and pitch.js's draftStrings both already produce (each entry carrying at
+ * least `number` and `midi`) - so a seven-string guitar, a dropped tuning, or
+ * a four-string bass draws its real strings rather than six assumed ones.
+ * Prefers `sounding_midi` over `midi` where present, because a capo changes
+ * what a string actually sounds and that is what a fretboard drill has to
+ * test against.
+ *
+ * An UNFRETTED instrument (fretted: false - a violin) has no frets, and
+ * position reasoning does not apply to it any more than it does on the
+ * server (see instruments.py's module docstring on why fret_count is
+ * rejected outright there). Rather than inventing frets for one, this falls
+ * back to the standard guitar - which is a known first-cut limitation, not a
+ * silent guess: the fretboard trainer route only offers itself against a
+ * fretted instrument or the fallback, and issue #29 (a "which instrument"
+ * picker aware of this) is the filed follow-up. */
+export function stringsFromInstrument(instrument) {
+  const rows = instrument?.fretted ? instrument.strings : null;
+  if (!Array.isArray(rows) || !rows.length) return defaultStrings();
+  const strings = rows
+    .map((s) => ({ number: s.number, midi: s.sounding_midi ?? s.midi }))
+    .filter((s) => Number.isInteger(s.number) && Number.isFinite(s.midi));
+  return strings.length ? strings : defaultStrings();
+}
+
+/** How many frets to draw: an instrument's own fret_count, or
+ * DEFAULT_FRET_COUNT when there is none to read (no instrument, or an
+ * unfretted one - see stringsFromInstrument). */
+export function fretCountFromInstrument(instrument, fallback = DEFAULT_FRET_COUNT) {
+  const count = instrument?.fretted ? Number(instrument.fret_count) : null;
+  return Number.isFinite(count) && count > 0 ? count : fallback;
+}
+
+/** The MIDI note sounding at a string and a fret, or null when that string
+ * number is not one of `strings` or the result falls outside MIDI's own
+ * range (pitch.js's MIN_MIDI/MAX_MIDI - the same bound an instrument
+ * definition is checked against server-side). */
+export function noteAt(strings, stringNumber, fret) {
+  const string = (strings ?? []).find((s) => s.number === stringNumber);
+  if (!string || !Number.isFinite(string.midi)) return null;
+  const midi = string.midi + fret;
+  return midi >= MIN_MIDI && midi <= MAX_MIDI ? midi : null;
+}
+
+/** A MIDI note's pitch class - the note on its own, with no octave, which is
+ * how a fretboard position is ordinarily named ("that's a C", not "that's a
+ * C4"). Derived from pitch.js's spellMidi by dropping the trailing octave
+ * digits rather than from a second spelling table, so this can never
+ * disagree with the one place pitch.js already spells a note - and PITCH_
+ * CLASSES below is exactly the twelve values it can produce. */
+export function pitchClass(midi) {
+  return spellMidi(midi).replace(/-?\d+$/, "");
+}
+
+// The twelve pitch classes pitchClass can produce, in that order - one sharp
+// OR flat per class, matching spellMidi's own table (which is itself
+// musicxml.spell_pitch at fifths=0). Exported so a drill's note-name choices
+// offer exactly these, and server/fermata/trainer.py's PITCH_CLASSES is kept
+// to the identical list by hand, checked by tests/unit/neck.spec.js reading
+// both.
+export const PITCH_CLASSES = [
+  "C", "C#", "D", "Eb", "E", "F", "F#", "G", "Ab", "A", "Bb", "B",
+];
+
+/** A stable key for one position, used to key a marker map or compare two
+ * positions for equality. Not meant to be parsed back apart - callers that
+ * need the numbers keep them separately. */
+export function posKey(stringNumber, fret) {
+  return `${stringNumber}:${fret}`;
+}
+
+/** Every playable position across `strings`, from `startFret` to `endFret`
+ * inclusive, each with its note. The one place both Neck.svelte and a
+ * drill's question generator draw positions from, so "every position on the
+ * neck" cannot mean something different to the renderer than it means to a
+ * question. Positions that fall outside MIDI's range (noteAt returning null)
+ * are simply not included, rather than raising - the neck draws what is
+ * playable and says nothing about what is not. */
+export function positions(strings, startFret = 0, endFret = DEFAULT_FRET_COUNT) {
+  const out = [];
+  for (const string of strings ?? []) {
+    for (let fret = Math.max(0, startFret); fret <= endFret; fret++) {
+      const midi = noteAt(strings, string.number, fret);
+      if (midi == null) continue;
+      out.push({ string: string.number, fret, midi, note: pitchClass(midi) });
+    }
+  }
+  return out;
+}
+
+/** Every position (within the given range, on the given strings) that sounds
+ * a given pitch class - what "highlight this note across the neck" means,
+ * and what a note-to-position question's full answer is once revealed. */
+export function positionsForNote(strings, note, startFret = 0, endFret = DEFAULT_FRET_COUNT) {
+  return positions(strings, startFret, endFret).filter((p) => p.note === note);
+}
+
+// Frets a real fretboard marks with an inlay dot: the ordinary single-dot
+// positions, and the double dot at the octave. Not tied to any one
+// instrument's fret count - a dot beyond fretCount is simply never drawn,
+// the same way a position beyond it is never in `positions`.
+const SINGLE_DOTS = new Set([3, 5, 7, 9, 15, 17, 19, 21]);
+const DOUBLE_DOTS = new Set([12, 24]);
+
+/** How many inlay dots a fret carries: 0, 1, or 2. */
+export function inlayDots(fret) {
+  if (DOUBLE_DOTS.has(fret)) return 2;
+  if (SINGLE_DOTS.has(fret)) return 1;
+  return 0;
+}

--- a/web/tests/browser/fretboard-trainer.spec.js
+++ b/web/tests/browser/fretboard-trainer.spec.js
@@ -1,0 +1,476 @@
+// The interactive neck (issue #25) and the fret-to-note drill built on it
+// (issue #27), against the real backend and the real build.
+//
+// Unlike ear-training.spec.js, no audio path is involved here at all - a
+// fretboard question is answered by choosing a note name or tapping an SVG
+// position, both of which are ordinary DOM events. So these tests read
+// their ground truth off the section's own data-question-* attributes
+// (set from the question this component actually picked - see
+// FretToNote.svelte) rather than off anything a mock would make true for
+// free, the same discipline ear-training.spec.js applies to
+// data-sounded-midi.
+import { expect, test } from "@playwright/test";
+
+import { forbiddenWord, localDay } from "../../src/lib/practice.js";
+
+const drill = (page) => page.locator("section.drill");
+const startButton = (page) => page.locator(".start-drill");
+const progress = (page) => page.locator(".progress");
+const answerStatement = (page) => page.locator(".answer-statement");
+
+const today = localDay();
+
+async function reset(request) {
+  const existing = await (await request.get("/api/instruments")).json();
+  for (const instrument of existing) await request.delete(`/api/instruments/${instrument.id}`);
+  const goals = (await (await request.get(`/api/practice/goals?today=${today}`)).json()).goals;
+  for (const goal of goals) await request.delete(`/api/practice/goals/${goal.id}`);
+  const sessions = (
+    await (await request.get("/api/practice/sessions?limit=1000")).json()
+  ).sessions;
+  for (const session of sessions) await request.delete(`/api/practice/sessions/${session.id}`);
+}
+
+async function addInstrument(request, definition) {
+  const res = await request.post("/api/instruments", { data: definition });
+  expect(res.ok(), await res.text()).toBe(true);
+  return res.json();
+}
+
+const SEVEN_STRING = {
+  kind: "string",
+  name: "Seven-string guitar",
+  fretted: true,
+  string_count: 7,
+  string_pitches: ["B1", "E2", "A2", "D3", "G3", "B3", "E4"],
+  fret_count: 24,
+  capo: 0,
+  reference_pitch: 440,
+};
+
+test.beforeEach(async ({ page, request }) => {
+  const scores = await (await request.get("/api/scores")).json();
+  expect(
+    scores,
+    "refusing to run: this backend has scores in its library, so it is not the " +
+      "throwaway instance the suite creates - and these tests delete practice history",
+  ).toEqual([]);
+  await reset(request);
+
+  await page.goto("/#/fretboard");
+  await expect(drill(page)).toBeVisible();
+});
+
+function question(page) {
+  return drill(page).evaluate((el) => ({
+    note: el.dataset.questionNote,
+    string: el.dataset.questionString ? Number(el.dataset.questionString) : null,
+    fret: el.dataset.questionFret === "" ? null : Number(el.dataset.questionFret),
+  }));
+}
+
+// ---------------------------------------------------------------------------
+// The neck itself (#25): correct notes at sampled positions, standard tuning.
+// ---------------------------------------------------------------------------
+
+test("the neck renders the correct note at open strings and at the fifth-fret relationship, standard tuning", async ({
+  page,
+}) => {
+  // Reference mode: every position labelled, nothing answered yet. Proves
+  // the neck's own note-at-position arithmetic directly, independent of the
+  // drill's question-picking - the same claim tests/unit/neck.spec.js makes,
+  // now against what is actually rendered.
+  await startButton(page).click();
+  await expect(drill(page)).toHaveAttribute("data-running", "1");
+
+  // Neck.svelte publishes every position's note as a data-note attribute
+  // regardless of whether a label is drawn (showLabels is false here) - see
+  // the component's own comment on why a bare 'target' marker must not
+  // print its label. Reading data-note directly is the rendered proof that
+  // the neck's arithmetic is right, without needing to answer a question
+  // first.
+  const openE6 = await page
+    .locator('g.position[data-string="6"][data-fret="0"]')
+    .getAttribute("data-note");
+  const openA5 = await page
+    .locator('g.position[data-string="5"][data-fret="0"]')
+    .getAttribute("data-note");
+  const openD4 = await page
+    .locator('g.position[data-string="4"][data-fret="0"]')
+    .getAttribute("data-note");
+  const openG3 = await page
+    .locator('g.position[data-string="3"][data-fret="0"]')
+    .getAttribute("data-note");
+  const openB2 = await page
+    .locator('g.position[data-string="2"][data-fret="0"]')
+    .getAttribute("data-note");
+  const openE1 = await page
+    .locator('g.position[data-string="1"][data-fret="0"]')
+    .getAttribute("data-note");
+  expect({ openE6, openA5, openD4, openG3, openB2, openE1 }).toEqual({
+    openE6: "E",
+    openA5: "A",
+    openD4: "D",
+    openG3: "G",
+    openB2: "B",
+    openE1: "E",
+  });
+
+  // The fifth-fret relationship: fret 5 on one string matches the next
+  // string open, except the third-to-second pair, which is fret 4 (major
+  // third rather than a fourth) - the same guitarist's check
+  // tests/unit/neck.spec.js applies to the arithmetic directly, now read
+  // off the rendered SVG.
+  const fret5string6 = await page
+    .locator('g.position[data-string="6"][data-fret="5"]')
+    .getAttribute("data-note");
+  expect(fret5string6).toBe(openA5);
+  const fret4string3 = await page
+    .locator('g.position[data-string="3"][data-fret="4"]')
+    .getAttribute("data-note");
+  expect(fret4string3).toBe(openB2);
+
+  // And the twelfth fret is an octave above the open string - same pitch
+  // class, which is all `data-note` (a pitch class) can assert.
+  const fret12string6 = await page
+    .locator('g.position[data-string="6"][data-fret="12"]')
+    .getAttribute("data-note");
+  expect(fret12string6).toBe(openE6);
+});
+
+test("string count and fret count are published on the neck, matching the standard-guitar fallback", async ({
+  page,
+}) => {
+  await startButton(page).click();
+  const neck = page.locator(".neck");
+  await expect(neck).toHaveAttribute("data-string-count", "6");
+  await expect(neck).toHaveAttribute("data-fret-count", "12");
+});
+
+test("a saved instrument's own tuning drives the neck, not a hardcoded six strings", async ({
+  page,
+  request,
+}) => {
+  await addInstrument(request, SEVEN_STRING);
+  await page.reload();
+  await expect(drill(page)).toBeVisible();
+
+  await page.selectOption(".scope-source", { label: "Seven-string guitar" });
+  await startButton(page).click();
+  await expect(page.locator(".neck")).toHaveAttribute("data-string-count", "7");
+  await expect(page.locator(".neck")).toHaveAttribute("data-fret-count", "24");
+  // The low B string exists and sounds B.
+  await expect(
+    page.locator('g.position[data-string="7"][data-fret="0"]'),
+  ).toHaveAttribute("data-note", "B");
+});
+
+// ---------------------------------------------------------------------------
+// A tap highlights/identifies (#25's interaction contract).
+// ---------------------------------------------------------------------------
+
+test("in note-to-position mode, tapping the neck marks the position and reveals every place the note sounds", async ({
+  page,
+}) => {
+  await page.locator(".direction-choice").nth(1).click();
+  await startButton(page).click();
+  await expect(drill(page)).toHaveAttribute("data-direction", "note_to_position");
+  const q = await question(page);
+  expect(q.note).toBeTruthy();
+  expect(q.string).toBeNull();
+
+  // Tap the position this app's own arithmetic says sounds the asked note -
+  // trusting neck.js's own noteAt would be circular, so this scans the
+  // rendered positions for one whose data-note the page itself already
+  // agrees is the target, and taps THAT one.
+  const match = page.locator(`g.position[data-note="${q.note}"]`).first();
+  await expect(match).toBeVisible();
+  const { string, fret } = await match.evaluate((el) => ({
+    string: el.dataset.string,
+    fret: el.dataset.fret,
+  }));
+  await match.click();
+
+  await expect(drill(page)).toHaveAttribute("data-asked", "1");
+  await expect(drill(page)).toHaveAttribute("data-correct", "1");
+  const tapped = page.locator(
+    `g.position[data-string="${string}"][data-fret="${fret}"] .mark.correct`,
+  );
+  await expect(tapped).toBeVisible();
+  // Every OTHER position sounding the same note is revealed too - the
+  // answer, not only a verdict on the one tap.
+  const revealed = page.locator(`g.position[data-note="${q.note}"] .mark`);
+  await expect(revealed).toHaveCount(
+    await page.locator(`g.position[data-note="${q.note}"]`).count(),
+  );
+  await expect(answerStatement(page)).toContainText(q.note);
+});
+
+test("a second tap after answering does nothing - one answer per question", async ({ page }) => {
+  await page.locator(".direction-choice").nth(1).click();
+  await startButton(page).click();
+  const q = await question(page);
+  const first = page.locator(`g.position[data-note="${q.note}"]`).first();
+  await first.click();
+  await expect(drill(page)).toHaveAttribute("data-asked", "1");
+
+  // Tap a DIFFERENT position now that the question is answered.
+  const other = page.locator('g.position[data-string="1"][data-fret="0"]');
+  await other.click({ force: true });
+  await expect(drill(page)).toHaveAttribute("data-asked", "1");
+});
+
+// ---------------------------------------------------------------------------
+// The drill: prompt, answer, feedback, next - both directions, both a
+// correct and an incorrect answer, handled honestly (no shaming, no streak).
+// ---------------------------------------------------------------------------
+
+test("position-to-note: naming the right note says so plainly, and the count moves", async ({
+  page,
+}) => {
+  await startButton(page).click();
+  await expect(drill(page)).toHaveAttribute("data-direction", "position_to_note");
+  await expect(progress(page)).toHaveText("Nothing asked yet.");
+
+  const q = await question(page);
+  await page.locator(`.choice[data-note="${q.note}"]`).click();
+
+  await expect(drill(page)).toHaveAttribute("data-asked", "1");
+  await expect(drill(page)).toHaveAttribute("data-correct", "1");
+  await expect(progress(page)).toHaveText("1 question, 1 answered correctly.");
+  await expect(answerStatement(page)).toContainText(
+    `String ${q.string}, fret ${q.fret} is ${q.note}.`,
+  );
+  await expect(page.locator(`.choice[data-note="${q.note}"]`)).toHaveClass(/correct/);
+  await expect(page.locator(".choice.picked")).toHaveCount(0);
+
+  const text = await answerStatement(page).textContent();
+  expect(forbiddenWord(text), text).toBeNull();
+});
+
+test("position-to-note: naming a different note states which one, without a verdict word", async ({
+  page,
+}) => {
+  await startButton(page).click();
+  const q = await question(page);
+  // The pitch-class button grid always offers all twelve, so a wrong choice
+  // always exists.
+  const wrongNote = q.note === "C" ? "C#" : "C";
+  await page.locator(`.choice[data-note="${wrongNote}"]`).click();
+
+  await expect(drill(page)).toHaveAttribute("data-asked", "1");
+  await expect(drill(page)).toHaveAttribute("data-correct", "0");
+  await expect(progress(page)).toHaveText("1 question, none answered correctly.");
+  await expect(answerStatement(page)).toHaveText(
+    `String ${q.string}, fret ${q.fret} is ${q.note}. You named ${wrongNote}.`,
+  );
+  // The right answer is still marked, and the wrong pick is shown as picked
+  // rather than as a fault.
+  await expect(page.locator(`.choice[data-note="${q.note}"]`)).toHaveClass(/correct/);
+  await expect(page.locator(`.choice[data-note="${wrongNote}"]`)).toHaveClass(/picked/);
+
+  const text = await answerStatement(page).textContent();
+  expect(forbiddenWord(text), text).toBeNull();
+  expect(text).not.toMatch(/%/);
+
+  // Not --danger: the same rule ear-training.spec.js checks, applied here.
+  const danger = await page.evaluate(() =>
+    getComputedStyle(document.documentElement).getPropertyValue("--danger").trim(),
+  );
+  const dangerRgb = await page.evaluate((hex) => {
+    const probe = document.createElement("span");
+    probe.style.color = hex;
+    document.body.appendChild(probe);
+    const value = getComputedStyle(probe).color;
+    probe.remove();
+    return value;
+  }, danger);
+  const pickedColour = await page
+    .locator(`.choice[data-note="${wrongNote}"]`)
+    .evaluate((el) => getComputedStyle(el).borderColor);
+  expect(pickedColour).not.toBe(dangerRgb);
+});
+
+test("note-to-position: tapping the wrong spot names what is there instead, without a verdict word", async ({
+  page,
+}) => {
+  await page.locator(".direction-choice").nth(1).click();
+  await startButton(page).click();
+  const q = await question(page);
+  // A position guaranteed NOT to sound the asked note.
+  const wrong = page
+    .locator(`g.position:not([data-note="${q.note}"])`)
+    .first();
+  const wrongNote = await wrong.getAttribute("data-note");
+  await wrong.click();
+
+  await expect(drill(page)).toHaveAttribute("data-asked", "1");
+  await expect(drill(page)).toHaveAttribute("data-correct", "0");
+  await expect(answerStatement(page)).toContainText(wrongNote);
+  await expect(answerStatement(page)).toContainText(`${q.note} is elsewhere on the neck.`);
+  const text = await answerStatement(page).textContent();
+  expect(forbiddenWord(text), text).toBeNull();
+});
+
+test("a full cycle: prompt, answer, feedback, next, in both directions across a session", async ({
+  page,
+}) => {
+  await startButton(page).click();
+  let q = await question(page);
+  await page.locator(`.choice[data-note="${q.note}"]`).click();
+  await expect(drill(page)).toHaveAttribute("data-asked", "1");
+
+  await page.locator(".next-question").click();
+  await expect(progress(page)).toHaveText("1 question, 1 answered correctly.");
+  q = await question(page);
+  expect(q.note).toBeTruthy();
+  await expect(answerStatement(page)).toHaveCount(0);
+
+  const wrongNote = q.note === "C" ? "C#" : "C";
+  await page.locator(`.choice[data-note="${wrongNote}"]`).click();
+  await expect(drill(page)).toHaveAttribute("data-asked", "2");
+  await expect(drill(page)).toHaveAttribute("data-correct", "1");
+  await expect(progress(page)).toHaveText("2 questions, 1 answered correctly.");
+
+  await page.locator(".stop-drill").click();
+  await expect(page.locator(".logged")).toBeVisible();
+  await expect(page.locator(".logged")).toContainText("2 questions, 1 answered correctly.");
+});
+
+// ---------------------------------------------------------------------------
+// An empty/degenerate state is real.
+// ---------------------------------------------------------------------------
+
+test("deselecting every string keeps at least one selected, rather than silently asking about all of them", async ({
+  page,
+}) => {
+  for (const n of [6, 5, 4, 3, 2]) {
+    await page.locator(".string-choice", { hasText: new RegExp(`^${n}$`) }).click();
+  }
+  // Five of six are off; the drill still has one to ask about.
+  await expect(drill(page)).toHaveAttribute("data-askable", "1");
+  await startButton(page).click();
+  const q = await question(page);
+  expect(q.string ?? (await drill(page).getAttribute("data-question-string"))).toBeTruthy();
+
+  // The last remaining string cannot be turned off.
+  await page.locator(".stop-drill").click();
+  const last = page.locator(".string-choice", { hasText: /^1$/ });
+  await last.click();
+  await expect(last).toHaveClass(/active/);
+  await expect(drill(page)).toHaveAttribute("data-askable", "1");
+});
+
+test("a fret range with nothing in it says so and offers no drill, rather than asking an impossible question", async ({
+  page,
+}) => {
+  await page.selectOption(".scope-start-fret", "10");
+  await page.selectOption(".scope-end-fret", "3");
+  await expect(drill(page)).toHaveAttribute("data-askable", "0");
+  await expect(page.locator(".narrow-scope")).toContainText("Nothing is selected");
+  await expect(startButton(page)).toHaveCount(0);
+
+  await page.selectOption(".scope-end-fret", "12");
+  await expect(drill(page)).toHaveAttribute("data-askable", "1");
+  await expect(startButton(page)).toBeVisible();
+});
+
+// ---------------------------------------------------------------------------
+// Structured, queryable results (#32): every question is its own row.
+// ---------------------------------------------------------------------------
+
+test("every answered question is posted as a structured row, correct and incorrect alike", async ({
+  page,
+  request,
+}) => {
+  // trainer_attempts has no per-test reset (unlike instruments/sessions/
+  // goals - see reset() above): a real weak-spot query is meant to read
+  // across many sessions, so there is nothing to delete between tests, and
+  // this file's OTHER tests also write rows here. So this test reads its
+  // own two by BASELINE + newest-first ordering, not by an exact total.
+  const before = (await (await request.get("/api/trainer/attempts")).json()).total;
+
+  await startButton(page).click();
+  const q1 = await question(page);
+  await page.locator(`.choice[data-note="${q1.note}"]`).click();
+  await expect(drill(page)).toHaveAttribute("data-attempt-log-failures", "0");
+
+  await page.locator(".next-question").click();
+  const q2 = await question(page);
+  const wrong = q2.note === "C" ? "C#" : "C";
+  await page.locator(`.choice[data-note="${wrong}"]`).click();
+  await expect(drill(page)).toHaveAttribute("data-attempt-log-failures", "0");
+
+  await expect(async () => {
+    const { total } = await (await request.get("/api/trainer/attempts")).json();
+    expect(total).toBe(before + 2);
+  }).toPass({ timeout: 10_000 });
+
+  // Newest first (created_at DESC, id DESC - api.py's list_trainer_attempts):
+  // the two rows just written are exactly the top two.
+  const { attempts } = await (await request.get("/api/trainer/attempts?limit=2")).json();
+  expect(attempts).toHaveLength(2);
+  const [second, first] = attempts;
+
+  expect(first.drill).toBe("fret_to_note");
+  expect(first.direction).toBe("position_to_note");
+  expect(first.target_string).toBe(q1.string);
+  expect(first.target_fret).toBe(q1.fret);
+  expect(first.target_note).toBe(q1.note);
+  expect(first.given_note).toBe(q1.note);
+  expect(first.correct).toBe(true);
+  expect(first.given_string).toBeNull();
+  expect(first.given_fret).toBeNull();
+
+  expect(second.target_string).toBe(q2.string);
+  expect(second.target_fret).toBe(q2.fret);
+  expect(second.target_note).toBe(q2.note);
+  expect(second.given_note).toBe(wrong);
+  expect(second.correct).toBe(false);
+
+  // Queryable directly: which positions get missed is exactly this filter -
+  // this row is IN it, alongside whatever other tests in this file also
+  // missed (see the comment above on why there is no exact total here).
+  const missed = await (
+    await request.get("/api/trainer/attempts?correct=false&limit=100")
+  ).json();
+  expect(missed.attempts.map((a) => a.id)).toContain(second.id);
+  expect(missed.attempts.map((a) => a.id)).not.toContain(first.id);
+});
+
+test("stopping the drill also logs one fretboard practice session, with a human-readable summary", async ({
+  page,
+  request,
+}) => {
+  await startButton(page).click();
+  const q = await question(page);
+  await page.locator(`.choice[data-note="${q.note}"]`).click();
+  await page.locator(".stop-drill").click();
+  await expect(page.locator(".logged")).toBeVisible();
+
+  const { sessions, total } = await (
+    await request.get("/api/practice/sessions?limit=1000")
+  ).json();
+  expect(total).toBe(1);
+  expect(sessions[0].activity).toBe("fretboard");
+  expect(sessions[0].local_date).toBe(today);
+  expect(sessions[0].note).toBe(
+    "Fret to note, position to note. 1 question, 1 answered correctly. frets 0-12.",
+  );
+  expect(forbiddenWord(sessions[0].note), sessions[0].note).toBeNull();
+  expect(sessions[0].note).not.toMatch(/%/);
+});
+
+test("leaving the page mid-drill still logs the practice", async ({ page, request }) => {
+  await startButton(page).click();
+  const q = await question(page);
+  await page.locator(`.choice[data-note="${q.note}"]`).click();
+
+  await page.locator(".back").click();
+  await expect(page.locator("section.drill")).toHaveCount(0);
+
+  await expect(async () => {
+    const { total } = await (await request.get("/api/practice/sessions?limit=1000")).json();
+    expect(total).toBe(1);
+  }).toPass({ timeout: 10_000 });
+});

--- a/web/tests/spec-floors/browser-fretboard-trainer-25.json
+++ b/web/tests/spec-floors/browser-fretboard-trainer-25.json
@@ -1,0 +1,5 @@
+{
+  "file": "tests/browser/fretboard-trainer.spec.js",
+  "count": 14,
+  "reason": "issues #25/#27: the neck's note-at-position arithmetic rendered correctly (open strings, the fifth-fret relationship, an instrument's own tuning), a tap highlighting/identifying a position, the fret-to-note drill's full prompt-answer-feedback-next cycle in both directions with a correct and an incorrect answer, the degenerate scope states, and the structured per-question attempts (#32) plus the session log they sit beside."
+}

--- a/web/tests/spec-floors/unit-fret-to-note-27.json
+++ b/web/tests/spec-floors/unit-fret-to-note-27.json
@@ -1,0 +1,5 @@
+{
+  "file": "tests/unit/fret-to-note.spec.js",
+  "count": 18,
+  "reason": "issue #27: scoping a drill to particular strings and a fret range including the degenerate empty case, picking a question in both directions with no immediate repeat, grading each direction (a tap's SOUNDED note deciding note-to-position, mirroring ear-training.js's own rule), the structured attempt payload posted per question (#32), and the drill's wording never carrying a grading word, a streak, or a percentage."
+}

--- a/web/tests/spec-floors/unit-neck-25.json
+++ b/web/tests/spec-floors/unit-neck-25.json
@@ -1,0 +1,5 @@
+{
+  "file": "tests/unit/neck.spec.js",
+  "count": 15,
+  "reason": "issue #25: the neck's note-at-position arithmetic for standard tuning (open strings, the fifth-fret relationship, the twelfth-fret octave), reading tuning from an instrument definition rather than a hardcoded six strings (including a capo and an unfretted fallback), pitch-class spelling kept in step with pitch.js, position listing/scoping, and inlay dot placement."
+}

--- a/web/tests/unit/fret-to-note.spec.js
+++ b/web/tests/unit/fret-to-note.spec.js
@@ -1,0 +1,210 @@
+// The fret-to-note drill's own arithmetic and phrasing (issue #27), called
+// directly - no browser needed, same pattern as ear-training.spec.js.
+import { expect, test } from "@playwright/test";
+
+import { forbiddenWord } from "../../src/lib/practice.js";
+import { defaultStrings } from "../../src/lib/trainer/neck.js";
+import {
+  NOTE_TO_POSITION,
+  POSITION_TO_NOTE,
+  answerStatement,
+  attemptPayload,
+  checkPositionAnswer,
+  checkTapAnswer,
+  pickQuestion,
+  progressStatement,
+  scopeIsAskable,
+  scopeLabel,
+  scopePositions,
+  sessionNote,
+} from "../../src/lib/trainer/fret-to-note.js";
+
+const strings = defaultStrings();
+const fullScope = { startFret: 0, endFret: 12 };
+
+// ---------------------------------------------------------------- scoping
+
+test("the full scope covers every string across the fret range", () => {
+  const found = scopePositions(strings, fullScope);
+  expect(found).toHaveLength(6 * 13);
+  expect(scopeIsAskable(strings, fullScope)).toBe(true);
+});
+
+test("narrowing to particular strings narrows the pool to exactly those", () => {
+  const scope = { startFret: 0, endFret: 5, stringNumbers: [6, 5] };
+  const found = scopePositions(strings, scope);
+  expect(new Set(found.map((p) => p.string))).toEqual(new Set([6, 5]));
+  expect(found).toHaveLength(2 * 6);
+});
+
+test("an empty stringNumbers list means no filter, not 'select nothing'", () => {
+  // The UI never lets every string be deselected (FretToNote.svelte keeps at
+  // least one checked) - this is what that guarantee rests on: an empty
+  // array reads as "nothing excluded" rather than "nothing included".
+  expect(scopePositions(strings, { startFret: 0, endFret: 0, stringNumbers: [] })).toHaveLength(6);
+});
+
+test("a fret range that excludes everything asks nothing - the degenerate state is real, not a crash", () => {
+  expect(scopeIsAskable(strings, { startFret: 30, endFret: 20 })).toBe(false);
+  expect(scopePositions(strings, { startFret: 30, endFret: 20 })).toEqual([]);
+});
+
+test("scopeLabel states a narrowed scope and stays quiet about the default one", () => {
+  expect(scopeLabel(strings, { startFret: 0, endFret: 12 })).toBe("frets 0-12");
+  expect(scopeLabel(strings, { startFret: 0, endFret: 5, stringNumbers: [6, 5] })).toBe(
+    "strings 5, 6, frets 0-5",
+  );
+});
+
+// ---------------------------------------------------------------- questions
+
+test("a position-to-note question names a real position and its real note", () => {
+  const q = pickQuestion(strings, fullScope, POSITION_TO_NOTE, null, () => 0);
+  expect(q.direction).toBe(POSITION_TO_NOTE);
+  expect(typeof q.string).toBe("number");
+  expect(typeof q.fret).toBe("number");
+  expect(typeof q.note).toBe("string");
+});
+
+test("a note-to-position question names a note and no position", () => {
+  const q = pickQuestion(strings, fullScope, NOTE_TO_POSITION, null, () => 0);
+  expect(q.direction).toBe(NOTE_TO_POSITION);
+  expect(q.string).toBeNull();
+  expect(q.fret).toBeNull();
+  expect(typeof q.note).toBe("string");
+});
+
+test("a question never immediately repeats the previous one", () => {
+  const rand = (() => {
+    let calls = 0;
+    // Deterministic: always "pick the first" unless that is excluded, in
+    // which case the eligible-filtering is what has to do the excluding.
+    return () => {
+      calls += 1;
+      return 0;
+    };
+  })();
+  const scope = { startFret: 0, endFret: 0, stringNumbers: [6] }; // exactly one position
+  const first = pickQuestion(strings, scope, POSITION_TO_NOTE, null, rand);
+  // Only one position exists, so a second question MUST repeat it - proving
+  // the fallback (repeat rather than return null) rather than the ordinary
+  // no-repeat path, which the wider-scope test below covers.
+  const second = pickQuestion(strings, scope, POSITION_TO_NOTE, first, rand);
+  expect(second).toEqual(first);
+
+  const wider = { startFret: 0, endFret: 1, stringNumbers: [6] }; // two positions
+  const q1 = pickQuestion(strings, wider, POSITION_TO_NOTE, null, () => 0);
+  const q2 = pickQuestion(strings, wider, POSITION_TO_NOTE, q1, () => 0);
+  expect(q2).not.toEqual(q1);
+});
+
+test("an unaskable scope returns no question rather than throwing", () => {
+  expect(pickQuestion(strings, { startFret: 30, endFret: 20 }, POSITION_TO_NOTE)).toBeNull();
+});
+
+// ---------------------------------------------------------------- answers
+
+test("position-to-note: the chosen note is checked against the question's note", () => {
+  const q = { direction: POSITION_TO_NOTE, string: 6, fret: 3, note: "G" };
+  expect(checkPositionAnswer(q, "G")).toBe(true);
+  expect(checkPositionAnswer(q, "F#")).toBe(false);
+});
+
+test("note-to-position: the note that SOUNDS at the tap decides it, not the tap's intent", () => {
+  const q = { direction: NOTE_TO_POSITION, note: "G", string: null, fret: null };
+  // String 6 fret 3 sounds G.
+  const right = checkTapAnswer(strings, q, 6, 3);
+  expect(right).toEqual({ correct: true, note: "G" });
+  // String 6 fret 4 sounds Ab (this app's canonical spelling for that
+  // pitch class - see neck.js's PITCH_CLASSES), not G.
+  const wrong = checkTapAnswer(strings, q, 6, 4);
+  expect(wrong).toEqual({ correct: false, note: "Ab" });
+});
+
+test("a tap on a string number the neck does not have answers false and names no note", () => {
+  const q = { direction: NOTE_TO_POSITION, note: "G", string: null, fret: null };
+  expect(checkTapAnswer(strings, q, 99, 0)).toEqual({ correct: false, note: null });
+});
+
+// ---------------------------------------------------------------- the structured record (#32)
+
+test("a position-to-note attempt payload carries the target position and the chosen note", () => {
+  const q = { direction: POSITION_TO_NOTE, string: 6, fret: 3, note: "G" };
+  const payload = attemptPayload({ question: q, given: { note: "F#" }, responseMs: 1200 });
+  expect(payload).toEqual({
+    session_id: null,
+    drill: "fret_to_note",
+    direction: POSITION_TO_NOTE,
+    response_ms: 1200,
+    target_string: 6,
+    target_fret: 3,
+    target_note: "G",
+    given_note: "F#",
+  });
+});
+
+test("a note-to-position attempt payload carries the tapped position and its resolved note", () => {
+  const q = { direction: NOTE_TO_POSITION, note: "G", string: null, fret: null };
+  const payload = attemptPayload({
+    sessionId: 42,
+    question: q,
+    given: { string: 6, fret: 4, note: "G#" },
+  });
+  expect(payload).toEqual({
+    session_id: 42,
+    drill: "fret_to_note",
+    direction: NOTE_TO_POSITION,
+    response_ms: null,
+    target_note: "G",
+    given_string: 6,
+    given_fret: 4,
+    given_note: "G#",
+  });
+});
+
+// ---------------------------------------------------------------- phrasing, and the tone rules
+
+test("progress states two counts and nothing when nothing has been asked", () => {
+  expect(progressStatement()).toBe("Nothing asked yet.");
+  expect(progressStatement({ asked: 1, correct: 0 })).toBe("1 question, none answered correctly.");
+  expect(progressStatement({ asked: 3, correct: 2 })).toBe("3 questions, 2 answered correctly.");
+});
+
+test("answerStatement states the fact without a verdict word, either way", () => {
+  const q = { direction: POSITION_TO_NOTE, string: 6, fret: 3, note: "G" };
+  expect(answerStatement(q, { note: "G" }, true)).toBe("String 6, fret 3 is G.");
+  expect(answerStatement(q, { note: "F#" }, false)).toBe(
+    "String 6, fret 3 is G. You named F#.",
+  );
+  for (const text of [
+    answerStatement(q, { note: "G" }, true),
+    answerStatement(q, { note: "F#" }, false),
+  ]) {
+    expect(forbiddenWord(text), text).toBeNull();
+  }
+});
+
+test("every phrase this module produces avoids the forbidden words and never a percentage", () => {
+  const samples = [
+    progressStatement({ asked: 5, correct: 2 }),
+    sessionNote({ asked: 5, correct: 2, direction: POSITION_TO_NOTE, strings, scope: fullScope }),
+    scopeLabel(strings, fullScope),
+  ];
+  for (const text of samples) {
+    expect(forbiddenWord(text), text).toBeNull();
+    expect(text).not.toMatch(/%/);
+  }
+});
+
+test("sessionNote names the direction, the counts, and the scope", () => {
+  const note = sessionNote({
+    asked: 4,
+    correct: 3,
+    direction: NOTE_TO_POSITION,
+    strings,
+    scope: { startFret: 0, endFret: 5, stringNumbers: [6, 5] },
+  });
+  expect(note).toBe(
+    "Fret to note, note to position. 4 questions, 3 answered correctly. strings 5, 6, frets 0-5.",
+  );
+});

--- a/web/tests/unit/neck.spec.js
+++ b/web/tests/unit/neck.spec.js
@@ -1,0 +1,164 @@
+// The neck's arithmetic, called directly (issue #25) - which note sounds at
+// a string and a fret, for the standard tuning and for an arbitrary
+// instrument, and the geometry helpers a drill's question generator shares
+// with Neck.svelte. No browser needed for any of it - see neck.js's own
+// docstring for why.
+import { expect, test } from "@playwright/test";
+
+import { spellMidi } from "../../src/lib/pitch.js";
+import {
+  DEFAULT_FRET_COUNT,
+  PITCH_CLASSES,
+  defaultStrings,
+  fretCountFromInstrument,
+  inlayDots,
+  noteAt,
+  pitchClass,
+  posKey,
+  positions,
+  positionsForNote,
+  stringsFromInstrument,
+} from "../../src/lib/trainer/neck.js";
+
+// ---------------------------------------------------------------- standard tuning
+
+test("the standard six strings are numbered 6 (low) to 1 (high), open, spelled correctly", () => {
+  const strings = defaultStrings();
+  expect(strings.map((s) => s.number)).toEqual([6, 5, 4, 3, 2, 1]);
+  expect(strings.map((s) => spellMidi(s.midi))).toEqual([
+    "E2", "A2", "D3", "G3", "B3", "E4",
+  ]);
+});
+
+test("open strings sound their own tuning - the simplest falsifiable claim a neck can make", () => {
+  const strings = defaultStrings();
+  const open = { 6: "E2", 5: "A2", 4: "D3", 3: "G3", 2: "B3", 1: "E4" };
+  for (const [number, expected] of Object.entries(open)) {
+    const midi = noteAt(strings, Number(number), 0);
+    expect(spellMidi(midi), `string ${number} open`).toBe(expected);
+  }
+});
+
+test("the fifth-fret relationship holds between every adjacent pair except G to B", () => {
+  // A guitarist's own check when tuning by ear: fret 5 on one string matches
+  // the next string open - except between the third and second strings,
+  // where standard tuning is a major third (4 frets) rather than a fourth.
+  const strings = defaultStrings();
+  const fourths = [
+    [6, 5], [5, 4], [4, 3], [2, 1],
+  ];
+  for (const [lower, higher] of fourths) {
+    const fretted = noteAt(strings, lower, 5);
+    const openHigher = noteAt(strings, higher, 0);
+    expect(fretted, `string ${lower} fret 5 vs string ${higher} open`).toBe(openHigher);
+  }
+  // The one exception, at fret 4 instead of 5.
+  expect(noteAt(strings, 3, 4)).toBe(noteAt(strings, 2, 0));
+  expect(noteAt(strings, 3, 5)).not.toBe(noteAt(strings, 2, 0));
+});
+
+test("the twelfth fret is an octave above the open string, on every string", () => {
+  const strings = defaultStrings();
+  for (const string of strings) {
+    expect(noteAt(strings, string.number, 12)).toBe(string.midi + 12);
+  }
+});
+
+test("a known fretted note reads correctly - third fret, sixth string, is G", () => {
+  const strings = defaultStrings();
+  expect(spellMidi(noteAt(strings, 6, 3))).toBe("G2");
+  expect(pitchClass(noteAt(strings, 6, 3))).toBe("G");
+});
+
+// ---------------------------------------------------------------- reading a tuning
+
+test("stringsFromInstrument reads a saved instrument's own tuning, not a hardcoded six", () => {
+  const sevenString = {
+    fretted: true,
+    fret_count: 24,
+    strings: [
+      { number: 7, midi: 35 }, // B1
+      { number: 6, midi: 40 }, // E2
+      { number: 5, midi: 45 },
+      { number: 4, midi: 50 },
+      { number: 3, midi: 55 },
+      { number: 2, midi: 59 },
+      { number: 1, midi: 64 },
+    ],
+  };
+  const strings = stringsFromInstrument(sevenString);
+  expect(strings).toHaveLength(7);
+  expect(strings.map((s) => s.number)).toContain(7);
+  expect(fretCountFromInstrument(sevenString)).toBe(24);
+});
+
+test("a capo'd instrument's SOUNDING pitch is what the neck reads, not the nominal one", () => {
+  const capoed = {
+    fretted: true,
+    fret_count: 22,
+    strings: [{ number: 1, midi: 64, sounding_midi: 66 }],
+  };
+  expect(stringsFromInstrument(capoed)[0].midi).toBe(66);
+});
+
+test("an unfretted instrument (a violin) falls back to the standard guitar rather than inventing frets", () => {
+  const violin = { fretted: false, strings: [{ number: 4, midi: 55 }] };
+  expect(stringsFromInstrument(violin)).toEqual(defaultStrings());
+  expect(fretCountFromInstrument(violin)).toBe(DEFAULT_FRET_COUNT);
+});
+
+test("no instrument at all falls back to the standard guitar", () => {
+  expect(stringsFromInstrument(null)).toEqual(defaultStrings());
+  expect(fretCountFromInstrument(undefined)).toBe(DEFAULT_FRET_COUNT);
+});
+
+// ---------------------------------------------------------------- pitch classes
+
+test("pitchClass matches spellMidi with the octave stripped, for every semitone in an octave", () => {
+  for (let midi = 40; midi < 40 + 12; midi++) {
+    expect(pitchClass(midi)).toBe(spellMidi(midi).replace(/-?\d+$/, ""));
+  }
+});
+
+test("PITCH_CLASSES is exactly the twelve spellings pitchClass ever produces, in pitch order", () => {
+  const produced = Array.from({ length: 12 }, (_, i) => pitchClass(60 + i));
+  expect(produced).toEqual(PITCH_CLASSES);
+  expect(new Set(PITCH_CLASSES).size).toBe(12);
+});
+
+// ---------------------------------------------------------------- positions / scoping
+
+test("positions lists every playable spot in a fret range, each with its note", () => {
+  const strings = defaultStrings();
+  const found = positions(strings, 0, 3);
+  expect(found).toHaveLength(6 * 4); // 6 strings, frets 0-3
+  const openLowE = found.find((p) => p.string === 6 && p.fret === 0);
+  expect(openLowE.note).toBe("E");
+  expect(openLowE.midi).toBe(40);
+});
+
+test("positionsForNote finds every place a pitch class sounds, and only that class", () => {
+  const strings = defaultStrings();
+  const cs = positionsForNote(strings, "C", 0, 12);
+  expect(cs.length).toBeGreaterThan(0);
+  for (const p of cs) expect(p.note).toBe("C");
+  // A known one: fret 1, string 5 (A2 + 3 = C3).
+  expect(cs.some((p) => p.string === 5 && p.fret === 3)).toBe(true);
+});
+
+test("posKey distinguishes every position and is stable for the same one", () => {
+  expect(posKey(6, 3)).toBe(posKey(6, 3));
+  expect(posKey(6, 3)).not.toBe(posKey(3, 6));
+});
+
+// ---------------------------------------------------------------- inlay dots
+
+test("inlay dots land on the ordinary frets, single except the octave", () => {
+  const singles = [3, 5, 7, 9, 15, 17, 19, 21];
+  for (const fret of singles) expect(inlayDots(fret), `fret ${fret}`).toBe(1);
+  expect(inlayDots(12)).toBe(2);
+  expect(inlayDots(24)).toBe(2);
+  for (const fret of [0, 1, 2, 4, 6, 8, 10, 11, 13]) {
+    expect(inlayDots(fret), `fret ${fret}`).toBe(0);
+  }
+});


### PR DESCRIPTION
Closes #25. Closes #27.

An interactive fretboard neck (`web/src/lib/trainer/Neck.svelte`, `neck.js`),
and the first drill built on it: fret to note, in both directions
(`fret-to-note.js`, `FretToNote.svelte`), reachable from the library sidebar
at `#/fretboard`.

## The neck (#25)

Hand-rolled SVG, no new dependency - the house style everywhere else in this
app that draws something bespoke. Reads its tuning from an instrument
definition (`stringsFromInstrument`/`fretCountFromInstrument` in `neck.js`)
rather than assuming six strings: a seven-string guitar or a dropped tuning
draws its own real strings and fret count. Falls back to a plain standard
guitar only when there is no instrument to read from at all - not a guess,
the one tuning this drill can still be useful with when nobody has defined
one yet.

**The one honest limitation.** An *unfretted* instrument (a violin) has no
frets, and position reasoning does not apply to it any more than it does on
the server (`instruments.py` rejects `fret_count` outright on one). Rather
than inventing frets for it, `stringsFromInstrument` falls back to the
standard guitar and says so in its own comment. A "which instrument, and is
it even fretted" picker aware of this is the natural follow-up and belongs
with #29 rather than guessed at here.

Props chosen for reuse by #26/#29, not just this drill: `markers`
(`target`/`correct`/`incorrect`/`hint` per position), `highlightNote` (mark
every position sounding a pitch class across the whole neck - the
"highlight a note" interaction, built once here rather than recomputed by
every future caller), `showLabels`, `interactive`, and an `onTap` callback.
`incorrect` is deliberately not drawn in `--danger` - see the tone note
below.

## Fret to note, both directions (#27)

Shown a position, name its note; or shown a note, tap where it sounds -
picked with a toggle, not mixed within one run, since the issue treats them
as different skills. Scoped by particular strings and a fret range (`key`
scoping is not built - filed as a follow-up, since the issue's other two
scopes were enough to prove the shape and a third would be a guess about
what a key-aware drill actually wants). A real loop: prompt, answer,
feedback, next.

**Grading is symmetric across both directions, and it lives in one place.**
Every attempt reduces to two facts - `target_note` (what was being tested)
and `given_note` (what the answer actually named) - and `correct` is
`given_note == target_note`, always, computed server-side and never trusted
from the client. For `note_to_position`, `given_note` is the note that
*sounds* at the tapped position, worked out from the tuning by the same
client that drew the neck - mirroring `ear-training.js`'s own rule that a
question is built from what actually happened, not from intent.

**Tone.** Two counts, stated - no accuracy percentage, no streak, nothing
graded. A wrong answer is named plainly (`"String 6, fret 3 is G. You named
F#."`), in the same place and the same style as a right one; `--danger`
never appears in either component. `web/tests/browser/fretboard-
trainer.spec.js` checks the wrong-answer styling against `--danger` directly,
the same check `ear-training.spec.js` makes.

## Structured, queryable results (#32)

Every question answered is posted as its own row
(`POST /api/trainer/attempts`), independent of the `practice_sessions` row
that logs the drill's own time (`activity='fretboard'`, the same as every
other exercise). `docs/practice-data.md`'s "What is not here yet" section
had stood since the first trainer shipped, explicitly waiting for a *second*
exercise to decide the shape of a per-attempt table rather than guessing it
from one. This is that decision: one table, `trainer_attempts`, with exactly
one of the two position pairs populated depending on `direction` - see the
new "Trainer attempts" section in that doc and `db.py`'s own comment for the
full reasoning. `GET /api/trainer/attempts?correct=false&...` is the
"which positions am I weak on" query directly, no bespoke aggregate
endpoint required.

## Falsifiable targets, and what breaking them proves

**The neck's note-at-position arithmetic**, asserted directly against the
rendered SVG (`fretboard-trainer.spec.js`'s first test): open strings spell
E2/A2/D3/G3/B3/E4, the fifth-fret relationship holds between every adjacent
string pair except the third-to-second (which is the fourth fret, since
standard tuning is a major third there), and the twelfth fret is an octave
above the open string. Mutated `neck.js`'s `noteAt` (`midi + fret` →
`midi + fret + 1`) and it turned **8** specs red: the 7 in `neck.spec.js`
and this browser file that assert the arithmetic directly, plus one in
`fret-to-note.spec.js` (`checkTapAnswer`'s own "the right tap reads as
correct" case, which calls `noteAt` internally) - reverted cleanly
(`git status` clean against the commit below).

**The drill's answer-checking**, in both directions. Mutated
`checkPositionAnswer` to always return `true` → **3** specs red (a unit test
plus two browser tests, including the full both-directions cycle). Mutated
`checkTapAnswer`'s correctness rule (`===` → `!==`) → **3** specs red.
Reverted cleanly both times.

**Server-side grading**, independently. Mutated `trainer.normalise_attempt`'s
`correct` computation (`==` → `!=`) → **5** server tests red. Reverted
cleanly.

## Suites vs baseline

- Server: **1073 passed, 64 skipped**, on the rebased tree - rebased twice
  onto `main`'s latest (#81/#63, then #58's export/import). The second
  rebase conflicted textually on the operation-count pin, which #58 had
  also bumped for its own two routes; resolved by re-deriving the real
  count against a live `app.openapi()` on the merged tree rather than
  trusting either side's number - **56** operations, not the 54 either
  branch claimed alone (52 base + #58's 2 + this PR's 2). This PR adds
  **28** server tests: 23 functions in `test_trainer_api.py` (27
  collected - two are parametrized) plus one drift-guarded model check
  added to `test_api_docs.py`.
- Browser: **412 passed**, full run exits 0, spec-floor guard satisfied by
  the three new `tests/spec-floors/` entries this PR adds (14 in
  `fretboard-trainer.spec.js`, 15 in `tests/unit/neck.spec.js`, 18 in
  `tests/unit/fret-to-note.spec.js` - 47 tests total).

## Rendered

`#/fretboard` against `python -m uvicorn fermata.main:app --host 127.0.0.1
--port 8917` (never 8080), `FERMATA_WEB_DIST` pointed at a fresh
`npm run build`. Confirmed by hand: the scope controls, the neck rendering a
position-to-note question with its target marker, and - after switching
direction and tapping a real position - the tapped mark plus every other
occurrence of that note revealed across the neck via `highlightNote`.

## Review follow-up

Three items from an earlier pass, all addressed:

- Rebased onto current `main` (see the operation-count re-derivation above).
- This PR body's own figures were wrong (44 server tests claimed, 28 actual;
  7 specs turned red by the `noteAt` mutation, 8 actual - the extra is
  `fret-to-note.spec.js`'s "a right tap reads as correct" case, which calls
  `noteAt` internally) - corrected above rather than left standing.
- `docs/practice-data.md`'s new Trainer attempts section stated the
  counts-never-a-rate rule only implicitly (in the code and the
  `FORBIDDEN_WORDS` test); added one sentence stating it in prose too,
  beside the document's existing no-streaks/no-best-week language.

## What is not in this PR

- Key-scoping for the drill (see above).
- A third+ fretboard exercise building on `Neck.svelte` (#26, #29) or on
  `trainer_attempts` (a chord drill's own attempt shape) - explicitly left
  to those issues rather than guessed at here, the same restraint
  `docs/practice-data.md` already documented for this table before it
  existed.
