### PR TITLE
Note editor over the MusicXML model — first increment (#10)

### DIFF
--- a/web/src/lib/ScoreCompare.svelte
+++ b/web/src/lib/ScoreCompare.svelte
@@ -413,6 +413,20 @@
     }
   }
 
+  // The note editor's save (#10). Goes through the SAME edited-transcription
+  // path the source editor above uses - PUT stores the client's MusicXML
+  // verbatim as source='edited', which is never re-extracted (an existing
+  // server test guards that). Updating `transcription.content` here re-flows it
+  // to TabViewer, so the badge flips to "edited" and "Revert to extracted"
+  // appears, exactly as a source-editor save does. `res` states the cleared
+  // bar/warning figures for an edited row, same reason saveEdit spreads it.
+  async function saveNoteEdit(content) {
+    const res = await api.saveTranscription(score.id, content);
+    transcription = { ...transcription, ...res, content, source: "edited" };
+    draft = content;
+    refreshWarningsDisplay(score.id);
+  }
+
   async function revertToExtracted() {
     reverting = true;
     fetchError = "";
@@ -626,6 +640,8 @@
           {practiceLabel}
           {onStopPractice}
           active={activeLayout === "staff"}
+          editable={!gigMode}
+          onSaveEdit={saveNoteEdit}
         />
       </div>
     {/if}

--- a/web/src/lib/TabViewer.svelte
+++ b/web/src/lib/TabViewer.svelte
@@ -173,6 +173,11 @@
   // mirror or the pitch recompute is wrong, and this goes false loudly.
   let divergenceOk = $state(true);
   let editError = $state("");
+  // A transient "that edit was refused" message - distinct from editError,
+  // which is a load-time parse failure that replaces the whole panel. A refused
+  // edit leaves the fields in place so the value can be corrected, so its
+  // message sits beside the actions instead.
+  let editWarn = $state("");
   let dirty = $state(false);
   let saving = $state(false);
   let saveError = $state("");
@@ -203,6 +208,7 @@
     selFret = selString = selType = selMidi = selNoteId = null;
     divergenceOk = true;
     overlay = null;
+    editWarn = "";
   }
 
   function enterEdit() {
@@ -236,6 +242,7 @@
     if (!editMode || !view || !doc) return;
     const ord = view.editor.hitTest(clientX, clientY);
     if (ord == null) return;
+    editWarn = "";
     selectedOrdinal = ord;
     refreshSelection();
   }
@@ -279,10 +286,18 @@
     };
   }
 
-  async function applyEdit(mutate) {
+  async function applyEdit(mutate, refusal) {
     if (selectedOrdinal == null || !doc || !view) return;
     const before = doc.text();
-    if (!mutate()) return; // invalid or no-op - do not record an undo step
+    // The document refuses an edit it cannot write - a fret whose pitch has no
+    // valid <octave> (Rule 11), a string out of range. Say so plainly rather
+    // than swallowing it: a silent no-op reads as "the app is broken", and a
+    // silent bad save is exactly what this bound exists to prevent.
+    if (!mutate()) {
+      editWarn = refusal || "That change can't be applied to this note.";
+      return;
+    }
+    editWarn = "";
     const after = doc.text();
     if (after === before) return;
     undoStack = [...undoStack, before];
@@ -294,18 +309,27 @@
 
   function changeFret(value) {
     const v = Number(value);
-    if (!Number.isInteger(v)) return;
-    applyEdit(() => doc.setFret(selectedOrdinal, v));
+    if (!Number.isInteger(v) || v < 0) {
+      editWarn = "A fret is a whole number, zero or more.";
+      return;
+    }
+    applyEdit(
+      () => doc.setFret(selectedOrdinal, v),
+      "That fret would put the note outside the pitch range MusicXML can write (octaves 0–9).",
+    );
   }
 
   function changeString(value) {
     const v = Number(value);
     if (!Number.isInteger(v)) return;
-    applyEdit(() => doc.setString(selectedOrdinal, v));
+    applyEdit(
+      () => doc.setString(selectedOrdinal, v),
+      "That string would put the note outside the pitch range MusicXML can write (octaves 0–9).",
+    );
   }
 
   function changeDuration(type) {
-    applyEdit(() => doc.setDurationType(selectedOrdinal, type));
+    applyEdit(() => doc.setDurationType(selectedOrdinal, type), "That duration can't be written for this note.");
   }
 
   async function restore(text) {
@@ -731,6 +755,7 @@
   data-editor-available={canEditNotes()}
   data-editor-active={editMode}
   data-editor-error={editError || null}
+  data-editor-warn={editWarn || null}
   data-editor-selected={selectedOrdinal}
   data-editor-selected-fret={selFret}
   data-editor-selected-string={selString}
@@ -970,6 +995,7 @@
             ⚠ out of sync
           </span>
         {/if}
+        {#if editWarn}<span class="hint warn">{editWarn}</span>{/if}
         {#if saveError}<span class="hint warn">{saveError}</span>{/if}
         <button class="ghost" disabled={!undoStack.length} onclick={undo} title="Undo">Undo</button>
         <button class="ghost" disabled={!redoStack.length} onclick={redo} title="Redo">Redo</button>

--- a/web/src/lib/TabViewer.svelte
+++ b/web/src/lib/TabViewer.svelte
@@ -4,6 +4,7 @@
   import { createScoreView, UNRENDERABLE_MESSAGE, tabWithheldMessage } from "./score-render.js";
   import { getSettings, setSetting, STAFF_THEMES, STAFF_THEME_LABELS } from "./settings.svelte.js";
   import Metronome from "./Metronome.svelte";
+  import { createDocument, DURATION_TYPES } from "./editor/document.js";
 
   const settings = getSettings();
 
@@ -55,6 +56,17 @@
     // have on main - see the comment on PdfViewer's `active` prop in
     // ScoreCompare for the other half of this.
     active = true,
+    // Whether this score can be edited note-by-note and saved (#10). Set by
+    // ScoreCompare when a transcription is loaded and there is a score id to
+    // save under; false for the demo and any read-only mount. Note editing
+    // only works on a MusicXML document (that is the model the edits are
+    // written to), so the affordance also depends on `format` below.
+    editable = false,
+    // Persist the edited MusicXML - `async (content) => void`. ScoreCompare
+    // wires this to the existing edited-transcription save path (PUT
+    // /api/scores/{id}/transcription, stored verbatim as source='edited',
+    // never re-extracted). null when not editable.
+    onSaveEdit = null,
   } = $props();
 
   let host;
@@ -130,6 +142,244 @@
   let ladderStart = $state(60);
   let ladderStep = $state(5);
   let ladderTarget = $state(100);
+
+  // ---------------------------------------------------------- the note editor (#10)
+  //
+  // The document is the source of truth. Every edit is written to `doc` (a
+  // MusicXML document model - see editor/document.js), and the alphaTab view is
+  // then handed the new document text and asked to redraw it. Nothing is
+  // written to the renderer's object graph and left for the document to catch
+  // up with; the screen is always a fresh view of the document, which is what
+  // makes the two impossible to diverge (the renderer evaluation on #10 names
+  // that divergence as the one bug class this design must not create).
+  //
+  // `doc` is a plain (non-reactive) handle: it is mutated in place and its text
+  // re-imported, and nothing renders FROM it directly - the derived, reactive
+  // facts a reader sees (the selected note's fret, string, duration) are pulled
+  // out into the $state below on each selection.
+  let editMode = $state(false);
+  let doc = null;
+  let editStringCount = $state(6);
+  let selectedOrdinal = $state(null);
+  let selFret = $state(null);
+  let selString = $state(null);
+  let selType = $state(null);
+  let selMidi = $state(null);
+  let selNoteId = $state(null);
+  // The cross-check the evaluation asks for: the renderer's own read of the
+  // selected note (through the importer and the positional map) against the
+  // document's read of the same note. In this single-source-of-truth design
+  // they must always agree; when they do not, the positional map, the string
+  // mirror or the pitch recompute is wrong, and this goes false loudly.
+  let divergenceOk = $state(true);
+  let editError = $state("");
+  let dirty = $state(false);
+  let saving = $state(false);
+  let saveError = $state("");
+  let undoStack = $state([]);
+  let redoStack = $state([]);
+  let overlay = $state(null);
+
+  function canEditNotes() {
+    return editable && format === "musicxml" && tex != null;
+  }
+
+  function initEditDoc(text) {
+    editError = "";
+    const source = text ?? tex;
+    try {
+      doc = createDocument(source);
+      editStringCount = doc.stringCount;
+      return true;
+    } catch (e) {
+      doc = null;
+      editError = String(e?.message ?? e);
+      return false;
+    }
+  }
+
+  function clearSelection() {
+    selectedOrdinal = null;
+    selFret = selString = selType = selMidi = selNoteId = null;
+    divergenceOk = true;
+    overlay = null;
+  }
+
+  function enterEdit() {
+    if (!canEditNotes()) return;
+    if (!initEditDoc()) return;
+    undoStack = [];
+    redoStack = [];
+    dirty = false;
+    saveError = "";
+    clearSelection();
+    editMode = true;
+    // notation + doc are (re)applied by the $effect below, which also covers a
+    // rebuild of the view underneath us after a save.
+  }
+
+  function exitEdit() {
+    editMode = false;
+    clearSelection();
+    doc = null;
+    editError = "";
+    view?.editor?.setNotationShown(false);
+    if (typeof window !== "undefined") window.__scoreEditor = null;
+  }
+
+  function toggleEdit() {
+    if (editMode) exitEdit();
+    else enterEdit();
+  }
+
+  function selectAt(clientX, clientY) {
+    if (!editMode || !view || !doc) return;
+    const ord = view.editor.hitTest(clientX, clientY);
+    if (ord == null) return;
+    selectedOrdinal = ord;
+    refreshSelection();
+  }
+
+  function refreshSelection() {
+    if (selectedOrdinal == null || !doc || !view) return;
+    const d = doc.noteAt(selectedOrdinal);
+    if (!d) {
+      clearSelection();
+      return;
+    }
+    const v = view.editor.viewInfo(selectedOrdinal);
+    selFret = d.fret;
+    selString = d.string;
+    selType = d.type;
+    selNoteId = d.id;
+    selMidi = v?.midi ?? d.midi;
+    divergenceOk = !!v && v.mxString === d.string && v.fret === d.fret && v.midi === d.midi;
+    updateOverlay();
+  }
+
+  function updateOverlay() {
+    if (selectedOrdinal == null || !view || !scroller) {
+      overlay = null;
+      return;
+    }
+    const r = view.editor.headRect(selectedOrdinal);
+    if (!r) {
+      overlay = null;
+      return;
+    }
+    // The overlay lives inside the scroller and is positioned in its scroll
+    // space, so it tracks the note when the staff is scrolled without any
+    // scroll listener. headRect is in client space; convert once.
+    const sr = scroller.getBoundingClientRect();
+    overlay = {
+      left: r.left - sr.left + scroller.scrollLeft,
+      top: r.top - sr.top + scroller.scrollTop,
+      width: r.width,
+      height: r.height,
+    };
+  }
+
+  async function applyEdit(mutate) {
+    if (selectedOrdinal == null || !doc || !view) return;
+    const before = doc.text();
+    if (!mutate()) return; // invalid or no-op - do not record an undo step
+    const after = doc.text();
+    if (after === before) return;
+    undoStack = [...undoStack, before];
+    redoStack = [];
+    dirty = true;
+    await view.editor.reload(after);
+    refreshSelection();
+  }
+
+  function changeFret(value) {
+    const v = Number(value);
+    if (!Number.isInteger(v)) return;
+    applyEdit(() => doc.setFret(selectedOrdinal, v));
+  }
+
+  function changeString(value) {
+    const v = Number(value);
+    if (!Number.isInteger(v)) return;
+    applyEdit(() => doc.setString(selectedOrdinal, v));
+  }
+
+  function changeDuration(type) {
+    applyEdit(() => doc.setDurationType(selectedOrdinal, type));
+  }
+
+  async function restore(text) {
+    // Undo and redo both work by re-importing a whole document snapshot - the
+    // cheapest correct thing when the model IS the document text. createDocument
+    // cannot fail here: the snapshot was produced by our own serializer.
+    doc = createDocument(text);
+    editStringCount = doc.stringCount;
+    dirty = true;
+    await view.editor.reload(text);
+    refreshSelection();
+  }
+
+  async function undo() {
+    if (!undoStack.length || !doc || !view) return;
+    const prev = undoStack[undoStack.length - 1];
+    undoStack = undoStack.slice(0, -1);
+    redoStack = [...redoStack, doc.text()];
+    await restore(prev);
+  }
+
+  async function redo() {
+    if (!redoStack.length || !doc || !view) return;
+    const next = redoStack[redoStack.length - 1];
+    redoStack = redoStack.slice(0, -1);
+    undoStack = [...undoStack, doc.text()];
+    await restore(next);
+  }
+
+  async function saveEdits() {
+    if (!doc || !onSaveEdit) return;
+    saving = true;
+    saveError = "";
+    try {
+      await onSaveEdit(doc.text());
+      dirty = false;
+    } catch (e) {
+      saveError = String(e?.message ?? e);
+    } finally {
+      saving = false;
+    }
+  }
+
+  // Keeps the edit session alive across a rebuild of the underlying view - a
+  // save changes the `tex` prop, which tears down and recreates the alphaTab
+  // view (see the load effect below); this re-applies the notation staff and
+  // rebuilds `doc` from the new text so edit mode survives it. Runs on entering
+  // edit mode too (that is what first turns the notation staff on).
+  $effect(() => {
+    if (!editMode) return;
+    const v = view;
+    const t = tex;
+    void t;
+    if (!v) return;
+    untrack(() => {
+      if (!doc) initEditDoc();
+      v.editor.setNotationShown(true);
+      if (selectedOrdinal != null) refreshSelection();
+      // Test instrumentation, in the same spirit as window.__audioPeak and
+      // window.__heartbeats elsewhere: the note-head geometry is the renderer's
+      // to know, so a browser test that wants to click a SPECIFIC note asks the
+      // live view where that note is rather than guessing at pixels. Read-only
+      // - it exposes no way to mutate the score.
+      if (typeof window !== "undefined") {
+        window.__scoreEditor = {
+          headRect: (ordinal) => v.editor.headRect(ordinal),
+          headPoint: (ordinal) => v.editor.headPoint(ordinal),
+          hitTest: (x, y) => v.editor.hitTest(x, y),
+          noteCount: () => v.editor.noteCount(),
+          boundsCount: () => v.editor.boundsCount(),
+        };
+      }
+    });
+  });
 
   const PROFILE_LABELS = [
     ["score", "Notation"],
@@ -476,7 +726,22 @@
 
 <svelte:window onkeydown={onKey} />
 
-<div class="wrap">
+<div
+  class="wrap"
+  data-editor-available={canEditNotes()}
+  data-editor-active={editMode}
+  data-editor-error={editError || null}
+  data-editor-selected={selectedOrdinal}
+  data-editor-selected-fret={selFret}
+  data-editor-selected-string={selString}
+  data-editor-selected-type={selType}
+  data-editor-selected-midi={selMidi}
+  data-editor-selected-note-id={selNoteId}
+  data-editor-divergence-ok={editMode ? divergenceOk : null}
+  data-editor-dirty={dirty}
+  data-editor-can-undo={undoStack.length > 0}
+  data-editor-can-redo={redoStack.length > 0}
+>
   {#if gigMode}
     <!-- gig mode: hide the practice toolbar chrome, but playback and the way
     back out must stay reachable even with no keyboard (touch/tablet) -->
@@ -535,6 +800,16 @@
           <option value={t}>{STAFF_THEME_LABELS[t]}</option>
         {/each}
       </select>
+      {#if canEditNotes()}
+        <button
+          class="edit-toggle"
+          class:on={editMode}
+          onclick={toggleEdit}
+          title="Correct notes on the staff — click a note, then change its fret, string or duration"
+        >
+          {editMode ? "Done editing" : "Edit notes"}
+        </button>
+      {/if}
       <div class="player">
         <button class="primary" disabled={!playerReady} onclick={() => view?.playPause()}>
           {playing ? "❚❚ Pause ((Space))" : "▶ Play ((Space))"}
@@ -647,8 +922,86 @@
     </p>
   {/if}
 
-  <div class="score-scroll" class:hidden={profileOptions?.length === 0} bind:this={scroller}>
+  {#if editMode}
+    <div class="edit-panel">
+      {#if editError}
+        <p class="hint warn">{editError}</p>
+      {:else if selectedOrdinal == null}
+        <p class="edit-hint">Click a note on the staff to select it, then change its fret, string or duration.</p>
+      {:else}
+        <div class="edit-fields">
+          <label>
+            Fret
+            <input
+              type="number"
+              min="0"
+              max="36"
+              value={selFret}
+              onchange={(e) => changeFret(e.target.value)}
+            />
+          </label>
+          <label>
+            String
+            <select value={String(selString)} onchange={(e) => changeString(e.target.value)}>
+              {#each Array.from({ length: editStringCount }, (_, i) => i + 1) as s}
+                <option value={String(s)}>{s}</option>
+              {/each}
+            </select>
+          </label>
+          <label>
+            Duration
+            <select value={selType ?? ""} onchange={(e) => changeDuration(e.target.value)}>
+              {#if !DURATION_TYPES.includes(selType)}
+                <option value={selType ?? ""} disabled>{selType ?? "—"}</option>
+              {/if}
+              {#each DURATION_TYPES as t}
+                <option value={t}>{t}</option>
+              {/each}
+            </select>
+          </label>
+        </div>
+      {/if}
+      <div class="edit-actions">
+        {#if editMode && selectedOrdinal != null && !divergenceOk}
+          <!-- The document and the rendered model disagree about the selected
+               note. In this single-source-of-truth design that must never
+               happen; it is surfaced rather than hidden (see divergenceOk). -->
+          <span class="hint warn" title="The staff and the saved document disagree about this note.">
+            ⚠ out of sync
+          </span>
+        {/if}
+        {#if saveError}<span class="hint warn">{saveError}</span>{/if}
+        <button class="ghost" disabled={!undoStack.length} onclick={undo} title="Undo">Undo</button>
+        <button class="ghost" disabled={!redoStack.length} onclick={redo} title="Redo">Redo</button>
+        <button class="primary" disabled={!dirty || saving} onclick={saveEdits}>
+          {saving ? "Saving…" : "Save"}
+        </button>
+      </div>
+    </div>
+  {/if}
+
+  <!-- Selecting a note is a spatial gesture: the click is hit-tested against
+       the rendered note-head positions, which have no keyboard analogue here.
+       Note-to-note keyboard navigation (arrow keys, digit-sets-fret) is the
+       note-entry work #10 defers to a follow-up; when it lands it belongs on
+       the window key handler beside the transport shortcuts, not as a keydown
+       twin of this container's click. The staff itself is not a control. -->
+  <!-- svelte-ignore a11y_click_events_have_key_events -->
+  <!-- svelte-ignore a11y_no_static_element_interactions -->
+  <div
+    class="score-scroll"
+    class:hidden={profileOptions?.length === 0}
+    class:editing={editMode}
+    bind:this={scroller}
+    onclick={editMode ? (e) => selectAt(e.clientX, e.clientY) : undefined}
+  >
     <div class="at-host" bind:this={host}></div>
+    {#if editMode && overlay}
+      <div
+        class="note-selection"
+        style="left:{overlay.left}px; top:{overlay.top}px; width:{overlay.width}px; height:{overlay.height}px;"
+      ></div>
+    {/if}
   </div>
 </div>
 
@@ -837,6 +1190,100 @@
        sideways as well - page layout never overflows this way */
     overflow: auto;
     padding: 20px;
+    /* the note-selection overlay is an absolutely-positioned child in the
+       scroller's own scroll space (see updateOverlay), so it needs this as its
+       containing block to track the note when the staff is scrolled */
+    position: relative;
+  }
+
+  .score-scroll.editing {
+    cursor: pointer;
+  }
+
+  /* Drawn over the selected note's head(s) - a plain outline, positioned by
+     updateOverlay in the scroller's scroll space so it follows the note. It is
+     not interactive (clicks pass through to select another note). */
+  .note-selection {
+    position: absolute;
+    z-index: 1;
+    border: 2px solid var(--brass-bright);
+    border-radius: 4px;
+    background: rgba(200, 160, 70, 0.16);
+    pointer-events: none;
+    box-sizing: border-box;
+  }
+
+  .edit-toggle {
+    flex-shrink: 0;
+  }
+
+  .edit-toggle.on {
+    background: var(--brass);
+    color: #241d0f;
+    font-weight: 600;
+  }
+
+  .edit-panel {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 12px 16px;
+    padding: 10px 16px;
+    border-bottom: 1px solid var(--line);
+    background: var(--bg-raised);
+  }
+
+  .edit-hint {
+    margin: 0;
+    color: var(--ink-dim);
+    font-size: 13px;
+  }
+
+  .edit-fields {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 12px;
+  }
+
+  .edit-fields label {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 12.5px;
+    color: var(--ink-dim);
+  }
+
+  .edit-fields input {
+    width: 64px;
+  }
+
+  .edit-actions {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-left: auto;
+  }
+
+  .edit-panel .hint {
+    margin: 0;
+    font-size: 12.5px;
+    color: var(--ink-dim);
+  }
+
+  .edit-panel .hint.warn {
+    color: var(--danger);
+  }
+
+  .edit-panel .ghost {
+    background: none;
+    border-color: transparent;
+    color: var(--ink-dim);
+  }
+
+  .edit-panel .ghost:hover {
+    border-color: var(--line);
+    color: var(--ink);
   }
 
   /* Stays in the DOM (score-render.js's `host` binding has to stay stable)

--- a/web/src/lib/editor/document.js
+++ b/web/src/lib/editor/document.js
@@ -17,6 +17,7 @@
 import {
   DURATION_TYPES,
   durationForType,
+  isWritablePitch,
   midiForStringFret,
   midiOfPitch,
   pitchFromMidi,
@@ -169,14 +170,18 @@ export function createDocument(xml) {
 
   /**
    * Set a sounding note's fret, recomputing its <pitch>. Refuses a negative
-   * fret. Returns true when the document changed.
+   * fret, and refuses any fret whose resulting pitch cannot be written (Rule
+   * 11: a <pitch> outside MIDI 12-131 has no valid <octave>, and writing it
+   * anyway makes the whole document unreadable to a validating consumer). The
+   * note is left exactly as it was rather than written as some other pitch.
+   * Returns true when the document changed.
    */
   function setFret(ordinal, fret) {
     const el = noteEls[ordinal];
     if (!el || !Number.isInteger(fret) || fret < 0) return false;
     const string = Number(tagText(technicalOf(el), "string"));
     const midi = midiForStringFret(tuningByLine, stringCount, string, fret);
-    if (midi == null) return false;
+    if (midi == null || !isWritablePitch(midi)) return false;
     if (!setTechText(el, "fret", fret)) return false;
     writePitch(el, midi);
     return true;
@@ -193,7 +198,8 @@ export function createDocument(xml) {
     if (!el || !Number.isInteger(string) || string < 1 || string > stringCount) return false;
     const fret = Number(tagText(technicalOf(el), "fret"));
     const midi = midiForStringFret(tuningByLine, stringCount, string, fret);
-    if (midi == null) return false;
+    // Same Rule 11 refusal as setFret: an unwritable pitch is not written.
+    if (midi == null || !isWritablePitch(midi)) return false;
     if (!setTechText(el, "string", string)) return false;
     writePitch(el, midi);
     return true;

--- a/web/src/lib/editor/document.js
+++ b/web/src/lib/editor/document.js
@@ -1,0 +1,248 @@
+// The MusicXML document, as the editor's source of truth (#10).
+//
+// The renderer-evaluation on #10 settled the shape of this whole feature: the
+// MusicXML document is the model, and alphaTab's Score is a VIEW of it. Every
+// edit is written here, to the document; the renderer is then handed the new
+// document and asked to draw it afresh. Nothing is written to the renderer's
+// object graph and left for the document to catch up with later - that
+// "two writes, one edited" divergence is the bug class the evaluation names as
+// the one this design must not create, and the way this file avoids it is by
+// being the ONLY writer. The screen is always a re-import of what is written
+// here, so the two cannot drift.
+//
+// This runs in the browser (it uses DOMParser/XMLSerializer). The pure
+// arithmetic it leans on - pitch from string+fret, the Rule 5 string/tuning
+// mirror, duration from type - is in editor/notes.js, which has no DOM and is
+// unit-tested on its own.
+import {
+  DURATION_TYPES,
+  durationForType,
+  midiForStringFret,
+  midiOfPitch,
+  pitchFromMidi,
+  stringToTuningLine,
+} from "./notes.js";
+
+export { DURATION_TYPES };
+
+function firstChildTag(el, tag) {
+  if (!el) return null;
+  for (const child of el.children) if (child.tagName === tag) return child;
+  return null;
+}
+
+function tagText(el, tag) {
+  const found = firstChildTag(el, tag);
+  return found ? found.textContent.trim() : null;
+}
+
+// A note is a rest exactly when it carries a <rest/> child. Both a rest and a
+// sounding note carry a Rule 17 id and a <duration>; only a sounding note
+// carries <pitch> and <notations><technical>. The editor selects and edits
+// sounding notes; rests keep their place in document order (so an ordinal
+// never shifts) but are not offered as edit targets in this increment.
+function isRest(noteEl) {
+  return !!firstChildTag(noteEl, "rest");
+}
+
+function technicalOf(noteEl) {
+  const notations = firstChildTag(noteEl, "notations");
+  return notations ? firstChildTag(notations, "technical") : null;
+}
+
+/**
+ * Build the editable document from MusicXML text. Throws if the text is not
+ * parseable XML or is not a score this profile writes (one part, a tab staff
+ * with a tuning) - the caller shows that plainly rather than entering an edit
+ * mode over something it cannot map.
+ */
+export function createDocument(xml) {
+  // The parameter is `xml`, deliberately NOT `text`: this closure defines a
+  // `text()` serializer method below, and a same-named function declaration
+  // hoists over a parameter of that name - so a parameter called `text` would
+  // be the function, and this parse would read the function's source ("function
+  // ...") instead of the document, failing at column 1.
+  const doc = new DOMParser().parseFromString(xml, "application/xml");
+  // DOMParser reports a malformed document as a <parsererror> element rather
+  // than by throwing, so it has to be looked for.
+  const parseError = doc.getElementsByTagName("parsererror")[0];
+  if (parseError) {
+    throw new Error("This transcription is not valid XML, so it cannot be opened in the note editor.");
+  }
+  const root = doc.documentElement;
+  if (!root || root.tagName !== "score-partwise") {
+    throw new Error("The note editor works on partwise MusicXML transcriptions only.");
+  }
+
+  // The tuning, read once. line -> MIDI of that open string. `<staff-tuning
+  // line=>` numbers from the bottom staff line (the lowest string); a note's
+  // <string> numbers from the top. midiForStringFret / stringToTuningLine keep
+  // that mirror in one place (Rule 5).
+  const tuningByLine = new Map();
+  for (const st of doc.getElementsByTagName("staff-tuning")) {
+    const line = Number(st.getAttribute("line"));
+    const step = tagText(st, "tuning-step");
+    const octave = Number(tagText(st, "tuning-octave"));
+    const alter = Number(tagText(st, "tuning-alter") ?? 0) || 0;
+    const midi = step != null ? midiOfPitch(step, octave, alter) : null;
+    if (Number.isFinite(line) && midi != null) tuningByLine.set(line, midi);
+  }
+  const stringCount = tuningByLine.size;
+  if (stringCount === 0) {
+    throw new Error("This transcription has no string tuning, so its notes have no fretboard to edit on.");
+  }
+
+  const divisionsText = doc.getElementsByTagName("divisions")[0]?.textContent;
+  const divisions = Number(divisionsText);
+
+  // The sounding notes, in document order (measure -> voice's onset -> chord
+  // member), each paired with its <note> element. This is exactly the order
+  // score-render.js walks the alphaTab model in to build the positional map,
+  // so an index into this array IS the "ordinal" the two sides agree on. Rests
+  // are skipped by both, consistently.
+  const noteEls = [...doc.getElementsByTagName("note")].filter((n) => !isRest(n));
+
+  function describe(el, ordinal) {
+    const tech = technicalOf(el);
+    const string = tech ? Number(tagText(tech, "string")) : null;
+    const fret = tech ? Number(tagText(tech, "fret")) : null;
+    const type = tagText(el, "type");
+    const dots = [...el.children].filter((c) => c.tagName === "dot").length;
+    const pitchEl = firstChildTag(el, "pitch");
+    const midi = pitchEl
+      ? midiOfPitch(tagText(pitchEl, "step"), Number(tagText(pitchEl, "octave")), Number(tagText(pitchEl, "alter") ?? 0))
+      : null;
+    return {
+      ordinal,
+      id: el.getAttribute("id"),
+      string: Number.isFinite(string) ? string : null,
+      fret: Number.isFinite(fret) ? fret : null,
+      type,
+      dots,
+      midi,
+    };
+  }
+
+  function soundingNotes() {
+    return noteEls.map(describe);
+  }
+
+  function noteAt(ordinal) {
+    const el = noteEls[ordinal];
+    return el ? describe(el, ordinal) : null;
+  }
+
+  // Rewrite a sounding note's <pitch> to match a MIDI number, keeping the
+  // schema's child order (step, alter?, octave). Called whenever a fret or a
+  // string changes, so Rule 10's <pitch> never disagrees with the Rule 9
+  // position that determines it.
+  function writePitch(el, midi) {
+    const spelled = pitchFromMidi(midi);
+    if (!spelled) return;
+    let pitch = firstChildTag(el, "pitch");
+    if (!pitch) {
+      pitch = doc.createElement("pitch");
+      el.insertBefore(pitch, el.firstChild);
+    }
+    while (pitch.firstChild) pitch.removeChild(pitch.firstChild);
+    const step = doc.createElement("step");
+    step.textContent = spelled.step;
+    pitch.appendChild(step);
+    if (spelled.alter) {
+      const alter = doc.createElement("alter");
+      alter.textContent = String(spelled.alter);
+      pitch.appendChild(alter);
+    }
+    const octave = doc.createElement("octave");
+    octave.textContent = String(spelled.octave);
+    pitch.appendChild(octave);
+  }
+
+  function setTechText(el, tag, value) {
+    const tech = technicalOf(el);
+    if (!tech) return false;
+    const target = firstChildTag(tech, tag);
+    if (!target) return false;
+    target.textContent = String(value);
+    return true;
+  }
+
+  /**
+   * Set a sounding note's fret, recomputing its <pitch>. Refuses a negative
+   * fret. Returns true when the document changed.
+   */
+  function setFret(ordinal, fret) {
+    const el = noteEls[ordinal];
+    if (!el || !Number.isInteger(fret) || fret < 0) return false;
+    const string = Number(tagText(technicalOf(el), "string"));
+    const midi = midiForStringFret(tuningByLine, stringCount, string, fret);
+    if (midi == null) return false;
+    if (!setTechText(el, "fret", fret)) return false;
+    writePitch(el, midi);
+    return true;
+  }
+
+  /**
+   * Move a sounding note to a different string, recomputing its <pitch>.
+   * Refuses a string outside 1..stringCount - the invalid, un-drawable
+   * position #165's guard exists to catch is never written in the first place.
+   * Returns true when the document changed.
+   */
+  function setString(ordinal, string) {
+    const el = noteEls[ordinal];
+    if (!el || !Number.isInteger(string) || string < 1 || string > stringCount) return false;
+    const fret = Number(tagText(technicalOf(el), "fret"));
+    const midi = midiForStringFret(tuningByLine, stringCount, string, fret);
+    if (midi == null) return false;
+    if (!setTechText(el, "string", string)) return false;
+    writePitch(el, midi);
+    return true;
+  }
+
+  /**
+   * Set a sounding note's written duration to a plain (undotted) type,
+   * updating both <duration> and <type> and dropping any <dot/> it carried.
+   * Returns true when the document changed. Structural by nature - it changes
+   * the bar's arithmetic - which is why the caller re-imports the whole
+   * document rather than trusting an in-place tweak (see score-render.js).
+   */
+  function setDurationType(ordinal, type) {
+    const el = noteEls[ordinal];
+    if (!el) return false;
+    const value = durationForType(type, divisions);
+    if (value == null) return false;
+    const durationEl = firstChildTag(el, "duration");
+    if (!durationEl) return false;
+    durationEl.textContent = String(value);
+    let typeEl = firstChildTag(el, "type");
+    if (!typeEl) {
+      // <type> follows <voice> in the schema's sequence; insert it after
+      // <duration> if the note somehow lacked one (a tab-only onset can).
+      typeEl = doc.createElement("type");
+      durationEl.insertAdjacentElement?.("afterend", typeEl) ?? el.appendChild(typeEl);
+    }
+    typeEl.textContent = type;
+    for (const dot of [...el.children].filter((c) => c.tagName === "dot")) el.removeChild(dot);
+    return true;
+  }
+
+  function text() {
+    const body = new XMLSerializer().serializeToString(root);
+    // DOMParser drops the XML declaration; the server sniffs "starts with <"
+    // (a declaration does), and alphaTab reads either way - but a well-formed
+    // MusicXML file the user might export deserves its declaration back.
+    return `<?xml version="1.0" encoding="UTF-8"?>\n${body}`;
+  }
+
+  return {
+    stringCount,
+    divisions,
+    soundingNotes,
+    noteAt,
+    count: () => noteEls.length,
+    setFret,
+    setString,
+    setDurationType,
+    text,
+  };
+}

--- a/web/src/lib/editor/notes.js
+++ b/web/src/lib/editor/notes.js
@@ -1,0 +1,136 @@
+// The arithmetic behind a fret/string/duration edit, with no DOM and no
+// renderer in it - so it can be exercised directly by tests/unit/editor.spec.js
+// the same way metronome.js and pitch.js are (see their headers). Everything
+// that touches the MusicXML document lives in editor/document.js; everything
+// that touches the renderer lives behind score-render.js's edit sub-API. This
+// file is only the numbers that both of them need and neither should own a
+// second, divergent copy of.
+//
+// docs/musicxml-tab-profile.md is the contract this implements:
+//   - Rule 9: every sounding note carries <string>/<fret>.
+//   - Rule 10: every sounding note carries <pitch>, and the pitch is the one
+//     the string, the fret and the tuning determine together - so editing a
+//     fret or a string means recomputing <pitch> here, not leaving the old one
+//     to disagree with the new position (the exact "two facts, one edited"
+//     divergence #10's own comment warns about).
+//   - Rule 5: <string> numbers from the HIGHEST-pitched string (1 = highest),
+//     while <staff-tuning line=> numbers from the LOWEST (1 = bottom staff
+//     line). They are mirror images, and conflating them is a measured trap -
+//     see stringToTuningLine below.
+
+// Semitone of each pitch-class letter above C.
+const STEP_SEMITONE = { C: 0, D: 2, E: 4, F: 5, G: 7, A: 9, B: 11 };
+
+// The spelling written back out for each of the twelve pitch classes. Sharps
+// throughout: the extractor emits no <accidental> and no key-aware spelling
+// today (see the renderer-evaluation on #10 - "the emitter produces none"),
+// and choosing flats vs sharps by key is the accidentals work this increment
+// explicitly defers. A fretted position has one sounding pitch; how it is
+// spelled enharmonically is a later, key-signature-aware decision. Every entry
+// is [step, alter].
+const SEMITONE_SPELLING = [
+  ["C", 0], // 0
+  ["C", 1], // 1  C#
+  ["D", 0], // 2
+  ["D", 1], // 3  D#
+  ["E", 0], // 4
+  ["F", 0], // 5
+  ["F", 1], // 6  F#
+  ["G", 0], // 7
+  ["G", 1], // 8  G#
+  ["A", 0], // 9
+  ["A", 1], // 10 A#
+  ["B", 0], // 11
+];
+
+/**
+ * The MIDI note number of a written pitch. Middle C (C4) is 60, so the octave
+ * offset is `12 * (octave + 1)` - the convention alphaTab's own `realValue`
+ * uses, which is what lets a value computed here be compared straight against
+ * the note the renderer derived from the same string and fret (the divergence
+ * guard #10 asks for).
+ */
+export function midiOfPitch(step, octave, alter = 0) {
+  const s = STEP_SEMITONE[String(step).toUpperCase()];
+  if (s == null || !Number.isFinite(octave)) return null;
+  return 12 * (octave + 1) + s + (Number(alter) || 0);
+}
+
+/**
+ * The written pitch for a MIDI number - `{ step, octave, alter }`, spelled
+ * with sharps (see SEMITONE_SPELLING). The inverse of midiOfPitch: feeding its
+ * output back in returns the same MIDI number.
+ */
+export function pitchFromMidi(midi) {
+  if (!Number.isFinite(midi)) return null;
+  const m = Math.round(midi);
+  const octave = Math.floor(m / 12) - 1;
+  const [step, alter] = SEMITONE_SPELLING[((m % 12) + 12) % 12];
+  return { step, octave, alter };
+}
+
+/**
+ * The `<staff-tuning line=>` a `<string>` value maps to (Rule 5). `<string>` 1
+ * is the highest-pitched string; staff line 1 is the bottom line, i.e. the
+ * lowest string - so on a `count`-string staff they are mirror images:
+ * `line = count + 1 - string`. Measured against Fermata's own emitter: a note
+ * with `<string>1</string>` (highest) reads its tuning from
+ * `<staff-tuning line="6">` (the top line's pitch) on a six-string staff.
+ *
+ * This is the SAME mirror alphaTab applies in the other direction between its
+ * own bottom-up string numbering and MusicXML's - kept in one named function
+ * so the trap has exactly one home.
+ */
+export function stringToTuningLine(stringCount, string) {
+  return stringCount + 1 - string;
+}
+
+/**
+ * The sounding MIDI of a fretted position: the open-string pitch (the tuning
+ * of the staff line this `<string>` maps to) plus the fret in semitones.
+ *
+ * `tuningByLine` is `line -> midi`, exactly the map document.js reads out of
+ * the `<staff-tuning>` elements. `string` is the MusicXML `<string>` value.
+ * Returns null when the string has no tuning line (an out-of-range string -
+ * the invalid edit #165's guard must not be handed).
+ */
+export function midiForStringFret(tuningByLine, stringCount, string, fret) {
+  const open = tuningByLine.get(stringToTuningLine(stringCount, string));
+  if (open == null || !Number.isFinite(fret) || fret < 0) return null;
+  return open + fret;
+}
+
+// The written duration types this increment can set, coarsest to finest, each
+// as a multiple of a quarter note. Tuplets, ties and dotted values are the
+// deferred entry work (see #10 and this file's header); a plain type is the
+// common correction - "this eighth should be a quarter" - and is what the
+// duration control offers.
+export const DURATION_TYPES = ["whole", "half", "quarter", "eighth", "16th", "32nd"];
+
+const TYPE_QUARTERS = {
+  whole: 4,
+  half: 2,
+  quarter: 1,
+  eighth: 0.5,
+  "16th": 0.25,
+  "32nd": 0.125,
+};
+
+/**
+ * The `<duration>` value (in the document's own divisions-per-quarter) for a
+ * plain, undotted note of the given `<type>`. `divisions` is the document's
+ * `<divisions>` - the number of duration units in one quarter note - so a
+ * quarter is `divisions`, a half is `2 * divisions`, an eighth is
+ * `divisions / 2`, and so on.
+ *
+ * Returns null for a type this increment does not write, or a divisions value
+ * that cannot express the type as a whole number of units (a 32nd against a
+ * divisions of 1, say) - the caller keeps the note as it was rather than
+ * writing a rounded, wrong duration.
+ */
+export function durationForType(type, divisions) {
+  const q = TYPE_QUARTERS[type];
+  if (q == null || !Number.isFinite(divisions) || divisions <= 0) return null;
+  const value = q * divisions;
+  return Number.isInteger(value) ? value : null;
+}

--- a/web/src/lib/editor/notes.js
+++ b/web/src/lib/editor/notes.js
@@ -56,6 +56,21 @@ export function midiOfPitch(step, octave, alter = 0) {
   return 12 * (octave + 1) + s + (Number(alter) || 0);
 }
 
+// The range a `<pitch>` can actually express, and so the range an edit is
+// allowed to produce (Rule 11). MusicXML's `octave` is an integer 0-9, so the
+// lowest writable pitch is C0 (MIDI 12) and the highest is B9 (MIDI 131). A
+// note outside it cannot be written as some OTHER pitch instead - an `<octave>`
+// of 10 makes the whole document unreadable to a validating consumer - so an
+// edit that would land there is refused rather than written, exactly as the
+// extractor refuses to emit one.
+export const MIN_WRITABLE_MIDI = 12;
+export const MAX_WRITABLE_MIDI = 131;
+
+/** Whether a MIDI number can be written as a `<pitch>` at all (Rule 11). */
+export function isWritablePitch(midi) {
+  return Number.isFinite(midi) && midi >= MIN_WRITABLE_MIDI && midi <= MAX_WRITABLE_MIDI;
+}
+
 /**
  * The written pitch for a MIDI number - `{ step, octave, alter }`, spelled
  * with sharps (see SEMITONE_SPELLING). The inverse of midiOfPitch: feeding its

--- a/web/src/lib/score-render.js
+++ b/web/src/lib/score-render.js
@@ -1913,6 +1913,65 @@ export function createScoreView(host, opts = {}) {
   // a queued resize render must not touch a torn-down renderer
   let destroyed = false;
 
+  // ------------------------------------------------------- the note editor (#10)
+  //
+  // Whether the linked notation staff is shown. The renderer evaluation on #10
+  // established that a Fermata tab-only file imports with
+  // Staff.showStandardNotation = false, and that flipping the MODEL flag (not
+  // the staveProfile display setting, which alone does nothing and whose
+  // "Score" value crashes on such a file) is what draws the notation staff the
+  // editor needs so a fret change can be seen to move the pitch. Applied in the
+  // scoreLoaded handler, before the load's own first render, the same way and
+  // for the same timing reason disqualifyUnstrungTabStaves is.
+  let editNotation = false;
+  // Note -> ordinal (its position among sounding notes in document order),
+  // rebuilt after every render. This is the positional map the renderer
+  // evaluation measured at 100% agreement with MusicXML document order: an
+  // ordinal here indexes exactly the same sounding note as the same ordinal
+  // into editor/document.js's soundingNotes(). A MusicXML @id does not reach
+  // alphaTab's model (also measured), so the handle between the two is this
+  // position, not the id - the id (Rule 17) is what makes it auditable.
+  let noteOrdinals = new Map();
+  let notesInOrder = [];
+  // Resolved by the next postRenderFinished, so reloadScore() can await the
+  // redraw the way an editor step needs to before re-reading bounds.
+  let pendingEditResolve = null;
+
+  // Walk the one rendered track's model in document order - bar, then each
+  // voice in turn, then each beat, then each chord member - skipping rests, so
+  // the ordinal assigned here matches document.js's sounding-note order beat
+  // for beat. One part, one staff is this profile's scope (Rule 17); a second
+  // staff or track would need an axis this walk does not name, exactly as
+  // Rule 17's own uniqueness note says of its id formula.
+  function buildNoteOrdinals() {
+    noteOrdinals = new Map();
+    notesInOrder = [];
+    const track = api.score?.tracks?.[0];
+    if (!track) return;
+    for (const staff of track.staves ?? []) {
+      for (const bar of staff.bars ?? []) {
+        for (const voice of bar.voices ?? []) {
+          for (const beat of voice.beats ?? []) {
+            if (beat.isRest) continue;
+            for (const note of beat.notes ?? []) {
+              noteOrdinals.set(note, notesInOrder.length);
+              notesInOrder.push(note);
+            }
+          }
+        }
+      }
+    }
+  }
+
+  // showStandardNotation is a per-Staff model flag the importer resets on every
+  // load, so it is re-applied here on the loaded score before its first render.
+  function applyEditStaffFlags(loadedScore) {
+    if (!editNotation) return;
+    for (const track of loadedScore?.tracks ?? []) {
+      for (const staff of track?.staves ?? []) staff.showStandardNotation = true;
+    }
+  }
+
   const api = new alphaTab.AlphaTabApi(host, {
     // worker/audio-worklet URLs are wired up by the @coderline/alphatab-vite
     // plugin (vite.config.js); fontDirectory/soundFont still need to match
@@ -1920,6 +1979,16 @@ export function createScoreView(host, opts = {}) {
     core: {
       fontDirectory: "/font/",
       useWorkers: RENDER_IN_WORKER,
+      // Every note gets its own rectangle in the bounds lookup, not just its
+      // beat. Off by default, and the practice-cursor work never needed it;
+      // the note editor (#10) does - its click-to-select is an app-side
+      // point-in-rectangle search over these note bounds, because alphaTab's
+      // own getBeatAtPos was measured resolving the wrong voice on polyphony.
+      // Measured cost of turning it on: below this harness's render-time noise
+      // (see the renderer evaluation on #10), so it is left on for every view
+      // rather than toggled with an edit mode - a mode switch that changed a
+      // core setting would force a reload, and this costs nothing to carry.
+      includeNoteBounds: true,
     },
     player: {
       enablePlayer: true,
@@ -2526,6 +2595,16 @@ export function createScoreView(host, opts = {}) {
     // generated, which is after every scoreLoaded listener has returned, so
     // the played bar order cannot be published from there.
     publishPlaybackBars();
+    // The bounds lookup and the model are both rebuilt by the render that just
+    // finished, so the positional map is rebuilt from them here - after which
+    // an edit step that awaited this render can re-read note bounds and
+    // re-select by ordinal.
+    buildNoteOrdinals();
+    if (pendingEditResolve) {
+      const resolve = pendingEditResolve;
+      pendingEditResolve = null;
+      resolve();
+    }
   });
 
   // A profile carried over from a previous score, or the "scoretab" default,
@@ -2616,6 +2695,10 @@ export function createScoreView(host, opts = {}) {
     // asked about it, or "tab"/"scoretab" would still be offered for a staff
     // whose paint throws (issue #165) - see disqualifyUnstrungTabStaves.
     const tabWithheld = disqualifyUnstrungTabStaves(loadedScore);
+    // Before supportedProfiles() reads the score: turning on the notation
+    // staff is what makes "score"/"scoretab" drawable for a tab-only file, so
+    // it has to happen before canDraw is asked (see applyEditStaffFlags).
+    applyEditStaffFlags(loadedScore);
     // Disclosed the same way applyLoadedNavigation discloses an unread
     // navigation mark a few lines above: a dataset attribute a test (or a
     // person with devtools open) can read, plus a console line, present only
@@ -2640,6 +2723,15 @@ export function createScoreView(host, opts = {}) {
     unrenderable = scoreProfiles.length === 0;
     if (!unrenderable && !scoreProfiles.includes(profile)) {
       profile = scoreProfiles[0];
+      api.settings.display.staveProfile = STAVE_PROFILE[profile];
+      api.updateSettings();
+    }
+    // In edit mode both staves are wanted (tab to click a fret on, notation to
+    // watch the pitch move) - "scoretab" draws both, and applyEditStaffFlags
+    // above just made it drawable. Preferred over whatever profile carried
+    // over, but only if the score actually supports it.
+    if (editNotation && scoreProfiles.includes("scoretab") && profile !== "scoretab") {
+      profile = "scoretab";
       api.settings.display.staveProfile = STAVE_PROFILE[profile];
       api.updateSettings();
     }
@@ -2842,6 +2934,179 @@ export function createScoreView(host, opts = {}) {
   }
 
   load(source);
+
+  // ------------------------------------------------- the note editor's seam
+  //
+  // Everything alphaTab-specific the editor needs lives here, behind the same
+  // seam the rest of this file is: the caller (TabViewer) deals in ordinals,
+  // MusicXML string numbers and document text, and never sees a Note, a
+  // BoundsLookup or alphaTab's own bottom-up string numbering. document.js owns
+  // the document; this owns the view of it.
+
+  // The element alphaTab draws into. Note bounds are absolute within it, so a
+  // client (mouse) coordinate maps to a bounds coordinate by subtracting this
+  // rectangle's own top-left - getBoundingClientRect already accounts for
+  // scroll, so nothing here has to.
+  function surfaceRect() {
+    const surface = host?.querySelector(".at-surface") ?? host;
+    return surface ? surface.getBoundingClientRect() : null;
+  }
+
+  // A few pixels of slack so a click just outside a tight note-head rectangle
+  // still lands on it - the fret digits especially are small targets.
+  const NOTE_HIT_PADDING = 3;
+
+  function boundsOf() {
+    return api.renderer?.boundsLookup ?? api.boundsLookup ?? null;
+  }
+
+  // The sounding-note ordinal at a client position, or null. A point-in-
+  // rectangle search over every note's head bounds - the renderer evaluation
+  // measured this resolving 100% where alphaTab's own getBeatAtPos returned a
+  // different voice's beat on polyphony. With the notation staff shown a note
+  // carries two head rectangles (one per staff); both belong to the same Note,
+  // so clicking either selects the same ordinal. On a genuine overlap the
+  // nearest head centre wins.
+  function hitTestNote(clientX, clientY) {
+    const lookup = boundsOf();
+    const rect = surfaceRect();
+    if (!lookup || !rect) return null;
+    const x = clientX - rect.left;
+    const y = clientY - rect.top;
+    let best = null;
+    let bestDist = Infinity;
+    for (const sys of lookup.staffSystems ?? []) {
+      for (const mb of sys.bars ?? []) {
+        for (const bar of mb.bars ?? []) {
+          for (const beat of bar.beats ?? []) {
+            for (const nb of beat.notes ?? []) {
+              const b = nb.noteHeadBounds;
+              if (!b) continue;
+              if (
+                x < b.x - NOTE_HIT_PADDING ||
+                x > b.x + b.w + NOTE_HIT_PADDING ||
+                y < b.y - NOTE_HIT_PADDING ||
+                y > b.y + b.h + NOTE_HIT_PADDING
+              )
+                continue;
+              const dx = x - (b.x + b.w / 2);
+              const dy = y - (b.y + b.h / 2);
+              const dist = dx * dx + dy * dy;
+              if (dist < bestDist) {
+                bestDist = dist;
+                best = nb.note;
+              }
+            }
+          }
+        }
+      }
+    }
+    if (!best) return null;
+    const ordinal = noteOrdinals.get(best);
+    return ordinal == null ? null : ordinal;
+  }
+
+  // What alphaTab itself makes of the sounding note at `ordinal` - read back
+  // through a completely different path from document.js's read of the same
+  // note (the importer plus this positional map, versus a DOM walk), which is
+  // exactly what lets TabViewer cross-check the two for the divergence the
+  // evaluation warns of. The string is mirrored back into MusicXML's
+  // convention here (alphaTab numbers strings from the lowest, MusicXML from
+  // the highest - Rule 5, and a measured trap), so the seam speaks the
+  // document's language and the trap has one home.
+  function noteViewInfo(ordinal) {
+    const note = notesInOrder[ordinal];
+    if (!note) return null;
+    const stringCount = note.beat?.voice?.bar?.staff?.tuning?.length ?? 0;
+    const mxString = stringCount > 0 && note.string >= 1 ? stringCount + 1 - note.string : null;
+    return {
+      mxString,
+      fret: note.fret ?? null,
+      midi: Number.isFinite(note.realValue) ? note.realValue : null,
+    };
+  }
+
+  // The client-space rectangle of a note's head, for a selection overlay the
+  // caller draws. Union of the note's (up to two) head rectangles, so the
+  // highlight covers both its tab digit and its notation head.
+  function noteHeadRect(ordinal) {
+    const note = notesInOrder[ordinal];
+    const lookup = boundsOf();
+    const rect = surfaceRect();
+    if (!note || !lookup || !rect) return null;
+    let box = null;
+    for (const sys of lookup.staffSystems ?? []) {
+      for (const mb of sys.bars ?? []) {
+        for (const bar of mb.bars ?? []) {
+          for (const beat of bar.beats ?? []) {
+            for (const nb of beat.notes ?? []) {
+              if (nb.note !== note) continue;
+              const b = nb.noteHeadBounds;
+              if (!b) continue;
+              if (!box) box = { x1: b.x, y1: b.y, x2: b.x + b.w, y2: b.y + b.h };
+              else {
+                box.x1 = Math.min(box.x1, b.x);
+                box.y1 = Math.min(box.y1, b.y);
+                box.x2 = Math.max(box.x2, b.x + b.w);
+                box.y2 = Math.max(box.y2, b.y + b.h);
+              }
+            }
+          }
+        }
+      }
+    }
+    if (!box) return null;
+    return {
+      left: rect.left + box.x1,
+      top: rect.top + box.y1,
+      width: box.x2 - box.x1,
+      height: box.y2 - box.y1,
+    };
+  }
+
+  // The client-space centre of ONE of a note's head rectangles (the first
+  // found) - a point guaranteed to be inside a real, clickable head, unlike
+  // the centre of noteHeadRect's union of the tab and notation heads, which
+  // with both staves shown falls in the empty space between them. Used to
+  // drive a click at a known note in tests; the union rect stays the overlay's.
+  function noteHeadPoint(ordinal) {
+    const note = notesInOrder[ordinal];
+    const lookup = boundsOf();
+    const rect = surfaceRect();
+    if (!note || !lookup || !rect) return null;
+    for (const sys of lookup.staffSystems ?? [])
+      for (const mb of sys.bars ?? [])
+        for (const bar of mb.bars ?? [])
+          for (const beat of bar.beats ?? [])
+            for (const nb of beat.notes ?? []) {
+              if (nb.note !== note) continue;
+              const b = nb.noteHeadBounds;
+              if (b) return { x: rect.left + b.x + b.w / 2, y: rect.top + b.y + b.h / 2 };
+            }
+    return null;
+  }
+
+  // Re-import the edited document and redraw, resolving once the redraw has
+  // finished so the caller can re-read bounds and re-select. This is the whole
+  // "apply an edit" path: the document is the source of truth, and the screen
+  // is a fresh view of it - there is no second write to the object graph to
+  // diverge from it. Measured cost of a reload is a few ms on a typical score
+  // (see the evaluation), which is what makes single-source-of-truth
+  // affordable here rather than only in principle.
+  function reloadScore(text) {
+    return new Promise((resolve, reject) => {
+      if (destroyed) return resolve();
+      pendingEditResolve = resolve;
+      pendingSourceText = text;
+      pendingUnreadReason = null;
+      try {
+        api.load(new TextEncoder().encode(text));
+      } catch (e) {
+        pendingEditResolve = null;
+        reject(e instanceof Error ? e : new Error(String(e)));
+      }
+    });
+  }
 
   return {
     get layout() {
@@ -3098,6 +3363,62 @@ export function createScoreView(host, opts = {}) {
       // is now (unchanged), not a value that predates either move.
       publishLoopRange();
       publishCursor();
+    },
+
+    /**
+     * The note editor's view surface (#10). All of it deals in ordinals
+     * (a sounding note's position in document order, the same index
+     * editor/document.js uses), MusicXML string numbers, and document text -
+     * never an alphaTab Note or its own string numbering. See the "note
+     * editor's seam" block above.
+     *
+     * - `setNotationShown(on)` turns the linked notation staff on or off,
+     *   re-rendering. Wanted on while editing so a fret change can be seen to
+     *   move the pitch.
+     * - `hitTest(clientX, clientY)` -> the ordinal of the note under a click,
+     *   or null.
+     * - `viewInfo(ordinal)` -> `{ mxString, fret, midi }` as the RENDERER sees
+     *   that note, for the divergence cross-check.
+     * - `headRect(ordinal)` -> a client-space `{ left, top, width, height }`
+     *   for a selection overlay, or null.
+     * - `reload(text)` -> Promise resolved once the edited document has been
+     *   re-imported and redrawn.
+     * - `noteCount()` -> how many sounding notes the rendered model holds, so
+     *   the caller can assert its positional map lines up with the document's.
+     */
+    editor: {
+      setNotationShown(on) {
+        const next = !!on;
+        if (next === editNotation) return;
+        editNotation = next;
+        for (const track of api.score?.tracks ?? []) {
+          for (const staff of track?.staves ?? []) staff.showStandardNotation = next;
+        }
+        if (next && scoreProfiles?.includes("scoretab")) {
+          profile = "scoretab";
+        }
+        reapply();
+      },
+      hitTest: hitTestNote,
+      viewInfo: noteViewInfo,
+      headRect: noteHeadRect,
+      headPoint: noteHeadPoint,
+      reload: reloadScore,
+      noteCount: () => notesInOrder.length,
+      // How many note-head rectangles the render produced across every staff.
+      // With the notation staff off this equals the sounding-note count (one
+      // tab digit each); with it on it doubles (a tab digit and a notation
+      // head per note) - so it is how a caller confirms the linked notation
+      // staff is actually drawn, not merely requested.
+      boundsCount() {
+        const lookup = boundsOf();
+        let n = 0;
+        for (const sys of lookup?.staffSystems ?? [])
+          for (const mb of sys.bars ?? [])
+            for (const bar of mb.bars ?? [])
+              for (const beat of bar.beats ?? []) n += (beat.notes ?? []).length;
+        return n;
+      },
     },
 
     destroy() {

--- a/web/tests/browser/fixtures/editor-score.js
+++ b/web/tests/browser/fixtures/editor-score.js
@@ -1,0 +1,156 @@
+// Fixtures for the note editor (#10), see ../score-editor.spec.js.
+//
+// The MusicXML below is the shape Fermata's own emitter writes - one part, one
+// TAB staff, a six-string standard tuning, <divisions>480</divisions>, and a
+// Rule 17 id on every note (n{measure}-{voice}-{onset}-{chord}). It is a real
+// document the real alphaTab importer renders and the real editor/document.js
+// parses; nothing here is stubbed but the HTTP transport. Kept monophonic (one
+// note per beat) so a click lands unambiguously on a known note.
+//
+// The notes, in document order, are what the spec asserts against:
+//
+//   ord  id          string  fret   pitch  midi
+//   0    n1-1-0-0    1       0      E4     64
+//   1    n1-1-1-0    1       2      F#4    66
+//   2    n1-1-2-0    1       3      G4     67
+//   3    n1-1-3-0    1       5      A4     69
+//   4    n2-1-0-0    2       0      B3     59
+//   5    n2-1-1-0    2       1      C4     60
+//   6    n2-1-2-0    2       3      D4     62
+//   7    n2-1-3-0    2       5      E4     64
+//
+// <string> 1 is the highest string (E4); on this six-string staff it reads its
+// tuning from <staff-tuning line="6"> - the Rule 5 mirror the editor has to get
+// right, and the divergence guard checks.
+
+export const SCORE = {
+  id: 1,
+  title: "Editor Test Score",
+  file_type: "pdf",
+  has_transcription: true,
+  favorite: false,
+  content_kind: "tab",
+  tags: [],
+};
+
+export const MIN_PDF = Buffer.from(
+  "%PDF-1.4\n1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj\n" +
+    "2 0 obj<</Type/Pages/Kids[3 0 R]/Count 1>>endobj\n" +
+    "3 0 obj<</Type/Page/Parent 2 0 R/MediaBox[0 0 200 200]>>endobj\n" +
+    "xref\n0 4\n0000000000 65535 f \n0000000009 00000 n \n0000000052 00000 n \n0000000101 00000 n \n" +
+    "trailer<</Size 4/Root 1 0 R>>\nstartxref\n164\n%%EOF",
+  "utf-8",
+);
+
+const STAFF_DETAILS = `
+        <staff-details>
+          <staff-lines>6</staff-lines>
+          <staff-tuning line="1"><tuning-step>E</tuning-step><tuning-octave>2</tuning-octave></staff-tuning>
+          <staff-tuning line="2"><tuning-step>A</tuning-step><tuning-octave>2</tuning-octave></staff-tuning>
+          <staff-tuning line="3"><tuning-step>D</tuning-step><tuning-octave>3</tuning-octave></staff-tuning>
+          <staff-tuning line="4"><tuning-step>G</tuning-step><tuning-octave>3</tuning-octave></staff-tuning>
+          <staff-tuning line="5"><tuning-step>B</tuning-step><tuning-octave>3</tuning-octave></staff-tuning>
+          <staff-tuning line="6"><tuning-step>E</tuning-step><tuning-octave>4</tuning-octave></staff-tuning>
+        </staff-details>`;
+
+function note(id, step, alter, octave, string, fret) {
+  const alterEl = alter ? `<alter>${alter}</alter>` : "";
+  return `      <note id="${id}">
+        <pitch><step>${step}</step>${alterEl}<octave>${octave}</octave></pitch>
+        <duration>480</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <notations><technical><string>${string}</string><fret>${fret}</fret></technical></notations>
+      </note>`;
+}
+
+export const EDITOR_MUSICXML = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list>
+    <score-part id="P1"><part-name>Guitar</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>480</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>TAB</sign><line>5</line></clef>${STAFF_DETAILS}
+      </attributes>
+${note("n1-1-0-0", "E", 0, 4, 1, 0)}
+${note("n1-1-1-0", "F", 1, 4, 1, 2)}
+${note("n1-1-2-0", "G", 0, 4, 1, 3)}
+${note("n1-1-3-0", "A", 0, 4, 1, 5)}
+    </measure>
+    <measure number="2">
+${note("n2-1-0-0", "B", 0, 3, 2, 0)}
+${note("n2-1-1-0", "C", 0, 4, 2, 1)}
+${note("n2-1-2-0", "D", 0, 4, 2, 3)}
+${note("n2-1-3-0", "E", 0, 4, 2, 5)}
+    </measure>
+  </part>
+</score-partwise>`;
+
+// The same score with one note moved to a string the six-string staff does not
+// have (<string>7</string>) - the under-specified tab a directly uploaded or
+// hand-edited file can carry (issue #165). The editor never writes this; it is
+// here to prove that loading it, with note bounds and the notation staff turned
+// on for edit mode, still does not crash the renderer's paint - the
+// disqualifyUnstrungTabStaves guard holds.
+export const UNSTRUNG_MUSICXML = EDITOR_MUSICXML.replace(
+  '<technical><string>1</string><fret>0</fret></technical>',
+  '<technical><string>7</string><fret>0</fret></technical>',
+);
+
+export function transcriptionBody(content) {
+  return {
+    id: 1,
+    score_id: 1,
+    format: "musicxml",
+    content,
+    source: "extracted",
+    confidence: JSON.stringify({ warnings: [], confidence: {} }),
+    warnings: [],
+  };
+}
+
+/**
+ * Stubs every /api route the score view touches for score id 1, serving the
+ * given MusicXML as the transcription. A PUT (the editor's save) captures the
+ * body and, from then on, GET returns that saved content as a source='edited'
+ * row - so "save, reload the page, and the edit is still there" is a real
+ * round trip through the same client the app uses, not an assumption.
+ *
+ * Returns `{ saved }` - `saved.content` is the last PUT body, for a test that
+ * wants to assert on exactly what was persisted.
+ */
+export async function stubEditorApi(page, initialContent) {
+  const saved = { content: null };
+  let current = transcriptionBody(initialContent);
+
+  await page.route("**/api/scores/1", (route) => route.fulfill({ json: SCORE }));
+  await page.route("**/api/scores/1/file", (route) =>
+    route.fulfill({ body: MIN_PDF, contentType: "application/pdf" }),
+  );
+  await page.route("**/api/scores/1/practice", (route) =>
+    route.fulfill({ json: { total_seconds: 0, sessions: [] } }),
+  );
+  await page.route("**/api/scores/1/transcription/analysis", (route) =>
+    route.fulfill({ json: { extractable: true } }),
+  );
+  await page.route("**/api/scores/1/transcription", async (route) => {
+    const method = route.request().method();
+    if (method === "PUT") {
+      const body = JSON.parse(route.request().postData() || "{}");
+      saved.content = body.content;
+      current = { ...transcriptionBody(body.content), source: "edited", confidence: null };
+      return route.fulfill({ json: current });
+    }
+    if (method === "DELETE") {
+      return route.fulfill({ json: { ...transcriptionBody(initialContent), source: "extracted" } });
+    }
+    return route.fulfill({ json: current });
+  });
+
+  return { saved };
+}

--- a/web/tests/browser/score-editor.spec.js
+++ b/web/tests/browser/score-editor.spec.js
@@ -121,6 +121,37 @@ test.describe("note editor", () => {
     await expect(wrap(page)).toHaveAttribute("data-editor-divergence-ok", "true");
   });
 
+  test("an out-of-range fret is refused, never written, and says why", async ({ page }) => {
+    await openEditor(page, EDITOR_MUSICXML);
+    // Note 0: string 1 (E4 = MIDI 64). Fret 68 would sound MIDI 132 = octave
+    // 10, which MusicXML's <octave> (0-9) cannot express (Rule 11). The editor
+    // must refuse it rather than write a document a validating consumer would
+    // reject - the divergence guard would NOT catch this, because both the
+    // renderer and the document would agree on the same out-of-range pitch.
+    await selectNote(page, 0);
+    await fretInput(page).fill("68");
+    await fretInput(page).blur();
+    // Unchanged: still fret 0, still MIDI 64, nothing to save.
+    await expect(wrap(page)).toHaveAttribute("data-editor-selected-fret", "0");
+    await expect(wrap(page)).toHaveAttribute("data-editor-selected-midi", "64");
+    await expect(wrap(page)).toHaveAttribute("data-editor-dirty", "false");
+    // And it said so, honestly, rather than swallowing the edit.
+    await expect(wrap(page)).toHaveAttribute("data-editor-warn", /octaves 0–9/);
+  });
+
+  test("a fret at the very top of the writable range is accepted", async ({ page }) => {
+    await openEditor(page, EDITOR_MUSICXML);
+    // The boundary: fret 67 on the high E string reaches B9 = MIDI 131, the
+    // highest pitch MusicXML can write - so it is allowed, where 68 was not.
+    await selectNote(page, 0);
+    await fretInput(page).fill("67");
+    await fretInput(page).blur();
+    await expect(wrap(page)).toHaveAttribute("data-editor-selected-fret", "67");
+    await expect(wrap(page)).toHaveAttribute("data-editor-selected-midi", "131");
+    await expect(wrap(page)).toHaveAttribute("data-editor-dirty", "true");
+    await expect(wrap(page)).toHaveAttribute("data-editor-divergence-ok", "true");
+  });
+
   test("undo restores the previous value and redo re-applies it", async ({ page }) => {
     await openEditor(page, EDITOR_MUSICXML);
     await selectNote(page, 0);
@@ -164,6 +195,9 @@ test.describe("note editor", () => {
     // The persisted MusicXML carries the new fret on that note - stored
     // verbatim through the edited-transcription path.
     await expect.poll(() => saved.content).toContain("<fret>7</fret>");
+    // And every <octave> it carries is inside MusicXML's 0-9 range, so the
+    // saved document is not one a validating consumer would reject (Rule 11).
+    expect(saved.content).not.toMatch(/<octave>(1\d|\d\d\d)<\/octave>/);
 
     // Reload the whole page: the stub now serves the saved (source='edited')
     // content, so re-opening the editor and selecting the same note shows the

--- a/web/tests/browser/score-editor.spec.js
+++ b/web/tests/browser/score-editor.spec.js
@@ -1,0 +1,209 @@
+// The note editor (#10), end to end against the real alphaTab render and the
+// real editor/document.js parse - only the HTTP transport is stubbed (see
+// fixtures/editor-score.js). Every assertion is on state the app publishes onto
+// the DOM (data-editor-*) or persists through the save client, never on an
+// internal this test reaches into - the one exception being window.__scoreEditor,
+// the read-only geometry hook the app exposes so a click can land on a KNOWN
+// note (the same window.__ instrumentation pattern ear-training.spec.js uses).
+//
+// What each mutation would turn red, so this suite is falsifiable, not just
+// green:
+//   - break the document write (setFret et al. no-op): the fret/pitch never
+//     changes on reload -> "change fret" and "undo/redo" go red.
+//   - break the positional map (buildNoteOrdinals off by one): clicking a
+//     known note selects the wrong one -> "click selects the right note" red.
+//   - break the Rule 5 string mirror in the seam: the renderer's mxString stops
+//     matching the document's -> data-editor-divergence-ok goes false -> the
+//     divergence test red.
+//   - break the notation flip: only 8 note bounds instead of 16 -> "both staves
+//     drawn" red.
+import { test, expect } from "@playwright/test";
+
+import { EDITOR_MUSICXML, UNSTRUNG_MUSICXML, stubEditorApi } from "./fixtures/editor-score.js";
+
+const wrap = (page) => page.locator(".staff-render .wrap");
+const host = (page) => page.locator(".staff-render .at-host");
+
+// Waits for a render to have finished (data-score-render-ok is published by
+// score-render.js after every successful render).
+async function renderedOk(page) {
+  await expect(host(page)).toHaveAttribute("data-score-render-ok", "true");
+}
+
+async function openEditor(page, content) {
+  const handle = await stubEditorApi(page, content);
+  await page.goto("/#/score/1");
+  await page.waitForSelector(".staff-render");
+  // Full-width staff, so every note is on screen to click (side-by-side would
+  // give the staff half the width). The layout toggle is ScoreCompare's.
+  await page.getByRole("button", { name: "Staff", exact: true }).click();
+  await renderedOk(page);
+  await page.getByRole("button", { name: "Edit notes" }).click();
+  await expect(wrap(page)).toHaveAttribute("data-editor-active", "true");
+  // The notation staff flip re-renders; wait until the geometry hook reports
+  // the whole score (8 sounding notes) is laid out before clicking anything.
+  await expect
+    .poll(() => page.evaluate(() => window.__scoreEditor?.noteCount() ?? 0))
+    .toBe(8);
+  return handle;
+}
+
+async function selectNote(page, ordinal) {
+  const point = await page.evaluate((o) => window.__scoreEditor.headPoint(o), ordinal);
+  expect(point, `note ${ordinal} has a clickable head`).toBeTruthy();
+  await page.mouse.click(point.x, point.y);
+  await expect(wrap(page)).toHaveAttribute("data-editor-selected", String(ordinal));
+}
+
+const fretInput = (page) => page.locator(".edit-fields input");
+const durationSelect = (page) => page.locator(".edit-fields label", { hasText: "Duration" }).locator("select");
+
+test.describe("note editor", () => {
+  test("edit mode is reachable from the score view and draws both staves", async ({ page }) => {
+    await openEditor(page, EDITOR_MUSICXML);
+    // 8 sounding notes, each with a tab head AND a notation head = 16 note
+    // bounds. Off (notation not shown) it would be 8 - so this is the proof the
+    // linked notation staff is actually drawn, not merely asked for.
+    await expect
+      .poll(() => page.evaluate(() => window.__scoreEditor?.boundsCount() ?? 0))
+      .toBe(16);
+    await expect(host(page)).toHaveAttribute("data-score-profile", "scoretab");
+  });
+
+  test("clicking a note selects that exact note", async ({ page }) => {
+    await openEditor(page, EDITOR_MUSICXML);
+    // Note ordinal 2 is string 1, fret 3, id n1-1-2-0 (see the fixture table).
+    // Clicking its head must select ordinal 2 and read back exactly that fret,
+    // string and id - which only holds if the positional map lines the
+    // rendered note up with the same document note.
+    await selectNote(page, 2);
+    await expect(wrap(page)).toHaveAttribute("data-editor-selected-fret", "3");
+    await expect(wrap(page)).toHaveAttribute("data-editor-selected-string", "1");
+    await expect(wrap(page)).toHaveAttribute("data-editor-selected-note-id", "n1-1-2-0");
+    await expect(wrap(page)).toHaveAttribute("data-editor-divergence-ok", "true");
+  });
+
+  test("changing the fret moves both the tab and the sounding pitch", async ({ page }) => {
+    await openEditor(page, EDITOR_MUSICXML);
+    // Note 0: string 1 (E4), fret 0, MIDI 64.
+    await selectNote(page, 0);
+    await expect(wrap(page)).toHaveAttribute("data-editor-selected-midi", "64");
+    await fretInput(page).fill("5");
+    await fretInput(page).blur();
+    // fret 5 on the high E string sounds A4 = 69 = 64 + 5.
+    await expect(wrap(page)).toHaveAttribute("data-editor-selected-fret", "5");
+    await expect(wrap(page)).toHaveAttribute("data-editor-selected-midi", "69");
+    await expect(wrap(page)).toHaveAttribute("data-editor-divergence-ok", "true");
+    await expect(wrap(page)).toHaveAttribute("data-editor-dirty", "true");
+    // Both staves still drawn after the edit's reload.
+    await expect
+      .poll(() => page.evaluate(() => window.__scoreEditor?.boundsCount() ?? 0))
+      .toBe(16);
+  });
+
+  test("moving a note to another string re-pitches it", async ({ page }) => {
+    await openEditor(page, EDITOR_MUSICXML);
+    // Note 0: string 1 (E4), fret 0, MIDI 64. Move it to string 2 (B3) at the
+    // same fret 0 -> B3 = 59.
+    await selectNote(page, 0);
+    await page.locator(".edit-fields label", { hasText: "String" }).locator("select").selectOption("2");
+    await expect(wrap(page)).toHaveAttribute("data-editor-selected-string", "2");
+    await expect(wrap(page)).toHaveAttribute("data-editor-selected-midi", "59");
+    await expect(wrap(page)).toHaveAttribute("data-editor-divergence-ok", "true");
+  });
+
+  test("changing the duration is applied to the document", async ({ page }) => {
+    await openEditor(page, EDITOR_MUSICXML);
+    await selectNote(page, 0);
+    await expect(wrap(page)).toHaveAttribute("data-editor-selected-type", "quarter");
+    await durationSelect(page).selectOption("half");
+    await expect(wrap(page)).toHaveAttribute("data-editor-selected-type", "half");
+    await expect(wrap(page)).toHaveAttribute("data-editor-divergence-ok", "true");
+  });
+
+  test("undo restores the previous value and redo re-applies it", async ({ page }) => {
+    await openEditor(page, EDITOR_MUSICXML);
+    await selectNote(page, 0);
+    await fretInput(page).fill("7");
+    await fretInput(page).blur();
+    await expect(wrap(page)).toHaveAttribute("data-editor-selected-fret", "7");
+    await expect(wrap(page)).toHaveAttribute("data-editor-can-undo", "true");
+
+    await page.getByRole("button", { name: "Undo" }).click();
+    await expect(wrap(page)).toHaveAttribute("data-editor-selected-fret", "0");
+    await expect(wrap(page)).toHaveAttribute("data-editor-selected-midi", "64");
+    await expect(wrap(page)).toHaveAttribute("data-editor-can-redo", "true");
+
+    await page.getByRole("button", { name: "Redo" }).click();
+    await expect(wrap(page)).toHaveAttribute("data-editor-selected-fret", "7");
+    await expect(wrap(page)).toHaveAttribute("data-editor-selected-midi", "71");
+  });
+
+  test("the divergence guard stays green across several edits", async ({ page }) => {
+    await openEditor(page, EDITOR_MUSICXML);
+    await selectNote(page, 3);
+    await fretInput(page).fill("4");
+    await fretInput(page).blur();
+    await expect(wrap(page)).toHaveAttribute("data-editor-divergence-ok", "true");
+    await selectNote(page, 5);
+    await page.locator(".edit-fields label", { hasText: "String" }).locator("select").selectOption("3");
+    await expect(wrap(page)).toHaveAttribute("data-editor-divergence-ok", "true");
+    await durationSelect(page).selectOption("eighth");
+    await expect(wrap(page)).toHaveAttribute("data-editor-divergence-ok", "true");
+  });
+
+  test("a saved edit persists and is there after a reload", async ({ page }) => {
+    const { saved } = await openEditor(page, EDITOR_MUSICXML);
+    await selectNote(page, 0);
+    await fretInput(page).fill("7");
+    await fretInput(page).blur();
+    await expect(wrap(page)).toHaveAttribute("data-editor-selected-fret", "7");
+
+    await page.getByRole("button", { name: "Save", exact: true }).click();
+    await expect(wrap(page)).toHaveAttribute("data-editor-dirty", "false");
+    // The persisted MusicXML carries the new fret on that note - stored
+    // verbatim through the edited-transcription path.
+    await expect.poll(() => saved.content).toContain("<fret>7</fret>");
+
+    // Reload the whole page: the stub now serves the saved (source='edited')
+    // content, so re-opening the editor and selecting the same note shows the
+    // edit still there.
+    await page.reload();
+    await page.waitForSelector(".staff-render");
+    await page.getByRole("button", { name: "Staff", exact: true }).click();
+    await renderedOk(page);
+    await page.getByRole("button", { name: "Edit notes" }).click();
+    await expect(wrap(page)).toHaveAttribute("data-editor-active", "true");
+    await expect.poll(() => page.evaluate(() => window.__scoreEditor?.noteCount() ?? 0)).toBe(8);
+    await selectNote(page, 0);
+    await expect(wrap(page)).toHaveAttribute("data-editor-selected-fret", "7");
+  });
+
+  test("the source PDF page sits alongside the staff for correcting an import", async ({ page }) => {
+    await stubEditorApi(page, EDITOR_MUSICXML);
+    await page.goto("/#/score/1");
+    await page.waitForSelector(".staff-render");
+    await page.getByRole("button", { name: "Side by side", exact: true }).click();
+    // Both panes visible at once: the PDF to check against, the editable staff
+    // to fix - the side-by-side ScoreCompare already provides, which is the
+    // "source page alongside while correcting" this increment reuses.
+    await expect(page.locator(".panes.side")).toBeVisible();
+    await expect(page.locator(".pane.staff-pane")).toBeVisible();
+    await expect(page.locator(".pane").first()).toBeVisible();
+  });
+
+  test("an under-strung note does not crash the render", async ({ page }) => {
+    // A note on a string the staff does not have (issue #165) - the shape a
+    // directly uploaded or hand-edited file can carry, which the editor itself
+    // never writes. Turning on note bounds for the editor must not reintroduce
+    // the paint crash disqualifyUnstrungTabStaves guards against: the staff is
+    // withheld and a plain notice shown, not a stack trace.
+    await stubEditorApi(page, UNSTRUNG_MUSICXML);
+    await page.goto("/#/score/1");
+    await page.waitForSelector(".staff-render");
+    await page.getByRole("button", { name: "Staff", exact: true }).click();
+    await expect(page.locator(".staff-render .notice")).toBeVisible();
+    // The page is alive, not frozen on a thrown render.
+    await expect(page.locator(".staff-render .wrap")).toBeVisible();
+  });
+});

--- a/web/tests/spec-floors/browser-score-editor-10.json
+++ b/web/tests/spec-floors/browser-score-editor-10.json
@@ -1,0 +1,5 @@
+{
+  "file": "tests/browser/score-editor.spec.js",
+  "count": 10,
+  "reason": "issue #10 first increment: the note editor over the MusicXML model - edit mode reachable from the score view with the linked notation staff drawn (16 note bounds, not 8), click-to-select the exact note via the app-side NoteBounds hit test, fret/string/duration edits written to the document and re-rendered with the sounding pitch following, undo/redo, save through the edited-transcription path with the edit surviving a reload, the divergence guard staying green across edits, the source PDF alongside for correcting an import, and an under-strung note not crashing paint."
+}

--- a/web/tests/spec-floors/browser-score-editor-10.json
+++ b/web/tests/spec-floors/browser-score-editor-10.json
@@ -1,5 +1,5 @@
 {
   "file": "tests/browser/score-editor.spec.js",
-  "count": 10,
-  "reason": "issue #10 first increment: the note editor over the MusicXML model - edit mode reachable from the score view with the linked notation staff drawn (16 note bounds, not 8), click-to-select the exact note via the app-side NoteBounds hit test, fret/string/duration edits written to the document and re-rendered with the sounding pitch following, undo/redo, save through the edited-transcription path with the edit surviving a reload, the divergence guard staying green across edits, the source PDF alongside for correcting an import, and an under-strung note not crashing paint."
+  "count": 12,
+  "reason": "issue #10 first increment: the note editor over the MusicXML model - edit mode reachable from the score view with the linked notation staff drawn (16 note bounds, not 8), click-to-select the exact note via the app-side NoteBounds hit test, fret/string/duration edits written to the document and re-rendered with the sounding pitch following, undo/redo, save through the edited-transcription path with the edit surviving a reload (and every saved octave inside 0-9), the divergence guard staying green across edits, a Rule 11 out-of-range fret refused rather than written while the boundary fret is accepted, the source PDF alongside for correcting an import, and an under-strung note not crashing paint."
 }

--- a/web/tests/spec-floors/unit-editor-10.json
+++ b/web/tests/spec-floors/unit-editor-10.json
@@ -1,5 +1,5 @@
 {
   "file": "tests/unit/editor.spec.js",
-  "count": 11,
-  "reason": "issue #10: the note editor's pure arithmetic - pitch<->MIDI round-trip and sharp spelling, the Rule 5 string/staff-tuning mirror, sounding pitch from string+fret with out-of-range strings and negative frets refused, and duration-from-type including a divisions value that cannot express the type."
+  "count": 12,
+  "reason": "issue #10: the note editor's pure arithmetic - pitch<->MIDI round-trip and sharp spelling, the Rule 5 string/staff-tuning mirror, sounding pitch from string+fret with out-of-range strings and negative frets refused, the Rule 11 writable-pitch range (MIDI 12-131 / octaves 0-9), and duration-from-type including a divisions value that cannot express the type."
 }

--- a/web/tests/spec-floors/unit-editor-10.json
+++ b/web/tests/spec-floors/unit-editor-10.json
@@ -1,0 +1,5 @@
+{
+  "file": "tests/unit/editor.spec.js",
+  "count": 11,
+  "reason": "issue #10: the note editor's pure arithmetic - pitch<->MIDI round-trip and sharp spelling, the Rule 5 string/staff-tuning mirror, sounding pitch from string+fret with out-of-range strings and negative frets refused, and duration-from-type including a divisions value that cannot express the type."
+}

--- a/web/tests/unit/editor.spec.js
+++ b/web/tests/unit/editor.spec.js
@@ -1,0 +1,104 @@
+// The note editor's arithmetic, called directly - no DOM, no renderer, no
+// page - the same way tests/unit/pitch.spec.js and metronome.spec.js exercise
+// their modules. editor/notes.js has no imports beyond itself precisely so
+// this can. The document model and the renderer seam are exercised end to end
+// by tests/browser/score-editor.spec.js instead, where a real DOM and a real
+// alphaTab render exist.
+import { expect, test } from "@playwright/test";
+
+import {
+  DURATION_TYPES,
+  durationForType,
+  midiForStringFret,
+  midiOfPitch,
+  pitchFromMidi,
+  stringToTuningLine,
+} from "../../src/lib/editor/notes.js";
+
+// Standard six-string guitar, as Fermata's own emitter writes it: staff-tuning
+// line 1 is the lowest string (E2), line 6 the highest (E4). This is the
+// `line -> midi` map document.js builds from the <staff-tuning> elements.
+const STANDARD = new Map([
+  [1, 40], // E2
+  [2, 45], // A2
+  [3, 50], // D3
+  [4, 55], // G3
+  [5, 59], // B3
+  [6, 64], // E4
+]);
+const STRINGS = 6;
+
+// ---------------------------------------------------------------- pitch <-> midi
+
+test("middle C is MIDI 60 and E4 is 64", () => {
+  expect(midiOfPitch("C", 4)).toBe(60);
+  expect(midiOfPitch("E", 4)).toBe(64);
+  expect(midiOfPitch("A", 2)).toBe(45);
+});
+
+test("an alter shifts the pitch by that many semitones", () => {
+  expect(midiOfPitch("C", 4, 1)).toBe(61);
+  expect(midiOfPitch("D", 4, -1)).toBe(61);
+});
+
+test("pitchFromMidi round-trips every MIDI number back to the same number", () => {
+  for (let m = 21; m <= 108; m++) {
+    const p = pitchFromMidi(m);
+    expect(midiOfPitch(p.step, p.octave, p.alter)).toBe(m);
+  }
+});
+
+test("pitchFromMidi spells a black key as a sharp", () => {
+  expect(pitchFromMidi(61)).toEqual({ step: "C", octave: 4, alter: 1 });
+  expect(pitchFromMidi(66)).toEqual({ step: "F", octave: 4, alter: 1 });
+});
+
+// ---------------------------------------------------------------- the Rule 5 mirror
+
+test("string 1 is the highest staff line and string 6 the lowest", () => {
+  // <string> numbers from the highest-pitched string; <staff-tuning line=>
+  // from the bottom line. On six strings they mirror.
+  expect(stringToTuningLine(6, 1)).toBe(6);
+  expect(stringToTuningLine(6, 6)).toBe(1);
+  expect(stringToTuningLine(6, 3)).toBe(4);
+});
+
+// ---------------------------------------------------------------- fretted pitch
+
+test("an open string sounds its own tuning", () => {
+  expect(midiForStringFret(STANDARD, STRINGS, 1, 0)).toBe(64); // E4
+  expect(midiForStringFret(STANDARD, STRINGS, 6, 0)).toBe(40); // E2
+});
+
+test("a fret raises the open string by that many semitones", () => {
+  expect(midiForStringFret(STANDARD, STRINGS, 6, 3)).toBe(43); // E2 + 3 = G2
+  expect(midiForStringFret(STANDARD, STRINGS, 2, 2)).toBe(61); // B3 + 2 = C#4
+});
+
+test("an out-of-range string or a negative fret has no pitch", () => {
+  expect(midiForStringFret(STANDARD, STRINGS, 7, 0)).toBeNull();
+  expect(midiForStringFret(STANDARD, STRINGS, 0, 0)).toBeNull();
+  expect(midiForStringFret(STANDARD, STRINGS, 1, -1)).toBeNull();
+});
+
+// ---------------------------------------------------------------- durations
+
+test("a quarter is one division-per-quarter's worth of duration", () => {
+  expect(durationForType("quarter", 480)).toBe(480);
+  expect(durationForType("half", 480)).toBe(960);
+  expect(durationForType("whole", 480)).toBe(1920);
+  expect(durationForType("eighth", 480)).toBe(240);
+  expect(durationForType("16th", 480)).toBe(120);
+});
+
+test("a duration that cannot be expressed as a whole number of units is refused", () => {
+  // A 32nd against a divisions of 1 would be a quarter of a unit - not
+  // writable, so kept as it was rather than rounded.
+  expect(durationForType("32nd", 1)).toBeNull();
+  expect(durationForType("quarter", 1)).toBe(1);
+});
+
+test("an unknown type has no duration", () => {
+  expect(durationForType("breve", 480)).toBeNull();
+  expect(DURATION_TYPES).toContain("quarter");
+});

--- a/web/tests/unit/editor.spec.js
+++ b/web/tests/unit/editor.spec.js
@@ -8,7 +8,10 @@ import { expect, test } from "@playwright/test";
 
 import {
   DURATION_TYPES,
+  MAX_WRITABLE_MIDI,
+  MIN_WRITABLE_MIDI,
   durationForType,
+  isWritablePitch,
   midiForStringFret,
   midiOfPitch,
   pitchFromMidi,
@@ -79,6 +82,25 @@ test("an out-of-range string or a negative fret has no pitch", () => {
   expect(midiForStringFret(STANDARD, STRINGS, 7, 0)).toBeNull();
   expect(midiForStringFret(STANDARD, STRINGS, 0, 0)).toBeNull();
   expect(midiForStringFret(STANDARD, STRINGS, 1, -1)).toBeNull();
+});
+
+// ---------------------------------------------------------------- Rule 11 range
+
+test("a pitch is writable only inside MusicXML's octave range (MIDI 12-131)", () => {
+  // <octave> is 0-9, so C0 (12) and B9 (131) are the extremes and octave 10
+  // (132) is unwritable - the value that would make a validating consumer
+  // reject the whole document.
+  expect(MIN_WRITABLE_MIDI).toBe(12);
+  expect(MAX_WRITABLE_MIDI).toBe(131);
+  expect(isWritablePitch(64)).toBe(true);
+  expect(isWritablePitch(12)).toBe(true);
+  expect(isWritablePitch(131)).toBe(true);
+  expect(isWritablePitch(132)).toBe(false);
+  expect(isWritablePitch(11)).toBe(false);
+  // The high E string (E4 = 64): fret 67 reaches B9 (131, the top of the
+  // range) and is still writable; fret 68 would be octave 10 and is not.
+  expect(isWritablePitch(midiForStringFret(STANDARD, STRINGS, 1, 67))).toBe(true);
+  expect(isWritablePitch(midiForStringFret(STANDARD, STRINGS, 1, 68))).toBe(false);
 });
 
 // ---------------------------------------------------------------- durations


### PR DESCRIPTION
First increment of the notation/tab editor from #10. Not a close of #10 — one mergeable slice of it. Rebased onto current `origin/main` (clean; the diff is 10 files all under `web/`, no overlap with the merges that landed).

## The design

The MusicXML document is the source of truth; the alphaTab `Score` is a view of it, exactly as the renderer evaluation on #10 concluded. Every edit is written to the document, and the document is re-imported and redrawn. Nothing is written to the renderer's object graph and left for the document to catch up with — the screen is always a fresh view of the model, so the "two writes, one edited" divergence the evaluation names as this design's one bug class cannot arise.

- `web/src/lib/editor/notes.js` — pure arithmetic (pitch ⟷ MIDI, the Rule 5 string/staff-tuning mirror, the Rule 11 writable-pitch range, duration from type), unit-tested with no DOM.
- `web/src/lib/editor/document.js` — the MusicXML document model: parse, sounding notes in document order, and fret/string/duration mutations that recompute `<pitch>` (Rule 10) and refuse an unwritable one (Rule 11).
- `web/src/lib/score-render.js` — a small edit sub-API behind the existing renderer seam: `core.includeNoteBounds` is now on; an app-side point-in-rectangle hit test over `NoteBounds` (alphaTab's own `getBeatAtPos` was measured resolving the wrong voice on polyphony); the string mirror; `showStandardNotation` for the linked notation staff; and a reload that awaits the redraw.
- `web/src/lib/TabViewer.svelte` — edit mode, selection, the fret/string/duration panel, undo/redo, save, and honest refusal messages. `web/src/lib/ScoreCompare.svelte` — passes `editable` and wires save through the existing edited-transcription path.

## Landed

- Edit mode over an existing transcription, reachable from the score view; the source PDF sits alongside in ScoreCompare's side-by-side, unchanged.
- Click-to-select a note via the app-side `NoteBounds` hit test.
- Edit the selected note's fret, string and duration, written to the document and re-rendered, with the linked notation staff shown so a fret change is seen to move the pitch.
- **Rule 11 range bound:** an edit whose resulting pitch has no valid `<octave>` (outside MIDI 12–131) is refused rather than written — the note is left as it was and the UI says why, so the editor cannot save a document a validating consumer would reject. (Fixed a real gap found in review: the fret had no upper bound, so a large typed fret could emit `<octave>10</octave>`; the divergence guard didn't catch it because both paths agreed on the same out-of-range pitch.)
- Undo / redo.
- Save through `PUT /api/scores/{id}/transcription` (stored verbatim as `source='edited'`, never re-extracted — the guarding server test still holds).
- The divergence guard: the renderer's read of the selected note is cross-checked against the document's read of the same note; it stays green across edits and goes red if the positional map, the string mirror or the pitch recompute is wrong.
- An under-strung note still does not crash paint (#165 guard intact with note bounds on).

## Semantics to confirm

- **String move re-pitches** (it keeps the fret and lets the pitch change), rather than GP-style pitch-preserving refingering (keep the pitch, change the fret). The increment implements the first; the panel's separate fret and string controls make each an independent fact. If pitch-preserving refinger is wanted, it belongs as its own operation.

## Not covered in this increment (non-blocking)

- **Polyphonic selection is untested** — the fixture is monophonic (consistent with the voice-move deferral to #182). The evaluation's overlapping-voices spike item — the ~1.5% of note heads that genuinely overlap — is unverified here; tracked in #189.
- The divergence guard is a **per-selection live cross-check**, not the evaluation's "N-random-edits fuzz" guard. It's adequate for these three operations; the fuzz guard belongs before the operations that reorder or add/remove notes, filed as #189.

## Deferred (follow-ups filed)

- Note entry from nothing / from-scratch — #144 (blank-document).
- Move a note between voices — #182.
- Dotted durations, tuplets, ties — #183.
- Accidentals and key-aware pitch spelling — #185.
- Keyboard core loop (arrows, digit-sets-fret, backspace) — #186.
- Server-side validate-on-save of an edited transcription (belt-and-suspenders to the client bound above) — #188.
- N-random-edits divergence fuzz guard and polyphonic selection — #189.

## Tests (on the rebased tree)

- New: `tests/unit/editor.spec.js` (12), `tests/browser/score-editor.spec.js` (12) — selection, fret→pitch, string, duration, undo/redo, save+reload (with every saved octave in 0–9), the divergence guard, the Rule 11 refusal and its accepted boundary, the source PDF alongside, and an under-strung note not crashing.
- Mutation-checked: breaking the document write, the positional map, the string mirror, or the Rule 11 bound each turns the matching test red.
- Full suites green: **browser 389 passed, server 1045 passed** (64 library-gated skips). #150 note-id and #165 render tests stay green. (The reviewer's stale-base 357 with ~105 ECONNREFUSED was a backend-died-mid-run infra flake, not code.)
