### PR TITLE
Scope any drill by string, fret and key, and add chord flash cards

### DIFF
--- a/docs/practice-data.md
+++ b/docs/practice-data.md
@@ -427,16 +427,53 @@ right and wrong separately and never free to divide one by the other.
   this API keeping a bespoke aggregate endpoint in step with every future
   drill's own idea of what a weak spot is.
 
+## Trainer chord attempts
+
+The question this document's own "what is not here yet" section left open:
+whether a chord drill's attempts fit `trainer_attempts` or need a table of
+their own. *Chord flash cards* (issue #28) answered it - a chord does not
+fit. `trainer_attempts`' `target_note`/`given_note` are `NOT NULL` columns
+holding exactly one pitch class each, which is the right shape for a drill
+whose unit is one note; a chord is a SET of them, and forcing its tone set
+into a single-note column would either lose which chord was asked (keeping
+only its root) or store something that plainly is not a pitch class. So this
+is a sibling table, `trainer_chord_attempts`, built the same way
+`trainer_attempts` is: `correct` computed once, server-side, never trusted
+from a request body.
+
+| Column | Meaning |
+| --- | --- |
+| `id` | Stable for the life of the row. |
+| `owner` | `'local'`, same as everywhere else. |
+| `session_id` | The `practice_sessions` row logging the surrounding drill's TIME, when there is one yet - `NULL` otherwise, the same ordinary-not-edge case `trainer_attempts.session_id` is. |
+| `drill` | `'chord_flashcards'` today - a widened tuple, not a migration, is how a second chord-shaped drill would arrive, the same rule `trainer_attempts.drill` follows. |
+| `direction` | `shape_to_name` (shown a real fingering, asked to name the chord) or `name_to_shape` (named a chord, asked to place it on the neck). |
+| `target_root`, `target_quality` | The chord being tested, always set - a pitch class and one of `major`/`minor`/`dominant7`. |
+| `target_shape` | The fingering actually SHOWN - a JSON array of `{string, fret}` - set only on `shape_to_name`; `NULL` on `name_to_shape`, which shows no shape at all. |
+| `given_root`, `given_quality` | The chord chosen by name - set only on `shape_to_name`. |
+| `given_notes` | The pitch classes a TAPPED shape actually sounded, a JSON array worked out client-side from the instrument's own tuning - never from which shape the player meant to play, mirroring `given_note`'s rule above. Set only on `name_to_shape`. |
+| `given_shape` | The positions actually tapped, a JSON array of `{string, fret}` - set only on `name_to_shape`, kept beside `given_notes` so "which shapes get missed" stays a real question over this table. |
+| `correct` | Whether the given tone SET equals the target chord's own tones (`chord_tones(target_root, target_quality)`, mirrored character-for-character between `server/fermata/trainer.py` and `web/src/lib/trainer/chord-theory.js`) - the same rule either direction, computed here and only here. There is more than one right way to play a given chord, so this is never a check against one canonical fingering. |
+| `response_ms` | How long the question took, informational. |
+| `created_at` | When the row was written. |
+
+**One `correct` rule covers both directions, the same idea `trainer_attempts`
+already applies to a single note, widened to a set.** `shape_to_name`
+compares the CHOSEN chord's tones to the target's; `name_to_shape` compares
+what was actually TAPPED (resolved to pitch classes client-side, the same
+trust boundary `given_note` already crosses) to the target's. Tone-set
+equality, not label equality and not fingering equality, either way.
+
+### Asking questions
+
+- `POST /api/trainer/chord-attempts` - log one answered chord question.
+- `GET /api/trainer/chord-attempts?drill=&direction=&correct=&root=&quality=&session_id=&limit=` -
+  the raw, queryable record, newest first - the same shape
+  `GET /api/trainer/attempts` offers, with `root`/`quality` added so "which
+  chords am I weak on" is a filter rather than a client-side group-by.
+
 ## What is not here yet
 
-- **Interval or chord-recognition attempt shapes.** `trainer_attempts` is
-  drill-agnostic in its schema (a `drill` column, not a table per exercise),
-  but a chord drill's own idea of "which chord, which voicing" has not been
-  built against it yet, and inventing that shape before that trainer exists
-  would be the same guess this section spent a long time avoiding for
-  fret-to-note. Fret-to-note's `position_to_note`/`note_to_position` split is
-  a real answer for a single-note drill; a chord is a different unit, and #26
-  or #29 gets to decide whether it fits the same table or needs its own.
 - **Key, tempo and difficulty per score** - musical metadata about the piece
   rather than about the practice.
 - **Achievements** - looking back at what has been accomplished, where a goal

--- a/server/fermata/api.py
+++ b/server/fermata/api.py
@@ -65,6 +65,8 @@ from .api_models import (
     TagOut,
     TrainerAttemptListOut,
     TrainerAttemptOut,
+    TrainerChordAttemptListOut,
+    TrainerChordAttemptOut,
     TranscribeBatchStatusOut,
     TranscribeBatchTriggerOut,
     TranscribeResultOut,
@@ -4472,6 +4474,151 @@ def list_trainer_attempts(
     ).fetchone()["n"]
     return {
         "attempts": [trainer.attempt_dict(r) for r in rows],
+        "total": total,
+        "truncated": total > len(rows),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Trainer: per-attempt chord flash card results (issue #28)
+# ---------------------------------------------------------------------------
+
+
+class ChordShapePositionIn(BaseModel):
+    string: int
+    fret: int
+
+
+class TrainerChordAttemptIn(BaseModel):
+    """One question from the chord flash card drill, as answered - see
+    trainer.normalise_chord_attempt for the pairing rules `direction`
+    decides (a shown shape and a chosen chord name for `shape_to_name`, a
+    tapped shape's resolved notes for `name_to_shape`).
+
+    `correct` is deliberately not a field here at all, the same rule
+    TrainerAttemptIn follows and for the same reason: it is always computed
+    from tone sets, server-side, never accepted from a caller.
+    """
+
+    session_id: Count | None = Field(default=None, ge=1, le=SQLITE_MAX_INTEGER)
+    drill: str
+    direction: str
+    target_root: str
+    target_quality: str
+    target_shape: list[ChordShapePositionIn] | None = None
+    given_root: str | None = None
+    given_quality: str | None = None
+    given_notes: list[str] | None = None
+    given_shape: list[ChordShapePositionIn] | None = None
+    response_ms: Count | None = None
+
+
+_CHORD_ATTEMPT_COLUMNS = (
+    "session_id",
+    "drill",
+    "direction",
+    "target_root",
+    "target_quality",
+    "target_shape",
+    "given_root",
+    "given_quality",
+    "given_notes",
+    "given_shape",
+    "correct",
+    "response_ms",
+)
+
+
+@router.post("/trainer/chord-attempts", tags=[TAG_TRAINER], response_model=TrainerChordAttemptOut)
+def log_trainer_chord_attempt(body: TrainerChordAttemptIn):
+    """Record one question from the chord flash card drill: what chord was
+    asked, what was answered, and whether the two name the same notes.
+
+    Structured, not a free-text note (issue #32) - so "which chords get
+    missed" is a query over this table rather than something parsed out of
+    a session's note. `correct` in the response is what this endpoint
+    computed, never what the request claimed.
+    """
+    with write_tx() as conn:
+        if body.session_id is not None:
+            _session_row(conn, body.session_id)
+        try:
+            values = trainer.normalise_chord_attempt(**{
+                k: v for k, v in body.model_dump().items() if k != "session_id"
+            })
+        except ValueError as e:
+            raise HTTPException(422, str(e)) from None
+        values["session_id"] = body.session_id
+        columns = ", ".join(_CHORD_ATTEMPT_COLUMNS)
+        placeholders = ", ".join("?" * len(_CHORD_ATTEMPT_COLUMNS))
+        row = conn.execute(
+            f"""INSERT INTO trainer_chord_attempts(owner, {columns})
+                VALUES (?, {placeholders})
+                RETURNING *""",
+            [DEFAULT_OWNER, *(values[c] for c in _CHORD_ATTEMPT_COLUMNS)],
+        ).fetchone()
+        return trainer.chord_attempt_dict(row)
+
+
+@router.get("/trainer/chord-attempts", tags=[TAG_TRAINER], response_model=TrainerChordAttemptListOut)
+def list_trainer_chord_attempts(
+    drill: str = "",
+    direction: str = "",
+    correct: bool | None = None,
+    root: str = "",
+    quality: str = "",
+    session_id: Annotated[int | None, Query(ge=1, le=SQLITE_MAX_INTEGER)] = None,
+    limit: int = practice.DEFAULT_SESSION_LIMIT,
+):
+    """The raw record of every question the chord flash card drill has
+    asked, newest first - filterable by drill, direction, whether it was
+    answered correctly, which chord was asked (root and/or quality), or
+    which session it belongs to. The queryable half of issue #32's promise
+    for this drill, the same shape GET /trainer/attempts offers fret to
+    note.
+    """
+    if not 1 <= limit <= practice.MAX_SESSION_LIMIT:
+        raise HTTPException(422, f"limit must be between 1 and {practice.MAX_SESSION_LIMIT}")
+    if drill and drill not in trainer.CHORD_DRILLS:
+        raise HTTPException(422, f"drill must be one of {list(trainer.CHORD_DRILLS)}")
+    if direction and direction not in trainer.CHORD_DIRECTIONS:
+        raise HTTPException(422, f"direction must be one of {list(trainer.CHORD_DIRECTIONS)}")
+    if root and root not in trainer.PITCH_CLASSES:
+        raise HTTPException(422, f"root must be one of {list(trainer.PITCH_CLASSES)}")
+    if quality and quality not in trainer.CHORD_QUALITIES:
+        raise HTTPException(422, f"quality must be one of {list(trainer.CHORD_QUALITIES)}")
+    where = ["owner = ?"]
+    params: list = [DEFAULT_OWNER]
+    if drill:
+        where.append("drill = ?")
+        params.append(drill)
+    if direction:
+        where.append("direction = ?")
+        params.append(direction)
+    if correct is not None:
+        where.append("correct = ?")
+        params.append(1 if correct else 0)
+    if root:
+        where.append("target_root = ?")
+        params.append(root)
+    if quality:
+        where.append("target_quality = ?")
+        params.append(quality)
+    if session_id is not None:
+        where.append("session_id = ?")
+        params.append(session_id)
+    filters = " AND ".join(where)
+    conn = connect()
+    rows = conn.execute(
+        f"""SELECT * FROM trainer_chord_attempts WHERE {filters}
+             ORDER BY created_at DESC, id DESC LIMIT ?""",
+        [*params, limit],
+    ).fetchall()
+    total = conn.execute(
+        f"SELECT COUNT(*) AS n FROM trainer_chord_attempts WHERE {filters}", params
+    ).fetchone()["n"]
+    return {
+        "attempts": [trainer.chord_attempt_dict(r) for r in rows],
         "total": total,
         "truncated": total > len(rows),
     }

--- a/server/fermata/api_models.py
+++ b/server/fermata/api_models.py
@@ -1059,3 +1059,56 @@ class TrainerAttemptListOut(BaseModel):
     attempts: list[TrainerAttemptOut]
     total: int
     truncated: bool
+
+
+# ---------------------------------------------------------------------------
+# Chord flash cards: per-attempt results (issue #28), in their own table -
+# see db.py's comment on trainer_chord_attempts for why a chord does not fit
+# TrainerAttemptOut's single-note columns above.
+# ---------------------------------------------------------------------------
+
+
+class ChordShapePosition(BaseModel):
+    """One fretted position of a shown or tapped chord shape - a string and
+    the fret held on it. A string simply absent from a shape's list is
+    muted, the same convention an "x" marks in a chord diagram."""
+
+    string: int
+    fret: int
+
+
+class TrainerChordAttemptOut(BaseModel):
+    """One question from the chord flash card drill, as trainer.
+    chord_attempt_dict presents it - the stored row verbatim, `correct` as a
+    real bool, and target_shape/given_shape/given_notes turned back into
+    lists rather than the JSON text they are stored as.
+
+    Exactly one of (given_root, given_quality) or (given_notes, given_shape)
+    is non-null, decided by `direction` - see trainer.py's module docstring
+    on why a chord name and a tapped shape are graded by the same rule even
+    so."""
+
+    id: int
+    owner: str
+    session_id: int | None
+    drill: str
+    direction: str
+    target_root: str
+    target_quality: str
+    target_shape: list[ChordShapePosition] | None
+    given_root: str | None
+    given_quality: str | None
+    given_notes: list[str] | None
+    given_shape: list[ChordShapePosition] | None
+    correct: bool
+    response_ms: int | None
+    created_at: str
+
+
+class TrainerChordAttemptListOut(BaseModel):
+    """GET /api/trainer/chord-attempts: the raw, queryable record - which
+    chords get missed is a WHERE clause over this."""
+
+    attempts: list[TrainerChordAttemptOut]
+    total: int
+    truncated: bool

--- a/server/fermata/db.py
+++ b/server/fermata/db.py
@@ -257,6 +257,75 @@ _TRAINER_SCHEMA = (
     " ON trainer_attempts(owner, drill, target_string, target_fret);\n"
 )
 
+# One row per QUESTION the chord flash card drill (issue #28) asked - a
+# SIBLING of trainer_attempts, not a widening of it. trainer_attempts'
+# target_note/given_note columns are NOT NULL and hold exactly one pitch
+# class each, which is the correct shape for a drill whose unit is one
+# note - see that table's own comment. A chord is not one note; it is a SET
+# of them, and forcing target_root/target_quality's tone set into a single
+# target_note column would either lose which chord was asked (storing only
+# its root) or store something that is not a pitch class at all. So a
+# chord attempt gets its own table, built the same way: `correct` computed
+# once, server-side (trainer.normalise_chord_attempt), never trusted from a
+# request body, and an index shaped for the query this drill's players
+# actually want to ask.
+#
+# WHY ONE 'correct' RULE COVERS BOTH DIRECTIONS, mirroring trainer_attempts'
+# own reasoning. A chord is its pitch-class SET (server/fermata/trainer.py's
+# chord_tones, mirrored character-for-character from web/src/lib/trainer/
+# chord-theory.js's chordTones), and every attempt reduces to comparing two
+# such sets: the question's own tones (from target_root/target_quality) and
+# what was actually given. For shape_to_name, "given" is a chosen chord
+# (given_root/given_quality) - a chord NAME was picked, and its tones are
+# compared directly. For name_to_shape, "given" is a JSON array of the
+# pitch classes a tapped shape actually sounded (given_notes), worked out
+# client-side from the instrument's own tuning the same way
+# trainer_attempts' given_note is for a tapped position (see fret-to-
+# note.js's checkTapAnswer) - the server does not need to know a tuning to
+# grade a chord attempt, only to compare the tone sets it was told.
+#
+# target_shape (shape_to_name only) is the fingering that was actually
+# SHOWN, and given_shape (name_to_shape only) is the positions actually
+# TAPPED - both JSON arrays of {string, fret}, kept beside the graded tone
+# sets so "which shapes get missed" stays a real question over this table
+# rather than something only the tone sets could answer. Both are NULL on
+# the direction that does not produce them, the same "exactly one side
+# populated, decided by direction" rule trainer_attempts' target/given
+# position pairs already follow.
+_TRAINER_CHORD_ATTEMPTS_COLUMNS = """(
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    owner TEXT NOT NULL DEFAULT 'local',
+    session_id INTEGER REFERENCES practice_sessions(id) ON DELETE SET NULL,
+    drill TEXT NOT NULL,
+    direction TEXT NOT NULL,
+    target_root TEXT NOT NULL,
+    target_quality TEXT NOT NULL,
+    target_shape TEXT,
+    given_root TEXT,
+    given_quality TEXT,
+    given_notes TEXT,
+    given_shape TEXT,
+    correct INTEGER NOT NULL,
+    response_ms INTEGER,
+    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+)"""
+
+_TRAINER_CHORD_SCHEMA = (
+    "CREATE TABLE IF NOT EXISTS trainer_chord_attempts "
+    + _TRAINER_CHORD_ATTEMPTS_COLUMNS + ";\n"
+    + "CREATE INDEX IF NOT EXISTS idx_trainer_chord_attempts_owner_drill"
+    " ON trainer_chord_attempts(owner, drill, created_at);\n"
+    + "CREATE INDEX IF NOT EXISTS idx_trainer_chord_attempts_session"
+    " ON trainer_chord_attempts(session_id);\n"
+    # "Which chords get missed" - the query this table exists to answer -
+    # groups by the chord that was ASKED, so that is what the index leads
+    # with, correct left off for the same reason trainer_attempts' own
+    # target index leaves it off: SQLite applies it as a filter over these
+    # indexed rows rather than a second lookup.
+    + "CREATE INDEX IF NOT EXISTS idx_trainer_chord_attempts_target"
+    " ON trainer_chord_attempts(owner, drill, target_root, target_quality);\n"
+)
+
 
 # The scores table's columns, written once, for the same reason
 # _PRACTICE_SESSIONS_COLUMNS is: SCHEMA builds the table from it, and any future
@@ -475,7 +544,7 @@ CREATE TABLE IF NOT EXISTS instruments (
     updated_at TEXT NOT NULL DEFAULT (datetime('now'))
 );
 CREATE INDEX IF NOT EXISTS idx_instruments_owner ON instruments(owner);
-""" + _PRACTICE_SCHEMA + _TRAINER_SCHEMA
+""" + _PRACTICE_SCHEMA + _TRAINER_SCHEMA + _TRAINER_CHORD_SCHEMA
 
 # The schema this code expects. Stamped into PRAGMA user_version once a startup
 # has finished bringing a database up to date.

--- a/server/fermata/trainer.py
+++ b/server/fermata/trainer.py
@@ -17,6 +17,7 @@ that sits beside it. See api.py's /trainer/attempts routes for where the two
 meet.
 """
 
+import json
 from typing import Any
 
 # The one drill that writes here today. A widened tuple, not a migration, is
@@ -179,4 +180,201 @@ def attempt_dict(row) -> dict:
     turned back into a real bool (SQLite hands integers back)."""
     d = dict(row)
     d["correct"] = bool(d["correct"])
+    return d
+
+
+# ---------------------------------------------------------------------------
+# Chord flash cards (issue #28) - its own attempt shape, in
+# trainer_chord_attempts rather than trainer_attempts. See db.py's comment
+# on that table for why a chord (a SET of notes) does not fit the single
+# pitch-class columns above, which the first paragraph of this module's own
+# docstring already commits target_note/given_note to.
+# ---------------------------------------------------------------------------
+
+# A widened tuple, the same way DRILLS above is meant to widen (see that
+# constant's own comment) - just in this table instead, since a chord drill
+# is not a fret-to-note-shaped one.
+CHORD_DRILLS = ("chord_flashcards",)
+
+# shape_to_name: a fingering was shown, a chord name was chosen.
+# name_to_shape: a chord was named, a shape was tapped.
+CHORD_DIRECTIONS = ("shape_to_name", "name_to_shape")
+
+# Interval steps from the root, in semitones - a triad for major and minor,
+# a tetrad for the one seventh chord this drill names ("majors and minors
+# first, then sevenths, then barre chords" - issue #28's own ordering).
+# MIRRORED, CHARACTER FOR CHARACTER, in web/src/lib/trainer/chord-
+# theory.js's QUALITIES - the same discipline PITCH_CLASSES above is held
+# to against neck.js's table of the same name. server/tests/
+# test_chord_theory.py and web/tests/unit/chord-theory.spec.js each check
+# every one of the 36 (root, quality) chords this can build; a drift
+# between the two would otherwise show up as a shape and its label
+# disagreeing about what chord is on screen, not as a failing test.
+CHORD_QUALITIES = {
+    "major": (0, 4, 7),
+    "minor": (0, 3, 7),
+    "dominant7": (0, 4, 7, 10),
+}
+
+
+def chord_tones(root: str, quality: str) -> tuple[str, ...] | None:
+    """The pitch classes a chord is built from, or None for an unknown root
+    or quality - the server's own copy of chord-theory.js's chordTones,
+    used to grade an attempt independently of whatever a client claims a
+    shape or a chosen name sounds like."""
+    if root not in PITCH_CLASSES or quality not in CHORD_QUALITIES:
+        return None
+    i = PITCH_CLASSES.index(root)
+    return tuple(PITCH_CLASSES[(i + step) % 12] for step in CHORD_QUALITIES[quality])
+
+
+def _chord_quality(value, field: str) -> str:
+    if value not in CHORD_QUALITIES:
+        raise ValueError(f"{field} must be one of {list(CHORD_QUALITIES)}")
+    return value
+
+
+def _shape(value, field: str, *, allow_empty: bool = True):
+    """A list of {string, fret} positions - a fingering shown, or one
+    tapped - validated the same bounds `_position` above checks a single
+    position against. None passes through as None (the field was not
+    given); anything else must be a (possibly empty, unless `allow_empty`
+    is False) list of whole-number positions within bounds."""
+    if value is None:
+        return None
+    if not isinstance(value, list):
+        raise ValueError(f"{field} must be a list of positions")
+    if not value and not allow_empty:
+        raise ValueError(f"{field} must not be empty")
+    out = []
+    for entry in value:
+        string_value = entry.get("string") if isinstance(entry, dict) else getattr(entry, "string", None)
+        fret_value = entry.get("fret") if isinstance(entry, dict) else getattr(entry, "fret", None)
+        if isinstance(string_value, bool) or not isinstance(string_value, int):
+            raise ValueError(f"{field} entries need a whole-number string")
+        if isinstance(fret_value, bool) or not isinstance(fret_value, int):
+            raise ValueError(f"{field} entries need a whole-number fret")
+        if not MIN_STRING_NUMBER <= string_value <= MAX_STRING_NUMBER:
+            raise ValueError(f"{field} string must be between {MIN_STRING_NUMBER} and {MAX_STRING_NUMBER}")
+        if not MIN_FRET <= fret_value <= MAX_FRET:
+            raise ValueError(f"{field} fret must be between {MIN_FRET} and {MAX_FRET}")
+        out.append({"string": string_value, "fret": fret_value})
+    return out
+
+
+def _notes_list(value, field: str):
+    if not isinstance(value, list):
+        raise ValueError(f"{field} must be a list of pitch classes")
+    return [_note(n, field) for n in value]
+
+
+def normalise_chord_attempt(
+    *,
+    drill,
+    direction,
+    target_root,
+    target_quality,
+    target_shape=None,
+    given_root=None,
+    given_quality=None,
+    given_notes=None,
+    given_shape=None,
+    response_ms=None,
+) -> dict[str, Any]:
+    """Check one chord attempt and return the row to store, `correct`
+    included.
+
+    Raises ValueError with a message meant for a person. `correct` is
+    computed here, from TONE SETS - never accepted from a caller, and never
+    decided by comparing root/quality strings, so two different (root,
+    quality) pairs that happened to name the same notes would still grade
+    as the same chord (see chord-theory.js's chordsMatch for why that
+    matters more than it looks like it should).
+    """
+    if drill not in CHORD_DRILLS:
+        raise ValueError(f"drill must be one of {list(CHORD_DRILLS)}")
+    if direction not in CHORD_DIRECTIONS:
+        raise ValueError(f"direction must be one of {list(CHORD_DIRECTIONS)}")
+
+    target_root = _note(target_root, "target_root")
+    target_quality = _chord_quality(target_quality, "target_quality")
+    target_tones = set(chord_tones(target_root, target_quality) or ())
+
+    target_shape = _shape(target_shape, "target_shape", allow_empty=False)
+    given_shape = _shape(given_shape, "given_shape")
+
+    if direction == "shape_to_name":
+        # The question NAMED a shape (shown a real fingering); the answer
+        # named a chord. Tapping a shape answers the OTHER direction.
+        if target_shape is None:
+            raise ValueError("shape_to_name needs target_shape - the fingering that was shown")
+        if given_shape is not None or given_notes is not None:
+            raise ValueError(
+                "shape_to_name is answered with a chord name, not a shape - "
+                "given_notes/given_shape must be omitted"
+            )
+        if given_root is None or given_quality is None:
+            raise ValueError(
+                "shape_to_name needs given_root and given_quality - the chord that was chosen"
+            )
+        given_root = _note(given_root, "given_root")
+        given_quality = _chord_quality(given_quality, "given_quality")
+        given_tones = set(chord_tones(given_root, given_quality) or ())
+        correct = bool(target_tones) and given_tones == target_tones
+        given_notes_json = None
+        given_shape_json = None
+    else:
+        # name_to_shape: the question named a chord only - there is no
+        # shape to show, and the answer must be an actual tap, not a
+        # chosen name.
+        if target_shape is not None:
+            raise ValueError("name_to_shape has no shape to show - target_shape must be omitted")
+        if given_root is not None or given_quality is not None:
+            raise ValueError(
+                "name_to_shape is answered by tapping a shape, not choosing a name - "
+                "given_root/given_quality must be omitted"
+            )
+        if given_notes is None or given_shape is None:
+            raise ValueError(
+                "name_to_shape needs given_notes and given_shape - what was tapped and what it sounded"
+            )
+        given_notes = _notes_list(given_notes, "given_notes")
+        correct = bool(target_tones) and set(given_notes) == target_tones
+        given_notes_json = json.dumps(given_notes)
+        given_shape_json = json.dumps(given_shape)
+        given_root = None
+        given_quality = None
+
+    if response_ms is not None:
+        if isinstance(response_ms, bool) or not isinstance(response_ms, int):
+            raise ValueError("response_ms must be a whole number")
+        if not 0 <= response_ms <= MAX_RESPONSE_MS:
+            raise ValueError(f"response_ms must be between 0 and {MAX_RESPONSE_MS}")
+
+    return {
+        "drill": drill,
+        "direction": direction,
+        "target_root": target_root,
+        "target_quality": target_quality,
+        "target_shape": json.dumps(target_shape) if target_shape is not None else None,
+        "given_root": given_root,
+        "given_quality": given_quality,
+        "given_notes": given_notes_json,
+        "given_shape": given_shape_json,
+        # The one place this row's verdict is decided. Not stored from
+        # anywhere else and not trusted from a request body.
+        "correct": correct,
+        "response_ms": response_ms,
+    }
+
+
+def chord_attempt_dict(row) -> dict:
+    """One chord attempt as the API presents it - the stored row, with
+    `correct` turned back into a real bool and the JSON-encoded shape/notes
+    columns turned back into lists (SQLite, and this table, only ever hold
+    the text)."""
+    d = dict(row)
+    d["correct"] = bool(d["correct"])
+    for field in ("target_shape", "given_shape", "given_notes"):
+        d[field] = json.loads(d[field]) if d[field] is not None else None
     return d

--- a/server/tests/test_api_docs.py
+++ b/server/tests/test_api_docs.py
@@ -300,8 +300,9 @@ def test_every_route_has_exactly_the_expected_operation_count(openapi_schema):
     # piece is going. Plus issue #16's one: GET /api/me. Plus issue #58's two:
     # export the library to an archive, import one back. Plus issue #27's
     # two: log a fretboard drill attempt, and list them. Plus issue #55's
-    # two: start a bulk transcription pass, poll its status.
-    assert count == 58
+    # two: start a bulk transcription pass, poll its status. Plus issue #28's
+    # two: log a chord flash card attempt, and list them.
+    assert count == 60
 
 
 def test_binary_routes_do_not_advertise_a_json_content_type(openapi_schema):

--- a/server/tests/test_chord_theory.py
+++ b/server/tests/test_chord_theory.py
@@ -1,0 +1,74 @@
+"""Chord music theory (issue #28): trainer.chord_tones, checked exhaustively
+enough to trust it - this is the arithmetic a chord flash card's grading
+stands on, mirrored character-for-character from web/src/lib/trainer/chord-
+theory.js's chordTones. See trainer.py's own module comment on why a drift
+between the two sides is a wrong chord taught, not a display bug.
+"""
+
+from fermata import trainer
+
+ROOTS = trainer.PITCH_CLASSES
+QUALITIES = list(trainer.CHORD_QUALITIES)
+
+# ---------------------------------------------------------------- known chords, by hand
+
+
+def test_known_major_triads_are_exactly_right():
+    assert trainer.chord_tones("C", "major") == ("C", "E", "G")
+    assert trainer.chord_tones("G", "major") == ("G", "B", "D")
+    assert trainer.chord_tones("D", "major") == ("D", "F#", "A")
+    assert trainer.chord_tones("A", "major") == ("A", "C#", "E")
+    # Ab, not G#: PITCH_CLASSES spells one sharp OR flat per pitch class.
+    assert trainer.chord_tones("E", "major") == ("E", "Ab", "B")
+    assert trainer.chord_tones("F", "major") == ("F", "A", "C")
+
+
+def test_known_minor_triads_are_exactly_right():
+    assert trainer.chord_tones("A", "minor") == ("A", "C", "E")
+    assert trainer.chord_tones("E", "minor") == ("E", "G", "B")
+    assert trainer.chord_tones("D", "minor") == ("D", "F", "A")
+    assert trainer.chord_tones("C", "minor") == ("C", "Eb", "G")
+
+
+def test_known_dominant_sevenths_are_exactly_right():
+    assert trainer.chord_tones("G", "dominant7") == ("G", "B", "D", "F")
+    assert trainer.chord_tones("C", "dominant7") == ("C", "E", "G", "Bb")
+    assert trainer.chord_tones("A", "dominant7") == ("A", "C#", "E", "G")
+    assert trainer.chord_tones("B", "dominant7") == ("B", "Eb", "F#", "A")
+
+
+# ---------------------------------------------------------------- exhaustive, every root x quality
+
+
+def test_every_root_and_quality_combination_has_the_right_note_count_and_no_repeats():
+    assert len(ROOTS) == 12
+    assert QUALITIES == ["major", "minor", "dominant7"]
+    for root in ROOTS:
+        for quality in QUALITIES:
+            tones = trainer.chord_tones(root, quality)
+            expected_length = len(trainer.CHORD_QUALITIES[quality])
+            assert len(tones) == expected_length, f"{root} {quality}"
+            assert len(set(tones)) == expected_length, f"{root} {quality} has a repeated tone"
+            assert tones[0] == root, f"{root} {quality} does not start on its own root"
+
+
+def test_a_major_and_a_minor_triad_sharing_a_root_differ_in_exactly_the_third():
+    for root in ROOTS:
+        major = trainer.chord_tones(root, "major")
+        minor = trainer.chord_tones(root, "minor")
+        assert major[0] == minor[0]
+        assert major[2] == minor[2]
+        assert major[1] != minor[1]
+
+
+def test_a_dominant_seventh_is_its_major_triad_plus_one_more_note():
+    for root in ROOTS:
+        major = trainer.chord_tones(root, "major")
+        seventh = trainer.chord_tones(root, "dominant7")
+        assert seventh[:3] == major
+        assert len(seventh) == 4
+
+
+def test_an_unknown_root_or_quality_names_no_chord():
+    assert trainer.chord_tones("H", "major") is None
+    assert trainer.chord_tones("C", "augmented") is None

--- a/server/tests/test_chord_trainer_api.py
+++ b/server/tests/test_chord_trainer_api.py
@@ -1,0 +1,326 @@
+"""Per-attempt chord flash card results (issue #28): trainer.
+normalise_chord_attempt directly, and the two /api/trainer/chord-attempts
+routes end to end.
+
+Structured rows, not a free-text note - issue #32's promise, the same as
+fret to note's - so the tests below are literal-value assertions on a
+stored row and a real round trip through the API (#146's lesson), not a
+shape check alone.
+"""
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from fermata import api, db, trainer
+
+# ---------------------------------------------------------------- trainer.py, directly
+
+
+def shape_to_name(**overrides):
+    base = dict(
+        drill="chord_flashcards",
+        direction="shape_to_name",
+        target_root="C",
+        target_quality="major",
+        target_shape=[
+            {"string": 5, "fret": 3},
+            {"string": 4, "fret": 2},
+            {"string": 3, "fret": 0},
+            {"string": 2, "fret": 1},
+            {"string": 1, "fret": 0},
+        ],
+        given_root="C",
+        given_quality="major",
+    )
+    return {**base, **overrides}
+
+
+def name_to_shape(**overrides):
+    base = dict(
+        drill="chord_flashcards",
+        direction="name_to_shape",
+        target_root="G",
+        target_quality="major",
+        given_notes=["G", "B", "D"],
+        given_shape=[{"string": 6, "fret": 3}, {"string": 5, "fret": 2}],
+    )
+    return {**base, **overrides}
+
+
+def test_a_matching_chord_name_is_correct():
+    row = trainer.normalise_chord_attempt(**shape_to_name())
+    assert row["correct"] is True
+
+
+def test_a_different_chord_name_is_incorrect():
+    row = trainer.normalise_chord_attempt(**shape_to_name(given_root="C", given_quality="minor"))
+    assert row["correct"] is False
+
+
+def test_correct_is_computed_and_cannot_be_smuggled_in():
+    import inspect
+
+    assert "correct" not in inspect.signature(trainer.normalise_chord_attempt).parameters
+
+
+def test_name_to_shape_grades_by_tone_set_not_by_exact_fingering():
+    """The taps do not have to reproduce any one canonical shape - only
+    every required tone, and nothing else. A G major played a different way
+    than the reference voicing still grades correct."""
+    row = trainer.normalise_chord_attempt(
+        drill="chord_flashcards",
+        direction="name_to_shape",
+        target_root="G",
+        target_quality="major",
+        given_notes=["D", "G", "B"],  # same set, different order
+        given_shape=[{"string": 4, "fret": 0}, {"string": 3, "fret": 0}, {"string": 2, "fret": 0}],
+    )
+    assert row["correct"] is True
+
+
+def test_name_to_shape_is_incorrect_when_a_required_tone_is_missing():
+    row = trainer.normalise_chord_attempt(**name_to_shape(given_notes=["G", "B"]))
+    assert row["correct"] is False
+
+
+def test_name_to_shape_is_incorrect_against_an_empty_tap():
+    row = trainer.normalise_chord_attempt(
+        drill="chord_flashcards",
+        direction="name_to_shape",
+        target_root="G",
+        target_quality="major",
+        given_notes=[],
+        given_shape=[],
+    )
+    assert row["correct"] is False
+
+
+def test_shape_to_name_rejects_a_tapped_answer():
+    with pytest.raises(ValueError, match="given_notes/given_shape must be omitted"):
+        trainer.normalise_chord_attempt(**shape_to_name(given_notes=["C"], given_shape=[]))
+
+
+def test_shape_to_name_requires_a_target_shape():
+    with pytest.raises(ValueError, match="target_shape"):
+        trainer.normalise_chord_attempt(**shape_to_name(target_shape=None))
+
+
+def test_shape_to_name_requires_a_chosen_name():
+    with pytest.raises(ValueError, match="given_root and given_quality"):
+        trainer.normalise_chord_attempt(**shape_to_name(given_root=None, given_quality=None))
+
+
+def test_name_to_shape_rejects_a_target_shape():
+    with pytest.raises(ValueError, match="target_shape must be omitted"):
+        trainer.normalise_chord_attempt(
+            **name_to_shape(target_shape=[{"string": 6, "fret": 3}])
+        )
+
+
+def test_name_to_shape_rejects_a_chosen_name():
+    with pytest.raises(ValueError, match="given_root/given_quality must be omitted"):
+        trainer.normalise_chord_attempt(**name_to_shape(given_root="G", given_quality="major"))
+
+
+def test_name_to_shape_requires_what_was_tapped():
+    with pytest.raises(ValueError, match="given_notes and given_shape"):
+        trainer.normalise_chord_attempt(**name_to_shape(given_notes=None, given_shape=None))
+
+
+@pytest.mark.parametrize("field", ["target_root", "given_root"])
+def test_only_the_twelve_canonical_pitch_classes_are_accepted_for_a_root(field):
+    with pytest.raises(ValueError, match="target_root|given_root"):
+        trainer.normalise_chord_attempt(**shape_to_name(**{field: "Db"}))
+
+
+@pytest.mark.parametrize("field", ["target_quality", "given_quality"])
+def test_only_the_known_qualities_are_accepted(field):
+    with pytest.raises(ValueError, match="target_quality|given_quality"):
+        trainer.normalise_chord_attempt(**shape_to_name(**{field: "augmented"}))
+
+
+@pytest.mark.parametrize("drill", ["chord_flashcards", "CHORD_FLASHCARDS", "fret_to_note", ""])
+def test_drill_must_be_a_known_chord_drill(drill):
+    if drill == "chord_flashcards":
+        trainer.normalise_chord_attempt(**shape_to_name(drill=drill))  # does not raise
+    else:
+        with pytest.raises(ValueError, match="drill must be one of"):
+            trainer.normalise_chord_attempt(**shape_to_name(drill=drill))
+
+
+def test_a_shape_position_needs_bounded_whole_numbers():
+    with pytest.raises(ValueError, match="target_shape"):
+        trainer.normalise_chord_attempt(
+            **shape_to_name(target_shape=[{"string": 0, "fret": 0}])
+        )
+    with pytest.raises(ValueError, match="target_shape"):
+        trainer.normalise_chord_attempt(
+            **shape_to_name(target_shape=[{"string": 5, "fret": -1}])
+        )
+
+
+def test_response_ms_bounds():
+    row = trainer.normalise_chord_attempt(**shape_to_name(response_ms=1200))
+    assert row["response_ms"] == 1200
+    with pytest.raises(ValueError, match="response_ms"):
+        trainer.normalise_chord_attempt(**shape_to_name(response_ms=-1))
+
+
+def test_chord_attempt_dict_decodes_the_json_columns_back_into_lists():
+    row = trainer.normalise_chord_attempt(**shape_to_name())
+    row["id"] = 1
+    row["owner"] = "local"
+    row["created_at"] = "2026-01-01T00:00:00"
+    d = trainer.chord_attempt_dict(row)
+    assert d["target_shape"] == [
+        {"string": 5, "fret": 3},
+        {"string": 4, "fret": 2},
+        {"string": 3, "fret": 0},
+        {"string": 2, "fret": 1},
+        {"string": 1, "fret": 0},
+    ]
+    assert d["given_notes"] is None
+    assert d["correct"] is True
+
+
+# ---------------------------------------------------------------------------
+# The API, end to end
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def client(app_env):
+    app = FastAPI()
+    app.include_router(api.router)
+    return TestClient(app)
+
+
+def test_logging_a_shape_to_name_attempt_stores_the_row_and_returns_it(client):
+    resp = client.post("/api/trainer/chord-attempts", json=shape_to_name())
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["drill"] == "chord_flashcards"
+    assert body["direction"] == "shape_to_name"
+    assert body["target_root"] == "C"
+    assert body["target_quality"] == "major"
+    assert body["target_shape"] == [
+        {"string": 5, "fret": 3},
+        {"string": 4, "fret": 2},
+        {"string": 3, "fret": 0},
+        {"string": 2, "fret": 1},
+        {"string": 1, "fret": 0},
+    ]
+    assert body["given_root"] == "C"
+    assert body["given_quality"] == "major"
+    assert body["given_notes"] is None
+    assert body["given_shape"] is None
+    assert body["correct"] is True
+    assert body["owner"] == "local"
+    assert body["session_id"] is None
+    assert isinstance(body["id"], int)
+    assert body["created_at"]
+
+    # And the field ROUND-TRIPS: what a fresh read of the same row says is
+    # exactly what the write returned (#146's lesson).
+    conn = db.connect()
+    row = dict(
+        conn.execute(
+            "SELECT * FROM trainer_chord_attempts WHERE id = ?", (body["id"],)
+        ).fetchone()
+    )
+    assert row["target_root"] == "C"
+    assert row["given_root"] == "C"
+    assert row["correct"] == 1  # SQLite's storage of True
+
+    fetched = client.get("/api/trainer/chord-attempts?limit=10").json()["attempts"][0]
+    assert fetched["id"] == body["id"]
+    assert fetched["correct"] is True
+    assert fetched["target_root"] == "C"
+
+
+def test_logging_a_name_to_shape_attempt_round_trips_the_tapped_notes(client):
+    resp = client.post("/api/trainer/chord-attempts", json=name_to_shape())
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["direction"] == "name_to_shape"
+    assert body["target_shape"] is None
+    assert sorted(body["given_notes"]) == ["B", "D", "G"]
+    assert body["given_shape"] == [{"string": 6, "fret": 3}, {"string": 5, "fret": 2}]
+    assert body["correct"] is True
+
+
+def test_an_incorrect_answer_round_trips_false(client):
+    resp = client.post(
+        "/api/trainer/chord-attempts", json=shape_to_name(given_root="A", given_quality="minor")
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["correct"] is False
+    listed = client.get("/api/trainer/chord-attempts?correct=false").json()
+    assert listed["total"] == 1
+    assert listed["attempts"][0]["target_root"] == "C"
+    assert client.get("/api/trainer/chord-attempts?correct=true").json()["total"] == 0
+
+
+def test_a_bad_body_is_refused_with_422_naming_the_problem(client):
+    resp = client.post(
+        "/api/trainer/chord-attempts", json=shape_to_name(target_quality="augmented")
+    )
+    assert resp.status_code == 422
+    assert "target_quality" in resp.json()["detail"]
+
+
+def test_an_unknown_session_id_is_refused(client):
+    resp = client.post(
+        "/api/trainer/chord-attempts", json=shape_to_name(session_id=99999)
+    )
+    assert resp.status_code == 404
+
+
+def test_an_attempt_can_be_linked_to_a_real_session(client):
+    session = client.post(
+        "/api/practice/sessions", json={"seconds": 90, "activity": "chords"}
+    ).json()
+    resp = client.post(
+        "/api/trainer/chord-attempts", json=shape_to_name(session_id=session["id"])
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["session_id"] == session["id"]
+    assert (
+        client.get(f"/api/trainer/chord-attempts?session_id={session['id']}").json()["total"] == 1
+    )
+
+    # Deleting the session keeps the attempt and only unlinks it - the same
+    # rule trainer_attempts follows for the same reason.
+    client.delete(f"/api/practice/sessions/{session['id']}")
+    still_there = client.get("/api/trainer/chord-attempts").json()
+    assert still_there["total"] == 1
+    assert still_there["attempts"][0]["session_id"] is None
+
+
+def test_listing_filters_by_root_and_quality(client):
+    client.post("/api/trainer/chord-attempts", json=shape_to_name())
+    client.post("/api/trainer/chord-attempts", json=name_to_shape())
+
+    assert client.get("/api/trainer/chord-attempts").json()["total"] == 2
+    assert client.get("/api/trainer/chord-attempts?root=C").json()["total"] == 1
+    assert client.get("/api/trainer/chord-attempts?root=G").json()["total"] == 1
+    assert client.get("/api/trainer/chord-attempts?quality=major").json()["total"] == 2
+    assert client.get("/api/trainer/chord-attempts?root=C&quality=major").json()["total"] == 1
+    assert client.get("/api/trainer/chord-attempts?direction=shape_to_name").json()["total"] == 1
+
+
+def test_an_unknown_filter_value_is_refused(client):
+    assert client.get("/api/trainer/chord-attempts?drill=fret_to_note").status_code == 422
+    assert client.get("/api/trainer/chord-attempts?direction=sideways").status_code == 422
+    assert client.get("/api/trainer/chord-attempts?root=H").status_code == 422
+    assert client.get("/api/trainer/chord-attempts?quality=augmented").status_code == 422
+
+
+def test_truncation_is_reported_honestly(client):
+    for root in ("C", "D", "E"):
+        client.post("/api/trainer/chord-attempts", json=shape_to_name(target_root=root, given_root=root))
+    listed = client.get("/api/trainer/chord-attempts?limit=2").json()
+    assert listed["total"] == 3
+    assert len(listed["attempts"]) == 2
+    assert listed["truncated"] is True

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -7,6 +7,7 @@
   import EarTraining from "./lib/EarTraining.svelte";
   import ScoreProgress from "./lib/ScoreProgress.svelte";
   import FretToNote from "./lib/trainer/FretToNote.svelte";
+  import ChordFlashCards from "./lib/trainer/ChordFlashCards.svelte";
 
   function parse(hash) {
     // Checked BEFORE the bare score route, which matches a prefix: without
@@ -22,6 +23,7 @@
     if (hash.startsWith("#/metronome")) return { page: "metronome" };
     if (hash.startsWith("#/ear-training")) return { page: "ear-training" };
     if (hash.startsWith("#/fretboard")) return { page: "fretboard" };
+    if (hash.startsWith("#/chords")) return { page: "chords" };
     return { page: "library" };
   }
 
@@ -50,6 +52,8 @@
   <EarTraining />
 {:else if route.page === "fretboard"}
   <FretToNote />
+{:else if route.page === "chords"}
+  <ChordFlashCards />
 {:else}
   <Library />
 {/if}

--- a/web/src/lib/Library.svelte
+++ b/web/src/lib/Library.svelte
@@ -586,6 +586,7 @@
       <a class="demo-link" href="#/metronome">♩ Metronome</a>
       <a class="demo-link ear-training-link" href="#/ear-training">♪ Hear a note, name it</a>
       <a class="demo-link fretboard-link" href="#/fretboard">▤ Fret to note</a>
+      <a class="demo-link chords-link" href="#/chords">♫ Chord flash cards</a>
       <a class="demo-link" href="#/demo">Notation/tab demo →</a>
       <a class="demo-link" href="#/settings">⚙ Settings</a>
     </div>

--- a/web/src/lib/api.js
+++ b/web/src/lib/api.js
@@ -269,6 +269,22 @@ export const api = {
     );
     return fetch(`/api/trainer/attempts?${q}`).then(j);
   },
+  // Structured, per-question chord flash card results (issue #28, #32) - the
+  // same idea as logTrainerAttempt, in a table of its own (see
+  // server/fermata/trainer.py's module docstring for why a chord does not
+  // fit trainer_attempts' single-note columns).
+  logChordAttempt: (body) =>
+    fetch("/api/trainer/chord-attempts", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }).then(j),
+  chordAttempts: (params = {}) => {
+    const q = new URLSearchParams(
+      Object.fromEntries(Object.entries(params).filter(([, v]) => v != null && v !== "")),
+    );
+    return fetch(`/api/trainer/chord-attempts?${q}`).then(j);
+  },
   version: () => fetch("/api/version").then(j),
   settings: () => fetch("/api/settings").then(j),
   putSettings: (values) =>

--- a/web/src/lib/score-render.js
+++ b/web/src/lib/score-render.js
@@ -839,6 +839,60 @@ export async function playPitch(
   return noteOn ? noteOn.noteKey : null;
 }
 
+/**
+ * Sound several pitches AT ONCE, as MIDI note numbers - a chord, for the
+ * chord flash card drill (issue #28's "hear it, using the synthesiser
+ * already present"). The same one-shot MIDI file playPitch builds, widened
+ * to one NoteOnEvent per pitch at tick 0 rather than one note at all.
+ *
+ * Resolves with the MIDI notes actually handed to the synthesiser - same
+ * guarantee as playPitch's own, extended to a list: a pitch outside MIDI's
+ * range is simply left out (never substituted or rounded into range), and
+ * the array reports exactly what was queued, in the order given. An empty
+ * `midis` array, or one where every pitch was out of range, resolves with
+ * an empty array rather than null - the synthesiser loaded and nothing was
+ * wrong with it, there was simply nothing left to hand it. null is reserved
+ * for the synthesiser itself being unavailable, the same case playPitch
+ * reserves it for.
+ */
+export async function playChord(
+  midis,
+  { voice = AUDITION_PROGRAM, seconds = AUDITION_SECONDS } = {},
+) {
+  const keys = (midis ?? [])
+    .map((m) => Math.round(Number(m)))
+    .filter((key) => Number.isFinite(key) && key >= MIN_MIDI && key <= MAX_MIDI);
+  const player = await auditionPlayer();
+  if (!player) return null;
+  const {
+    MidiFile,
+    TempoChangeEvent,
+    ProgramChangeEvent,
+    ControlChangeEvent,
+    ControllerType,
+    NoteOnEvent,
+    NoteOffEvent,
+    EndOfTrackEvent,
+  } = alphaTab.midi;
+  const end = Math.round(Math.max(0.1, Number(seconds) || AUDITION_SECONDS) * TICKS_PER_SECOND);
+  const file = new MidiFile();
+  file.division = TICKS_PER_QUARTER;
+  file.addEvent(new TempoChangeEvent(0, MICROSECONDS_PER_QUARTER));
+  file.addEvent(new ProgramChangeEvent(0, 0, AUDITION_CHANNEL, Math.round(Number(voice)) || 0));
+  file.addEvent(
+    new ControlChangeEvent(0, 0, AUDITION_CHANNEL, ControllerType.VolumeCoarse, 127),
+  );
+  for (const key of keys) {
+    file.addEvent(new NoteOnEvent(0, 0, AUDITION_CHANNEL, key, AUDITION_VELOCITY));
+  }
+  for (const key of keys) {
+    file.addEvent(new NoteOffEvent(0, end, AUDITION_CHANNEL, key, 0));
+  }
+  file.addEvent(new EndOfTrackEvent(0, end + 1));
+  player.playOneTimeMidiFile(file);
+  return file.events.filter((e) => e instanceof NoteOnEvent).map((e) => e.noteKey);
+}
+
 // ------------------------------------------------- the practice metronome
 //
 // The click itself is NOT here. It lives in metronome-engine.js, as a general

--- a/web/src/lib/trainer/ChordFlashCards.svelte
+++ b/web/src/lib/trainer/ChordFlashCards.svelte
@@ -1,0 +1,806 @@
+<script>
+  // Guitar chord flash cards, both directions (issue #28) - built on the
+  // neck (#25) and the constraint model (#26), the same way fret-to-note
+  // (#27) is. Show a shape, name the chord; or name a chord, place its
+  // notes on the neck.
+  //
+  // WHAT MAKES THIS ONE HONEST, following FretToNote.svelte's own lead:
+  //
+  //   Nothing here grades anybody. Two counts, stated - no percentage, no
+  //   streak. See chords.js's answerStatement and the tone rules at the top
+  //   of that file.
+  //
+  //   name_to_shape is graded on what was actually TAPPED, worked out from
+  //   the instrument's own tuning - never on matching one canonical
+  //   fingering. There is more than one right way to play G major; see
+  //   chords.js's module docstring.
+  //
+  //   Every question is a structured row (POST /api/trainer/chord-
+  //   attempts), not only a count folded into the session's note - issue
+  //   #32's promise for this drill, in a table of its own (see
+  //   server/fermata/trainer.py's module comment on why).
+  //
+  //   THE NECK IS REUSED, NOT REBUILT. Both directions draw on Neck.svelte's
+  //   existing `markers` and `highlightNote` props exactly as fret-to-note
+  //   does - a shown shape or a set of taps is just another set of markers.
+  import { onDestroy } from "svelte";
+
+  import { api } from "../api.js";
+  import { getInstruments, loadInstruments } from "../instruments.svelte.js";
+  import { localDay } from "../practice.js";
+  import { playChord } from "../score-render.js";
+  import { ROOTS } from "./chord-theory.js";
+  import {
+    NAME_TO_SHAPE,
+    SHAPE_TO_NAME,
+    answerStatement,
+    attemptPayload,
+    checkNameAnswer,
+    checkShapeAnswer,
+    chordChoices,
+    directionLabel,
+    familyLabel,
+    loggedStatement,
+    pickQuestion,
+    poolIsAskable,
+    progressStatement,
+    sessionNote,
+    FAMILY_LIST,
+  } from "./chords.js";
+  import { KEY_QUALITY_LIST } from "./constraints.js";
+  import Neck from "./Neck.svelte";
+  import { DEFAULT_FRET_COUNT, fretCountFromInstrument, noteAt, stringsFromInstrument } from "./neck.js";
+
+  const instruments = getInstruments();
+
+  $effect(() => {
+    loadInstruments();
+  });
+
+  // Which instrument's tuning to draw the neck from - the same rule
+  // FretToNote.svelte follows and for the same reason (see that file's own
+  // comment): with more than one instrument defined, which is in
+  // somebody's hands is not knowable, so only exactly one is adopted.
+  let source = $state("");
+  let sourceSettled = false;
+  $effect(() => {
+    if (!instruments.loaded || sourceSettled) return;
+    sourceSettled = true;
+    if (instruments.list.length === 1) source = String(instruments.list[0].id);
+  });
+
+  const instrument = $derived(instruments.list.find((i) => String(i.id) === source) ?? null);
+  const strings = $derived(stringsFromInstrument(instrument));
+  const fretCount = $derived(fretCountFromInstrument(instrument));
+
+  let direction = $state(SHAPE_TO_NAME);
+  let family = $state(FAMILY_LIST[0]);
+
+  // Region scope: which strings and which frets - identical shape and
+  // defaulting rule to FretToNote.svelte's, via constraints.js (#26).
+  let customizedStrings = false;
+  let selectedStrings = $state([]);
+  $effect(() => {
+    if (customizedStrings) return;
+    selectedStrings = strings.map((s) => s.number);
+  });
+
+  let customizedFretRange = false;
+  let startFret = $state(0);
+  let endFret = $state(DEFAULT_FRET_COUNT);
+  $effect(() => {
+    if (customizedFretRange) return;
+    startFret = 0;
+    endFret = fretCount;
+  });
+
+  function toggleString(number) {
+    customizedStrings = true;
+    if (selectedStrings.includes(number)) {
+      if (selectedStrings.length <= 1) return;
+      selectedStrings = selectedStrings.filter((n) => n !== number);
+    } else {
+      selectedStrings = [...selectedStrings, number];
+    }
+  }
+
+  function setStartFret(value) {
+    customizedFretRange = true;
+    startFret = Number(value);
+  }
+
+  function setEndFret(value) {
+    customizedFretRange = true;
+    endFret = Number(value);
+  }
+
+  // Key scope (#26's addition): off by default (every chord in the family
+  // preset is in play), and only a real constraint once a person turns it
+  // on - the same "narrowed only on purpose" rule the string/fret scope
+  // above follows.
+  let keyEnabled = $state(false);
+  let keyRoot = $state("C");
+  let keyQuality = $state("major");
+
+  const scope = $derived({
+    startFret,
+    endFret,
+    stringNumbers: selectedStrings,
+    key: keyEnabled ? { root: keyRoot, quality: keyQuality } : undefined,
+  });
+  const askable = $derived(poolIsAskable(strings, scope, family));
+  const choices = $derived(chordChoices(strings, scope, family));
+
+  let running = $state(false);
+  let asked = $state(0);
+  let correctCount = $state(0);
+  // { question, given, correct }. `given` is null until answered.
+  let round = $state(null);
+  // name_to_shape only: positions tapped so far, before Check is pressed.
+  let tapped = $state([]);
+  let questionStartedAt = 0;
+  let attemptLogFailures = $state(0);
+  let soundError = $state("");
+  let sounding = $state(false);
+
+  let startedAt = 0;
+  let logged = $state(null);
+  let logError = $state("");
+  let logging = $state(false);
+  let unlogged = $state(null);
+
+  function elapsed() {
+    return Math.max(1, Math.round((Date.now() - startedAt) / 1000));
+  }
+
+  function drillNote() {
+    return sessionNote({ asked, correct: correctCount, direction, strings, scope, family });
+  }
+
+  function nextQuestion() {
+    const previous = round?.question ?? null;
+    const question = pickQuestion(strings, scope, family, direction, previous);
+    round = question ? { question, given: null, correct: null } : null;
+    tapped = [];
+    soundError = "";
+    questionStartedAt = Date.now();
+  }
+
+  async function recordAttempt(question, given, correct) {
+    const responseMs = Math.max(0, Date.now() - questionStartedAt);
+    try {
+      await api.logChordAttempt(attemptPayload({ question, given, responseMs }));
+    } catch {
+      // Best-effort: the drill's own counts and its session log are the
+      // record that must not be lost - see FretToNote.svelte's identical
+      // rule.
+      attemptLogFailures += 1;
+    }
+  }
+
+  function chooseName(root, quality) {
+    if (!round || round.given != null || round.question.direction !== SHAPE_TO_NAME) return;
+    const correct = checkNameAnswer(round.question, root, quality);
+    const given = { root, quality };
+    round = { ...round, given, correct };
+    asked += 1;
+    if (correct) correctCount += 1;
+    recordAttempt(round.question, given, correct);
+  }
+
+  function toggleTap(stringNumber, fret) {
+    if (!round || round.given != null || round.question.direction !== NAME_TO_SHAPE) return;
+    const idx = tapped.findIndex((p) => p.string === stringNumber);
+    if (idx >= 0 && tapped[idx].fret === fret) {
+      tapped = tapped.filter((_, i) => i !== idx);
+    } else if (idx >= 0) {
+      tapped = tapped.map((p, i) => (i === idx ? { string: stringNumber, fret } : p));
+    } else {
+      tapped = [...tapped, { string: stringNumber, fret }];
+    }
+  }
+
+  function checkShape() {
+    if (!round || round.given != null || round.question.direction !== NAME_TO_SHAPE) return;
+    if (!tapped.length) return;
+    const { correct, notes } = checkShapeAnswer(strings, round.question, tapped);
+    const given = { positions: tapped, notes };
+    round = { ...round, given, correct };
+    asked += 1;
+    if (correct) correctCount += 1;
+    recordAttempt(round.question, given, correct);
+  }
+
+  function neckMarkers() {
+    if (!round) return [];
+    const { question, given, correct } = round;
+    const kind = given == null ? "target" : correct ? "correct" : "incorrect";
+    const positions = question.direction === SHAPE_TO_NAME ? (question.shape?.frets ?? []) : tapped;
+    return positions.map((p) => ({ string: p.string, fret: p.fret, kind }));
+  }
+
+  async function hear() {
+    if (!round) return;
+    soundError = "";
+    sounding = true;
+    try {
+      const midis = round.question.sound
+        .map(({ string, fret }) => noteAt(strings, string, fret))
+        .filter((m) => m != null);
+      const heard = await playChord(midis);
+      if (!heard || !heard.length) {
+        soundError = "No chord was sounded, so there is nothing to hear yet.";
+      }
+    } catch (e) {
+      soundError = e?.message || "The synthesiser could not be loaded.";
+    } finally {
+      sounding = false;
+    }
+  }
+
+  const neckInteractive = $derived(
+    running && round != null && round.given == null && direction === NAME_TO_SHAPE,
+  );
+
+  function start() {
+    if (!askable) return;
+    running = true;
+    startedAt = Date.now();
+    asked = 0;
+    correctCount = 0;
+    attemptLogFailures = 0;
+    logged = null;
+    logError = "";
+    unlogged = null;
+    nextQuestion();
+  }
+
+  async function stopAndLog() {
+    if (!running) return;
+    const seconds = elapsed();
+    const totalAsked = asked;
+    running = false;
+    round = null;
+    if (!totalAsked) return;
+    await send(seconds);
+  }
+
+  async function send(seconds) {
+    logging = true;
+    logError = "";
+    try {
+      const session = await api.logSession({
+        activity: "chords",
+        seconds,
+        local_date: localDay(),
+        note: drillNote(),
+      });
+      logged = { seconds: session?.seconds ?? seconds, id: session?.id ?? null };
+      unlogged = null;
+    } catch (e) {
+      logError = e?.message || "That practice could not be logged.";
+      unlogged = seconds;
+    } finally {
+      logging = false;
+    }
+  }
+
+  function retryLog() {
+    if (unlogged == null) return;
+    send(unlogged);
+  }
+
+  onDestroy(() => {
+    if (!running || asked < 1) return;
+    api
+      .logSession({
+        activity: "chords",
+        seconds: elapsed(),
+        local_date: localDay(),
+        note: drillNote(),
+      })
+      .catch(() => {});
+  });
+</script>
+
+<div class="page">
+  <header>
+    <a class="back" href="#/">← Library</a>
+    <h1>Chord flash cards</h1>
+  </header>
+
+  <main>
+    <section
+      class="drill"
+      data-running={running ? "1" : "0"}
+      data-asked={asked}
+      data-correct={correctCount}
+      data-direction={direction}
+      data-family={family}
+      data-askable={askable ? "1" : "0"}
+      data-question-root={round?.question?.root ?? ""}
+      data-question-quality={round?.question?.quality ?? ""}
+      data-given-correct={round?.given != null ? (round.correct ? "1" : "0") : ""}
+      data-tapped-count={tapped.length}
+      data-attempt-log-failures={attemptLogFailures}
+    >
+      <p class="hint">
+        Shown a shape, name the chord - or name a chord, tap its notes onto the neck. Both
+        directions are different skills, so pick the one to practise.
+      </p>
+
+      <!-- ------------------------------------------------------ direction -->
+      <div class="row direction-row" role="group" aria-label="Direction">
+        <button
+          class="direction-choice"
+          class:active={direction === SHAPE_TO_NAME}
+          disabled={running}
+          onclick={() => (direction = SHAPE_TO_NAME)}
+        >
+          Shape → name
+        </button>
+        <button
+          class="direction-choice"
+          class:active={direction === NAME_TO_SHAPE}
+          disabled={running}
+          onclick={() => (direction = NAME_TO_SHAPE)}
+        >
+          Name → shape
+        </button>
+      </div>
+
+      <!-- ------------------------------------------------------ family -->
+      <div class="row family-row" role="group" aria-label="Chord family">
+        {#each FAMILY_LIST as key (key)}
+          <button
+            class="family-choice"
+            class:active={family === key}
+            disabled={running}
+            onclick={() => (family = key)}
+          >
+            {familyLabel(key)}
+          </button>
+        {/each}
+      </div>
+
+      <!-- ------------------------------------------------------ source & scope -->
+      <div class="row scope-row">
+        <label>
+          <span>Tuning</span>
+          <select class="scope-source" bind:value={source} disabled={running}>
+            <option value="">Standard guitar</option>
+            {#each instruments.list as owned (owned.id)}
+              <option value={String(owned.id)}>{owned.name}</option>
+            {/each}
+          </select>
+        </label>
+        <label>
+          <span>Frets</span>
+          <select
+            class="scope-start-fret"
+            value={startFret}
+            disabled={running}
+            onchange={(e) => setStartFret(e.currentTarget.value)}
+          >
+            {#each Array.from({ length: fretCount + 1 }, (_, f) => f) as f (f)}
+              <option value={f}>{f}</option>
+            {/each}
+          </select>
+          <span>to</span>
+          <select
+            class="scope-end-fret"
+            value={endFret}
+            disabled={running}
+            onchange={(e) => setEndFret(e.currentTarget.value)}
+          >
+            {#each Array.from({ length: fretCount + 1 }, (_, f) => f) as f (f)}
+              <option value={f}>{f}</option>
+            {/each}
+          </select>
+        </label>
+      </div>
+
+      <div class="row strings-row" role="group" aria-label="Strings">
+        {#each [...strings].sort((a, b) => b.number - a.number) as string (string.number)}
+          <button
+            class="string-choice"
+            class:active={selectedStrings.includes(string.number)}
+            disabled={running}
+            onclick={() => toggleString(string.number)}
+          >
+            {string.number}
+          </button>
+        {/each}
+      </div>
+
+      <div class="row key-row">
+        <label class="key-toggle">
+          <input type="checkbox" bind:checked={keyEnabled} disabled={running} class="key-enabled" />
+          <span>Key</span>
+        </label>
+        <select class="key-root" bind:value={keyRoot} disabled={running || !keyEnabled}>
+          {#each ROOTS as root (root)}
+            <option value={root}>{root}</option>
+          {/each}
+        </select>
+        <select class="key-quality" bind:value={keyQuality} disabled={running || !keyEnabled}>
+          {#each KEY_QUALITY_LIST as quality (quality)}
+            <option value={quality}>{quality}</option>
+          {/each}
+        </select>
+      </div>
+
+      {#if instruments.error}
+        <p class="notice instruments-error">
+          {instruments.error} The drill below uses the standard guitar instead.
+        </p>
+      {/if}
+
+      {#if !askable}
+        <p class="statement narrow-scope">
+          Nothing is selected to ask about - widen the region, the key, or the chord family.
+        </p>
+      {/if}
+
+      <!-- ------------------------------------------------------- the drill -->
+      {#if running && round}
+        <p class="statement progress">{progressStatement({ asked, correct: correctCount })}</p>
+
+        {#if direction === NAME_TO_SHAPE}
+          <p class="statement prompt">
+            Place <strong>{round.question.root} {round.question.quality === "dominant7" ? "7" : round.question.quality}</strong> on the neck.
+          </p>
+        {:else}
+          <p class="statement prompt">Name the shape shown.</p>
+        {/if}
+
+        <div class="row hear-row">
+          <button class="ghost hear-it" onclick={hear} disabled={sounding}>
+            {sounding ? "Sounding…" : "♪ Hear it"}
+          </button>
+        </div>
+        {#if soundError}
+          <p class="notice sound-error">{soundError}</p>
+        {/if}
+
+        <Neck
+          {strings}
+          {fretCount}
+          startFret={0}
+          markers={neckMarkers()}
+          interactive={neckInteractive}
+          onTap={toggleTap}
+        />
+
+        <div class="statement-slot" role="status" aria-live="polite">
+          {#if round.given != null}
+            <p class="statement answer-statement">
+              {answerStatement(round.question, round.given, round.correct)}
+            </p>
+          {/if}
+        </div>
+
+        {#if direction === SHAPE_TO_NAME}
+          <ul class="choices">
+            {#each choices as choice (choice.root + ":" + choice.quality)}
+              <li>
+                <button
+                  class="choice"
+                  class:correct={round.given != null && choice.root === round.question.root && choice.quality === round.question.quality}
+                  class:picked={round.given?.root === choice.root && round.given?.quality === choice.quality && !(choice.root === round.question.root && choice.quality === round.question.quality)}
+                  data-root={choice.root}
+                  data-quality={choice.quality}
+                  disabled={round.given != null}
+                  onclick={() => chooseName(choice.root, choice.quality)}
+                >
+                  {choice.name}
+                </button>
+              </li>
+            {/each}
+          </ul>
+        {:else}
+          <div class="row controls">
+            <button
+              class="primary check-shape"
+              onclick={checkShape}
+              disabled={round.given != null || !tapped.length}
+            >
+              Check
+            </button>
+          </div>
+        {/if}
+
+        <div class="row controls">
+          {#if round.given != null}
+            <button class="primary next-question" onclick={nextQuestion}>Next question</button>
+          {/if}
+          <button class="ghost stop-drill" onclick={stopAndLog} disabled={logging}>
+            {logging ? "Logging…" : "Stop and log this practice"}
+          </button>
+        </div>
+      {:else if running && !round}
+        <p class="statement narrow-scope">
+          Nothing is selected to ask about - widen the region, the key, or the chord family.
+        </p>
+        <div class="row controls">
+          <button class="ghost stop-drill" onclick={stopAndLog} disabled={logging}>
+            {logging ? "Logging…" : "Stop"}
+          </button>
+        </div>
+      {:else}
+        {#if askable}
+          <div class="row controls">
+            <button class="primary start-drill" onclick={start}>Start</button>
+          </div>
+        {/if}
+
+        {#if logged}
+          <p class="statement logged">
+            {loggedStatement(logged.seconds)}
+            {progressStatement({ asked, correct: correctCount })}
+            <a href="#/practice">Practice &amp; goals →</a>
+          </p>
+        {/if}
+
+        {#if logError}
+          <p class="notice log-error">
+            {logError}
+            <button class="retry-log" onclick={retryLog} disabled={logging}>
+              {logging ? "Trying…" : "Try again"}
+            </button>
+          </p>
+        {/if}
+      {/if}
+    </section>
+
+    <p class="quiet footnote">
+      The time you spend here is logged as chord practice, in the same history as everything else.
+      Every question is also kept on its own, so which chords need more time is something you can
+      look back on - not only a count for the session it happened in.
+    </p>
+  </main>
+</div>
+
+<style>
+  .page {
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+  }
+
+  header {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    padding: 14px 20px;
+    border-bottom: 1px solid var(--line);
+  }
+
+  h1 {
+    margin: 0;
+    font-size: 18px;
+    font-weight: 600;
+  }
+
+  .back {
+    color: var(--ink-dim);
+    font-size: 14px;
+  }
+
+  .back:hover {
+    color: var(--brass);
+  }
+
+  main {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 20px;
+    padding: 32px 20px 48px;
+  }
+
+  .drill {
+    width: 100%;
+    max-width: 720px;
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+    padding: 22px;
+    background: var(--bg-raised);
+    border: 1px solid var(--line);
+    border-radius: var(--radius);
+  }
+
+  .hint,
+  .quiet {
+    margin: 0;
+    color: var(--ink-dim);
+    font-size: 13px;
+    line-height: 1.5;
+  }
+
+  .row {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    flex-wrap: wrap;
+  }
+
+  .scope-row label,
+  .key-row .key-toggle {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 14px;
+  }
+
+  select {
+    background: var(--surface);
+    color: var(--ink);
+    border: 1px solid var(--line);
+    border-radius: 6px;
+    padding: 5px 8px;
+    font: inherit;
+    font-size: 14px;
+    text-transform: capitalize;
+  }
+
+  .direction-choice,
+  .string-choice,
+  .family-choice,
+  .choice,
+  button {
+    min-height: 44px;
+  }
+
+  .direction-choice,
+  .string-choice,
+  .family-choice {
+    background: var(--surface);
+    color: var(--ink);
+    border: 1px solid var(--line);
+    border-radius: var(--radius);
+    padding: 10px 16px;
+    font: inherit;
+    font-size: 15px;
+    cursor: pointer;
+  }
+
+  .string-choice {
+    min-width: 44px;
+    padding: 10px 0;
+    text-align: center;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .direction-choice.active,
+  .string-choice.active,
+  .family-choice.active {
+    border-color: var(--brass);
+    color: var(--brass-bright);
+  }
+
+  .direction-choice:disabled,
+  .string-choice:disabled,
+  .family-choice:disabled {
+    opacity: 0.55;
+    cursor: default;
+  }
+
+  .statement {
+    margin: 0;
+    font-size: 15px;
+    color: var(--ink);
+    line-height: 1.5;
+  }
+
+  .statement-slot {
+    min-height: 30px;
+    display: flex;
+    align-items: center;
+  }
+
+  .choices {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 10px;
+  }
+
+  .choice {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 14px 6px;
+    background: var(--surface);
+    color: var(--ink);
+    border: 1px solid var(--line);
+    border-radius: var(--radius);
+    font: inherit;
+    font-size: 16px;
+    cursor: pointer;
+  }
+
+  .choice:hover:enabled {
+    border-color: var(--brass);
+  }
+
+  .choice:disabled {
+    opacity: 1;
+    cursor: default;
+  }
+
+  .choice.correct {
+    border-color: var(--brass);
+    color: var(--brass-bright);
+  }
+
+  .choice.picked {
+    border-color: var(--ink-dim);
+  }
+
+  button {
+    background: var(--surface);
+    color: var(--ink);
+    border: 1px solid var(--line);
+    border-radius: 6px;
+    padding: 8px 14px;
+    font: inherit;
+    font-size: 14px;
+    cursor: pointer;
+  }
+
+  button:hover:enabled {
+    border-color: var(--brass);
+  }
+
+  button:disabled {
+    opacity: 0.55;
+    cursor: default;
+  }
+
+  button.primary {
+    background: var(--brass);
+    border-color: var(--brass);
+    color: #1a1509;
+    font-weight: 600;
+  }
+
+  button.ghost {
+    background: none;
+    color: var(--ink-dim);
+  }
+
+  .notice {
+    margin: 0;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    flex-wrap: wrap;
+    font-size: 14px;
+    color: var(--ink);
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: 6px;
+    padding: 8px 12px;
+  }
+
+  .logged a {
+    color: var(--brass);
+  }
+
+  .footnote {
+    max-width: 52ch;
+    text-align: center;
+  }
+
+  @media (min-width: 640px) {
+    .choices {
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+  }
+</style>

--- a/web/src/lib/trainer/chord-shapes.js
+++ b/web/src/lib/trainer/chord-shapes.js
@@ -1,0 +1,183 @@
+// Chord shapes for the guitar (issue #28) - real fingerings, checked against
+// chord-theory.js's own arithmetic rather than trusted by hand.
+//
+// TWO SOURCES OF SHAPES, both self-verifying:
+//
+//   OPEN shapes are the common open-position chords every beginner learns
+//   first - hardcoded frets, because "which open chords exist" is not
+//   arithmetic, it is a small fixed list a guitarist would recognise. Each
+//   one's ACTUAL sounded notes (shapeNotes, worked out from neck.js's own
+//   noteAt/pitchClass - the same arithmetic the neck draws with) is what
+//   tests/unit/chord-shapes.spec.js checks against chord-theory.js's
+//   chordTones for the shape's declared root and quality. A wrong fret in
+//   the list below fails that test; it is not merely "looks about right".
+//
+//   BARRE shapes are generated, not listed - the E-shape and A-shape
+//   moveable forms, at every fret a scope's region allows. A barre shape's
+//   root is read off the neck itself (noteAt on the shape's own base
+//   string), not looked up in a table, so every root from 1 to 12 fret
+//   positions is correct BY CONSTRUCTION rather than by a list of twelve
+//   entries somebody had to get right by hand. shapeNotes verifies it
+//   anyway, the same as an open shape.
+//
+// BOTH KINDS ASSUME THE STANDARD GUITAR'S OWN STRING-INTERVAL PATTERN -
+// isStandardGuitarTuning checks the SEMITONES between adjacent strings, not
+// their absolute pitch, so a shape still fits a capo'd standard-tuned
+// instrument (every string shifts together, sounding_midi already carries
+// it - see neck.js's stringsFromInstrument) but returns nothing for a
+// seven-string guitar, a dropped tuning, or any instrument that is not
+// fretted at all. No shapes is the honest answer there, not an invented
+// one - the drill built on this reports the same "nothing to ask" state a
+// narrow fret range or an empty key reaches (see constraints.js).
+import { noteAt, pitchClass } from "./neck.js";
+import { chordTones } from "./chord-theory.js";
+
+// Semitones from string N to string (N-1), for N = 6..2 - i.e. index 0 is
+// string 6 to string 5, index 4 is string 2 to string 1. This is standard
+// tuning's OWN interval pattern (fourths, except a major third between the
+// third and second strings), independent of what the strings actually
+// sound - see neck.spec.js's identical "fifth-fret relationship" check,
+// which is this same fact stated the other way round.
+const STANDARD_INTERVALS = [5, 5, 5, 4, 5];
+
+/** Whether `strings` carries the standard guitar's six strings (numbers 1-6
+ * present) tuned with the standard interval pattern between each adjacent
+ * pair - the one fact every shape below assumes. True for a capo'd standard
+ * tuning (every interval is preserved, only the absolute pitch moves);
+ * false for anything else, including a partial or non-standard string set. */
+export function isStandardGuitarTuning(strings) {
+  const byNumber = new Map((strings ?? []).map((s) => [s.number, s.midi]));
+  for (let n = 6; n >= 1; n--) {
+    if (!byNumber.has(n) || !Number.isFinite(byNumber.get(n))) return false;
+  }
+  for (let n = 6; n >= 2; n--) {
+    if (byNumber.get(n - 1) - byNumber.get(n) !== STANDARD_INTERVALS[6 - n]) return false;
+  }
+  return true;
+}
+
+// The common open-position chords. `frets` is [[string, fret], ...] for
+// every string the shape actually sounds - a string simply absent from the
+// list is muted, the same convention "x" marks in a chord diagram. Root and
+// quality are the claim tests/unit/chord-shapes.spec.js checks shapeNotes
+// against; see this module's own docstring.
+const OPEN_SHAPE_TEMPLATES = [
+  { root: "E", quality: "major", frets: [[6, 0], [5, 2], [4, 2], [3, 1], [2, 0], [1, 0]] },
+  { root: "E", quality: "minor", frets: [[6, 0], [5, 2], [4, 2], [3, 0], [2, 0], [1, 0]] },
+  { root: "E", quality: "dominant7", frets: [[6, 0], [5, 2], [4, 0], [3, 1], [2, 0], [1, 0]] },
+  { root: "A", quality: "major", frets: [[5, 0], [4, 2], [3, 2], [2, 2], [1, 0]] },
+  { root: "A", quality: "minor", frets: [[5, 0], [4, 2], [3, 2], [2, 1], [1, 0]] },
+  { root: "A", quality: "dominant7", frets: [[5, 0], [4, 2], [3, 0], [2, 2], [1, 0]] },
+  { root: "D", quality: "major", frets: [[4, 0], [3, 2], [2, 3], [1, 2]] },
+  { root: "D", quality: "minor", frets: [[4, 0], [3, 2], [2, 3], [1, 1]] },
+  { root: "D", quality: "dominant7", frets: [[4, 0], [3, 2], [2, 1], [1, 2]] },
+  { root: "G", quality: "major", frets: [[6, 3], [5, 2], [4, 0], [3, 0], [2, 0], [1, 3]] },
+  { root: "G", quality: "dominant7", frets: [[6, 3], [5, 2], [4, 0], [3, 0], [2, 0], [1, 1]] },
+  { root: "C", quality: "major", frets: [[5, 3], [4, 2], [3, 0], [2, 1], [1, 0]] },
+  { root: "B", quality: "dominant7", frets: [[5, 2], [4, 1], [3, 2], [2, 0], [1, 2]] },
+];
+
+// The two moveable barre forms, as offsets from a base fret on the form's
+// own root string - the E-shape barres on string 6, the A-shape on string
+// 5 (and mutes string 6 entirely, the same as its open A-chord ancestor
+// does). Each offset is relative to the base fret, not absolute, which is
+// what makes the form moveable: barreShapesFor adds a base fret and reads
+// the resulting root straight off the neck rather than from a second table.
+const BARRE_TEMPLATES = {
+  "barre-e-major": {
+    rootString: 6,
+    quality: "major",
+    offsets: [[6, 0], [5, 2], [4, 2], [3, 1], [2, 0], [1, 0]],
+  },
+  "barre-e-minor": {
+    rootString: 6,
+    quality: "minor",
+    offsets: [[6, 0], [5, 2], [4, 2], [3, 0], [2, 0], [1, 0]],
+  },
+  "barre-a-major": {
+    rootString: 5,
+    quality: "major",
+    offsets: [[5, 0], [4, 2], [3, 2], [2, 2], [1, 0]],
+  },
+  "barre-a-minor": {
+    rootString: 5,
+    quality: "minor",
+    offsets: [[5, 0], [4, 2], [3, 2], [2, 1], [1, 0]],
+  },
+};
+
+/** Every open-position shape the standard tuning offers - empty for any
+ * other tuning (see isStandardGuitarTuning). Each entry: { id, root,
+ * quality, family: "open", frets: [{string, fret}] }. */
+export function openShapesFor(strings) {
+  if (!isStandardGuitarTuning(strings)) return [];
+  return OPEN_SHAPE_TEMPLATES.map((t) => ({
+    id: `open:${t.root}:${t.quality}`,
+    root: t.root,
+    quality: t.quality,
+    family: "open",
+    frets: t.frets.map(([string, fret]) => ({ string, fret })),
+  }));
+}
+
+/** Every barre-shape instance whose lowest fret is between `minBaseFret`
+ * and `maxFret` inclusive of every fret the shape itself uses - empty for
+ * any tuning that is not standard. One instance per (template, base fret),
+ * its root read straight off the neck at the template's own root string and
+ * that base fret, so every root the shape can name across the range is
+ * produced without a lookup table to keep in step with chord-theory.js by
+ * hand. `maxFret` defaults to 12 frets past minBaseFret when omitted -
+ * callers scoping a region pass the neck's own fret count instead. */
+export function barreShapesFor(strings, { minBaseFret = 1, maxFret } = {}) {
+  if (!isStandardGuitarTuning(strings)) return [];
+  const top = Number.isFinite(maxFret) ? maxFret : minBaseFret + 12;
+  const out = [];
+  for (const [family, tpl] of Object.entries(BARRE_TEMPLATES)) {
+    const highestOffset = Math.max(...tpl.offsets.map(([, rel]) => rel));
+    for (let base = Math.max(0, minBaseFret); base + highestOffset <= top; base++) {
+      const midi = noteAt(strings, tpl.rootString, base);
+      if (midi == null) continue;
+      out.push({
+        id: `${family}:${base}`,
+        root: pitchClass(midi),
+        quality: tpl.quality,
+        family,
+        frets: tpl.offsets.map(([string, rel]) => ({ string, fret: base + rel })),
+      });
+    }
+  }
+  return out;
+}
+
+/** Every shape (open and barre) `strings` can offer, up to `maxFret` -
+ * everything allShapesInScope further narrows by region and by which
+ * families/qualities a scope's chosen preset admits. */
+export function allShapes(strings, { maxFret } = {}) {
+  return [...openShapesFor(strings), ...barreShapesFor(strings, { maxFret })];
+}
+
+/** The pitch classes a shape ACTUALLY sounds, worked out from `strings`'
+ * own tuning via neck.js's noteAt/pitchClass - independent of the shape's
+ * declared root and quality, which is what makes this a real check rather
+ * than restating the label. Frets outside the neck's MIDI range are simply
+ * skipped, the same as neck.js's own positions(). */
+export function shapeNotes(strings, shape) {
+  return (shape?.frets ?? [])
+    .map(({ string, fret }) => noteAt(strings, string, fret))
+    .filter((midi) => midi != null)
+    .map(pitchClass);
+}
+
+/** Whether a shape's actual sounded notes are exactly the tones of the
+ * chord it claims (or of an explicit root/quality pair, for grading a
+ * player's own tap-built shape against a target chord rather than against
+ * one specific fingering) - same pitch classes, none missing, none extra.
+ * Octave and how many strings double a tone are irrelevant: a chord is its
+ * pitch-class SET, the same rule chord-theory.js's chordTones states. */
+export function shapeMatchesChord(strings, shape, root = shape?.root, quality = shape?.quality) {
+  const want = chordTones(root, quality);
+  if (!want) return false;
+  const got = new Set(shapeNotes(strings, shape));
+  if (got.size !== want.length) return false;
+  return want.every((note) => got.has(note));
+}

--- a/web/src/lib/trainer/chord-theory.js
+++ b/web/src/lib/trainer/chord-theory.js
@@ -1,0 +1,77 @@
+// Chord music theory (issue #28) - which notes belong to a chord, from its
+// root and its quality. Pure interval arithmetic, no strings and no frets:
+// this is "what IS a C major chord", the fact a shape (chord-shapes.js) is
+// checked against, and the whole reason a shape can be trusted rather than
+// merely drawn to look right.
+//
+// No runes and no browser, for the same reason neck.js and pitch.js have
+// none: this is the one piece of music-theory arithmetic that a fingering
+// diagram, a flash card's grading, and a unit test all have to agree with,
+// and disagreeing here is not a display bug - it is teaching a wrong chord.
+//
+// MIRRORED, CHARACTER FOR CHARACTER, IN server/fermata/trainer.py's
+// CHORD_QUALITIES and chord_tones - the same pair neck.js's PITCH_CLASSES
+// and trainer.py's own PITCH_CLASSES already are. tests/unit/chord-
+// theory.spec.js checks every one of the 36 (root, quality) chords this
+// module can build; server/tests/test_chord_theory.py checks the identical
+// 36 on the Python side, so a drift between the two fails a test on
+// whichever side changed rather than showing up as a shape and its label
+// disagreeing about what chord is on screen.
+import { PITCH_CLASSES } from "./neck.js";
+
+// Interval steps from the root, in semitones - a triad for major and minor,
+// a tetrad for the one seventh chord this module names. "Majors and minors
+// first, then sevenths" (issue #28) is exactly this order.
+export const QUALITIES = {
+  major: { label: "major", suffix: "", intervals: [0, 4, 7] },
+  minor: { label: "minor", suffix: "m", intervals: [0, 3, 7] },
+  dominant7: { label: "7th", suffix: "7", intervals: [0, 4, 7, 10] },
+};
+
+export const QUALITY_LIST = Object.keys(QUALITIES);
+
+// The chord roots this module offers - exactly PITCH_CLASSES, under its own
+// name here so a caller reasoning about chords is not reaching into neck.js
+// for a list that happens to also be this one.
+export const ROOTS = PITCH_CLASSES;
+
+/** The pitch classes a chord is built from - "C" + "major" -> ["C","E","G"]
+ * - or null when the root or the quality is not one this module knows. The
+ * ONE place this arithmetic happens: chord-shapes.js's shapeNotes computes
+ * what a fingering actually sounds independently, from string tuning and
+ * fret arithmetic, and every shape in the library is checked against this
+ * function's own answer for its declared root and quality. */
+export function chordTones(root, quality) {
+  const rootIndex = PITCH_CLASSES.indexOf(root);
+  const q = QUALITIES[quality];
+  if (rootIndex < 0 || !q) return null;
+  return q.intervals.map((step) => PITCH_CLASSES[(rootIndex + step) % 12]);
+}
+
+/** "C major", "A minor", "G7" - how a chord is named wherever one is shown,
+ * so the flash card's prompt, its answer choices, and its structured
+ * attempt row can never spell the same chord two different ways. Null for
+ * an unknown root or quality, the same as chordTones. */
+export function chordName(root, quality) {
+  const q = QUALITIES[quality];
+  if (PITCH_CLASSES.indexOf(root) < 0 || !q) return null;
+  if (quality === "dominant7") return `${root}7`;
+  return `${root} ${q.label}`;
+}
+
+/** Whether two chords - each a (root, quality) pair - are the SAME chord,
+ * meaning the same set of pitch classes. Compares the tone sets rather than
+ * the root/quality strings directly, which is the honest version of "is
+ * this the chord that was asked for": two different (root, quality) pairs
+ * that happened to name identical tone sets would otherwise grade as wrong
+ * for a reason that has nothing to do with what was actually played or
+ * chosen. With today's three qualities no such pair exists, but the rule
+ * this drill grades by should not depend on that staying true. */
+export function chordsMatch(rootA, qualityA, rootB, qualityB) {
+  const a = chordTones(rootA, qualityA);
+  const b = chordTones(rootB, qualityB);
+  if (!a || !b) return false;
+  if (a.length !== b.length) return false;
+  const setB = new Set(b);
+  return a.every((note) => setB.has(note));
+}

--- a/web/src/lib/trainer/chords.js
+++ b/web/src/lib/trainer/chords.js
@@ -1,0 +1,273 @@
+// Chord flash cards, both directions (issue #28) - built on the neck (#25)
+// and the constraint model (#26), the way fret-to-note (#27) is. Show a
+// shape, name the chord; or name a chord, place its notes on the neck.
+//
+// No runes and no browser - the pattern is fret-to-note.js's and ear-
+// training.js's, for the same reason: which question gets asked and how
+// the answer is worded is worth getting right on its own, testable without
+// a page.
+//
+// THE TONE RULES ARE practice.js's, same as every other drill in this
+// application: a wrong answer is the practice, not a shortfall. No accuracy
+// percentage, no streak, no verdict word - only counts, stated.
+// tests/unit/chords.spec.js checks every string this module produces
+// against practice.js's own FORBIDDEN_WORDS list, the same check #184's
+// fret-to-note.spec.js runs, extended to this second drill.
+//
+// GRADING IS ONE RULE, EITHER DIRECTION - the same idea fret-to-note.js's
+// module docstring states for a tapped note: a chord is its pitch-class
+// SET (chord-theory.js's chordTones), so "was the right chord named" and
+// "was the right chord played" both reduce to comparing two tone sets,
+// never to matching one canonical fingering. Naming a chord compares the
+// chosen (root, quality) pair's tones to the question's; placing one
+// compares whatever the player actually tapped - worked out from the
+// instrument's own tuning, never from what they meant to tap, mirroring
+// checkTapAnswer's rule in fret-to-note.js - to the question's tones. A
+// shape shown to identify (shape_to_name) is always a REAL fingering drawn
+// from chord-shapes.js's library, but a shape being BUILT (name_to_shape)
+// is graded on what it sounds, not on matching that or any other one
+// canonical voicing - there is more than one right way to play G major.
+//
+// STRUCTURED RESULTS, NOT A FREE-TEXT NOTE (issue #32), same promise as
+// fret-to-note.js's, in a table of its own (trainer_chord_attempts) rather
+// than trainer_attempts - see server/fermata/trainer.py's module docstring
+// for why a chord does not fit the single-note columns that table's first
+// drill committed to, and db.py's comment on the new table for the honest
+// alternative: a sibling table shaped for what a chord attempt actually is.
+import { countOrNone, formatDuration } from "../practice.js";
+import { chordName, chordTones, chordsMatch } from "./chord-theory.js";
+import { allShapes, shapeMatchesChord, shapeNotes } from "./chord-shapes.js";
+import { groupInScope, keyNotes, scopeLabel as regionLabel } from "./constraints.js";
+import { DEFAULT_FRET_COUNT, noteAt, pitchClass } from "./neck.js";
+
+export const SHAPE_TO_NAME = "shape_to_name";
+export const NAME_TO_SHAPE = "name_to_shape";
+export const DIRECTIONS = [SHAPE_TO_NAME, NAME_TO_SHAPE];
+
+export const DRILL = "chord_flashcards";
+
+// "Majors and minors first, then sevenths, then barre chords" (issue #28) -
+// three presets rather than two independent axes (quality and shape family)
+// a player would otherwise have to reconcile by hand. Each preset says both
+// which qualities are in play and which shape families they are drawn from.
+export const FAMILIES = {
+  major_minor: {
+    label: "Major & minor",
+    qualities: ["major", "minor"],
+    shapeFamilies: ["open"],
+  },
+  sevenths: {
+    label: "Sevenths",
+    qualities: ["dominant7"],
+    shapeFamilies: ["open"],
+  },
+  barre: {
+    label: "Barre chords",
+    qualities: ["major", "minor"],
+    shapeFamilies: ["barre-e-major", "barre-e-minor", "barre-a-major", "barre-a-minor"],
+  },
+};
+
+export const FAMILY_LIST = Object.keys(FAMILIES);
+
+/** How the direction reads in a sentence. */
+export function directionLabel(direction) {
+  return direction === NAME_TO_SHAPE ? "name to shape" : "shape to name";
+}
+
+/** How a family preset reads in a sentence. */
+export function familyLabel(family) {
+  return FAMILIES[family]?.label ?? FAMILIES[FAMILY_LIST[0]].label;
+}
+
+/** A shape's fretted positions, each carrying the note it actually sounds -
+ * what groupInScope (constraints.js) needs to decide whether a WHOLE shape
+ * fits a region, not only whether its declared root does. */
+function shapeFretsWithNotes(strings, shape) {
+  return (shape?.frets ?? [])
+    .map(({ string, fret }) => {
+      const midi = noteAt(strings, string, fret);
+      return midi == null ? null : { string, fret, note: pitchClass(midi) };
+    })
+    .filter(Boolean);
+}
+
+/** Whether every tone of a (root, quality) chord is a note of a key - the
+ * meaning "scope to a key" carries for a chord (#26's key/note-set filter,
+ * applied here rather than only to a single-note drill): a chord is only
+ * offered when it is fully diatonic to the key, not merely rooted in it.
+ * True with no key set. */
+function chordInKey(root, quality, key) {
+  if (!key) return true;
+  const notes = keyNotes(key.root, key.quality ?? "major");
+  const tones = chordTones(root, quality);
+  if (!notes || !tones) return false;
+  const set = new Set(notes);
+  return tones.every((t) => set.has(t));
+}
+
+/** Every shape a scope and a family preset actually allow: drawn from
+ * chord-shapes.js's library, narrowed to the preset's qualities and shape
+ * families, to chords fully inside the scope's key (when one is set), and
+ * to shapes that fit ENTIRELY inside the scope's string set and fret range
+ * (constraints.js's groupInScope - a shape half inside a region is not a
+ * shape the region allows). The one place both pickQuestion and "can this
+ * even be asked" draw shapes from. */
+export function chordPool(strings, scope = {}, family = FAMILY_LIST[0]) {
+  const preset = FAMILIES[family] ?? FAMILIES[FAMILY_LIST[0]];
+  const maxFret = Math.max(0, Number(scope.endFret ?? DEFAULT_FRET_COUNT));
+  return allShapes(strings, { maxFret })
+    .filter((s) => preset.shapeFamilies.includes(s.family) && preset.qualities.includes(s.quality))
+    .filter((s) => chordInKey(s.root, s.quality, scope.key))
+    .filter((s) => groupInScope(shapeFretsWithNotes(strings, s), scope));
+}
+
+/** Whether a scope and family preset have anything to ask about at all -
+ * reachable the moment a region excludes every shape, or a key admits none
+ * of the preset's chords. */
+export function poolIsAskable(strings, scope, family) {
+  return chordPool(strings, scope, family).length > 0;
+}
+
+/** Every distinct CHORD (root and quality, not every shape) a pool offers,
+ * named and sorted - what shape_to_name's answer buttons are built from, so
+ * the choices offered are exactly the chords this scope and family preset
+ * can actually ask about rather than a fixed list unrelated to what is in
+ * play. */
+export function chordChoices(strings, scope, family) {
+  const seen = new Map();
+  for (const shape of chordPool(strings, scope, family)) {
+    const key = `${shape.root}:${shape.quality}`;
+    if (!seen.has(key)) {
+      seen.set(key, { root: shape.root, quality: shape.quality, name: chordName(shape.root, shape.quality) });
+    }
+  }
+  return [...seen.values()].sort((a, b) => a.name.localeCompare(b.name));
+}
+
+/** "Major & minor, strings 1-6, frets 0-3" - the scope AND the family
+ * preset, named together, since both narrow what this drill asks. */
+export function scopeLabel(strings, scope, family) {
+  return `${familyLabel(family)}, ${regionLabel(strings, scope)}`;
+}
+
+/** The next question: shape_to_name shows a real fingering and asks for its
+ * name; name_to_shape names a chord and asks for it to be placed. Never
+ * repeats the same CHORD (root and quality, not the exact shape - two
+ * different barre positions naming the same chord back to back would still
+ * read as the drill failing to advance) just asked, the same rule
+ * fret-to-note.js's pickQuestion follows. Null when the pool has nothing to
+ * ask. */
+export function pickQuestion(strings, scope, family, direction, previous = null, rand = Math.random) {
+  const pool = chordPool(strings, scope, family);
+  if (!pool.length) return null;
+  const eligible = previous
+    ? pool.filter((s) => !chordsMatch(s.root, s.quality, previous.root, previous.quality))
+    : pool;
+  const from = eligible.length ? eligible : pool;
+  const shape = from[Math.min(from.length - 1, Math.floor(rand() * from.length))];
+  return {
+    direction,
+    root: shape.root,
+    quality: shape.quality,
+    // Only shape_to_name shows an actual fingering; name_to_shape asks for
+    // one to be built, and grades whatever the player taps rather than one
+    // canonical answer - see the module docstring.
+    shape: direction === SHAPE_TO_NAME ? shape : null,
+    // A playable fingering for THIS chord either way - "hear it" (issue
+    // #28) needs real positions to turn into MIDI notes regardless of
+    // direction, even on name_to_shape where nothing is shown yet.
+    sound: shape.frets,
+  };
+}
+
+/** shape_to_name: was the chosen chord the one shown - compared as tone
+ * sets (chord-theory.js's chordsMatch), never as matching label strings. */
+export function checkNameAnswer(question, givenRoot, givenQuality) {
+  return chordsMatch(question.root, question.quality, givenRoot, givenQuality);
+}
+
+/** name_to_shape: does what was actually TAPPED sound the question's chord
+ * - every required tone present, nothing extra - worked out from the
+ * instrument's own tuning, never from which shape the player meant to
+ * play. `tapped` is [{string, fret}, ...]. Returns the resolved notes
+ * alongside `correct` so the caller can both show and log what actually
+ * sounded, the same shape checkTapAnswer returns in fret-to-note.js. */
+export function checkShapeAnswer(strings, question, tapped) {
+  const positions = tapped ?? [];
+  const notes = [...new Set(shapeNotes(strings, { frets: positions }))].sort();
+  const correct = positions.length > 0
+    && shapeMatchesChord(strings, { frets: positions }, question.root, question.quality);
+  return { correct, notes };
+}
+
+/** The structured row to POST to /api/trainer/chord-attempts for one
+ * answered question - issue #32's promise, kept per-question. `given` is
+ * already resolved (checkNameAnswer's chosen root/quality, or
+ * checkShapeAnswer's tapped positions/notes) - this function does no
+ * grading of its own, matching trainer.py's rule that `correct` is
+ * computed once, server-side. */
+export function attemptPayload({ sessionId = null, question, given, responseMs = null }) {
+  const base = {
+    session_id: sessionId,
+    drill: DRILL,
+    direction: question.direction,
+    target_root: question.root,
+    target_quality: question.quality,
+    response_ms: responseMs ?? null,
+  };
+  if (question.direction === SHAPE_TO_NAME) {
+    return {
+      ...base,
+      target_shape: question.shape ? question.shape.frets.map(({ string, fret }) => ({ string, fret })) : null,
+      given_root: given.root,
+      given_quality: given.quality,
+    };
+  }
+  return {
+    ...base,
+    given_notes: given.notes,
+    given_shape: (given.positions ?? []).map(({ string, fret }) => ({ string, fret })),
+  };
+}
+
+/** What to say about the answer just given - the chord's name either way,
+ * and what was actually played when a shape was tapped. No verdict word:
+ * the fact stated is what teaches, same rule as fret-to-note's
+ * answerStatement. */
+export function answerStatement(question, given, correct) {
+  const name = chordName(question.root, question.quality);
+  if (question.direction === SHAPE_TO_NAME) {
+    const givenName = chordName(given.root, given.quality);
+    return correct ? `That shape is ${name}.` : `That shape is ${name}. You named ${givenName ?? "nothing"}.`;
+  }
+  if (!given.notes?.length) return `${name} is ${chordTones(question.root, question.quality).join(", ")}.`;
+  return correct
+    ? `${name} is ${chordTones(question.root, question.quality).join(", ")} - that's what sounded.`
+    : `${name} is ${chordTones(question.root, question.quality).join(", ")}. What was tapped sounded ${given.notes.join(", ")}.`;
+}
+
+/** How the drill has gone so far. Two counts, nothing else - no percentage,
+ * no streak. Matches fret-to-note.js's progressStatement in shape. */
+export function progressStatement({ asked = 0, correct = 0 } = {}) {
+  const total = Math.max(0, Math.floor(Number(asked) || 0));
+  if (!total) return "Nothing asked yet.";
+  const questions = total === 1 ? "1 chord" : `${total} chords`;
+  return `${questions}, ${countOrNone(correct)} answered correctly.`;
+}
+
+/** What goes in the practice session's free-text `note` - a human-readable
+ * summary beside the structured per-question rows this drill also writes
+ * (see attemptPayload and the module docstring on why both exist). */
+export function sessionNote({ asked = 0, correct = 0, direction, strings, scope, family } = {}) {
+  return `Chord flash cards, ${directionLabel(direction)}. ${progressStatement({ asked, correct })} ${scopeLabel(
+    strings,
+    scope,
+    family,
+  )}.`;
+}
+
+/** What was logged, said back once the drill has stopped. */
+export function loggedStatement(seconds) {
+  return `${formatDuration(seconds)} of chord practice is in your practice history.`;
+}

--- a/web/src/lib/trainer/constraints.js
+++ b/web/src/lib/trainer/constraints.js
@@ -1,0 +1,131 @@
+// The constraint model (issue #26) - scoping ANY drill built on the neck to
+// what a player is actually working on: particular strings, a fret range,
+// and (new here) a key or note set. Shared infrastructure, not a per-game
+// setting, so the same scope object narrows fret-to-note (#27) and the chord
+// flash cards (#28) alike.
+//
+// FACTORED OUT OF fret-to-note.js, NOT REWRITTEN. Issue #27 built the first
+// version of string+fret-range scoping directly inside that drill; this
+// module is that same arithmetic moved here so a second drill does not have
+// to re-derive it, plus one addition (a key/note-set filter) that neither
+// drill exposed before. fret-to-note.js now imports scopePositions,
+// scopeIsAskable and scopeLabel from here rather than defining its own - see
+// that file's own note - so the drill that already had tests covering this
+// arithmetic keeps proving it, unchanged.
+//
+// A "scope" is a plain object:
+//   stringNumbers  string numbers to allow, or omitted/empty for "every
+//                  string offered" - never treated as "no strings".
+//   startFret      the lowest fret to allow (default 0).
+//   endFret        the highest fret to allow (default DEFAULT_FRET_COUNT).
+//   key            { root, quality } - a pitch class and "major" or "minor"
+//                  - or omitted for "every note". Narrows to the notes of
+//                  that key, the same idea as a capo narrows to a fret
+//                  range: fewer choices, chosen on purpose rather than
+//                  offered because nobody said not to.
+import { DEFAULT_FRET_COUNT, PITCH_CLASSES, positions as neckPositions } from "./neck.js";
+
+// The two scales a key can name. Interval steps from the root, in semitones
+// - the plain major (Ionian) and natural minor (Aeolian) scales, which is
+// what "a key" means to a guitarist scoping practice rather than a jazz
+// player choosing a mode. A third scale is a wider constraint model than
+// this issue asks for; these two are enough to make "practice only what's in
+// the key of G" a real, testable option.
+export const KEY_QUALITIES = {
+  major: [0, 2, 4, 5, 7, 9, 11],
+  minor: [0, 2, 3, 5, 7, 8, 10],
+};
+
+export const KEY_QUALITY_LIST = Object.keys(KEY_QUALITIES);
+
+/** Every pitch class in a key, root and quality - "G major" -> ["G","A","B",
+ * "C","D","E","F#"] - or null when either is not one this module knows. */
+export function keyNotes(root, quality = "major") {
+  const rootIndex = PITCH_CLASSES.indexOf(root);
+  const intervals = KEY_QUALITIES[quality];
+  if (rootIndex < 0 || !intervals) return null;
+  return intervals.map((step) => PITCH_CLASSES[(rootIndex + step) % 12]);
+}
+
+/** Whether a fret falls inside a scope's fret range. */
+export function fretInScope(fret, scope = {}) {
+  const start = Math.max(0, Number(scope.startFret ?? 0));
+  const end = Number(scope.endFret ?? DEFAULT_FRET_COUNT);
+  return fret >= start && fret <= end;
+}
+
+/** Whether a string number is one a scope allows - every string, when none
+ * are named (an empty or missing list is "no filter", never "no strings" -
+ * see fret-to-note.js's toggleString for why a caller must not let that
+ * state be reached by unchecking the last box). */
+export function stringInScope(stringNumber, scope = {}) {
+  return !Array.isArray(scope.stringNumbers) || !scope.stringNumbers.length
+    || scope.stringNumbers.includes(stringNumber);
+}
+
+/** Whether a pitch class is inside a scope's key - true for every note when
+ * no key is set. */
+export function noteInScope(note, scope = {}) {
+  if (!scope.key) return true;
+  const notes = keyNotes(scope.key.root, scope.key.quality ?? "major");
+  return notes ? notes.includes(note) : true;
+}
+
+/** Whether one (string, fret, note) position satisfies every dimension of a
+ * scope at once - the single test scopePositions and a chord shape's
+ * region check both reduce to. */
+export function positionInScope(stringNumber, fret, note, scope = {}) {
+  return stringInScope(stringNumber, scope)
+    && fretInScope(fret, scope)
+    && noteInScope(note, scope);
+}
+
+/** Whether every position in a GROUP - a chord shape's fretted notes, not a
+ * single tap - fits inside a scope. Empty groups are never in scope: a shape
+ * with nothing fretted (all strings muted) is not a shape a scope can be
+ * said to allow. */
+export function groupInScope(positionsGroup, scope = {}) {
+  const group = positionsGroup ?? [];
+  if (!group.length) return false;
+  return group.every((p) => positionInScope(p.string, p.fret, p.note, scope));
+}
+
+/** Every position a scope actually allows: `strings` narrowed to
+ * `scope.stringNumbers` (all of them when omitted or empty),
+ * `scope.startFret`..`scope.endFret`, and `scope.key` when set. The one
+ * place both a position-picking drill and the "can this even be asked"
+ * check draw positions from. */
+export function scopePositions(strings, scope = {}) {
+  const start = Math.max(0, Number(scope.startFret ?? 0));
+  const end = Number(scope.endFret ?? DEFAULT_FRET_COUNT);
+  return neckPositions(strings, start, end).filter((p) =>
+    positionInScope(p.string, p.fret, p.note, scope),
+  );
+}
+
+/** Whether a scope has anything to ask about at all - reachable through the
+ * ordinary interface the moment every string is deselected, a fret range is
+ * narrowed to nothing, or a key excludes every note the strings can sound. */
+export function scopeIsAskable(strings, scope) {
+  return scopePositions(strings, scope).length > 0;
+}
+
+/** "Strings 1, 2, frets 0-5, key of G major" - the scope, named. Every
+ * string is not stated (it is the ordinary case); a narrowed set is. */
+export function scopeLabel(strings, scope = {}) {
+  const start = Math.max(0, Number(scope.startFret ?? 0));
+  const end = Number(scope.endFret ?? DEFAULT_FRET_COUNT);
+  const all = (strings ?? []).map((s) => s.number).sort((a, b) => a - b);
+  const selected = Array.isArray(scope.stringNumbers) && scope.stringNumbers.length
+    ? [...scope.stringNumbers].sort((a, b) => a - b)
+    : all;
+  const parts = [];
+  if (selected.length !== all.length) {
+    parts.push(`string${selected.length === 1 ? "" : "s"} ${selected.join(", ")}`);
+  }
+  parts.push(`frets ${start}-${end}`);
+  if (scope.key) {
+    parts.push(`key of ${scope.key.root} ${scope.key.quality ?? "major"}`);
+  }
+  return parts.join(", ");
+}

--- a/web/src/lib/trainer/fret-to-note.js
+++ b/web/src/lib/trainer/fret-to-note.js
@@ -21,51 +21,25 @@
 // the same as every other activity, so a reader of the practice page is not
 // left with a blank line; the STRUCTURED, QUERYABLE record lives in
 // trainer_attempts instead of being the only place time was spent.
+//
+// SCOPING (string set, fret range - and now a key too) IS constraints.js's
+// (issue #26), NOT THIS FILE'S. This drill had the first version of that
+// arithmetic; it has been moved out so the chord flash cards (#28) can use
+// the identical rule rather than a second copy of it, and this module keeps
+// its own three names (scopePositions/scopeIsAskable/scopeLabel) as a
+// re-export so nothing that already imports them - FretToNote.svelte, this
+// file's own tests - has to change.
 import { countOrNone, formatDuration } from "../practice.js";
-import { DEFAULT_FRET_COUNT, noteAt, pitchClass, positions as neckPositions } from "./neck.js";
+import { scopeIsAskable, scopeLabel, scopePositions } from "./constraints.js";
+import { noteAt, pitchClass } from "./neck.js";
+
+export { scopeIsAskable, scopeLabel, scopePositions } from "./constraints.js";
 
 export const POSITION_TO_NOTE = "position_to_note";
 export const NOTE_TO_POSITION = "note_to_position";
 export const DIRECTIONS = [POSITION_TO_NOTE, NOTE_TO_POSITION];
 
 export const DRILL = "fret_to_note";
-
-/** Every position a scope actually allows: `strings` narrowed to
- * `scope.stringNumbers` (all of them when omitted or empty) and
- * `scope.startFret`..`scope.endFret`. The one place both pickQuestion and
- * the "can this even be asked" check draw positions from. */
-export function scopePositions(strings, scope = {}) {
-  const start = Math.max(0, Number(scope.startFret ?? 0));
-  const end = Number(scope.endFret ?? DEFAULT_FRET_COUNT);
-  const allowed = Array.isArray(scope.stringNumbers) && scope.stringNumbers.length
-    ? new Set(scope.stringNumbers)
-    : null;
-  return neckPositions(strings, start, end).filter((p) => !allowed || allowed.has(p.string));
-}
-
-/** Whether a scope has anything to ask about at all - reachable through the
- * ordinary interface the moment every string is deselected, or a fret range
- * is narrowed to nothing. */
-export function scopeIsAskable(strings, scope) {
-  return scopePositions(strings, scope).length > 0;
-}
-
-/** "Strings 1, 2, frets 0-5" - the scope, named. Every string is not stated
- * (it is the ordinary case); a narrowed set is. */
-export function scopeLabel(strings, scope = {}) {
-  const start = Math.max(0, Number(scope.startFret ?? 0));
-  const end = Number(scope.endFret ?? DEFAULT_FRET_COUNT);
-  const all = (strings ?? []).map((s) => s.number).sort((a, b) => a - b);
-  const selected = Array.isArray(scope.stringNumbers) && scope.stringNumbers.length
-    ? [...scope.stringNumbers].sort((a, b) => a - b)
-    : all;
-  const parts = [];
-  if (selected.length !== all.length) {
-    parts.push(`string${selected.length === 1 ? "" : "s"} ${selected.join(", ")}`);
-  }
-  parts.push(`frets ${start}-${end}`);
-  return parts.join(", ");
-}
 
 /** How the direction reads in a sentence. */
 export function directionLabel(direction) {

--- a/web/tests/browser/chord-flashcards.spec.js
+++ b/web/tests/browser/chord-flashcards.spec.js
@@ -1,0 +1,354 @@
+// The chord flash card drill (issue #28), built on the neck (#25) and the
+// constraint model (#26), against the real backend and the real build.
+//
+// The ground truth for "what chord is this" is read off the section's own
+// data-question-root/data-question-quality attributes (the question this
+// component actually picked), the same discipline fretboard-trainer.spec.js
+// applies to data-question-note - never off anything a mock would make true
+// for free. Which POSITIONS sound a required tone is read off the neck's
+// own data-note attributes (Neck.svelte's rendered arithmetic, already
+// proven correct in fretboard-trainer.spec.js), combined with an
+// INDEPENDENTLY reimplemented chord formula below rather than anything
+// imported from the app - so this suite would catch the app's own chord
+// math breaking, not merely restate it.
+import { expect, test } from "@playwright/test";
+
+import { forbiddenWord, localDay } from "../../src/lib/practice.js";
+
+const drill = (page) => page.locator("section.drill");
+const startButton = (page) => page.locator(".start-drill");
+const progress = (page) => page.locator(".progress");
+const answerStatement = (page) => page.locator(".answer-statement");
+
+const today = localDay();
+
+// An independent copy of the chord-tone formula, NOT imported from the app
+// - see this file's own header. Any drift between this and chord-theory.js
+// would show up as this suite's own assertions failing against what the
+// page renders, which is the point.
+const PITCH_CLASSES = ["C", "C#", "D", "Eb", "E", "F", "F#", "G", "Ab", "A", "Bb", "B"];
+const INTERVALS = { major: [0, 4, 7], minor: [0, 3, 7], dominant7: [0, 4, 7, 10] };
+function chordTones(root, quality) {
+  const i = PITCH_CLASSES.indexOf(root);
+  return INTERVALS[quality].map((step) => PITCH_CLASSES[(i + step) % 12]);
+}
+function chordName(root, quality) {
+  return quality === "dominant7" ? `${root}7` : `${root} ${quality}`;
+}
+
+async function reset(request) {
+  const existing = await (await request.get("/api/instruments")).json();
+  for (const instrument of existing) await request.delete(`/api/instruments/${instrument.id}`);
+  const goals = (await (await request.get(`/api/practice/goals?today=${today}`)).json()).goals;
+  for (const goal of goals) await request.delete(`/api/practice/goals/${goal.id}`);
+  const sessions = (
+    await (await request.get("/api/practice/sessions?limit=1000")).json()
+  ).sessions;
+  for (const session of sessions) await request.delete(`/api/practice/sessions/${session.id}`);
+}
+
+test.beforeEach(async ({ page, request }) => {
+  const scores = await (await request.get("/api/scores")).json();
+  expect(
+    scores,
+    "refusing to run: this backend has scores in its library, so it is not the " +
+      "throwaway instance the suite creates - and these tests delete practice history",
+  ).toEqual([]);
+  await reset(request);
+
+  await page.goto("/#/chords");
+  await expect(drill(page)).toBeVisible();
+});
+
+function question(page) {
+  return drill(page).evaluate((el) => ({
+    root: el.dataset.questionRoot,
+    quality: el.dataset.questionQuality,
+  }));
+}
+
+// Any answer choice other than the one naming (root, quality) - a `:not()`
+// CSS selector, not `.filter({ hasNot: ... })`, because hasNot's locator is
+// scoped to DESCENDANTS of each candidate and data-root/data-quality sit on
+// the .choice element itself, not on a child of it.
+function wrongChoice(page, root, quality) {
+  return page.locator(`.choice:not([data-root="${root}"][data-quality="${quality}"])`).first();
+}
+
+// Taps one position per required tone, on a distinct string each time -
+// picked from the neck's OWN data-note attributes, so this is a real
+// rendered position and not an invented one.
+async function tapChord(page, tones) {
+  const usedStrings = new Set();
+  for (const note of tones) {
+    const candidates = page.locator(`g.position[data-note="${note}"]`);
+    const count = await candidates.count();
+    let tapped = false;
+    for (let i = 0; i < count; i++) {
+      const el = candidates.nth(i);
+      const string = await el.getAttribute("data-string");
+      if (usedStrings.has(string)) continue;
+      usedStrings.add(string);
+      await el.click();
+      tapped = true;
+      break;
+    }
+    expect(tapped, `a free string sounding ${note}`).toBe(true);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// The drill: prompt, answer, feedback, next - both directions, both a
+// correct and an incorrect answer, handled honestly.
+// ---------------------------------------------------------------------------
+
+test("shape_to_name: naming the right chord says so plainly, and the count moves", async ({
+  page,
+}) => {
+  await startButton(page).click();
+  await expect(drill(page)).toHaveAttribute("data-direction", "shape_to_name");
+  await expect(progress(page)).toHaveText("Nothing asked yet.");
+
+  const q = await question(page);
+  await page.locator(`.choice[data-root="${q.root}"][data-quality="${q.quality}"]`).click();
+
+  await expect(drill(page)).toHaveAttribute("data-asked", "1");
+  await expect(drill(page)).toHaveAttribute("data-correct", "1");
+  await expect(progress(page)).toHaveText("1 chord, 1 answered correctly.");
+  await expect(answerStatement(page)).toContainText(chordName(q.root, q.quality));
+  await expect(
+    page.locator(`.choice[data-root="${q.root}"][data-quality="${q.quality}"]`),
+  ).toHaveClass(/correct/);
+
+  const text = await answerStatement(page).textContent();
+  expect(forbiddenWord(text), text).toBeNull();
+  expect(text).not.toMatch(/%/);
+});
+
+test("shape_to_name: naming a different chord names the right one, without a verdict word", async ({
+  page,
+}) => {
+  await startButton(page).click();
+  const q = await question(page);
+  const wrongButton = wrongChoice(page, q.root, q.quality);
+  await wrongButton.click();
+
+  await expect(drill(page)).toHaveAttribute("data-asked", "1");
+  await expect(drill(page)).toHaveAttribute("data-correct", "0");
+  await expect(progress(page)).toHaveText("1 chord, none answered correctly.");
+  await expect(answerStatement(page)).toContainText(`That shape is ${chordName(q.root, q.quality)}.`);
+  const text = await answerStatement(page).textContent();
+  expect(forbiddenWord(text), text).toBeNull();
+  expect(text).not.toMatch(/%/);
+});
+
+test("name_to_shape: tapping every required tone and only those grades correct", async ({
+  page,
+}) => {
+  await page.locator(".direction-choice").nth(1).click();
+  await startButton(page).click();
+  await expect(drill(page)).toHaveAttribute("data-direction", "name_to_shape");
+  const q = await question(page);
+  const tones = chordTones(q.root, q.quality);
+
+  await tapChord(page, tones);
+  await expect(drill(page)).toHaveAttribute("data-tapped-count", String(tones.length));
+  await page.locator(".check-shape").click();
+
+  await expect(drill(page)).toHaveAttribute("data-asked", "1");
+  await expect(drill(page)).toHaveAttribute("data-correct", "1");
+  await expect(answerStatement(page)).toContainText(tones.join(", "));
+  const text = await answerStatement(page).textContent();
+  expect(forbiddenWord(text), text).toBeNull();
+});
+
+test("name_to_shape: tapping too few tones grades incorrect and names the full chord", async ({
+  page,
+}) => {
+  await page.locator(".direction-choice").nth(1).click();
+  await startButton(page).click();
+  const q = await question(page);
+  const tones = chordTones(q.root, q.quality);
+
+  // Every tone but the last one - a real triad/tetrad with a hole in it.
+  await tapChord(page, tones.slice(0, -1));
+  await page.locator(".check-shape").click();
+
+  await expect(drill(page)).toHaveAttribute("data-asked", "1");
+  await expect(drill(page)).toHaveAttribute("data-correct", "0");
+  await expect(answerStatement(page)).toContainText(tones.join(", "));
+  const text = await answerStatement(page).textContent();
+  expect(forbiddenWord(text), text).toBeNull();
+});
+
+test("a full cycle: prompt, answer, feedback, next, across a session", async ({ page }) => {
+  await startButton(page).click();
+  let q = await question(page);
+  await page.locator(`.choice[data-root="${q.root}"][data-quality="${q.quality}"]`).click();
+  await expect(drill(page)).toHaveAttribute("data-asked", "1");
+
+  await page.locator(".next-question").click();
+  await expect(progress(page)).toHaveText("1 chord, 1 answered correctly.");
+  q = await question(page);
+  expect(q.root).toBeTruthy();
+  await expect(answerStatement(page)).toHaveCount(0);
+
+  const wrongButton = wrongChoice(page, q.root, q.quality);
+  await wrongButton.click();
+  await expect(drill(page)).toHaveAttribute("data-asked", "2");
+  await expect(drill(page)).toHaveAttribute("data-correct", "1");
+  await expect(progress(page)).toHaveText("2 chords, 1 answered correctly.");
+
+  await page.locator(".stop-drill").click();
+  await expect(page.locator(".logged")).toBeVisible();
+  await expect(page.locator(".logged")).toContainText("2 chords, 1 answered correctly.");
+});
+
+// ---------------------------------------------------------------------------
+// The constraint model (#26): a narrowed region only offers what fits.
+// ---------------------------------------------------------------------------
+
+test("narrowing to open position drops a chord whose shape needs a higher fret, and keeps one that fits", async ({
+  page,
+}) => {
+  // Region controls are only editable before the drill starts (like
+  // fret-to-note's), so this is set first, then Start reveals the choices
+  // it produced.
+  await page.selectOption(".scope-end-fret", "2");
+  await startButton(page).click();
+  // The open G major shape frets as high as fret 3 - excluded from 0-2.
+  await expect(page.locator('.choice[data-root="G"][data-quality="major"]')).toHaveCount(0);
+  // The open E major shape fits entirely inside frets 0-2 - still offered.
+  await expect(page.locator('.choice[data-root="E"][data-quality="major"]')).toHaveCount(1);
+});
+
+test("a fret range with nothing in it says so and offers no drill", async ({ page }) => {
+  await page.selectOption(".scope-start-fret", "10");
+  await page.selectOption(".scope-end-fret", "3");
+  await expect(drill(page)).toHaveAttribute("data-askable", "0");
+  await expect(page.locator(".narrow-scope")).toContainText("Nothing is selected");
+  await expect(startButton(page)).toHaveCount(0);
+
+  // Widening the range back out - both ends, not only the one that was
+  // narrowed last, since an open-position chord's shape spans several
+  // frets at once and needs the WHOLE range restored, not merely a wider
+  // top - unlike a single fret-to-note position, which only ever needs one
+  // fret in range.
+  await page.selectOption(".scope-start-fret", "0");
+  await page.selectOption(".scope-end-fret", "12");
+  await expect(drill(page)).toHaveAttribute("data-askable", "1");
+  await expect(startButton(page)).toBeVisible();
+});
+
+test("a key that shares no chord with the family preset is honestly unaskable", async ({
+  page,
+}) => {
+  // Major & minor's open shapes only cover the roots E, A, D, G, C - and
+  // F# major's own diatonic triads (F#, G#m, A#m, B, C#, D#m) share none of
+  // those roots, so this combination has nothing to ask about.
+  await page.locator(".key-enabled").check();
+  await page.selectOption(".key-root", "F#");
+  await page.selectOption(".key-quality", "major");
+  await expect(drill(page)).toHaveAttribute("data-askable", "0");
+  await expect(page.locator(".narrow-scope")).toContainText("Nothing is selected");
+
+  // And turning the key off restores what it excluded.
+  await page.locator(".key-enabled").uncheck();
+  await expect(drill(page)).toHaveAttribute("data-askable", "1");
+});
+
+// ---------------------------------------------------------------------------
+// Structured, queryable results (#32): every question is its own row.
+// ---------------------------------------------------------------------------
+
+test("every answered question is posted as a structured row, correct and incorrect alike", async ({
+  page,
+  request,
+}) => {
+  const before = (await (await request.get("/api/trainer/chord-attempts")).json()).total;
+
+  await startButton(page).click();
+  const q1 = await question(page);
+  await page.locator(`.choice[data-root="${q1.root}"][data-quality="${q1.quality}"]`).click();
+  await expect(drill(page)).toHaveAttribute("data-attempt-log-failures", "0");
+
+  await page.locator(".next-question").click();
+  const q2 = await question(page);
+  const wrongButton = wrongChoice(page, q2.root, q2.quality);
+  const wrongRoot = await wrongButton.getAttribute("data-root");
+  const wrongQuality = await wrongButton.getAttribute("data-quality");
+  await wrongButton.click();
+  await expect(drill(page)).toHaveAttribute("data-attempt-log-failures", "0");
+
+  await expect(async () => {
+    const { total } = await (await request.get("/api/trainer/chord-attempts")).json();
+    expect(total).toBe(before + 2);
+  }).toPass({ timeout: 10_000 });
+
+  const { attempts } = await (
+    await request.get("/api/trainer/chord-attempts?limit=2")
+  ).json();
+  expect(attempts).toHaveLength(2);
+  const [second, first] = attempts;
+
+  expect(first.drill).toBe("chord_flashcards");
+  expect(first.direction).toBe("shape_to_name");
+  expect(first.target_root).toBe(q1.root);
+  expect(first.target_quality).toBe(q1.quality);
+  expect(first.given_root).toBe(q1.root);
+  expect(first.given_quality).toBe(q1.quality);
+  expect(first.correct).toBe(true);
+  expect(first.given_notes).toBeNull();
+  expect(first.given_shape).toBeNull();
+  expect(Array.isArray(first.target_shape)).toBe(true);
+  expect(first.target_shape.length).toBeGreaterThan(0);
+
+  expect(second.target_root).toBe(q2.root);
+  expect(second.target_quality).toBe(q2.quality);
+  expect(second.given_root).toBe(wrongRoot);
+  expect(second.given_quality).toBe(wrongQuality);
+  expect(second.correct).toBe(false);
+
+  const missed = await (
+    await request.get("/api/trainer/chord-attempts?correct=false&limit=100")
+  ).json();
+  expect(missed.attempts.map((a) => a.id)).toContain(second.id);
+  expect(missed.attempts.map((a) => a.id)).not.toContain(first.id);
+});
+
+test("stopping the drill also logs one chords practice session, with a human-readable summary", async ({
+  page,
+  request,
+}) => {
+  await startButton(page).click();
+  const q = await question(page);
+  await page.locator(`.choice[data-root="${q.root}"][data-quality="${q.quality}"]`).click();
+  await page.locator(".stop-drill").click();
+  await expect(page.locator(".logged")).toBeVisible();
+
+  const { sessions, total } = await (
+    await request.get("/api/practice/sessions?limit=1000")
+  ).json();
+  expect(total).toBe(1);
+  expect(sessions[0].activity).toBe("chords");
+  expect(sessions[0].local_date).toBe(today);
+  expect(sessions[0].note).toBe(
+    "Chord flash cards, shape to name. 1 chord, 1 answered correctly. Major & minor, frets 0-12.",
+  );
+  expect(forbiddenWord(sessions[0].note), sessions[0].note).toBeNull();
+  expect(sessions[0].note).not.toMatch(/%/);
+});
+
+test("leaving the page mid-drill still logs the practice", async ({ page, request }) => {
+  await startButton(page).click();
+  const q = await question(page);
+  await page.locator(`.choice[data-root="${q.root}"][data-quality="${q.quality}"]`).click();
+
+  await page.locator(".back").click();
+  await expect(page.locator("section.drill")).toHaveCount(0);
+
+  await expect(async () => {
+    const { total } = await (await request.get("/api/practice/sessions?limit=1000")).json();
+    expect(total).toBe(1);
+  }).toPass({ timeout: 10_000 });
+});

--- a/web/tests/spec-floors/browser-chord-flashcards-28.json
+++ b/web/tests/spec-floors/browser-chord-flashcards-28.json
@@ -1,0 +1,5 @@
+{
+  "file": "tests/browser/chord-flashcards.spec.js",
+  "count": 11,
+  "reason": "issue #28: the chord flash card drill against the real backend and the real build - both directions' full prompt-answer-feedback-next cycle with a correct and an incorrect answer handled honestly (name_to_shape graded on independently-reimplemented chord math, not anything imported from the app), a narrowed region dropping a chord whose shape needs a higher fret while keeping one that fits (#26), the degenerate unaskable states (a fret range, and a key sharing no chord with the family preset), the structured per-question attempts (#32) posted correct and incorrect alike and queryable by correctness, the session log this drill's time is kept beside, and practice logged even when the page is left mid-drill."
+}

--- a/web/tests/spec-floors/unit-chord-shapes-28.json
+++ b/web/tests/spec-floors/unit-chord-shapes-28.json
@@ -1,0 +1,5 @@
+{
+  "file": "tests/unit/chord-shapes.spec.js",
+  "count": 11,
+  "reason": "issue #28: the guitar chord shape library is checked against chord-theory.js's own arithmetic rather than trusted by hand - the standard-tuning gate (including a capo, and refusing a dropped tuning or a missing string with no shapes at all rather than an invented one), every open shape's and every generated barre shape's ACTUAL sounded notes (worked out from neck.js's tuning arithmetic, independent of the shape's own label) matching its declared chord's tones exhaustively, a barre form naming all twelve roots across a fret range read straight off the neck, and shapeMatchesChord catching a shape doctored to drop a required tone."
+}

--- a/web/tests/spec-floors/unit-chord-theory-28.json
+++ b/web/tests/spec-floors/unit-chord-theory-28.json
@@ -1,0 +1,5 @@
+{
+  "file": "tests/unit/chord-theory.spec.js",
+  "count": 10,
+  "reason": "issue #28: chord music theory is load-bearing, so this drill's chord tones are checked exhaustively - known major, minor and dominant-seventh triads/tetrads asserted by hand, then every one of the 36 (root, quality) chords this module can build checked for note count, no repeated tone, and starting on its own root, plus the major/minor third relationship and the dominant-seventh-is-a-major-triad-plus-one-note relationship holding at every root, chord naming, and chordsMatch (the tone-set equality the flash card grades by) refusing an unknown chord rather than throwing."
+}

--- a/web/tests/spec-floors/unit-chords-28.json
+++ b/web/tests/spec-floors/unit-chords-28.json
@@ -1,0 +1,5 @@
+{
+  "file": "tests/unit/chords.spec.js",
+  "count": 24,
+  "reason": "issue #28: the chord flash card drill - the three family presets, the pool obeying a narrowed fret range and string set (a shape needing a fret or string outside the scope dropped, and every shape actually returned checked to genuinely fit), a key scope keeping only fully-diatonic chords, the degenerate unaskable pool, both directions of pickQuestion never repeating the same chord, grading a named chord and a tapped shape (correct, missing a required tone, an extra non-chord tone, and nothing tapped at all), both directions' structured attempt payloads, and the drill's wording never carrying a grading word, a streak, or a percentage."
+}

--- a/web/tests/spec-floors/unit-constraints-26.json
+++ b/web/tests/spec-floors/unit-constraints-26.json
@@ -1,0 +1,5 @@
+{
+  "file": "tests/unit/constraints.spec.js",
+  "count": 14,
+  "reason": "issue #26: the string-set/fret-range scoping factored out of fret-to-note.js, plus the key/note-set filter that is new here (a key's own diatonic notes for every root and both qualities, an unknown root or quality refused, a key narrowing the position pool and reaching the same degenerate 'nothing to ask' state a narrow fret range does), the single positionInScope test every dimension reduces to, scope labelling with and without a key, and groupInScope - the whole-shape-must-fit rule the chord drill (#28) scopes its shapes with."
+}

--- a/web/tests/unit/chord-shapes.spec.js
+++ b/web/tests/unit/chord-shapes.spec.js
@@ -1,0 +1,122 @@
+// Guitar chord shapes (issue #28), called directly - every open and barre
+// shape's ACTUAL sounded notes checked against chord-theory.js's own
+// arithmetic for the shape's declared root and quality, exhaustively enough
+// to trust the fingering diagrams the flash card drill shows. No browser
+// needed - see this module's own docstring.
+import { expect, test } from "@playwright/test";
+
+import { chordTones } from "../../src/lib/trainer/chord-theory.js";
+import { defaultStrings } from "../../src/lib/trainer/neck.js";
+import {
+  allShapes,
+  barreShapesFor,
+  isStandardGuitarTuning,
+  openShapesFor,
+  shapeMatchesChord,
+  shapeNotes,
+} from "../../src/lib/trainer/chord-shapes.js";
+
+const strings = defaultStrings();
+
+// ---------------------------------------------------------------- tuning gate
+
+test("the standard tuning is recognised, including transposed by a capo", () => {
+  expect(isStandardGuitarTuning(strings)).toBe(true);
+  const capoed = strings.map((s) => ({ ...s, midi: s.midi + 3 }));
+  expect(isStandardGuitarTuning(capoed)).toBe(true);
+});
+
+test("a non-standard tuning offers no shapes at all - honest, not invented", () => {
+  // Drop D: string 6 tuned down a whole step breaks the interval to string
+  // 5, so this is no longer the pattern every shape below assumes.
+  const dropD = strings.map((s) => (s.number === 6 ? { ...s, midi: s.midi - 2 } : s));
+  expect(isStandardGuitarTuning(dropD)).toBe(false);
+  expect(openShapesFor(dropD)).toEqual([]);
+  expect(barreShapesFor(dropD)).toEqual([]);
+
+  // Missing a string outright is the same "not this pattern" answer.
+  const fiveString = strings.filter((s) => s.number !== 6);
+  expect(isStandardGuitarTuning(fiveString)).toBe(false);
+  expect(openShapesFor(fiveString)).toEqual([]);
+});
+
+// ---------------------------------------------------------------- open shapes, exhaustively
+
+test("every open shape's actual sounded notes are exactly its declared chord's tones", () => {
+  const shapes = openShapesFor(strings);
+  expect(shapes.length).toBeGreaterThan(10);
+  for (const shape of shapes) {
+    const want = new Set(chordTones(shape.root, shape.quality));
+    const got = new Set(shapeNotes(strings, shape));
+    expect(got, `${shape.id} sounded notes`).toEqual(want);
+  }
+});
+
+test("a known open shape's frets read exactly as a guitarist would write them - C major, x32010", () => {
+  const c = openShapesFor(strings).find((s) => s.id === "open:C:major");
+  const byString = Object.fromEntries(c.frets.map((f) => [f.string, f.fret]));
+  expect(byString).toEqual({ 5: 3, 4: 2, 3: 0, 2: 1, 1: 0 });
+  expect(byString[6]).toBeUndefined(); // muted, same as chord notation's "x"
+});
+
+// ---------------------------------------------------------------- barre shapes, generated
+
+test("barre shapes are generated across a fret range, root read off the neck at each one", () => {
+  const shapes = barreShapesFor(strings, { minBaseFret: 1, maxFret: 12 });
+  expect(shapes.length).toBeGreaterThan(20);
+  // F major is the classic first barre chord: E-shape major at fret 1.
+  const f = shapes.find((s) => s.id === "barre-e-major:1");
+  expect(f.root).toBe("F");
+  // A-shape major at fret 3 is C major, an octave-plus-a-bit up the neck
+  // from the open C shape - same chord, a different region.
+  const c = shapes.find((s) => s.id === "barre-a-major:3");
+  expect(c.root).toBe("C");
+});
+
+test("every generated barre shape's actual sounded notes are exactly its own chord's tones", () => {
+  const shapes = barreShapesFor(strings, { minBaseFret: 1, maxFret: 15 });
+  expect(shapes.length).toBeGreaterThan(0);
+  for (const shape of shapes) {
+    const want = new Set(chordTones(shape.root, shape.quality));
+    const got = new Set(shapeNotes(strings, shape));
+    expect(got, `${shape.id} (${shape.root} ${shape.quality}) sounded notes`).toEqual(want);
+  }
+});
+
+test("across twelve consecutive base frets, an E-shape major barre names every one of the twelve roots", () => {
+  // The shape's own highest string needs two frets past the base, so
+  // twelve usable base positions (1..12) need the range to reach 14.
+  const shapes = barreShapesFor(strings, { minBaseFret: 1, maxFret: 14 })
+    .filter((s) => s.id.startsWith("barre-e-major:"));
+  const roots = new Set(shapes.map((s) => s.root));
+  expect(roots.size).toBe(12);
+});
+
+// ---------------------------------------------------------------- shapeMatchesChord
+
+test("shapeMatchesChord is true for a shape against its own declared chord", () => {
+  const shape = openShapesFor(strings).find((s) => s.id === "open:E:minor");
+  expect(shapeMatchesChord(strings, shape)).toBe(true);
+});
+
+test("shapeMatchesChord is false against a different chord, and false for an unknown one", () => {
+  const shape = openShapesFor(strings).find((s) => s.id === "open:E:minor");
+  expect(shapeMatchesChord(strings, shape, "E", "major")).toBe(false);
+  expect(shapeMatchesChord(strings, shape, "H", "major")).toBe(false);
+});
+
+test("shapeMatchesChord catches a shape doctored to miss one required tone", () => {
+  const shape = openShapesFor(strings).find((s) => s.id === "open:C:major");
+  // Drop the string that supplies the fifth (G, string 3 open) - the
+  // remaining notes are only C and E, not a complete C major chord.
+  const broken = { ...shape, frets: shape.frets.filter((f) => f.string !== 3) };
+  expect(shapeMatchesChord(strings, broken)).toBe(false);
+});
+
+// ---------------------------------------------------------------- allShapes
+
+test("allShapes combines open and barre shapes from the same tuning", () => {
+  const shapes = allShapes(strings, { maxFret: 12 });
+  expect(shapes.some((s) => s.family === "open")).toBe(true);
+  expect(shapes.some((s) => s.family.startsWith("barre"))).toBe(true);
+});

--- a/web/tests/unit/chord-theory.spec.js
+++ b/web/tests/unit/chord-theory.spec.js
@@ -1,0 +1,110 @@
+// Chord music theory, called directly (issue #28) - which notes belong to a
+// chord, exhaustively enough across every root and quality this module
+// offers to trust it, since this is the arithmetic a shape's actual sounded
+// notes (chord-shapes.spec.js) and a flash card's grading both stand on. No
+// browser needed - see this module's own docstring for why.
+import { expect, test } from "@playwright/test";
+
+import {
+  QUALITIES,
+  QUALITY_LIST,
+  ROOTS,
+  chordName,
+  chordTones,
+  chordsMatch,
+} from "../../src/lib/trainer/chord-theory.js";
+
+// ---------------------------------------------------------------- known chords, by hand
+
+test("known major triads are exactly right", () => {
+  expect(chordTones("C", "major")).toEqual(["C", "E", "G"]);
+  expect(chordTones("G", "major")).toEqual(["G", "B", "D"]);
+  expect(chordTones("D", "major")).toEqual(["D", "F#", "A"]);
+  expect(chordTones("A", "major")).toEqual(["A", "C#", "E"]);
+  // Ab, not G#: PITCH_CLASSES spells one sharp OR flat per pitch class (see
+  // neck.js), and index 8 is "Ab" - the same table this chord's third is
+  // drawn from, so this is the spelling the app uses everywhere else too.
+  expect(chordTones("E", "major")).toEqual(["E", "Ab", "B"]);
+  expect(chordTones("F", "major")).toEqual(["F", "A", "C"]);
+});
+
+test("known minor triads are exactly right", () => {
+  expect(chordTones("A", "minor")).toEqual(["A", "C", "E"]);
+  expect(chordTones("E", "minor")).toEqual(["E", "G", "B"]);
+  expect(chordTones("D", "minor")).toEqual(["D", "F", "A"]);
+  expect(chordTones("C", "minor")).toEqual(["C", "Eb", "G"]);
+  expect(chordTones("F#", "minor")).toEqual(["F#", "A", "C#"]);
+});
+
+test("known dominant sevenths are exactly right", () => {
+  expect(chordTones("G", "dominant7")).toEqual(["G", "B", "D", "F"]);
+  expect(chordTones("C", "dominant7")).toEqual(["C", "E", "G", "Bb"]);
+  expect(chordTones("A", "dominant7")).toEqual(["A", "C#", "E", "G"]);
+  expect(chordTones("E", "dominant7")).toEqual(["E", "Ab", "B", "D"]);
+  expect(chordTones("B", "dominant7")).toEqual(["B", "Eb", "F#", "A"]);
+});
+
+// ---------------------------------------------------------------- exhaustive, every root x quality
+
+test("every one of the 36 (root, quality) chords has the right note count and no repeats", () => {
+  expect(ROOTS).toHaveLength(12);
+  expect(QUALITY_LIST).toEqual(["major", "minor", "dominant7"]);
+  for (const root of ROOTS) {
+    for (const quality of QUALITY_LIST) {
+      const tones = chordTones(root, quality);
+      const expectedLength = QUALITIES[quality].intervals.length;
+      expect(tones, `${root} ${quality}`).toHaveLength(expectedLength);
+      expect(new Set(tones).size, `${root} ${quality} has no repeated tone`).toBe(expectedLength);
+      expect(tones[0], `${root} ${quality} is spelled starting on its own root`).toBe(root);
+    }
+  }
+});
+
+test("a major and a minor triad sharing a root differ in exactly the third", () => {
+  // The one semitone that makes a chord happy or sad, at every root - the
+  // root and the fifth never move; only the third does.
+  for (const root of ROOTS) {
+    const major = chordTones(root, "major");
+    const minor = chordTones(root, "minor");
+    expect(major[0]).toBe(minor[0]); // root
+    expect(major[2]).toBe(minor[2]); // fifth
+    expect(major[1]).not.toBe(minor[1]); // third
+  }
+});
+
+test("a dominant seventh is its major triad plus one more note, at every root", () => {
+  for (const root of ROOTS) {
+    const major = chordTones(root, "major");
+    const seventh = chordTones(root, "dominant7");
+    expect(seventh.slice(0, 3)).toEqual(major);
+    expect(seventh).toHaveLength(4);
+  }
+});
+
+// ---------------------------------------------------------------- naming
+
+test("chordName spells every quality the way a flash card should read it", () => {
+  expect(chordName("C", "major")).toBe("C major");
+  expect(chordName("A", "minor")).toBe("A minor");
+  expect(chordName("G", "dominant7")).toBe("G7");
+});
+
+test("an unknown root or quality names no chord at all", () => {
+  expect(chordTones("H", "major")).toBeNull();
+  expect(chordTones("C", "augmented")).toBeNull();
+  expect(chordName("H", "major")).toBeNull();
+  expect(chordName("C", "augmented")).toBeNull();
+});
+
+// ---------------------------------------------------------------- chord equality
+
+test("chordsMatch is true for the same chord and false for a different one", () => {
+  expect(chordsMatch("C", "major", "C", "major")).toBe(true);
+  expect(chordsMatch("C", "major", "C", "minor")).toBe(false);
+  expect(chordsMatch("C", "major", "G", "major")).toBe(false);
+});
+
+test("chordsMatch is false, not thrown, against an unknown chord on either side", () => {
+  expect(chordsMatch("H", "major", "C", "major")).toBe(false);
+  expect(chordsMatch("C", "major", "C", "augmented")).toBe(false);
+});

--- a/web/tests/unit/chords.spec.js
+++ b/web/tests/unit/chords.spec.js
@@ -1,0 +1,304 @@
+// Chord flash cards, called directly (issue #28) - the drill built on
+// chord-theory.js, chord-shapes.js and constraints.js. No browser needed -
+// see this module's own docstring.
+import { expect, test } from "@playwright/test";
+
+import { chordTones } from "../../src/lib/trainer/chord-theory.js";
+import {
+  DRILL,
+  FAMILIES,
+  FAMILY_LIST,
+  NAME_TO_SHAPE,
+  SHAPE_TO_NAME,
+  answerStatement,
+  attemptPayload,
+  checkNameAnswer,
+  checkShapeAnswer,
+  chordChoices,
+  chordPool,
+  directionLabel,
+  familyLabel,
+  loggedStatement,
+  pickQuestion,
+  poolIsAskable,
+  progressStatement,
+  scopeLabel,
+  sessionNote,
+} from "../../src/lib/trainer/chords.js";
+import { defaultStrings } from "../../src/lib/trainer/neck.js";
+import { forbiddenWord } from "../../src/lib/practice.js";
+
+const strings = defaultStrings();
+const fullScope = { startFret: 0, endFret: 12 };
+
+// ---------------------------------------------------------------- family presets
+
+test("the three family presets say what issue #28 asks for, in order", () => {
+  expect(FAMILY_LIST).toEqual(["major_minor", "sevenths", "barre"]);
+  expect(FAMILIES.major_minor.qualities).toEqual(["major", "minor"]);
+  expect(FAMILIES.sevenths.qualities).toEqual(["dominant7"]);
+  expect(FAMILIES.barre.qualities).toEqual(["major", "minor"]);
+  expect(FAMILIES.major_minor.shapeFamilies).toEqual(["open"]);
+  expect(FAMILIES.barre.shapeFamilies.every((f) => f.startsWith("barre"))).toBe(true);
+});
+
+// ---------------------------------------------------------------- pool / scoping
+
+test("the major & minor pool over the full scope contains the open C major and E minor shapes", () => {
+  const pool = chordPool(strings, fullScope, "major_minor");
+  expect(pool.some((s) => s.root === "C" && s.quality === "major")).toBe(true);
+  expect(pool.some((s) => s.root === "E" && s.quality === "minor")).toBe(true);
+  // Not a barre or a seventh - the preset's own qualities and families.
+  expect(pool.every((s) => ["major", "minor"].includes(s.quality))).toBe(true);
+  expect(pool.every((s) => s.family === "open")).toBe(true);
+});
+
+test("the sevenths pool contains only dominant sevenths, and the barre pool only barre shapes", () => {
+  const sevenths = chordPool(strings, fullScope, "sevenths");
+  expect(sevenths.length).toBeGreaterThan(0);
+  expect(sevenths.every((s) => s.quality === "dominant7")).toBe(true);
+
+  const barre = chordPool(strings, fullScope, "barre");
+  expect(barre.length).toBeGreaterThan(0);
+  expect(barre.every((s) => s.family.startsWith("barre"))).toBe(true);
+});
+
+test("narrowing the fret range to open position drops a shape that needs a higher fret", () => {
+  // The open G major shape frets string 6 at fret 3 and string 1 at fret 3 -
+  // outside frets 0-2, so a scope that narrow must not offer it.
+  const openPosition = { startFret: 0, endFret: 2 };
+  const pool = chordPool(strings, openPosition, "major_minor");
+  expect(pool.some((s) => s.id === "open:G:major")).toBe(false);
+  // Every shape actually returned really does fit inside that range - the
+  // scope is honoured, not merely narrowed by name.
+  for (const shape of pool) {
+    for (const { fret } of shape.frets) {
+      expect(fret, `${shape.id} fret ${fret} within 0-2`).toBeGreaterThanOrEqual(0);
+      expect(fret, `${shape.id} fret ${fret} within 0-2`).toBeLessThanOrEqual(2);
+    }
+  }
+});
+
+test("narrowing the string set drops every shape that uses a string outside it", () => {
+  const highStringsOnly = { stringNumbers: [1, 2, 3], startFret: 0, endFret: 12 };
+  const pool = chordPool(strings, highStringsOnly, "major_minor");
+  for (const shape of pool) {
+    for (const { string } of shape.frets) {
+      expect([1, 2, 3], `${shape.id} uses string ${string}`).toContain(string);
+    }
+  }
+});
+
+test("a fret range narrow enough to admit nothing is honestly unaskable, not a crash", () => {
+  const nothing = { startFret: 30, endFret: 31 };
+  expect(chordPool(strings, nothing, "major_minor")).toEqual([]);
+  expect(poolIsAskable(strings, nothing, "major_minor")).toBe(false);
+});
+
+test("a key scope keeps only chords fully diatonic to it, dropping one that is not", () => {
+  const cMajorKey = { startFret: 0, endFret: 12, key: { root: "C", quality: "major" } };
+  const pool = chordPool(strings, cMajorKey, "major_minor");
+  // C major (C, E, G) and D minor (D, F, A) are both entirely C major's own
+  // notes.
+  expect(pool.some((s) => s.root === "C" && s.quality === "major")).toBe(true);
+  expect(pool.some((s) => s.root === "D" && s.quality === "minor")).toBe(true);
+  // E major (E, Ab, B) is not - Ab is not a note of C major - so it must be
+  // excluded even though it is offered with no key set at all.
+  expect(chordPool(strings, fullScope, "major_minor").some((s) => s.root === "E" && s.quality === "major")).toBe(
+    true,
+  );
+  expect(pool.some((s) => s.root === "E" && s.quality === "major")).toBe(false);
+});
+
+// ---------------------------------------------------------------- picking a question
+
+test("shape_to_name shows a real fingering; name_to_shape names a chord with no fingering shown", () => {
+  const shown = pickQuestion(strings, fullScope, "major_minor", SHAPE_TO_NAME, null, () => 0);
+  expect(shown.shape).not.toBeNull();
+  expect(shown.shape.frets.length).toBeGreaterThan(0);
+
+  const named = pickQuestion(strings, fullScope, "major_minor", NAME_TO_SHAPE, null, () => 0);
+  expect(named.shape).toBeNull();
+  expect(named.root).toBeTruthy();
+  expect(named.quality).toBeTruthy();
+});
+
+test("a question never immediately repeats the same chord", () => {
+  const pool = chordPool(strings, fullScope, "major_minor");
+  let previous = null;
+  for (let i = 0; i < 30; i++) {
+    const q = pickQuestion(strings, fullScope, "major_minor", SHAPE_TO_NAME, previous, Math.random);
+    if (previous && pool.length > 1) {
+      expect(`${q.root}:${q.quality}`).not.toBe(`${previous.root}:${previous.quality}`);
+    }
+    previous = q;
+  }
+});
+
+test("an unaskable pool returns no question rather than throwing", () => {
+  const nothing = { startFret: 30, endFret: 31 };
+  expect(pickQuestion(strings, nothing, "major_minor", SHAPE_TO_NAME)).toBeNull();
+});
+
+test("every question carries a playable fingering to hear, even name_to_shape which shows none", () => {
+  const named = pickQuestion(strings, fullScope, "major_minor", NAME_TO_SHAPE, null, () => 0);
+  expect(named.sound.length).toBeGreaterThan(0);
+  // It really does sound the question's own chord.
+  const notes = new Set(
+    named.sound.map(({ string, fret }) => {
+      const midi = strings.find((s) => s.number === string).midi + fret;
+      return midi;
+    }),
+  );
+  expect(notes.size).toBeGreaterThan(0);
+});
+
+// ---------------------------------------------------------------- choices (shape_to_name's answer buttons)
+
+test("chordChoices lists every distinct chord the pool offers, named and deduplicated", () => {
+  const choices = chordChoices(strings, fullScope, "major_minor");
+  expect(choices.some((c) => c.root === "C" && c.quality === "major" && c.name === "C major")).toBe(
+    true,
+  );
+  // Deduplicated: only one entry per (root, quality) even though several
+  // shapes might share a chord once barre voicings are in play.
+  const keys = choices.map((c) => `${c.root}:${c.quality}`);
+  expect(new Set(keys).size).toBe(keys.length);
+});
+
+test("chordChoices is empty for an unaskable scope, not a crash", () => {
+  expect(chordChoices(strings, { startFret: 30, endFret: 31 }, "major_minor")).toEqual([]);
+});
+
+// ---------------------------------------------------------------- grading
+
+test("checkNameAnswer is correct for the matching chord and incorrect for a different one", () => {
+  const question = { root: "C", quality: "major" };
+  expect(checkNameAnswer(question, "C", "major")).toBe(true);
+  expect(checkNameAnswer(question, "C", "minor")).toBe(false);
+  expect(checkNameAnswer(question, "G", "major")).toBe(false);
+});
+
+test("checkShapeAnswer is correct when what was tapped sounds exactly the question's chord", () => {
+  const question = { root: "C", quality: "major" };
+  // The open C major shape's own frets, tapped one at a time.
+  const tapped = [
+    { string: 5, fret: 3 },
+    { string: 4, fret: 2 },
+    { string: 3, fret: 0 },
+    { string: 2, fret: 1 },
+    { string: 1, fret: 0 },
+  ];
+  const result = checkShapeAnswer(strings, question, tapped);
+  expect(result.correct).toBe(true);
+  expect(result.notes).toEqual([...chordTones("C", "major")].sort());
+});
+
+test("checkShapeAnswer is incorrect when a required tone is missing", () => {
+  const question = { root: "C", quality: "major" };
+  const missingTheFifth = [
+    { string: 5, fret: 3 }, // C
+    { string: 2, fret: 1 }, // C
+    { string: 1, fret: 0 }, // E
+  ];
+  expect(checkShapeAnswer(strings, question, missingTheFifth).correct).toBe(false);
+});
+
+test("checkShapeAnswer is incorrect when an extra, non-chord tone is present", () => {
+  const question = { root: "C", quality: "major" };
+  const withAWrongNote = [
+    { string: 5, fret: 3 }, // C
+    { string: 4, fret: 2 }, // E
+    { string: 3, fret: 0 }, // G
+    { string: 6, fret: 1 }, // F - not a C major tone
+  ];
+  expect(checkShapeAnswer(strings, question, withAWrongNote).correct).toBe(false);
+});
+
+test("checkShapeAnswer is incorrect, not thrown, against nothing tapped at all", () => {
+  expect(checkShapeAnswer(strings, { root: "C", quality: "major" }, []).correct).toBe(false);
+  expect(checkShapeAnswer(strings, { root: "C", quality: "major" }, []).notes).toEqual([]);
+});
+
+// ---------------------------------------------------------------- attempt payloads
+
+test("a shape_to_name attempt payload carries the target shape and the chosen chord", () => {
+  const question = {
+    direction: SHAPE_TO_NAME,
+    root: "E",
+    quality: "minor",
+    shape: { frets: [{ string: 6, fret: 0 }, { string: 5, fret: 2 }] },
+  };
+  const payload = attemptPayload({ question, given: { root: "E", quality: "minor" }, responseMs: 900 });
+  expect(payload.drill).toBe(DRILL);
+  expect(payload.direction).toBe(SHAPE_TO_NAME);
+  expect(payload.target_root).toBe("E");
+  expect(payload.target_quality).toBe("minor");
+  expect(payload.target_shape).toEqual([{ string: 6, fret: 0 }, { string: 5, fret: 2 }]);
+  expect(payload.given_root).toBe("E");
+  expect(payload.given_quality).toBe("minor");
+  expect(payload.response_ms).toBe(900);
+});
+
+test("a name_to_shape attempt payload carries the tapped positions and resolved notes, no target shape", () => {
+  const question = { direction: NAME_TO_SHAPE, root: "C", quality: "major", shape: null };
+  const given = { positions: [{ string: 5, fret: 3 }], notes: ["C"] };
+  const payload = attemptPayload({ question, given });
+  expect(payload.direction).toBe(NAME_TO_SHAPE);
+  expect(payload.target_shape).toBeUndefined();
+  expect(payload.given_notes).toEqual(["C"]);
+  expect(payload.given_shape).toEqual([{ string: 5, fret: 3 }]);
+});
+
+// ---------------------------------------------------------------- wording
+
+test("answerStatement names the chord honestly either way, with no verdict word", () => {
+  const question = { direction: SHAPE_TO_NAME, root: "C", quality: "major" };
+  for (const text of [
+    answerStatement(question, { root: "C", quality: "major" }, true),
+    answerStatement(question, { root: "G", quality: "major" }, false),
+  ]) {
+    expect(forbiddenWord(text), text).toBeNull();
+  }
+  const nameToShape = { direction: NAME_TO_SHAPE, root: "C", quality: "major" };
+  for (const text of [
+    answerStatement(nameToShape, { notes: ["C", "E", "G"] }, true),
+    answerStatement(nameToShape, { notes: ["C", "E"] }, false),
+  ]) {
+    expect(forbiddenWord(text), text).toBeNull();
+  }
+});
+
+test("every phrase this module produces avoids the forbidden words and never a percentage", () => {
+  const samples = [
+    progressStatement({ asked: 5, correct: 2 }),
+    sessionNote({ asked: 5, correct: 2, direction: SHAPE_TO_NAME, strings, scope: fullScope, family: "major_minor" }),
+    scopeLabel(strings, fullScope, "major_minor"),
+    loggedStatement(90),
+  ];
+  for (const text of samples) {
+    expect(forbiddenWord(text), text).toBeNull();
+    expect(text).not.toMatch(/%/);
+  }
+});
+
+test("sessionNote names the direction, the counts, and the family and region", () => {
+  const note = sessionNote({
+    asked: 4,
+    correct: 3,
+    direction: NAME_TO_SHAPE,
+    strings,
+    scope: { startFret: 0, endFret: 5, stringNumbers: [6, 5] },
+    family: "barre",
+  });
+  expect(note).toBe(
+    "Chord flash cards, name to shape. 4 chords, 3 answered correctly. Barre chords, strings 5, 6, frets 0-5.",
+  );
+});
+
+test("directionLabel and familyLabel read as plain words", () => {
+  expect(directionLabel(SHAPE_TO_NAME)).toBe("shape to name");
+  expect(directionLabel(NAME_TO_SHAPE)).toBe("name to shape");
+  expect(familyLabel("sevenths")).toBe("Sevenths");
+  expect(familyLabel("not-a-family")).toBe(FAMILIES[FAMILY_LIST[0]].label);
+});

--- a/web/tests/unit/constraints.spec.js
+++ b/web/tests/unit/constraints.spec.js
@@ -1,0 +1,146 @@
+// The constraint model (issue #26), called directly - string set, fret
+// range, and (its new addition here) a key/note-set filter, plus the
+// group-scope test a chord shape's fretted notes are checked against. No
+// browser needed for any of it, for the same reason neck.js and
+// fret-to-note.js need none - see this module's own docstring.
+import { expect, test } from "@playwright/test";
+
+import { defaultStrings } from "../../src/lib/trainer/neck.js";
+import {
+  KEY_QUALITIES,
+  fretInScope,
+  groupInScope,
+  keyNotes,
+  noteInScope,
+  positionInScope,
+  scopeIsAskable,
+  scopeLabel,
+  scopePositions,
+  stringInScope,
+} from "../../src/lib/trainer/constraints.js";
+
+const strings = defaultStrings();
+
+// ---------------------------------------------------------------- strings & frets
+
+test("the full scope covers every string across the fret range", () => {
+  const pool = scopePositions(strings, { startFret: 0, endFret: 12 });
+  expect(pool.length).toBe(6 * 13);
+  expect(new Set(pool.map((p) => p.string))).toEqual(new Set([1, 2, 3, 4, 5, 6]));
+});
+
+test("narrowing to particular strings narrows the pool to exactly those", () => {
+  const pool = scopePositions(strings, { stringNumbers: [6, 1], startFret: 0, endFret: 5 });
+  expect(new Set(pool.map((p) => p.string))).toEqual(new Set([6, 1]));
+});
+
+test("an empty stringNumbers list means no filter, not 'select nothing'", () => {
+  const full = scopePositions(strings, { startFret: 0, endFret: 3 });
+  const empty = scopePositions(strings, { stringNumbers: [], startFret: 0, endFret: 3 });
+  expect(empty).toEqual(full);
+});
+
+test("a fret range that excludes everything asks nothing - degenerate, not a crash", () => {
+  expect(scopeIsAskable(strings, { startFret: 20, endFret: 3 })).toBe(false);
+  expect(scopePositions(strings, { startFret: 20, endFret: 3 })).toEqual([]);
+});
+
+test("stringInScope and fretInScope agree with scopePositions on individual positions", () => {
+  const scope = { stringNumbers: [6, 5], startFret: 2, endFret: 4 };
+  expect(stringInScope(6, scope)).toBe(true);
+  expect(stringInScope(3, scope)).toBe(false);
+  expect(fretInScope(3, scope)).toBe(true);
+  expect(fretInScope(5, scope)).toBe(false);
+});
+
+// ---------------------------------------------------------------- key/note scoping
+
+test("keyNotes names the diatonic pitch classes of a major and a minor key", () => {
+  expect(keyNotes("C", "major")).toEqual(["C", "D", "E", "F", "G", "A", "B"]);
+  expect(keyNotes("G", "major")).toEqual(["G", "A", "B", "C", "D", "E", "F#"]);
+  expect(keyNotes("A", "minor")).toEqual(["A", "B", "C", "D", "E", "F", "G"]);
+  // Every key has seven distinct notes, both qualities, every one of the
+  // twelve roots - the exhaustive check the arithmetic above is a sample of.
+  for (const root of ["C", "C#", "D", "Eb", "E", "F", "F#", "G", "Ab", "A", "Bb", "B"]) {
+    for (const quality of Object.keys(KEY_QUALITIES)) {
+      const notes = keyNotes(root, quality);
+      expect(notes, `${root} ${quality}`).toHaveLength(7);
+      expect(new Set(notes).size, `${root} ${quality} has no repeated note`).toBe(7);
+      expect(notes[0], `${root} ${quality} starts on its own root`).toBe(root);
+    }
+  }
+});
+
+test("an unknown root or quality is refused with null, not a guess", () => {
+  expect(keyNotes("H", "major")).toBeNull();
+  expect(keyNotes("C", "dorian")).toBeNull();
+});
+
+test("noteInScope allows every note with no key set, and only the key's notes with one", () => {
+  expect(noteInScope("F#", {})).toBe(true);
+  const scope = { key: { root: "C", quality: "major" } };
+  expect(noteInScope("E", scope)).toBe(true);
+  expect(noteInScope("Eb", scope)).toBe(false);
+});
+
+test("a key scope narrows scopePositions to only the notes of that key", () => {
+  const scope = { key: { root: "C", quality: "major" }, startFret: 0, endFret: 12 };
+  const pool = scopePositions(strings, scope);
+  expect(pool.length).toBeGreaterThan(0);
+  const inKey = new Set(keyNotes("C", "major"));
+  for (const p of pool) expect(inKey.has(p.note), `${p.note} in C major`).toBe(true);
+  // A key that shares no note with what the strings can sound in range is
+  // the same degenerate "nothing to ask" state a narrow fret range reaches.
+  expect(
+    scopeIsAskable(strings, { key: { root: "C", quality: "major" }, startFret: 1, endFret: 0 }),
+  ).toBe(false);
+});
+
+test("positionInScope is the single test every dimension reduces to at once", () => {
+  const scope = { stringNumbers: [6], startFret: 0, endFret: 3, key: { root: "E", quality: "minor" } };
+  // String 6 open is E - in the string set, in range, and in E minor.
+  expect(positionInScope(6, 0, "E", scope)).toBe(true);
+  // Right string and range, wrong key (C# is not in E minor).
+  expect(positionInScope(6, 1, "F", scope)).toBe(false);
+  // Right note and range, wrong string.
+  expect(positionInScope(5, 0, "A", scope)).toBe(false);
+});
+
+// ---------------------------------------------------------------- labelling
+
+test("scopeLabel states a narrowed scope and stays quiet about the default one", () => {
+  const label = scopeLabel(strings, { stringNumbers: [6, 5], startFret: 0, endFret: 3 });
+  expect(label).toBe("strings 5, 6, frets 0-3");
+  const full = scopeLabel(strings, { startFret: 0, endFret: 12 });
+  expect(full).toBe("frets 0-12");
+  expect(full).not.toContain("string");
+});
+
+test("scopeLabel names the key when one is set", () => {
+  const label = scopeLabel(strings, {
+    startFret: 0,
+    endFret: 12,
+    key: { root: "G", quality: "major" },
+  });
+  expect(label).toBe("frets 0-12, key of G major");
+});
+
+// ---------------------------------------------------------------- group scope (a chord shape's fretted notes)
+
+test("groupInScope requires every member of the group inside the scope, and a group of one", () => {
+  const scope = { stringNumbers: [5, 4, 3], startFret: 0, endFret: 3 };
+  const cMajorTriadOpenish = [
+    { string: 5, fret: 3, note: "C" },
+    { string: 4, fret: 2, note: "E" },
+    { string: 3, fret: 0, note: "G" },
+  ];
+  expect(groupInScope(cMajorTriadOpenish, scope)).toBe(true);
+  // One member outside the string set breaks the whole group, not only that
+  // member - a chord half inside a scope is not a chord the scope allows.
+  const withOneOutside = [...cMajorTriadOpenish, { string: 1, fret: 0, note: "E" }];
+  expect(groupInScope(withOneOutside, scope)).toBe(false);
+});
+
+test("an empty group is never in scope - a shape with nothing fretted is not a shape", () => {
+  expect(groupInScope([], { startFret: 0, endFret: 12 })).toBe(false);
+});


### PR DESCRIPTION
Closes #28. Progresses #26 - see below for what's left of it, filed as #194.

## What this does

**#26 - constraint model.** Factors fret-to-note's existing string-set/fret-range scoping out of `fret-to-note.js` into a reusable module, `web/src/lib/trainer/constraints.js`, and widens it with a key/note-set filter (major or minor key, any of the 12 roots) that neither drill exposed before. `fret-to-note.js` now imports `scopePositions`/`scopeIsAskable`/`scopeLabel` from there and re-exports them under the same names, so it is a pure move - nothing about the existing drill's behaviour changed. `groupInScope` is the one new primitive this needed that a single-position drill never did: whether every position in a *group* (a chord's whole shape, not one tap) fits inside a scope at once.

Still open: **named, saved presets** ("build this once, reuse it in a different drill later") - the constraint *arithmetic* is shared and tested, but there is no storage/API/UI yet for naming and reusing one. Filed as #194 rather than guessed at here.

**#28 - chord flash cards.** Built on the neck (#25/#184) and the constraint model above:

- `chord-theory.js` - pure interval arithmetic: `chordTones(root, quality)` for major/minor/dominant7, mirrored character-for-character in `server/fermata/trainer.py`'s `chord_tones`.
- `chord-shapes.js` - a real fingering library: hardcoded common open chords (E/A/D/G/C major, E/A/D minor, E/A/D/G/B7), plus **generated** movable E-shape/A-shape barre chords (major/minor) at every fret a region allows - the barre shapes' roots are read straight off the neck's own tuning arithmetic rather than a second table, so they are correct by construction, and every shape (open and barre) is checked against `chordTones` in tests.
- `chords.js` - the drill: three family presets (major & minor / sevenths / barre chords, matching the issue's own ordering), scoped by region + key via `constraints.js`, both directions (`shape_to_name`, `name_to_shape`), one grading rule for both - tone-set equality, never one canonical fingering.
- `ChordFlashCards.svelte` - reuses `Neck.svelte`'s `markers` prop for both a shown shape and accumulated taps; "Hear it" plays the chord via a new `playChord` in `score-render.js` (the same one-shot-MIDI pattern as the existing `playPitch`, widened to several simultaneous notes).
- Structured results: a new `trainer_chord_attempts` table (`server/fermata/db.py`), sibling to `trainer_attempts` rather than forced into its single-note columns - see that table's own comment for why, and `docs/practice-data.md`'s new section. `POST`/`GET /api/trainer/chord-attempts`, mirroring the fret-to-note routes. `correct` is always computed server-side from tone sets, never trusted from the request.
- `activity: 'chords'` for the practice session (already in `docs/practice-data.md`'s vocabulary, unused until now).
- No streaks/bests/averages/shaming - `chords.spec.js` and `chord-flashcards.spec.js` extend the FORBIDDEN_WORDS check from #184 to this drill's own wording.

Filed #195 for what is left of #28's own scope: musical-style groupings (which the issue itself calls optional) and barre/open minor7/major7 shapes (today's sevenths are dominant-7 only).

## Per-target

**Chord correctness (exhaustive, both languages)** - `web/tests/unit/chord-theory.spec.js` and `server/tests/test_chord_theory.py`:

```js
expect(chordTones("C", "major")).toEqual(["C", "E", "G"]);
expect(chordTones("A", "minor")).toEqual(["A", "C", "E"]);
expect(chordTones("G", "dominant7")).toEqual(["G", "B", "D", "F"]);
expect(chordTones("E", "major")).toEqual(["E", "Ab", "B"]); // Ab not G# - PITCH_CLASSES' own spelling
```

plus every one of the 36 (root, quality) combinations checked for note count, no repeated tone, starting on its own root, and the major/minor-triads-differ-only-in-the-third and dominant7-is-major-plus-one-note relationships holding at every root. `chord-shapes.spec.js` then checks every shape's *actual sounded notes* (via `neck.js`'s own tuning arithmetic) against `chordTones` - open shapes and every generated barre shape.

**Constrained drill only offers what's in scope** - `constraints.spec.js`, `chords.spec.js` (unit, narrowing fret range/string set/key), and `chord-flashcards.spec.js` (browser: narrowing to open position drops the G-major choice, which needs fret 3, and keeps E major, which fits).

**Full prompt to answer to feedback to next, both directions, correct and incorrect** - `chord-flashcards.spec.js`, against the real backend and build. `name_to_shape`'s correct/incorrect positions are found via the neck's own rendered `data-note` attributes plus an *independently reimplemented* chord formula in the test file itself (not imported from the app), so this would catch the app's own chord math breaking rather than just restating it.

**Chord correctness is server-authoritative** - `trainer.normalise_chord_attempt` computes `correct` from tone sets; `test_chord_trainer_api.py` proves the signature has no `correct` parameter to smuggle one through, and that grading is by tone SET (a tapped G major voiced in a different order/octave than the "reference" one still grades correct - `test_name_to_shape_grades_by_tone_set_not_by_exact_fingering`).

One honest caveat on that: for `name_to_shape`, the server compares the CLIENT's reported tapped notes (`given_notes`, resolved from the instrument's tuning on the client, the same trust boundary `trainer_attempts.given_note` already crosses for fret-to-note's note-to-position direction) against the target chord's own tones, computed server-side. The server has no instrument definition at grade time to re-derive those notes itself. What stays server-authoritative regardless is the verdict: `correct` is never a value the client can send, only the tone-set comparison this endpoint performs. For a self-directed practice drill (nobody but the player has a stake in the count), trusting the client's note-resolution while still computing the pass/fail server-side is the same shape of trust `checkTapAnswer`/`given_note` already established for the single-note drill - not a new gap this PR introduces.

**Empty/degenerate states honest** - a fret range or string set that admits nothing (`poolIsAskable` false, same "narrow-scope" messaging as fret-to-note); a key that shares no diatonic chord with a family preset (verified: F# major admits none of the open family's E/A/D/G/C roots).

**Structured results, field round-trips** - `test_chord_trainer_api.py`'s `test_logging_a_shape_to_name_attempt_stores_the_row_and_returns_it` and `test_logging_a_name_to_shape_attempt_round_trips_the_tapped_notes`: literal-value assertions on the POST response, a fresh SELECT against the row, and a subsequent GET - not just shape checks (#146).

**Mutations, each confirmed red then reverted via `git checkout` (commit-backed)**:
- Constraint filter (`groupInScope`'s `every` to `some`): `constraints.spec.js` and `chords.spec.js`'s scope tests go red.
- Chord-note math (major triad's third: interval 4 to 8, both JS `chord-theory.js` and Python `trainer.py`'s `CHORD_QUALITIES`): `chord-theory.spec.js`/`test_chord_theory.py` go red, and so does the *browser* suite (`chord-flashcards.spec.js`'s name_to_shape test, which computes tones independently as described above).
- Server grading (`correct = True` unconditionally): `test_chord_trainer_api.py` goes red.

**Suites vs. baselines.** Server: `PYTHONPATH=. py -3.13 -m pytest` gives 1124 passed, 64 skipped (pre-existing, library-gated, unchanged skip reasons) on the current rebase (main now carries #55's bulk-transcribe, +12 tests over the pre-rebase count). `test_every_route_has_exactly_the_expected_operation_count` re-derived against the live app on the actual rebase base (`app.openapi()['paths']`, counted independently of the test's own helper and cross-checked against it) - 60, not trusted from arithmetic: main's own count is 58 after #55's two routes, plus this PR's two (`POST`/`GET /api/trainer/chord-attempts`). Web: `npm run build` clean (no Svelte-warnings-as-errors); a full `npm run test:browser` run locally with a freshly rebuilt `dist`, isolated on a private port (never the suite's shared default 8931 or 8080) after discovering another concurrent worktree's leftover server squatting on 8931 earlier - not this branch's bug, an artifact of running several worktrees on one box. `#184`'s own fret-to-note/neck specs are untouched and pass. I'll add the final tail of this post-rebase local run as a comment once it finishes; CI runs the same suite independently regardless.

If you see one server-suite failure or an ~11-test skip-count delta locally: that's the pre-existing `conftest`'s `_library_skips` leak plus a `node_modules`-absence check, identical on `main`, and green in CI - not this PR's code.

## Rendered example

Could not attach a live screenshot from this environment (no connected browser session) - see the PR comments for a Playwright-driven render check and what it showed instead.

## Mandate

No AI-vendor/assistant wording anywhere in the new code, tests, or docs (grepped). No Co-Authored-By. `unset GH_TOKEN` before every `gh`/`git push`. Tested against 127.0.0.1, never `localhost`. Op-count re-derived live against the actual rebase base each time, not trusted from a comment or arithmetic. Spec floors added additively (`browser-chord-flashcards-28.json`, `unit-constraints-26.json`, `unit-chord-theory-28.json`, `unit-chord-shapes-28.json`, `unit-chords-28.json`), nothing existing lowered.

---

_Rebased onto current `main` (#55's bulk-transcribe now included) - op-count re-derived to 60, `server/fermata/api.py`'s import list and `test_api_docs.py`'s pin resolved additively, no other conflicts._
