### PR TITLE
Transcribe a library in bulk instead of one score at a time (#55)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -159,6 +159,43 @@ was nothing to move. Restoring it (or any score whose trashed file has since
 been removed by hand) answers `file_restored: false` and puts the score back in
 the library flagged `missing_since`, which is the state it was in before.
 
+## Transcribing many scores at once (issue #55)
+
+`POST /api/transcribe/batch` starts a background pass over many scores and
+`GET /api/transcribe/batch/status` polls it - the same start/poll shape
+`POST /api/scan` and `GET /api/scan/status` use, rather than a client looping
+single `POST /api/scores/{id}/transcribe` calls itself. The planned MCP
+layer (see below) wraps this endpoint for exactly that reason.
+
+**Selection.** Give `score_ids` (an explicit list, honoured exactly - even an
+id that turns out not to be a pdf or to be in the trash gets its own outcome
+rather than vanishing), or `collection` (every live pdf score under one
+folder), or neither (every live pdf score in the whole library). Giving both
+is a `422`.
+
+**Every score gets an outcome - never a silent skip.** `results` on the
+status response carries one line per score: `transcribed`,
+`already_transcribed` (with why - already extracted, or hand-edited and
+therefore protected), `non_extractable` (with the extractor's own reason), or
+`errored` (with its own reason, e.g. a missing file). `reconvert: true` asks
+an already-EXTRACTED score to be re-run; an EDITED transcription is never
+replaced, `reconvert` or not (issue #10's protection, applied in bulk).
+
+**Not a dry run, and not held against a running scan, in either direction.**
+Unlike the library-management endpoints above, this never moves, renames or
+deletes a file - it only reads a score's PDF and writes to the
+`transcriptions` table - so there is nothing here for a scan's directory
+listing to be invalidated by, and no destructive action needing a preview
+first. A scan may start while a batch is running and a batch may start while
+a scan is running; each score's row is read fresh at its own turn rather than
+from a snapshot taken when the batch started.
+
+**No job state persists across a restart.** A killed pass leaves only
+complete, already-committed rows behind - nothing half-written - so
+"resuming" is simply starting a fresh pass over the same selection: the
+scores already done come back `already_transcribed` and the rest are
+attempted for the first time.
+
 ## Getting everything in and out (issue #58)
 
 Two endpoints, one archive format, and one rule that holds for both directions:

--- a/server/fermata/api.py
+++ b/server/fermata/api.py
@@ -24,7 +24,7 @@ from fastapi import (
 from fastapi.responses import FileResponse, Response
 from pydantic import BaseModel, Field, StrictInt
 
-from . import instruments, practice, scanner, trainer
+from . import instruments, practice, scanner, trainer, transcribe_batch
 from . import version as version_info
 from .api_models import (
     ByActivityOut,
@@ -65,6 +65,8 @@ from .api_models import (
     TagOut,
     TrainerAttemptListOut,
     TrainerAttemptOut,
+    TranscribeBatchStatusOut,
+    TranscribeBatchTriggerOut,
     TranscribeResultOut,
     TranscriptionAnalysisOut,
     TranscriptionOut,
@@ -1860,10 +1862,26 @@ def transcribe(score_id: RowId, body: TranscribeIn | None = Body(default=None)):
     result = extract_pdf(path, time_signature=ts)
     if not result.extractable:
         raise HTTPException(422, result.reason or "pdf is not extractable")
+    return _store_extraction_result(score_id, result)
 
-    # Only ever writes the source='extracted' row (see unique index on
-    # (score_id, source) in db.py) - a source='edited' row is untouched.
-    #
+
+def _store_extraction_result(score_id: int, result) -> dict:
+    """Write an EXTRACTABLE ExtractionResult as this score's extracted
+    transcription and return the same dict transcribe() has always handed
+    back - the confidence blob, read back from the row just written, plus
+    bars/beats/notes/tempo from `result` itself (see the closing comment
+    below for why those four are not re-read from the row).
+
+    THE ONE PLACE THIS IS BUILT. transcribe_batch's bulk pass calls this too
+    (through api._batch_process_one), rather than each caller building its
+    own confidence dict - two copies of the ~50-field mapping below are two
+    chances for a bulk-transcribed row to end up missing a figure a
+    single-transcribed one has, which is exactly the class of bug #137,
+    #143 and #146 each shipped once over this same dict.
+
+    Only ever writes the source='extracted' row (see unique index on
+    (score_id, source) in db.py) - a source='edited' row is untouched.
+    """
     # MusicXML REPLACES alphaTex as the stored format rather than sitting
     # beside it: the unique index is (score_id, source) with no format in it,
     # so two extracted rows in different formats could not coexist anyway, and
@@ -2072,6 +2090,181 @@ def delete_transcription(score_id: RowId):
     if not row:
         raise HTTPException(404, "no transcription for this score")
     return _transcription_dict(row)
+
+
+# ---------------------------------------------------------------------------
+# Bulk transcription (issue #55): many scores in one background pass, rather
+# than a client looping single POST /transcribe calls itself - the planned
+# MCP layer wraps THIS, not a loop (#32). Follows the library scan's own
+# pattern (start it, poll a status endpoint) rather than adding a queue -
+# see transcribe_batch.py for the state machine and the reasoning behind
+# every choice below; this section is only what needs api.py's own helpers.
+# ---------------------------------------------------------------------------
+
+
+def _batch_process_one(score_id: int, reconvert: bool) -> dict:
+    """One score's outcome for POST /transcribe/batch. Never raises for an
+    ordinary refusal - not found, deleted, not a pdf, already transcribed,
+    file missing, not extractable - because a silent skip is exactly what
+    issue #55 asks not to have; every one of those comes back as a dict
+    naming the outcome instead. transcribe_batch.start_batch/_run_batch call
+    this back (see transcribe_batch.py's own comment for why the dependency
+    runs this direction and not the other), and still catch anything this
+    raises regardless, so a genuine bug in one score cannot cost every score
+    after it its result.
+
+    Reads the score's row FRESH, not from a list snapshotted when the batch
+    started - a scan running at the same time (deliberately not held against
+    this, see start_batch's docstring) may mark a score missing or relink it
+    between the batch starting and this score's own turn, and this is what
+    makes that read as of NOW rather than raced against.
+    """
+    conn = connect()
+    row = conn.execute("SELECT * FROM scores WHERE id = ?", (score_id,)).fetchone()
+    if not row:
+        return {
+            "score_id": score_id, "title": None, "outcome": "errored",
+            "reason": "score not found", "bars_defective": None, "bars_measured": None,
+        }
+    title = row["title"]
+    if row["deleted_at"] is not None:
+        return {
+            "score_id": score_id, "title": title, "outcome": "errored",
+            "reason": f"{title} is in the trash, so bulk transcription skipped it",
+            "bars_defective": None, "bars_measured": None,
+        }
+    if row["file_type"] != "pdf":
+        return {
+            "score_id": score_id, "title": title, "outcome": "errored",
+            "reason": "transcription is only supported for pdf scores",
+            "bars_defective": None, "bars_measured": None,
+        }
+
+    # Never overwrites an edited transcription, `reconvert` or not (#10) -
+    # checked before anything else about "already transcribed" so that
+    # protection reads as its own, unconditional rule rather than a special
+    # case of the reconvert branch below.
+    sources = {
+        r["source"]
+        for r in conn.execute(
+            "SELECT source FROM transcriptions WHERE score_id = ?", (score_id,)
+        )
+    }
+    if "edited" in sources:
+        return {
+            "score_id": score_id, "title": title, "outcome": "already_transcribed",
+            "reason": "has a hand-edited transcription, which bulk transcription never "
+                      "overwrites",
+            "bars_defective": None, "bars_measured": None,
+        }
+    if "extracted" in sources and not reconvert:
+        return {
+            "score_id": score_id, "title": title, "outcome": "already_transcribed",
+            "reason": "already has an extracted transcription - pass reconvert to redo it",
+            "bars_defective": None, "bars_measured": None,
+        }
+
+    path = LIBRARY_DIR / row["path"]
+    if not path.is_file():
+        return {
+            "score_id": score_id, "title": title, "outcome": "errored",
+            "reason": "file missing from library", "bars_defective": None, "bars_measured": None,
+        }
+
+    result = extract_pdf(path)
+    if not result.extractable:
+        return {
+            "score_id": score_id, "title": title, "outcome": "non_extractable",
+            "reason": result.reason or "pdf is not extractable",
+            "bars_defective": None, "bars_measured": None,
+        }
+
+    stored = _store_extraction_result(score_id, result)
+    return {
+        "score_id": score_id, "title": title, "outcome": "transcribed", "reason": None,
+        "bars_defective": stored.get("bars_defective"), "bars_measured": stored.get("bars_measured"),
+    }
+
+
+class TranscribeBatchIn(BaseModel):
+    """What to bulk-transcribe (issue #55).
+
+    Give EITHER `score_ids` (a person selecting particular scores) OR
+    `collection` (a person pointing at a folder) - not both, since a caller
+    that meant one and typed the other deserves to be told rather than have
+    one silently win. Omitting both selects every eligible score in the
+    whole library.
+
+    `score_ids`, when given, is honoured EXACTLY - every id in it gets an
+    outcome, including one that turns out not to be a pdf or to already be
+    deleted, because a person who explicitly chose a score is exactly the
+    caller a silent omission would mislead. Omitted, the selection is built
+    from the library itself and is already narrowed to live pdf scores -
+    nothing here filters a folder's non-pdf or deleted scores in loudly,
+    because nobody named them.
+    """
+
+    score_ids: list[Count] | None = Field(default=None, min_length=1, max_length=500)
+    collection: str | None = None
+    # False by default: an extracted row already on a score is real work an
+    # earlier pass did, and the extractor keeps improving - see transcribe()'s
+    # own note on why a re-run replaces the extracted row and never the
+    # edited one. reconvert=True asks for exactly that replacement, in bulk.
+    # An EDITED row is never replaced regardless of this flag - see
+    # _batch_process_one.
+    reconvert: bool = False
+
+
+@router.post(
+    "/transcribe/batch", tags=[TAG_TRANSCRIPTION], response_model=TranscribeBatchTriggerOut
+)
+def start_transcribe_batch(body: TranscribeBatchIn):
+    """Start transcribing many scores in one background pass and return the
+    status left behind by whichever pass (this one, or one already running)
+    is now current - poll GET /transcribe/batch/status for progress, the
+    same pattern POST /scan uses (issue #55).
+
+    Selects every live pdf score named by `score_ids`, or every live pdf
+    score under `collection`, or every live pdf score in the whole library
+    if neither is given - see TranscribeBatchIn. Reports what happened to
+    EVERY one of them: transcribed, already had a transcription (and why
+    that was not replaced - an edited one never is), not extractable (with
+    the extractor's own reason), or errored (with its own reason) - never a
+    silent skip.
+
+    Refuses (`started: false`, nothing changed) only if a batch is already
+    running. A library scan running at the same time is not held against
+    this in either direction - see transcribe_batch.start_batch's docstring
+    for why the two may run together safely.
+    """
+    if body.score_ids and body.collection is not None:
+        raise HTTPException(422, "give score_ids or collection, not both")
+    conn = connect()
+    if body.score_ids:
+        # De-duplicated, order preserved, and NOT filtered to live pdf scores
+        # here - every id given gets its own outcome, including "not a pdf"
+        # or "in the trash", from _batch_process_one. See TranscribeBatchIn.
+        score_ids = list(dict.fromkeys(body.score_ids))
+    else:
+        where, params = ["deleted_at IS NULL", "file_type = 'pdf'"], []
+        if body.collection is not None:
+            where.append("collection = ?")
+            params.append(body.collection)
+        rows = conn.execute(
+            f"SELECT id FROM scores WHERE {' AND '.join(where)} ORDER BY id", params
+        ).fetchall()
+        score_ids = [r["id"] for r in rows]
+    started = transcribe_batch.start_batch(_batch_process_one, score_ids, body.reconvert)
+    return {"started": started, **transcribe_batch.batch_status()}
+
+
+@router.get(
+    "/transcribe/batch/status", tags=[TAG_TRANSCRIPTION], response_model=TranscribeBatchStatusOut
+)
+def get_transcribe_batch_status():
+    """Where the most recent (or currently running) bulk transcription pass
+    stands - see transcribe_batch.batch_status()."""
+    return transcribe_batch.batch_status()
 
 
 @router.post("/scan", tags=[TAG_SCAN], response_model=ScanTriggerOut)

--- a/server/fermata/api_models.py
+++ b/server/fermata/api_models.py
@@ -718,6 +718,55 @@ class TranscribeResultOut(TranscriptionOut):
     tempo: int | None
 
 
+class TranscribeBatchResultLineOut(BaseModel):
+    """One score's outcome from a bulk transcription pass - see
+    api._batch_process_one for what earns each `outcome`. `reason` is set
+    for every outcome except "transcribed"; never a silent skip is the
+    whole point of this shape (issue #55). `bars_defective` /
+    `bars_measured` are only ever set for "transcribed" - see
+    api._store_extraction_result's own comment on why a bar count cannot be
+    inherited from anything but a measurement of the content that produced
+    it."""
+
+    score_id: int
+    # None only when the id named no score at all - every other outcome has
+    # the title of a real row, even a deleted or non-pdf one, because "which
+    # score" is the first thing a person reading this list needs.
+    title: str | None
+    outcome: str
+    reason: str | None
+    bars_defective: int | None
+    bars_measured: int | None
+
+
+class TranscribeBatchStatusOut(BaseModel):
+    """transcribe_batch.batch_status()'s shape - see transcribe_batch._state
+    for what each running total means, and TranscribeBatchResultLineOut for
+    one line of `results`."""
+
+    running: bool
+    total: int
+    processed: int
+    transcribed: int
+    already_transcribed: int
+    non_extractable: int
+    errored: int
+    with_defective_bars: int
+    reconvert: bool
+    results: list[TranscribeBatchResultLineOut]
+    started_at: float | None
+    finished_at: float | None
+
+
+class TranscribeBatchTriggerOut(TranscribeBatchStatusOut):
+    """POST /api/transcribe/batch: whether this call actually started a
+    pass, plus the status left behind by whichever pass (this one, or one
+    already running) is current - mirrors ScanTriggerOut for the same
+    reason POST /transcribe/batch mirrors POST /scan."""
+
+    started: bool
+
+
 # ---------------------------------------------------------------------------
 # Scan / upload
 # ---------------------------------------------------------------------------

--- a/server/fermata/transcribe_batch.py
+++ b/server/fermata/transcribe_batch.py
@@ -1,0 +1,188 @@
+import logging
+import threading
+import time
+
+# Transcribing a whole library one score at a time is exactly the thing
+# issue #55 exists to remove - a freshly scanned 300-score library has zero
+# transcriptions until someone clicks through all of it. This module owns
+# the ONE thing a bulk pass needs beyond what api.transcribe() already does:
+# running many scores in the background, with progress a client can poll and
+# an honest outcome recorded for every one of them.
+#
+# THE SAME SHAPE AS scanner.py's SCAN, DELIBERATELY - a module-level state
+# dict behind a lock, a synchronous pass most tests call directly, and a
+# threaded wrapper an HTTP request actually uses (see scanner._scan /
+# scanner.start_scan and test_scanner.py's own comment on why most of that
+# suite calls scanner._scan() directly). The issue itself asks for exactly
+# this: "run as a background job with progress and a running count, following
+# the pattern the library scan already uses rather than adding a queue."
+#
+# RESUMABLE BY CONSTRUCTION RATHER THAN BY DESIGN EFFORT. There is no
+# persisted job state to resume FROM - `_state` lives in memory only, so a
+# killed process forgets a pass was ever running the moment it dies, exactly
+# like `scanner._state`. What makes that safe rather than lossy is that
+# every score's own write is a complete, committed unit (api._store_
+# extraction_result's single INSERT ... ON CONFLICT, same as transcribe()'s
+# own) - so a kill between two scores leaves the ones already written fully
+# transcribed and the rest simply unprocessed, never a half-written row.
+# Starting a fresh pass over the same selection afterwards is then just
+# ordinary bulk transcription: the already-written scores come back
+# "already_transcribed" (see api._batch_process_one) and the rest are
+# attempted for the first time. No separate "resume" concept exists because
+# none is needed - the whole point of persisting nothing is that starting
+# over IS resuming.
+#
+# WHAT THIS MODULE DOES NOT KNOW, ON PURPOSE. It has no idea what a score is,
+# what extract() does, or what "already transcribed" means - `process_one`,
+# passed in by the caller, decides all of that per score and hands back a
+# plain dict naming the outcome. That is api._batch_process_one today, and
+# the dependency runs THIS DIRECTION - api.py imports this module, not the
+# other way - because the alternative (this module importing api.py to reach
+# _store_extraction_result) would be a circular import: api.py has to import
+# this module already, to register the two routes that drive it.
+log = logging.getLogger("fermata.transcribe_batch")
+
+# The outcome categories a per-score result may report. Never a silent skip:
+# every score handed to a batch pass ends up in exactly one of these, with a
+# reason attached to every one but "transcribed" - see api._batch_process_one
+# for what earns each one. Named to double as the state dict's own running
+# totals below, so recording a result is "increment the key already named by
+# its own outcome" rather than a second mapping that could drift from this
+# list.
+OUTCOMES = ("transcribed", "already_transcribed", "non_extractable", "errored")
+
+_state = {
+    "running": False,
+    "total": 0,
+    "processed": 0,
+    "transcribed": 0,
+    "already_transcribed": 0,
+    "non_extractable": 0,
+    "errored": 0,
+    # How many of the "transcribed" outcomes came back with at least one bar
+    # that does not add up (bars_defective > 0) - the issue's own ask: "how
+    # many came out with bars that do not add up, so the state of the
+    # library is visible without opening scores one by one." An aggregate
+    # count beside `results` rather than something a caller has to derive by
+    # scanning every line itself.
+    "with_defective_bars": 0,
+    # Whether the run under way (or the last one) was asked to replace an
+    # existing EXTRACTED transcription rather than skip it - carried here so
+    # a client reading only /status still knows what the counts above mean.
+    # Never affects an EDITED row - see api._batch_process_one.
+    "reconvert": False,
+    # One line per score processed so far, in the order they were processed
+    # - see api's TranscribeBatchResultLineOut for the shape of each line.
+    # Not capped: this is the one place "which scores, and why" lives, and
+    # the issue asks for that to be visible without opening scores one by
+    # one.
+    "results": [],
+    "started_at": None,
+    "finished_at": None,
+}
+_state_lock = threading.Lock()
+
+
+def batch_status() -> dict:
+    """A snapshot of the current (or most recent) pass. `results` is copied
+    out under the lock so a caller iterating it cannot race a pass still
+    appending to the live list."""
+    with _state_lock:
+        return dict(_state, results=list(_state["results"]))
+
+
+def _run_batch(process_one, score_ids: list, reconvert: bool) -> None:
+    """One synchronous pass over `score_ids`, in order - `process_one(score_id,
+    reconvert)` decides each one's outcome. Most tests call this directly,
+    the same way test_scanner.py calls scanner._scan() directly, for
+    determinism; start_batch (below) is the threaded wrapper an HTTP request
+    actually uses.
+
+    Resets the running totals and `results` but NOT `running` itself - the
+    caller (start_batch, or a test standing in for it) owns that flag, the
+    same split scanner._scan/start_scan makes for `scanning`.
+
+    process_one MUST NOT raise for an ordinary per-score refusal - a missing
+    file, a non-extractable pdf, an already-transcribed score - because that
+    is precisely the information a silent skip would lose; it returns a dict
+    naming the outcome instead (see api._batch_process_one). An exception
+    that reaches here regardless is still not allowed to end the pass early:
+    it is caught, recorded as `errored` with the exception's own text as the
+    reason, and logged, so one score's bug does not cost every score after it
+    its result.
+    """
+    with _state_lock:
+        _state.update(
+            total=len(score_ids),
+            processed=0,
+            transcribed=0,
+            already_transcribed=0,
+            non_extractable=0,
+            errored=0,
+            with_defective_bars=0,
+            reconvert=reconvert,
+            results=[],
+        )
+    for score_id in score_ids:
+        try:
+            outcome = process_one(score_id, reconvert)
+            if outcome.get("outcome") not in OUTCOMES:
+                raise ValueError(f"process_one returned an unrecognised outcome: {outcome!r}")
+        except Exception as exc:
+            outcome = {
+                "score_id": score_id,
+                "title": None,
+                "outcome": "errored",
+                "reason": str(exc),
+                "bars_defective": None,
+                "bars_measured": None,
+            }
+            log.error("bulk transcription of score %s failed: %s", score_id, exc)
+        with _state_lock:
+            _state["results"].append(outcome)
+            _state["processed"] += 1
+            _state[outcome["outcome"]] += 1
+            if outcome["outcome"] == "transcribed" and (outcome.get("bars_defective") or 0) > 0:
+                _state["with_defective_bars"] += 1
+
+
+def start_batch(process_one, score_ids: list, reconvert: bool = False) -> bool:
+    """Begin a bulk transcription pass in the background over `score_ids`.
+
+    Refuses (returns False, changes nothing) if a pass is already running -
+    the same rule scanner.start_scan applies to a second scan, and for the
+    same reason: the caller is an HTTP request with a person behind it, and
+    "a batch is already running, try again in a moment" is a better answer
+    than a second pass racing the first one's writes to the same rows.
+
+    DELIBERATELY NOT HELD AGAINST A RUNNING SCAN, in either direction - a
+    scan may start while a batch is running and a batch may start while a
+    scan is running. Argued in full where the two actually meet:
+    api._batch_process_one reads a score's current row (not a snapshot taken
+    when the batch started) before touching its file, so a scan marking a
+    score missing or relinking it mid-batch is read as of THAT score's own
+    turn rather than raced against. See scanner.hold_library_still's own
+    comment for the reasoning this mirrors: transcribing a score only ever
+    reads its file and writes to the transcriptions table, never moves or
+    removes anything a scan's directory listing depends on - the same
+    reasoning that keeps upload() from being held against a scan either.
+    """
+    with _state_lock:
+        if _state["running"]:
+            return False
+        _state["running"] = True
+        _state["started_at"] = time.time()
+        _state["finished_at"] = None
+
+    def run():
+        try:
+            _run_batch(process_one, score_ids, reconvert)
+        except Exception as exc:  # pragma: no cover - _run_batch itself does not raise
+            log.error("bulk transcription pass crashed: %s", exc)
+        finally:
+            with _state_lock:
+                _state["running"] = False
+                _state["finished_at"] = time.time()
+
+    threading.Thread(target=run, name="fermata-transcribe-batch", daemon=True).start()
+    return True

--- a/server/tests/test_api_docs.py
+++ b/server/tests/test_api_docs.py
@@ -299,8 +299,9 @@ def test_every_route_has_exactly_the_expected_operation_count(openapi_schema):
     # restore from it, and destroy from it. Plus issue #57's one: how one
     # piece is going. Plus issue #16's one: GET /api/me. Plus issue #58's two:
     # export the library to an archive, import one back. Plus issue #27's
-    # two: log a fretboard drill attempt, and list them.
-    assert count == 56
+    # two: log a fretboard drill attempt, and list them. Plus issue #55's
+    # two: start a bulk transcription pass, poll its status.
+    assert count == 58
 
 
 def test_binary_routes_do_not_advertise_a_json_content_type(openapi_schema):
@@ -627,6 +628,39 @@ def test_trainer_responses_match_their_models(client):
     api_models.TrainerAttemptListOut.model_validate(
         client.get("/api/trainer/attempts").json()
     )
+
+
+def test_transcribe_batch_responses_match_their_models(
+    client, insert_score, extractable_pdf, monkeypatch
+):
+    """POST /transcribe/batch and GET /transcribe/batch/status (issue #55).
+    Routed through `client`, so this also exercises claim 5's drift guard -
+    a field _batch_process_one/_run_batch computes but
+    TranscribeBatchStatusOut/TranscribeBatchResultLineOut do not declare
+    would fail here by name rather than silently reaching the wire
+    narrower than what was actually returned."""
+    monkeypatch.setattr(api, "LIBRARY_DIR", extractable_pdf.parent)
+    from fermata import db
+
+    conn = db.connect()
+    score_id = insert_score(conn, extractable_pdf.name)
+    conn.commit()
+
+    triggered = client.post("/api/transcribe/batch", json={"score_ids": [score_id]})
+    api_models.TranscribeBatchTriggerOut.model_validate(triggered.json())
+
+    import time as _time
+
+    deadline = _time.monotonic() + 10
+    while True:
+        status = client.get("/api/transcribe/batch/status")
+        api_models.TranscribeBatchStatusOut.model_validate(status.json())
+        if not status.json()["running"]:
+            break
+        if _time.monotonic() > deadline:
+            raise AssertionError("the bulk transcription pass did not finish")
+        _time.sleep(0.02)
+    assert status.json()["results"][0]["outcome"] == "transcribed"
 
 
 def test_scan_and_upload_responses_match_their_models(client, monkeypatch):

--- a/server/tests/test_transcribe_batch_api.py
+++ b/server/tests/test_transcribe_batch_api.py
@@ -1,0 +1,501 @@
+"""Bulk transcription (issue #55): many scores transcribed in one background
+pass, with an honest per-score outcome for every one of them.
+
+WHAT THIS FILE PROVES, beyond what test_transcription_api.py already proves
+about a single POST /transcribe:
+
+  1. a mixed batch - transcribable, already transcribed, hand-edited,
+     non-extractable, file missing - reports the CORRECT outcome for EVERY
+     one of them, by literal assertion, never a silent skip;
+  2. an edited transcription is never clobbered by a bulk pass, `reconvert`
+     or not - checked literally before and after, through the API, the same
+     #146 lesson test_transcription_api.py's structural guard exists for;
+  3. `reconvert` replaces an EXTRACTED row and leaves an edited one alone;
+  4. an explicit score_ids selection is honoured exactly - a non-pdf or
+     deleted id still gets its own outcome rather than vanishing from the
+     results;
+  5. the scan-interaction matrix: a scan running while a bulk pass is under
+     way, and a bulk pass running while a scan is under way, neither one
+     refusing the other and neither corrupting the other's work - see
+     transcribe_batch.start_batch's own docstring for why the two are not
+     held against one another, mirroring scanner.hold_library_still's
+     reasoning for why upload() is not held against a scan either;
+  6. a second batch refuses while one is already running, the same rule
+     scanner.start_scan applies to a second scan.
+"""
+import threading
+import time
+
+import pytest
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
+
+from fermata import api, db, scanner, thumbs, transcribe_batch
+
+
+@pytest.fixture(autouse=True)
+def _reset_batch_state():
+    """transcribe_batch._state is module-level, like scanner._state - reset
+    around every test in this file so one test's run cannot leak into the
+    next one's assertions."""
+    transcribe_batch._state.update(
+        running=False, total=0, processed=0, transcribed=0, already_transcribed=0,
+        non_extractable=0, errored=0, with_defective_bars=0, reconvert=False,
+        results=[], started_at=None, finished_at=None,
+    )
+    yield
+    transcribe_batch._state.update(running=False)
+
+
+@pytest.fixture
+def library(app_env, tmp_path, monkeypatch):
+    """A throwaway library the scanner will actually walk, for the tests
+    below that need a REAL scan to run - same fixture as test_scanner.py's,
+    duplicated rather than imported across test modules (see that file's
+    own comment on why scanner and api hold their own module-level bindings
+    of LIBRARY_DIR)."""
+    root = tmp_path / "library"
+    monkeypatch.setattr(scanner, "LIBRARY_DIR", root)
+    monkeypatch.setattr(api, "LIBRARY_DIR", root)
+    monkeypatch.setattr(thumbs, "CACHE_DIR", tmp_path / "config" / "cache")
+    return root
+
+
+@pytest.fixture
+def client(library):
+    app = FastAPI()
+    app.include_router(api.router)
+    return TestClient(app)
+
+
+def _wait_for_batch(timeout: float = 10.0) -> None:
+    deadline = time.monotonic() + timeout
+    while transcribe_batch.batch_status()["running"]:
+        if time.monotonic() > deadline:
+            raise AssertionError("the bulk transcription pass did not finish")
+        time.sleep(0.02)
+
+
+def _wait_for_scan(timeout: float = 10.0) -> None:
+    deadline = time.monotonic() + timeout
+    while scanner.scan_status()["scanning"]:
+        if time.monotonic() > deadline:
+            raise AssertionError("the scan did not finish")
+        time.sleep(0.02)
+
+
+def _outcomes_by_title(status: dict) -> dict:
+    return {line["title"]: line for line in status["results"]}
+
+
+# ---------------------------------------------------------------------------
+# 1. Honest per-score outcomes over a mixed batch.
+# ---------------------------------------------------------------------------
+
+
+def test_a_mixed_batch_reports_the_correct_outcome_for_every_score(
+    app_env, extractable_pdf, non_extractable_pdf, monkeypatch, insert_score, tmp_path
+):
+    # A score's `path` is UNIQUE, so exercising several scores that share one
+    # fixture's content needs several distinct files on disk - copied into
+    # their own scratch library rather than pointed at the read-only fixtures
+    # directory, which the "missing" case below must also be free to NOT
+    # create a file in.
+    lib = tmp_path / "mixed_library"
+    lib.mkdir()
+    monkeypatch.setattr(api, "LIBRARY_DIR", lib)
+    conn = db.connect()
+
+    def _copy(src, name):
+        dest = lib / name
+        dest.write_bytes(src.read_bytes())
+        return name
+
+    fresh_id = insert_score(conn, _copy(extractable_pdf, "fresh.pdf"), "Fresh")
+    already_id = insert_score(conn, _copy(extractable_pdf, "already.pdf"), "Already transcribed")
+    api.transcribe(already_id, body=None)  # give it an extracted row up front
+    edited_id = insert_score(conn, _copy(extractable_pdf, "edited.pdf"), "Hand edited")
+    api.transcribe(edited_id, body=None)
+    api.save_transcription(
+        edited_id, api.TranscriptionEditIn(content='\\title "hand edited"\n.\n:4 0.1 |')
+    )
+    bad_id = insert_score(conn, _copy(non_extractable_pdf, "bad.pdf"), "Not extractable")
+    missing_id = insert_score(conn, "nowhere.pdf", "File missing")
+
+    transcribe_batch._run_batch(
+        api._batch_process_one, [fresh_id, already_id, edited_id, bad_id, missing_id], False
+    )
+    status = transcribe_batch.batch_status()
+
+    assert status["total"] == 5
+    assert status["processed"] == 5
+    assert status["transcribed"] == 1
+    assert status["already_transcribed"] == 2
+    assert status["non_extractable"] == 1
+    assert status["errored"] == 1
+
+    by_title = _outcomes_by_title(status)
+    assert by_title["Fresh"]["outcome"] == "transcribed"
+    assert by_title["Fresh"]["reason"] is None
+    assert by_title["Fresh"]["bars_measured"] > 0
+
+    assert by_title["Already transcribed"]["outcome"] == "already_transcribed"
+    assert "reconvert" in by_title["Already transcribed"]["reason"]
+
+    assert by_title["Hand edited"]["outcome"] == "already_transcribed"
+    assert "never overwrites" in by_title["Hand edited"]["reason"]
+
+    assert by_title["Not extractable"]["outcome"] == "non_extractable"
+    assert by_title["Not extractable"]["reason"]  # the extractor's own reason, non-empty
+
+    assert by_title["File missing"]["outcome"] == "errored"
+    assert by_title["File missing"]["reason"] == "file missing from library"
+
+    # Nobody was skipped without a place in the results - the whole point.
+    assert {line["score_id"] for line in status["results"]} == {
+        fresh_id, already_id, edited_id, bad_id, missing_id
+    }
+
+    # The score actually transcribed really did get a stored row; the ones
+    # that were reported as skipped or failed did not gain one.
+    assert api.get_transcription(fresh_id)["source"] == "extracted"
+    with pytest.raises(HTTPException) as exc_info:
+        api.get_transcription(missing_id)
+    assert exc_info.value.status_code == 404
+
+
+def test_an_unrecognised_score_id_gets_its_own_errored_outcome(app_env):
+    transcribe_batch._run_batch(api._batch_process_one, [999999], False)
+    status = transcribe_batch.batch_status()
+    assert status["results"] == [
+        {
+            "score_id": 999999, "title": None, "outcome": "errored",
+            "reason": "score not found", "bars_defective": None, "bars_measured": None,
+        }
+    ]
+
+
+def test_a_killed_job_leaves_finished_work_intact_and_a_fresh_pass_resumes(
+    app_env, extractable_pdf, monkeypatch, insert_score, tmp_path
+):
+    """No job state is persisted anywhere (see transcribe_batch.py's own
+    comment on why) - so "resuming" a killed pass is just running a fresh
+    one over the same selection. This proves that is actually safe: the
+    scores a first, interrupted-in-spirit pass already wrote stay written,
+    exactly as they were, and a second pass over the same ids only touches
+    the ones still outstanding."""
+    lib = tmp_path / "resume_library"
+    lib.mkdir()
+    monkeypatch.setattr(api, "LIBRARY_DIR", lib)
+    conn = db.connect()
+
+    def _copy(name):
+        dest = lib / name
+        dest.write_bytes(extractable_pdf.read_bytes())
+        return name
+
+    ids = [insert_score(conn, _copy(f"score{i}.pdf"), f"Score {i}") for i in range(4)]
+
+    # The "kill" - a pass that only ever reaches the first two ids, standing
+    # in for a process that died after committing those two scores' rows and
+    # before touching the rest. Each committed row is a complete unit (see
+    # api._store_extraction_result), so nothing about score0/score1 is
+    # half-written by this.
+    transcribe_batch._run_batch(api._batch_process_one, ids[:2], False)
+    first_pass = transcribe_batch.batch_status()
+    assert first_pass["transcribed"] == 2
+    first_updated_at = {
+        score_id: api.get_transcription(score_id)["updated_at"] for score_id in ids[:2]
+    }
+
+    # The "restart" - a fresh pass over the FULL original selection, the same
+    # request a client would naturally retry with. The two already-written
+    # scores are recognised as already done and left untouched; only the
+    # previously-unreached two are actually transcribed now.
+    transcribe_batch._run_batch(api._batch_process_one, ids, False)
+    resumed = transcribe_batch.batch_status()
+    assert resumed["total"] == 4
+    by_id = {line["score_id"]: line for line in resumed["results"]}
+    assert by_id[ids[0]]["outcome"] == "already_transcribed"
+    assert by_id[ids[1]]["outcome"] == "already_transcribed"
+    assert by_id[ids[2]]["outcome"] == "transcribed"
+    assert by_id[ids[3]]["outcome"] == "transcribed"
+
+    # The rows the "killed" pass wrote were not touched a second time - same
+    # updated_at, not re-written and not corrupted.
+    for score_id in ids[:2]:
+        assert api.get_transcription(score_id)["updated_at"] == first_updated_at[score_id]
+    for score_id in ids[2:]:
+        assert api.get_transcription(score_id)["source"] == "extracted"
+
+
+# ---------------------------------------------------------------------------
+# 2 & 3. Edited transcriptions are never clobbered; reconvert only replaces
+#         the extracted row.
+# ---------------------------------------------------------------------------
+
+
+def test_edited_transcription_survives_a_bulk_run_through_the_api(
+    app_env, extractable_pdf, monkeypatch, insert_score
+):
+    """The #146 lesson, applied to the bulk path: literal before/after
+    through the API, not just a state assertion inside the process."""
+    monkeypatch.setattr(api, "LIBRARY_DIR", extractable_pdf.parent)
+    conn = db.connect()
+    score_id = insert_score(conn, extractable_pdf.name)
+
+    api.transcribe(score_id, body=None)
+    edited_content = '\\title "hand edited"\n.\n:4 0.1 |'
+    api.save_transcription(score_id, api.TranscriptionEditIn(content=edited_content))
+
+    before = api.get_transcription(score_id)
+    assert before["source"] == "edited"
+    assert before["content"] == edited_content
+
+    # Even with reconvert=True - the flag that DOES replace an extracted row
+    # below - an edited one is untouched.
+    transcribe_batch._run_batch(api._batch_process_one, [score_id], True)
+    status = transcribe_batch.batch_status()
+    assert status["results"][0]["outcome"] == "already_transcribed"
+    assert "never overwrites" in status["results"][0]["reason"]
+
+    after = api.get_transcription(score_id)
+    assert after["source"] == "edited"
+    assert after["content"] == edited_content
+
+    rows = conn.execute(
+        "SELECT source, content FROM transcriptions WHERE score_id = ? ORDER BY source",
+        (score_id,),
+    ).fetchall()
+    assert {r["source"] for r in rows} == {"edited", "extracted"}
+    edited_row = next(r for r in rows if r["source"] == "edited")
+    assert edited_row["content"] == edited_content
+
+
+def test_reconvert_replaces_the_extracted_row_but_not_edited(
+    app_env, extractable_pdf, monkeypatch, insert_score
+):
+    monkeypatch.setattr(api, "LIBRARY_DIR", extractable_pdf.parent)
+    conn = db.connect()
+    plain_id = insert_score(conn, extractable_pdf.name, "Plain")
+    api.transcribe(plain_id, body=None)
+    first_updated_at = api.get_transcription(plain_id)["updated_at"]
+
+    # Without reconvert, a second pass leaves it alone and says why.
+    transcribe_batch._run_batch(api._batch_process_one, [plain_id], False)
+    assert transcribe_batch.batch_status()["results"][0]["outcome"] == "already_transcribed"
+    assert api.get_transcription(plain_id)["updated_at"] == first_updated_at
+
+    # With reconvert, the extracted row is re-written.
+    transcribe_batch._run_batch(api._batch_process_one, [plain_id], True)
+    status = transcribe_batch.batch_status()
+    assert status["results"][0]["outcome"] == "transcribed"
+    assert status["reconvert"] is True
+    assert api.get_transcription(plain_id)["source"] == "extracted"
+
+
+# ---------------------------------------------------------------------------
+# 4. Explicit score_ids are honoured exactly - never silently filtered.
+# ---------------------------------------------------------------------------
+
+
+def test_explicit_score_ids_report_a_non_pdf_and_a_deleted_score_honestly(
+    app_env, extractable_pdf, monkeypatch, insert_score
+):
+    monkeypatch.setattr(api, "LIBRARY_DIR", extractable_pdf.parent)
+    conn = db.connect()
+    cur = conn.execute(
+        """INSERT INTO scores(title, path, file_type, hash, size, mtime)
+           VALUES ('Sheet music XML', 'x.musicxml', 'musicxml', 'h', 1, 0.0)"""
+    )
+    conn.commit()
+    musicxml_id = cur.lastrowid
+
+    deleted_id = insert_score(conn, extractable_pdf.name, "Deleted score")
+    conn.execute("UPDATE scores SET deleted_at = datetime('now') WHERE id = ?", (deleted_id,))
+    conn.commit()
+
+    body = api.TranscribeBatchIn(score_ids=[musicxml_id, deleted_id])
+    result = api.start_transcribe_batch(body)
+    assert result["started"] is True
+    _wait_for_batch()
+    status = transcribe_batch.batch_status()
+
+    by_id = {line["score_id"]: line for line in status["results"]}
+    assert by_id[musicxml_id]["outcome"] == "errored"
+    assert "pdf" in by_id[musicxml_id]["reason"]
+    assert by_id[deleted_id]["outcome"] == "errored"
+    assert "trash" in by_id[deleted_id]["reason"]
+
+
+def test_score_ids_and_collection_together_is_rejected(app_env):
+    body = api.TranscribeBatchIn(score_ids=[1], collection="Bach")
+    with pytest.raises(HTTPException) as exc_info:
+        api.start_transcribe_batch(body)
+    assert exc_info.value.status_code == 422
+
+
+def test_collection_selects_only_that_folders_eligible_scores(
+    app_env, extractable_pdf, monkeypatch, insert_score, tmp_path
+):
+    lib = tmp_path / "collection_library"
+    lib.mkdir()
+    monkeypatch.setattr(api, "LIBRARY_DIR", lib)
+    conn = db.connect()
+
+    def _copy(name):
+        dest = lib / name
+        dest.write_bytes(extractable_pdf.read_bytes())
+        return name
+
+    conn.execute(
+        """UPDATE scores SET collection = 'Bach' WHERE id = ?""",
+        (insert_score(conn, _copy("in_bach.pdf"), "In Bach"),),
+    )
+    conn.commit()
+    outside_id = insert_score(conn, _copy("outside_bach.pdf"), "Outside Bach")
+
+    result = api.start_transcribe_batch(api.TranscribeBatchIn(collection="Bach"))
+    assert result["started"] is True
+    _wait_for_batch()
+    status = transcribe_batch.batch_status()
+    assert status["total"] == 1
+    assert status["results"][0]["score_id"] != outside_id
+    assert status["results"][0]["outcome"] == "transcribed"
+
+
+# ---------------------------------------------------------------------------
+# 5. The scan-interaction matrix.
+# ---------------------------------------------------------------------------
+
+
+def test_a_scan_runs_while_a_bulk_transcription_pass_is_in_progress(
+    library, extractable_pdf, monkeypatch
+):
+    """A scan started WHILE a bulk pass is still working must not be refused,
+    and must not corrupt either one's results - see
+    transcribe_batch.start_batch's docstring for why the two are not held
+    against one another."""
+    import shutil
+
+    (library / "one.pdf").write_bytes(extractable_pdf.read_bytes())
+    shutil.copy(extractable_pdf, library / "two.pdf")
+    scanner._scan()
+    conn = db.connect()
+    ids = [r["id"] for r in conn.execute("SELECT id FROM scores ORDER BY path")]
+    assert len(ids) == 2
+
+    # Slow the batch down enough that a scan started right after it can
+    # genuinely overlap it, rather than racing to finish first every time.
+    def slow_process_one(score_id, reconvert):
+        time.sleep(0.15)
+        return api._batch_process_one(score_id, reconvert)
+
+    started = transcribe_batch.start_batch(slow_process_one, ids, False)
+    assert started is True
+
+    try:
+        scan_started = scanner.start_scan()
+        assert scan_started is True  # NOT refused by the bulk pass running
+    finally:
+        # Waited out unconditionally, even if an assertion above already
+        # failed - both are daemon threads that read module-level LIBRARY_DIR
+        # bindings this test's fixtures monkeypatch, and letting either
+        # outlive this test would have it read those bindings back reverted
+        # mid-run.
+        _wait_for_scan()
+        _wait_for_batch()
+
+    status = transcribe_batch.batch_status()
+    assert status["total"] == 2
+    assert status["processed"] == 2
+    assert status["transcribed"] == 2
+    assert not scanner.scan_status()["refused"]
+    # The scan's own reconciliation is undisturbed: both files are still
+    # accounted for, neither marked missing by a batch that never touches
+    # scores.missing_since.
+    rows = {r["path"]: dict(r) for r in conn.execute("SELECT * FROM scores")}
+    assert rows["one.pdf"]["missing_since"] is None
+    assert rows["two.pdf"]["missing_since"] is None
+
+
+def test_a_bulk_transcription_pass_runs_while_a_scan_is_in_progress(
+    library, extractable_pdf, monkeypatch
+):
+    """The other direction: a scan already under way when a bulk pass
+    starts must not block it either."""
+    import os
+    import shutil
+
+    (library / "one.pdf").write_bytes(extractable_pdf.read_bytes())
+    shutil.copy(extractable_pdf, library / "two.pdf")
+    scanner._scan()
+    conn = db.connect()
+    ids = [r["id"] for r in conn.execute("SELECT id FROM scores ORDER BY path")]
+    assert len(ids) == 2
+
+    # Slow every file's hashing down and force all of them to be re-hashed
+    # (bump every mtime forward, defeating _scan_file's same-size-same-mtime
+    # shortcut) so the scan is still genuinely running, several times over,
+    # by the time the assertion below checks it - not racing a fast pass
+    # that might finish inside the wake-up sleep on a loaded CI runner.
+    real_hash_file = scanner.hash_file
+
+    def slow_hash_file(path):
+        time.sleep(0.2)
+        return real_hash_file(path)
+
+    monkeypatch.setattr(scanner, "hash_file", slow_hash_file)
+    future = time.time() + 3600
+    for name in ("one.pdf", "two.pdf"):
+        os.utime(library / name, (future, future))
+
+    # scanner._scan() itself never touches _state["scanning"] - only
+    # start_scan() does, around spawning its own thread (see scanner.py) -
+    # so the real threaded entry point is what this needs, not a bare Thread
+    # wrapping _scan directly.
+    scan_started = scanner.start_scan()
+    assert scan_started is True
+    try:
+        time.sleep(0.1)  # let the scan actually get going before the batch starts
+        assert scanner.scan_status()["scanning"] is True
+
+        started = transcribe_batch.start_batch(api._batch_process_one, ids, False)
+        assert started is True  # NOT refused by the scan running
+
+        _wait_for_batch()
+    finally:
+        _wait_for_scan()
+
+    status = transcribe_batch.batch_status()
+    assert status["total"] == 2
+    assert status["transcribed"] == 2
+    assert not scanner.scan_status()["refused"]
+
+
+# ---------------------------------------------------------------------------
+# 6. A second batch refuses while one is already running.
+# ---------------------------------------------------------------------------
+
+
+def test_a_second_batch_refuses_while_one_is_running(app_env, extractable_pdf, monkeypatch, insert_score):
+    monkeypatch.setattr(api, "LIBRARY_DIR", extractable_pdf.parent)
+    conn = db.connect()
+    score_id = insert_score(conn, extractable_pdf.name)
+
+    release = threading.Event()
+
+    def blocking_process_one(sid, reconvert):
+        release.wait(timeout=10)
+        return api._batch_process_one(sid, reconvert)
+
+    first_started = transcribe_batch.start_batch(blocking_process_one, [score_id], False)
+    assert first_started is True
+
+    second_started = transcribe_batch.start_batch(api._batch_process_one, [score_id], False)
+    assert second_started is False  # refused - nothing was changed by it
+
+    release.set()
+    _wait_for_batch()
+    # The first (only) pass completed normally once released.
+    assert transcribe_batch.batch_status()["processed"] == 1

--- a/server/tests/test_transcription_api.py
+++ b/server/tests/test_transcription_api.py
@@ -673,21 +673,26 @@ def test_an_unpaired_tie_end_survives_a_reload(app_env, courage_pdf, monkeypatch
 
 
 def _confidence_json_keys() -> set:
-    """The set of keys `transcribe()` actually writes into the stored blob -
-    found by parsing the function's own source rather than duplicating the
-    dict by hand, which would be exactly the kind of second copy that could
-    drift from the first the way _BAR_KEYS and this dict already have three
-    times (#134's fields, #116's pair via #143, #137's counter via #146).
+    """The set of keys `_store_extraction_result()` actually writes into the
+    stored blob - found by parsing the function's own source rather than
+    duplicating the dict by hand, which would be exactly the kind of second
+    copy that could drift from the first the way _BAR_KEYS and this dict
+    already have three times (#134's fields, #116's pair via #143, #137's
+    counter via #146).
 
     Locates the `confidence_json = json.dumps({...})` assignment inside
-    transcribe() and returns the literal string keys of that dict."""
-    source = inspect.getsource(api.transcribe)
+    _store_extraction_result() - the one place BOTH transcribe() and the
+    issue #55 bulk pass write a transcription's confidence blob, see that
+    function's own docstring - and returns the literal string keys of that
+    dict."""
+    source = inspect.getsource(api._store_extraction_result)
     # inspect.getsource returns the function starting at its own indentation
     # (possibly non-zero, e.g. if decorated or nested); dedent so ast.parse,
     # which requires a module-level indent of zero, does not choke on it.
     tree = ast.parse(textwrap.dedent(source))
     func_def = tree.body[0]
-    assert isinstance(func_def, ast.FunctionDef), "expected transcribe() to parse as one function"
+    assert isinstance(func_def, ast.FunctionDef), (
+        "expected _store_extraction_result() to parse as one function")
 
     for node in ast.walk(func_def):
         if not (isinstance(node, ast.Assign)
@@ -697,8 +702,9 @@ def _confidence_json_keys() -> set:
             continue
         call = node.value
         assert isinstance(call, ast.Call) and call.args, (
-            "transcribe() no longer assigns confidence_json = json.dumps({...}) - "
-            "update _confidence_json_keys to match its new shape")
+            "_store_extraction_result() no longer assigns "
+            "confidence_json = json.dumps({...}) - update _confidence_json_keys to match "
+            "its new shape")
         dict_node = call.args[0]
         assert isinstance(dict_node, ast.Dict), (
             "confidence_json's argument is no longer a dict literal - "
@@ -712,7 +718,7 @@ def _confidence_json_keys() -> set:
         return keys
 
     raise AssertionError(
-        "transcribe() no longer assigns a local named confidence_json - "
+        "_store_extraction_result() no longer assigns a local named confidence_json - "
         "update _confidence_json_keys to match its new shape")
 
 

--- a/web/src/lib/Library.svelte
+++ b/web/src/lib/Library.svelte
@@ -79,6 +79,7 @@
     selected = [];
     moveOpen = false;
     deleteOpen = false;
+    transcribeOpen = false;
   }
 
   async function loadFolders() {
@@ -332,6 +333,98 @@
     setTimeout(poll, 800);
   }
 
+  // --- Bulk transcription (issue #55) -----------------------------------
+  //
+  // The scan's own pattern, reused rather than reinvented: start a pass,
+  // poll its status. Two ways in - select scores in Organise mode, or point
+  // at a whole folder from the sidebar - both open the same dialog and share
+  // the same progress/results view, because what happens after starting is
+  // identical either way.
+  //
+  // EVERY SCORE IN THE RESPONSE IS SHOWN, never filtered down to only the
+  // successes: the server's own promise is no silent skip, and a UI that
+  // then hid the skipped and failed lines would throw that promise away one
+  // layer up.
+  let transcribeOpen = $state(false);
+  let transcribeTarget = $state(null); // { kind: "ids", ids } | { kind: "collection", collection }
+  let transcribeReconvert = $state(false);
+  let transcribeError = $state("");
+  let transcribeStatus = $state(null);
+  let transcribePollTimer;
+
+  const OUTCOME_LABEL = {
+    already_transcribed: "already had one",
+    non_extractable: "not extractable",
+    errored: "error",
+    transcribed: "transcribed",
+  };
+
+  function transcribeLineDetail(line) {
+    if (line.outcome === "transcribed") {
+      return line.bars_defective
+        ? `${line.bars_defective} bar${line.bars_defective === 1 ? "" : "s"} do not add up`
+        : "";
+    }
+    return line.reason ?? "";
+  }
+
+  function openTranscribeSelected() {
+    transcribeTarget = { kind: "ids", ids: [...selected] };
+    transcribeError = "";
+    transcribeStatus = null;
+    transcribeReconvert = false;
+    transcribeOpen = true;
+  }
+
+  function openTranscribeCollection(name) {
+    transcribeTarget = { kind: "collection", collection: name };
+    transcribeError = "";
+    transcribeStatus = null;
+    transcribeReconvert = false;
+    transcribeOpen = true;
+  }
+
+  function pollTranscribeBatch() {
+    const poll = async () => {
+      transcribeStatus = await api.transcribeBatchStatus();
+      if (transcribeStatus.running) {
+        transcribePollTimer = setTimeout(poll, 800);
+      } else {
+        refresh();
+      }
+    };
+    transcribePollTimer = setTimeout(poll, 500);
+  }
+
+  async function startTranscribeBatch() {
+    if (!transcribeTarget) return;
+    busy = true;
+    transcribeError = "";
+    try {
+      const opts = { reconvert: transcribeReconvert };
+      if (transcribeTarget.kind === "collection") opts.collection = transcribeTarget.collection;
+      const ids = transcribeTarget.kind === "ids" ? transcribeTarget.ids : null;
+      transcribeStatus = await api.transcribeBatch(ids, opts);
+      pollTranscribeBatch();
+    } catch (err) {
+      transcribeError = err?.message ?? "Fermata could not start that.";
+    } finally {
+      busy = false;
+    }
+  }
+
+  function closeTranscribe() {
+    clearTimeout(transcribePollTimer);
+    if (transcribeStatus && !transcribeStatus.running) {
+      notice =
+        `${transcribeStatus.transcribed} transcribed, ${transcribeStatus.already_transcribed} ` +
+        `already had one, ${transcribeStatus.non_extractable} not extractable, ` +
+        `${transcribeStatus.errored} errored.`;
+    }
+    transcribeOpen = false;
+    if (organising) leaveOrganising();
+  }
+
   // A refused scan is the one thing here that needs a person, so it is the one
   // thing that gets a button. Fermata will not mark scores missing when the
   // evidence looks like a mount problem rather than like somebody tidying up -
@@ -433,22 +526,35 @@
 
       <div class="side-label">Collections</div>
       {#each collections as c}
-        <button
-          class="side-item"
-          class:active={collection === c.collection}
-          onclick={() => { collection = collection === c.collection ? "" : c.collection; showDuplicates = false; showTrash = false; }}
-        >
-          {c.collection}
-          <span class="count">{c.count}</span>
-          {#if c.missing}
-            <!-- Files this collection has on record that are not on disk. Shown
-                 because a folder that has partly gone used to be counted as
-                 though it were whole. -->
-            <span class="count missing-count" title="{c.missing} file(s) not found in your library folder">
-              {c.missing} missing
-            </span>
-          {/if}
-        </button>
+        <div class="side-row">
+          <button
+            class="side-item"
+            class:active={collection === c.collection}
+            onclick={() => { collection = collection === c.collection ? "" : c.collection; showDuplicates = false; showTrash = false; }}
+          >
+            {c.collection}
+            <span class="count">{c.count}</span>
+            {#if c.missing}
+              <!-- Files this collection has on record that are not on disk. Shown
+                   because a folder that has partly gone used to be counted as
+                   though it were whole. -->
+              <span class="count missing-count" title="{c.missing} file(s) not found in your library folder">
+                {c.missing} missing
+              </span>
+            {/if}
+          </button>
+          <!-- The "point at a folder" half of issue #55 - the other half is
+               selecting particular scores in Organise mode. Its own button
+               rather than folded into the row's click, because the row's
+               click already means "filter to this folder". -->
+          <button
+            class="side-transcribe"
+            title="Transcribe every un-transcribed score in {c.collection}"
+            onclick={() => openTranscribeCollection(c.collection)}
+          >
+            ♪
+          </button>
+        </div>
       {/each}
 
       {#if tags.length}
@@ -667,6 +773,9 @@
           <button class="move-open" disabled={!selected.length} onclick={openMove}>
             Move to folder…
           </button>
+          <button class="transcribe-open" disabled={!selected.length} onclick={openTranscribeSelected}>
+            Transcribe…
+          </button>
           <button class="delete-open" disabled={!selected.length} onclick={() => { deleteError = ""; deleteOpen = true; }}>
             Delete…
           </button>
@@ -870,6 +979,72 @@
             </button>
             <button class="dialog-cancel" onclick={() => (deleteOpen = false)}>Cancel</button>
           </div>
+        </div>
+      </div>
+    {/if}
+
+    {#if transcribeOpen}
+      <div class="dialog-scrim">
+        <div class="dialog transcribe" role="dialog" aria-label="Transcribe scores">
+          <div class="dialog-head">
+            {#if transcribeTarget?.kind === "collection"}
+              Transcribe {transcribeTarget.collection}
+            {:else}
+              Transcribe {transcribeTarget?.ids?.length ?? 0} score{(transcribeTarget?.ids?.length ?? 0) === 1 ? "" : "s"}
+            {/if}
+          </div>
+
+          {#if !transcribeStatus}
+            <!-- Said before the button that starts it, not after - the same
+                 habit as the delete dialog's own note. -->
+            <p class="transcribe-note">
+              Runs in the background - progress shows here, and every score gets its own
+              outcome. A hand-edited transcription is never replaced.
+            </p>
+            <label class="reconvert-option">
+              <input type="checkbox" bind:checked={transcribeReconvert} />
+              Also redo scores that already have an extracted transcription
+            </label>
+            {#if transcribeError}
+              <p class="alert-error">{transcribeError}</p>
+            {/if}
+            <div class="dialog-actions">
+              <button class="transcribe-apply" disabled={busy} onclick={startTranscribeBatch}>
+                Start
+              </button>
+              <button class="dialog-cancel" onclick={() => (transcribeOpen = false)}>Cancel</button>
+            </div>
+          {:else}
+            <p class="transcribe-progress">
+              {transcribeStatus.running
+                ? `Transcribing… ${transcribeStatus.processed}/${transcribeStatus.total}`
+                : `${transcribeStatus.transcribed} transcribed, ${transcribeStatus.already_transcribed} ` +
+                  `already had one, ${transcribeStatus.non_extractable} not extractable, ` +
+                  `${transcribeStatus.errored} errored.`}
+            </p>
+            {#if !transcribeStatus.running && transcribeStatus.with_defective_bars}
+              <p class="transcribe-progress">
+                {transcribeStatus.with_defective_bars} of those transcribed with bars that do not
+                add up - open the score to see which.
+              </p>
+            {/if}
+            <ul class="transcribe-results">
+              {#each transcribeStatus.results as line (line.score_id)}
+                <li class="transcribe-line outcome-{line.outcome}">
+                  <span class="transcribe-title">{line.title ?? `Score #${line.score_id}`}</span>
+                  <span class="transcribe-outcome">
+                    {OUTCOME_LABEL[line.outcome] ?? line.outcome}{#if transcribeLineDetail(line)}
+                      &nbsp;— {transcribeLineDetail(line)}{/if}
+                  </span>
+                </li>
+              {/each}
+            </ul>
+            {#if !transcribeStatus.running}
+              <div class="dialog-actions">
+                <button class="dialog-cancel" onclick={closeTranscribe}>Close</button>
+              </div>
+            {/if}
+          {/if}
         </div>
       </div>
     {/if}
@@ -1435,6 +1610,96 @@
     color: var(--ink-dim);
     font-size: 13px;
     line-height: 1.5;
+  }
+
+  /* ---- Bulk transcription (issue #55) ------------------------------------ */
+
+  .side-row {
+    display: flex;
+    align-items: center;
+    gap: 2px;
+  }
+
+  .side-row .side-item {
+    flex: 1;
+    min-width: 0;
+  }
+
+  .side-transcribe {
+    flex: none;
+    width: 30px;
+    height: 30px;
+    display: grid;
+    place-items: center;
+    background: none;
+    border: none;
+    border-radius: 8px;
+    color: var(--ink-dim);
+    font-size: 14px;
+  }
+
+  .side-transcribe:hover {
+    background: var(--surface);
+    color: var(--brass-bright);
+  }
+
+  .transcribe-note {
+    margin: 0;
+    color: var(--ink-dim);
+    font-size: 13px;
+    line-height: 1.5;
+  }
+
+  .reconvert-option {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 14px;
+  }
+
+  .transcribe-progress {
+    margin: 0;
+    color: var(--ink);
+    font-size: 14px;
+    line-height: 1.5;
+  }
+
+  .transcribe-results {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    max-height: 320px;
+    overflow-y: auto;
+    border-top: 1px solid var(--line);
+    display: flex;
+    flex-direction: column;
+  }
+
+  .transcribe-line {
+    display: flex;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 8px 2px;
+    border-bottom: 1px solid var(--line);
+    font-size: 13px;
+  }
+
+  .transcribe-title {
+    color: var(--ink);
+  }
+
+  .transcribe-outcome {
+    color: var(--ink-dim);
+    text-align: right;
+  }
+
+  .transcribe-line.outcome-transcribed .transcribe-outcome {
+    color: var(--brass-bright);
+  }
+
+  .transcribe-line.outcome-errored .transcribe-outcome,
+  .transcribe-line.outcome-non_extractable .transcribe-outcome {
+    color: #e8b45c;
   }
 
   .trash-intro {

--- a/web/src/lib/api.js
+++ b/web/src/lib/api.js
@@ -220,6 +220,21 @@ export const api = {
   deleteTranscription: (id) =>
     fetch(`/api/scores/${id}/transcription`, { method: "DELETE" }).then(j),
   transcriptionAnalysis: (id) => fetch(`/api/scores/${id}/transcription/analysis`).then(j),
+  // Bulk transcription (issue #55) - the scan's own pattern: start it, poll
+  // its status. `scoreIds` and `collection` are mutually exclusive (the
+  // server 422s if both are given); omitting both selects every eligible
+  // score in the whole library.
+  transcribeBatch: (scoreIds, { collection, reconvert = false } = {}) =>
+    fetch("/api/transcribe/batch", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        ...(scoreIds ? { score_ids: scoreIds } : {}),
+        ...(collection !== undefined ? { collection } : {}),
+        reconvert,
+      }),
+    }).then(j),
+  transcribeBatchStatus: () => fetch("/api/transcribe/batch/status").then(j),
   instruments: () => fetch("/api/instruments").then(j),
   instrumentPresets: () => fetch("/api/instruments/presets").then(j),
   // A whole definition, not a patch: string_count and string_pitches have to

--- a/web/tests/browser/zzzz-library-transcribe-batch.spec.js
+++ b/web/tests/browser/zzzz-library-transcribe-batch.spec.js
@@ -1,0 +1,240 @@
+// Bulk transcription (issue #55), against the real backend and the real
+// build.
+//
+// WHAT server/tests/test_transcribe_batch_api.py CANNOT PROVE: that any of
+// this reaches the screen. That file pins the per-score outcomes and the
+// scan-interaction matrix at the process level; #95's lesson, recorded in
+// zz-library-missing.spec.js, is that a guarantee nothing renders is a
+// guarantee nobody has. So what is asserted here is the seam:
+//
+//   1. selecting scores in Organise mode and starting a bulk pass shows
+//      live progress and, once it finishes, a per-score outcome line for
+//      EVERY score selected - transcribed, already-had-one and
+//      not-extractable are all real outcomes this asserts by literal text,
+//      not merely "some list rendered";
+//   2. a hand-edited transcription's own line says it was never touched,
+//      and the score's transcription content confirms that afterwards;
+//   3. the sidebar's per-folder Transcribe button selects only that
+//      folder's scores, not the whole library.
+//
+// WHY IT IS NAMED TO SORT AFTER zzz-library-organise AND BEFORE
+// zzzz-score-progress: it uploads and deletes scores like both of them, and
+// carries the same refusal-unless-throwaway-instance guard zzz-library-
+// organise.spec.js's own header explains.
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { expect, test } from "@playwright/test";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const ENGRAVED_DIR = path.join(here, "..", "..", "..", "server", "tests", "fixtures", "engraved");
+
+// Real committed fixtures (see server/tests/conftest.py's extractable_pdf /
+// non_extractable_pdf) - a genuine tab-staff score and a genuine notation-
+// only one, so "transcribed" and "not extractable" are both real extractor
+// outcomes rather than something this file has to fake.
+const EXTRACTABLE_PDF = fs.readFileSync(path.join(ENGRAVED_DIR, "notation_and_tab.pdf"));
+const NON_EXTRACTABLE_PDF = fs.readFileSync(path.join(ENGRAVED_DIR, "notation_only.pdf"));
+
+const SCAN_DEADLINE_MS = 30_000;
+
+async function scanSettled(request) {
+  const deadline = Date.now() + SCAN_DEADLINE_MS;
+  for (;;) {
+    const status = await (await request.get("/api/scan/status")).json();
+    if (!status.scanning) return status;
+    if (Date.now() > deadline) throw new Error("a scan never finished");
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+}
+
+/** Upload a real PDF and wait for its score row, then wait out the scan the
+ * upload started - the same two-wait pattern zzz-library-organise.spec.js
+ * uses and explains: a move or a bulk action started the instant the row
+ * appears can race the scan itself.
+ *
+ * Every copy of EXTRACTABLE_PDF carries the SAME embedded PDF title (MuseScore
+ * writes its source filename into the document's own metadata, and
+ * metadata.parse_path prefers that over the uploaded filename) - so distinct
+ * filenames alone do not give distinct titles the way they do for the plain
+ * MusicXML fixtures other specs in this suite use. `title`, when given,
+ * PATCHes the row to something distinct right after the scan settles, which
+ * is what this file's assertions actually key on. */
+async function upload(request, buffer, name, folder = "Uploads", title = null) {
+  const res = await request.post(`/api/upload?folder=${encodeURIComponent(folder)}`, {
+    multipart: { file: { name, mimeType: "application/pdf", buffer } },
+  });
+  expect(res.ok(), await res.text()).toBe(true);
+  let found;
+  await expect(async () => {
+    const scores = await (await request.get("/api/scores")).json();
+    found = scores.find((s) => s.path === `${folder}/${name}`);
+    expect(found, `${name} never appeared in the library`).toBeTruthy();
+  }).toPass({ timeout: SCAN_DEADLINE_MS });
+  await scanSettled(request);
+  if (title) {
+    const patched = await request.patch(`/api/scores/${found.id}`, { data: { title } });
+    expect(patched.ok(), await patched.text()).toBe(true);
+    found = await patched.json();
+  }
+  return found;
+}
+
+async function emptyTheLibrary(request) {
+  await scanSettled(request);
+  for (const score of await (await request.get("/api/scores")).json()) {
+    await request.delete(`/api/scores/${score.id}`);
+  }
+  for (const score of await (await request.get("/api/trash")).json()) {
+    await request.delete(`/api/trash/${score.id}`);
+  }
+}
+
+const SUITE_FOLDERS = new Set(["Uploads", "BulkFolder", "OtherFolder"]);
+
+test.beforeEach(async ({ request }) => {
+  const existing = await (await request.get("/api/scores")).json();
+  const foreign = existing.filter(
+    (s) => !s.missing_since && !SUITE_FOLDERS.has(s.path.split("/")[0]),
+  );
+  expect(
+    foreign,
+    "refusing to run: this backend has scores in folders the suite never creates, so it is " +
+      "not the throwaway instance the suite creates - and this file empties the library",
+  ).toEqual([]);
+  await emptyTheLibrary(request);
+});
+
+test.afterAll(async ({ request }) => {
+  await emptyTheLibrary(request);
+});
+
+async function organise(page) {
+  await page.goto("/#/");
+  await page.locator(".organise-toggle").click();
+  await expect(page.locator(".organise-bar")).toBeVisible();
+}
+
+async function choose(page, score) {
+  const card = page.locator(`.card[href="#/score/${score.id}"]`);
+  await expect(card).toBeVisible();
+  await card.click();
+  await expect(card).toHaveClass(/selected/);
+}
+
+/** Waits for the dialog's progress text to report the run has finished
+ * (the "Close" button only renders once `running` is false) - not a fixed
+ * sleep, since the pass runs for as long as real PDF extraction actually
+ * takes. */
+async function waitForBatchDone(page) {
+  await expect(page.locator(".dialog.transcribe .dialog-cancel")).toBeVisible({
+    timeout: SCAN_DEADLINE_MS,
+  });
+}
+
+test("a bulk pass over a mixed selection shows live progress and every score's real outcome", async ({
+  page,
+  request,
+}) => {
+  const fresh = await upload(request, EXTRACTABLE_PDF, "fresh.pdf", "Uploads", "Fresh score");
+  const already = await upload(
+    request, EXTRACTABLE_PDF, "already.pdf", "Uploads", "Already transcribed score",
+  );
+  const transcribed = await request.post(`/api/scores/${already.id}/transcribe`);
+  expect(transcribed.ok(), await transcribed.text()).toBe(true);
+  const edited = await upload(request, EXTRACTABLE_PDF, "edited.pdf", "Uploads", "Hand-edited score");
+  await request.post(`/api/scores/${edited.id}/transcribe`);
+  const savedEdit = await request.put(`/api/scores/${edited.id}/transcription`, {
+    data: { content: '\\title "hand edited"\n.\n:4 0.1 |' },
+  });
+  expect(savedEdit.ok(), await savedEdit.text()).toBe(true);
+  const bad = await upload(
+    request, NON_EXTRACTABLE_PDF, "bad.pdf", "Uploads", "Not-extractable score",
+  );
+
+  await organise(page);
+  await choose(page, fresh);
+  await choose(page, already);
+  await choose(page, edited);
+  await choose(page, bad);
+  await expect(page.locator(".selected-count")).toHaveText("4 selected");
+
+  await page.locator(".transcribe-open").click();
+  const dialog = page.locator(".dialog.transcribe");
+  await expect(dialog).toBeVisible();
+  await dialog.locator(".transcribe-apply").click();
+
+  // Progress is shown WHILE it runs, not only once it is done.
+  await expect(dialog.locator(".transcribe-progress")).toContainText("Transcribing");
+
+  await waitForBatchDone(page);
+
+  const line = (title) => dialog.locator(".transcribe-line", { hasText: title });
+  await expect(line("Fresh score")).toContainText("transcribed");
+  await expect(line("Already transcribed score")).toContainText("already had one");
+  await expect(line("Already transcribed score")).toContainText("reconvert");
+  await expect(line("Hand-edited score")).toContainText("already had one");
+  await expect(line("Hand-edited score")).toContainText("never overwrites");
+  await expect(line("Not-extractable score")).toContainText("not extractable");
+
+  // The aggregate summary, not just the per-line detail.
+  await expect(dialog.locator(".transcribe-progress").first()).toContainText("1 transcribed");
+  await expect(dialog.locator(".transcribe-progress").first()).toContainText(
+    "2 already had one",
+  );
+  await expect(dialog.locator(".transcribe-progress").first()).toContainText(
+    "1 not extractable",
+  );
+
+  await dialog.locator(".dialog-cancel").click();
+  await expect(page.locator(".dialog.transcribe")).toHaveCount(0);
+  await expect(page.locator(".notice")).toContainText("1 transcribed");
+
+  // The edited score's hand-corrected content survived the run, literally.
+  const stillEdited = await (
+    await request.get(`/api/scores/${edited.id}/transcription`)
+  ).json();
+  expect(stillEdited.source).toBe("edited");
+  expect(stillEdited.content).toBe('\\title "hand edited"\n.\n:4 0.1 |');
+
+  // The fresh score really does have a transcription now, reflected on the
+  // card once the grid refreshes.
+  await page.reload();
+  const freshTranscribed = await (await request.get(`/api/scores/${fresh.id}`)).json();
+  expect(freshTranscribed.has_transcription).toBe(true);
+});
+
+test("the sidebar's per-folder Transcribe button selects only that folder", async ({
+  page,
+  request,
+}) => {
+  const inFolder = await upload(
+    request, EXTRACTABLE_PDF, "in-folder.pdf", "BulkFolder", "In the folder",
+  );
+  await upload(request, EXTRACTABLE_PDF, "elsewhere.pdf", "OtherFolder", "Elsewhere entirely");
+
+  await page.goto("/#/");
+  await expect(page.locator(".side-item", { hasText: "BulkFolder" })).toBeVisible();
+  const row = page.locator(".side-row", { has: page.locator(".side-item", { hasText: "BulkFolder" }) });
+  await row.locator(".side-transcribe").click();
+
+  const dialog = page.locator(".dialog.transcribe");
+  await expect(dialog).toBeVisible();
+  await expect(dialog.locator(".dialog-head")).toContainText("BulkFolder");
+  await dialog.locator(".transcribe-apply").click();
+  await waitForBatchDone(page);
+
+  // Only the one score in BulkFolder was touched - the elsewhere.pdf score
+  // never appears in this run's results at all.
+  await expect(dialog.locator(".transcribe-line")).toHaveCount(1);
+  await expect(dialog.locator(".transcribe-line")).toContainText("In the folder");
+
+  // elsewhere.pdf was never selected, so it has no transcription of its own.
+  const scores = await (await request.get("/api/scores")).json();
+  const otherScore = scores.find((s) => s.path === "OtherFolder/elsewhere.pdf");
+  expect(otherScore.has_transcription).toBe(false);
+
+  const inFolderNow = scores.find((s) => s.id === inFolder.id);
+  expect(inFolderNow.has_transcription).toBe(true);
+});

--- a/web/tests/spec-floors/browser-library-transcribe-batch-55.json
+++ b/web/tests/spec-floors/browser-library-transcribe-batch-55.json
@@ -1,0 +1,5 @@
+{
+  "file": "tests/browser/zzzz-library-transcribe-batch.spec.js",
+  "count": 2,
+  "reason": "issue #55: a bulk pass over a mixed selection shows live progress and every score's real outcome (transcribed, already-had-one with why, not-extractable, and an edited transcription explicitly never overwritten), and the sidebar's per-folder button selects only that folder."
+}


### PR DESCRIPTION
## Summary

- Bulk transcription (issue #55): `POST /api/transcribe/batch` starts a background pass over many scores - by explicit `score_ids`, by `collection`, or the whole library - and `GET /api/transcribe/batch/status` polls it, mirroring the library scan's own start/poll shape (`transcribe_batch.py`) instead of a client looping single `POST /transcribe` calls.
- Every score gets an honest outcome, never a silent skip: `transcribed`, `already_transcribed` (with why), `non_extractable` (the extractor's own reason), or `errored`. An edited transcription is never replaced, `reconvert` or not (#10's protection, applied in bulk).
- The pass and a library scan are deliberately **not** held against one another - a scan may run during a batch and a batch may run during a scan - because a batch only ever reads a score's PDF and writes to the `transcriptions` table, never touches a file the scan's directory listing depends on. Each score's row is read fresh at its own turn rather than from a stale snapshot.
- No job state persists across a restart; a killed pass leaves only complete, committed rows behind, so re-running the same selection is simply how it resumes.
- Refactored `_store_extraction_result` out of the existing `transcribe()` endpoint so the confidence-blob storage (the ~50-field mapping that #137/#143/#146 each shipped a gap in once already) is written from exactly one place for both the single-score and bulk paths.
- `Library.svelte` gets a "Transcribe…" action in Organise mode's selection bar (explicit selection) and a per-folder Transcribe button in the sidebar ("point at a folder"), sharing one dialog with live progress and a per-score result list.

## Per-invariant

- **Documented endpoint(s), not a client loop.** `POST /api/transcribe/batch` + `GET /api/transcribe/batch/status`, both tagged, documented, response-modeled (`TranscribeBatchTriggerOut`/`TranscribeBatchStatusOut`/`TranscribeBatchResultLineOut`). The planned MCP layer (#32) wraps this endpoint. Documented in `docs/api.md`.
- **Interacts safely with a running scan.** Deliberately *not* held against `scanner.hold_library_still` - argued in `transcribe_batch.start_batch`'s docstring and `api._batch_process_one`'s (reads the score row fresh, not from a snapshot). Tested both directions with real overlapping threads in `test_transcribe_batch_api.py` (`test_a_scan_runs_while_a_bulk_transcription_pass_is_in_progress`, `test_a_bulk_transcription_pass_runs_while_a_scan_is_in_progress`) and confirmed live against a real server (see Manual verification below).
- **Progress is observable.** `GET /transcribe/batch/status` (`running`, `total`, `processed`, per-outcome counts, `results`) - polled by the UI every 800ms while a pass runs.
- **Per-score outcomes are honest.** Exactly the four categories the task specified: `transcribed` / `already_transcribed` / `non_extractable` (with reason) / `errored` (with reason). Never omitted - `test_a_mixed_batch_reports_the_correct_outcome_for_every_score` asserts every one by literal text; `test_explicit_score_ids_report_a_non_pdf_and_a_deleted_score_honestly` proves an explicitly-selected id that turns out ineligible still gets a line rather than vanishing.
- **Never clobbers an EDITED transcription.** Checked before the reconvert branch, unconditionally. `test_edited_transcription_survives_a_bulk_run_through_the_api` asserts literal before/after content through the API, with `reconvert=True` (the flag that *does* replace an extracted row) still in effect - the #146-style lesson applied to the bulk path.
- **Idempotent/resumable enough that a killed job doesn't corrupt state.** No persisted job state (matches `scanner._state`'s own in-memory-only design); each score's write is one committed unit. `test_a_killed_job_leaves_finished_work_intact_and_a_fresh_pass_resumes` simulates a pass that only reaches half its selection, then re-runs the full selection and asserts the first half is untouched (same `updated_at`) and the second half gets transcribed.

## Per-target

- **Mixed-library server tests, literal assertions**: `server/tests/test_transcribe_batch_api.py` (11 tests) - transcribable / non-extractable / already-transcribed / edited / file-missing / unrecognised-id, plus reconvert semantics, explicit score_ids honesty, collection filtering, and the resumability case above.
- **Scan-interaction matrix, tested both directions with real threads**: same file, `test_a_scan_runs_while_a_bulk_transcription_pass_is_in_progress` and `test_a_bulk_transcription_pass_runs_while_a_scan_is_in_progress`.
- **Mutation-tested** (see verification below): removing the edited-row guard turns two tests red; making `start_batch` check `scanner.scan_status()["scanning"]` turns the scan-during-bulk test red; dropping `bars_defective` from `TranscribeBatchResultLineOut` turns the OpenAPI drift-guard test red (claim 5 in `test_api_docs.py`).
- **OpenAPI guards green**: `test_every_route_is_documented`, `test_every_route_has_exactly_the_expected_operation_count` (54 → 58: this PR's 2, rebased onto #27's 2 already on main), `test_transcribe_batch_responses_match_their_models` (also exercises the systemic drift guard).
- **Browser spec for the batch UI + progress**: `web/tests/browser/zzzz-library-transcribe-batch.spec.js` (2 tests, `web/tests/spec-floors/browser-library-transcribe-batch-55.json`) - a mixed selection through Organise mode shows live progress and every real outcome (transcribed / already-had-one / not-extractable, plus the edited-never-overwritten line), and the sidebar's per-folder button selects only that folder. Runs against real committed PDF fixtures (`notation_and_tab.pdf` / `notation_only.pdf`) and the real server/build, sorted to run after `zzz-library-organise` and before `zzzz-score-progress` per the suite's own ordering convention.
- **Suites vs re-derived baselines**: full server suite 1085 passed / 64 skipped (skip count is the real-library/`node_modules` gates, unrelated); full browser suite (unit + browser) green post-rebase.

## Manual smoke test

Real server, scratch library in `C:\tmp`, odd port (8937, never 8080):

```
cd server
FERMATA_LIBRARY=/c/tmp/.../library FERMATA_CONFIG=/c/tmp/.../config \
  PYTHONPATH=. py -3.13 -m uvicorn fermata.main:app --host 127.0.0.1 --port 8937
```

Library: two copies of the committed `notation_and_tab.pdf` fixture and one `notation_only.pdf`. After the startup scan:

```
POST /api/transcribe/batch {"score_ids":[1,2,3,999]}   # 2 already, 1 not-extractable id, 1 bogus id
```
→ `{"transcribed":1,"already_transcribed":1,"non_extractable":1,"errored":1, "results":[...]}` with the literal reason text for each (score 2 pre-transcribed via a direct `POST /transcribe`; score 999 doesn't exist).

Then hand-edited score 1's transcription via `PUT /transcription`, and re-ran with `reconvert:true` over all three real scores:
→ score 1: `already_transcribed`, reason `"has a hand-edited transcription, which bulk transcription never overwrites"` - `GET /transcription` afterwards confirms the literal edited content survived unchanged; score 2 (extracted-only): actually `transcribed` again (reconvert honoured); score 3: still `non_extractable`.

Then dropped a fourth real PDF into the library folder and fired `POST /api/scan` immediately followed by `POST /api/transcribe/batch {}` (whole library) - both returned `started: true`, neither refused the other, both finished cleanly, and the new file was picked up and transcribed in the same run (`{"scanning":false,...,"added":1}` / batch `total:4, transcribed:1` for the new score, prior outcomes for scores 1-3 unchanged).

## Scope note

"Convert newly ingested scores as part of bringing them in" (auto-transcribe on scan/upload) from the issue text is *not* included - wiring extraction (CPU-heavy, can be slow on a real page) into the scan's own request path risked either blocking a scan a person is waiting on, or needing a second background-orchestration layer bolted onto `scanner.py` that felt like a separate, reviewable change of its own rather than something to fold in silently here. The explicit/folder-selection bulk pass this PR ships covers the rest of the issue (bulk conversion, background job with progress, skip-with-reason, edited-transcription protection, aggregate reporting) - filed the auto-ingest half as #190 rather than claiming full closure.
