### PR TITLE
Route three decoder signals that were computed and discarded (#91)

### DIFF
--- a/server/fermata/api.py
+++ b/server/fermata/api.py
@@ -1578,6 +1578,14 @@ def _transcription_row(conn, score_id: int):
 # tabextract._rhythm_report / glyph._assign_dots).
 _BAR_KEYS = ("bars_overfull", "bars_short", "bars_defective", "bars_measured",
              "bars_padded", "bars_unread", "notes_no_stem", "staves_no_stem",
+             # `staves_stemless` (issue #91): a notation staff whose stem/beam
+             # vector pass found NO stems at all, though it decoded noteheads
+             # that must carry one. A different, stronger fact than
+             # `staves_no_stem`, which counts a staff with one FILLED head
+             # whose own stem was missing - here the whole stem layer is
+             # empty, so nothing on the staff was read from a stem, flag or
+             # beam, and it is recoverable from nothing else stored here.
+             "staves_stemless",
              "dots_unassigned", "dots_unassigned_no_candidate",
              "dots_unassigned_eliminated", "staves_dots_unassigned",
              # Repeat barlines and volta brackets read only partly, and so
@@ -1953,6 +1961,7 @@ def _store_extraction_result(score_id: int, result) -> dict:
             "inferred_rest_quarters": result.inferred_rest_quarters,
             "notes_no_stem": result.notes_no_stem,
             "staves_no_stem": result.staves_no_stem,
+            "staves_stemless": result.staves_stemless,
             "dots_unassigned": result.dots_unassigned,
             "dots_unassigned_no_candidate": result.dots_unassigned_no_candidate,
             "dots_unassigned_eliminated": result.dots_unassigned_eliminated,

--- a/server/fermata/api_models.py
+++ b/server/fermata/api_models.py
@@ -630,6 +630,11 @@ class TranscriptionOut(BaseModel):
     bars_unread: int | None
     notes_no_stem: int | None
     staves_no_stem: int | None
+    # A notation staff whose stem/beam vector pass found no stems at all though
+    # it decoded noteheads that must carry one (issue #91) - the whole-staff
+    # version of notes_no_stem, and a stronger claim: nothing on the staff was
+    # read from a stem, flag or beam.
+    staves_stemless: int | None
     dots_unassigned: int | None
     dots_unassigned_no_candidate: int | None
     dots_unassigned_eliminated: int | None

--- a/server/fermata/glyph_rhythm.py
+++ b/server/fermata/glyph_rhythm.py
@@ -1338,7 +1338,14 @@ def page_drawings(page):
         try:
             cached = page.get_drawings()
         except Exception:
-            cached = []
+            # Cache SUCCESSES only (issue #91). A transient failure reading a
+            # malformed content stream must not be remembered as "this page
+            # has no drawings" for the rest of the process: every later stem/
+            # beam/barline scan would then see an empty list and report no
+            # stems, no beams and no barlines - at the same full confidence a
+            # genuinely blank page earns. Returning [] without storing it
+            # lets a subsequent call try the content stream again.
+            return []
         _DRAWINGS_CACHE[page] = cached
     return cached
 
@@ -3024,6 +3031,20 @@ def decode_note_events(page, staff_top, staff_bottom, staff_x0, staff_x1, line_y
         "band_glyphs": 0,
         "note_events": 0,
         "stem_count": 0,
+        # How many decoded noteheads carry a stem in standard notation - every
+        # notehead shape EXCEPT the whole note (a whole note is drawn without
+        # a stem by definition; a rest carries none either). Paired with
+        # stem_count, this is the staff-level self-check issue #91 asks for: a
+        # staff that decoded stem-bearing noteheads yet found ZERO stems on the
+        # whole staff had its entire stem/beam vector pass fail, so nothing on
+        # it was actually read from a stem, flag or beam - which is exactly
+        # what the "decoded directly from the notehead/stem/flag/beam/dot
+        # glyphs" confidence claims was. no_stem_noteheads cannot see this: it
+        # counts only the filled/x/diamond heads (a half note is excluded there
+        # because its value comes from the head shape), so a staff of half
+        # notes with no stems slips past it at full confidence. See
+        # tabextract._resolve_rhythm_source.
+        "stem_bearing_noteheads": 0,
         "beam_segment_count": 0,
         "curve_count": 0,
         # One-glyph rests whose half-or-whole reading the geometry could not
@@ -3373,6 +3394,10 @@ def decode_note_events(page, staff_top, staff_bottom, staff_x0, staff_x1, line_y
         "band_glyphs": len(staff_events),
         "note_events": len(notes),
         "stem_count": len(stems),
+        "stem_bearing_noteheads": sum(
+            1 for n in notes
+            if not n.is_rest and n.notehead_kind in NOTEHEAD_CATS
+            and n.notehead_kind != "notehead_whole"),
         "beam_segment_count": len(beams),
         "curve_count": len(curves),
         "undecided_rests": undecided_rests,

--- a/server/fermata/tabextract.py
+++ b/server/fermata/tabextract.py
@@ -370,6 +370,17 @@ class ExtractionResult:
     # and it cannot be recovered from any other figure on this result.
     notes_no_stem: int = 0
     staves_no_stem: int = 0
+    # Notation staves whose stem/beam vector pass found NO stems at all, though
+    # they decoded noteheads that must carry one (a half, filled, x or diamond
+    # head - everything but a whole note). The whole-staff self-check issue #91
+    # asks for, and distinct from `staves_no_stem`: that counts staves with at
+    # least one FILLED head whose own stem was missing; this counts staves
+    # where the entire stem layer is empty, which no_stem_noteheads cannot see
+    # when the heads are half notes (their value comes from the head shape, so
+    # they are excluded there). Such a staff is degraded rather than reported
+    # as read directly from its glyphs, because nothing on it was read from a
+    # stem, flag or beam. See _resolve_rhythm_source and glyph.decode_note_events.
+    staves_stemless: int = 0
     # Augmentation-dot glyphs that bound to no note, and how many notation
     # staves carried at least one. Left unattached rather than bound to the
     # nearest notehead - see glyph._assign_dots - so this is reported but
@@ -531,6 +542,7 @@ class ExtractionResult:
             "meter_digits_unreadable": self.meter_digits_unreadable,
             "notes_no_stem": self.notes_no_stem,
             "staves_no_stem": self.staves_no_stem,
+            "staves_stemless": self.staves_stemless,
             "dots_unassigned": self.dots_unassigned,
             "dots_unassigned_no_candidate": self.dots_unassigned_no_candidate,
             "dots_unassigned_eliminated": self.dots_unassigned_eliminated,
@@ -3492,9 +3504,11 @@ def _single_notatable_rest(quarters):
     is written with, or None when no single plain-or-dotted value equals it.
 
     Only a value a lone rest can actually carry is returned: 3.0 is a dotted
-    half, 3.5 is not any single rest and comes back None. The caller wants ONE
-    written rest, not a decomposition (which would change the bar's beat count),
-    so a length that needs two beats is declined rather than split here.
+    half and 3.5 a double-dotted half (dots go up to two here). A length no
+    single plain-or-dotted rest equals - 2.5, say, which is a half plus an
+    eighth - comes back None: the caller wants ONE written rest, not a
+    decomposition (which would change the bar's beat count), so a length that
+    needs two beats is declined rather than split here.
     """
     for code in (1, 2, 4, 8, 16, 32):
         for dots in (0, 1, 2):
@@ -3998,6 +4012,32 @@ def _resolve_rhythm_source(page, std_staff, pair_reason, decoded):
                 "shorter"
             ),
         )
+    stem_bearing = stats.get("stem_bearing_noteheads", 0)
+    if stats.get("stem_count", 0) == 0 and stem_bearing:
+        # The whole-staff self-check issue #91 asks for. This staff decoded
+        # stem-bearing noteheads (half, filled, x or diamond - everything but
+        # a whole note) yet the vector pass found ZERO stems anywhere on it,
+        # which is physically impossible in standard notation: every one of
+        # those heads is drawn with a stem. So the stem/beam vector pass failed
+        # for this staff entirely, and nothing on it was read from a stem, flag
+        # or beam - the very evidence "decoded directly from the
+        # notehead/stem/flag/beam/dot glyphs" claims. The notehead SHAPES were
+        # still read, so the durations they alone fix (a whole note, a half
+        # note) stand and the decode is kept rather than thrown back to
+        # spacing; but it is degraded, because no note here carries the voice
+        # its stem would have said, and any shorter head would have been
+        # floored. no_stem_noteheads does not catch this: it counts only the
+        # filled/x/diamond heads whose value needs a stem, so a staff whose
+        # heads are all half notes reaches here with no_stem_noteheads == 0.
+        return _RhythmSource(
+            PROV_GLYPHS_DEGRADED, note_events, stats=stats,
+            detail=(
+                f"the paired notation staff decoded {stem_bearing} stem-bearing notehead(s) "
+                "but the stem/beam vector pass found no stems on it at all - so no note's "
+                "flags, beams or voice could be read, and any duration shorter than the "
+                "notehead shape alone fixes would have been floored to a quarter"
+            ),
+        )
     return _RhythmSource(PROV_GLYPHS, note_events, stats=stats)
 
 
@@ -4415,6 +4455,7 @@ def _overfull_bars(measures) -> tuple[int, int]:
 
 def _rhythm_report(counts, details, conformance=None, unread_bars=(),
                    prov_bars=None, no_stem_notes=0, no_stem_staves=0,
+                   staves_stemless=0,
                    dots_unassigned=0, dots_unassigned_no_candidate=0,
                    dots_unassigned_eliminated=0, dots_unassigned_staves=0,
                    coincident_unsplit_pairs=0, coincident_unsplit_staves=0,
@@ -4442,6 +4483,12 @@ def _rhythm_report(counts, details, conformance=None, unread_bars=(),
     how many notation staves came out of the decode with no stem, and so with
     their duration floored at a quarter rather than read - see
     glyph.decode_note_events.
+
+    `staves_stemless` is how many notation staves decoded noteheads that must
+    carry a stem yet found no stem anywhere on the staff (issue #91) - the
+    stem/beam vector pass failed for them entirely, so nothing on them was read
+    from a stem, flag or beam. The whole-staff version of the fault above, and
+    a stronger claim; see _resolve_rhythm_source.
 
     `dots_unassigned` / `dots_unassigned_staves` are how many augmentation-dot
     glyphs across how many notation staves bound to no note - see
@@ -4569,6 +4616,23 @@ def _rhythm_report(counts, details, conformance=None, unread_bars=(),
             "notehead on its own allows"
         )
 
+    # A whole notation staff whose stem/beam vector pass found NO stems at all,
+    # even though it decoded noteheads that must carry one (issue #91). This is
+    # the whole-staff version of the fault above and is stated separately
+    # because it is a different, stronger claim: not "some heads on this staff
+    # lost their stem" but "no stem, flag or beam anywhere on this staff was
+    # read", so the durations came from the notehead shapes alone. Such a staff
+    # is degraded rather than reported as read directly from its glyphs.
+    if staves_stemless:
+        warnings.append(
+            f"{staves_stemless} notation staff system(s) decoded noteheads that must carry a "
+            "stem but no stem was found anywhere on the staff - the stem/beam vector pass "
+            "failed for them, so nothing on them was read from a stem, flag or beam. Their "
+            "durations come from the notehead shapes alone: a whole or half note is still its "
+            "own value, but no note carries the voice its stem would have said and any shorter "
+            "note would have been floored to a quarter"
+        )
+
     # A dot that bound to nothing, stated with its own count for the same
     # reason no_stem_notes is: a count of affected staves cannot say whether
     # one score has one stray dot or forty. The two are not the same claim
@@ -4642,15 +4706,38 @@ def _rhythm_report(counts, details, conformance=None, unread_bars=(),
     # Bars that don't add up outrank how the durations were obtained: a
     # confident reading of every notehead still produces a wrong bar when its
     # voices don't come apart, and playback follows the bar.
+    #
+    # WHY the bars overflowed depends on how the durations were read, so the
+    # explanation is conditional (issue #91). Where a staff was glyph-decoded,
+    # the cause is voice separation: two voices the stems did not come apart,
+    # or a missed flag or an undetected tuplet. But a document read ENTIRELY
+    # from the spacing heuristic - no glyph-decoded staff at all - never read a
+    # stem, a voice or a flag to begin with, so blaming merged voices is
+    # simply false. There the overflow is the heuristic's own arithmetic: it
+    # normalises the gaps between note columns to the bar and rounds each
+    # column to a notatable duration independently, so five evenly spaced
+    # columns in 4/4 each round to a quarter and sum to five.
     if bars and overfull:
-        warnings.append(
-            f"{overfull} of {bars} bar(s) hold more than their time signature allows. Music "
-            "written in two voices (a melody over a separate bass line) is separated into "
-            "concurrent voices where the stems say so, but a bar whose voices the stems do not "
-            "separate is still flattened into one, and an undetected tuplet or a missed flag "
-            "lands here too - the notes and their individual durations can still be right while "
-            "the bar as a whole is not, so playback timing will drift in those bars"
-        )
+        if not glyphs and not degraded:
+            warnings.append(
+                f"{overfull} of {bars} bar(s) hold more than their time signature allows. These "
+                "durations were estimated from the horizontal spacing between note columns, not "
+                "read from the score's engraving: the spacing between columns is normalised to "
+                "the bar and each column is then rounded to a notatable duration on its own, so a "
+                "bar's rounded durations can sum to more than it holds (five evenly spaced "
+                "columns in 4/4 each round to a quarter and sum to five). The notes are present "
+                "but their durations are a rough estimate, so playback timing will drift in those "
+                "bars"
+            )
+        else:
+            warnings.append(
+                f"{overfull} of {bars} bar(s) hold more than their time signature allows. Music "
+                "written in two voices (a melody over a separate bass line) is separated into "
+                "concurrent voices where the stems say so, but a bar whose voices the stems do not "
+                "separate is still flattened into one, and an undetected tuplet or a missed flag "
+                "lands here too - the notes and their individual durations can still be right while "
+                "the bar as a whole is not, so playback timing will drift in those bars"
+            )
     if bars and short:
         warnings.append(
             f"{short} of {bars} bar(s) hold less than their time signature allows - a note whose "
@@ -5529,6 +5616,12 @@ def _extract(doc, pdf_path, time_signature: tuple[int, int] | None,
     no_stem_notes = 0
     no_stem_staves = 0
     no_stem_seen = set()
+    # Notation staves that decoded stem-bearing noteheads but found ZERO stems
+    # on the whole staff - the vector pass failed for them entirely, so nothing
+    # was read from a stem, flag or beam (issue #91). Counted over the same
+    # de-duplicated decodes as no_stem_notes above, and distinct from it: this
+    # is the WHOLE-staff failure no_stem_noteheads structurally cannot see.
+    staves_stemless = 0
     # Rests read longer than their bar and trimmed to what it can hold (issue
     # #163, see _reduce_overlong_rests). A count, and the bar numbers so a
     # reader can carry each back to the PDF the way the padded-bars warning
@@ -5682,6 +5775,9 @@ def _extract(doc, pdf_path, time_signature: tuple[int, int] | None,
                     if staff_no_stem:
                         no_stem_notes += staff_no_stem
                         no_stem_staves += 1
+                    if (source.stats.get("stem_count", 0) == 0
+                            and source.stats.get("stem_bearing_noteheads", 0)):
+                        staves_stemless += 1
                     staff_dots_unassigned = source.stats.get("dots_unassigned", 0)
                     if staff_dots_unassigned:
                         dots_unassigned_total += staff_dots_unassigned
@@ -5851,6 +5947,7 @@ def _extract(doc, pdf_path, time_signature: tuple[int, int] | None,
         prov_counts, prov_details, conformance, tuple(unread_bars),
         prov_bars=prov_bars, no_stem_notes=no_stem_notes,
         no_stem_staves=no_stem_staves,
+        staves_stemless=staves_stemless,
         dots_unassigned=dots_unassigned_total,
         dots_unassigned_no_candidate=dots_unassigned_no_candidate_total,
         dots_unassigned_eliminated=dots_unassigned_eliminated_total,
@@ -6205,6 +6302,7 @@ def _extract(doc, pdf_path, time_signature: tuple[int, int] | None,
         meter_digits_unreadable=meter_digits_unreadable,
         notes_no_stem=no_stem_notes,
         staves_no_stem=no_stem_staves,
+        staves_stemless=staves_stemless,
         dots_unassigned=dots_unassigned_total,
         dots_unassigned_no_candidate=dots_unassigned_no_candidate_total,
         dots_unassigned_eliminated=dots_unassigned_eliminated_total,

--- a/server/tests/test_glyph_rhythm.py
+++ b/server/tests/test_glyph_rhythm.py
@@ -2072,3 +2072,64 @@ def test_glyph_positions_land_on_the_staffs_own_grid(zanarkand_pdf):
     # everywhere. (0.39 of a space, folded onto a grid whose step is half a
     # space, is 0.11 - the bias is bigger than this number, not smaller.)
     assert min(metrics) > 0.09, f"metrics centres were on the grid after all: {min(metrics)}"
+
+
+# ---------------------------------------------------------------------------
+# page_drawings memoises SUCCESSES only (issue #91)
+# ---------------------------------------------------------------------------
+
+
+class _FlakyPage:
+    """A page whose get_drawings() raises once, then returns real drawings -
+    a transient content-stream parse error followed by a clean read."""
+
+    def __init__(self):
+        self.calls = 0
+
+    def get_drawings(self):
+        self.calls += 1
+        if self.calls == 1:
+            raise RuntimeError("transient content-stream parse error")
+        return [{"stem": "here"}, {"beam": "here"}]
+
+
+def test_a_transient_drawing_failure_is_not_cached_forever():
+    """A failure reading the vector primitives must not be remembered as "this
+    page has no drawings": every later stem/beam/barline scan would then see an
+    empty list and report no stems, no beams and no barlines - at the same full
+    confidence a genuinely blank page earns. Successes are cached; failures are
+    retried."""
+    page = _FlakyPage()
+    G._DRAWINGS_CACHE.pop(page, None)
+
+    first = G.page_drawings(page)   # the transient failure
+    assert first == [], "a failed read yields an empty list to this caller"
+
+    second = G.page_drawings(page)  # must try again, not serve the cached failure
+    assert second == [{"stem": "here"}, {"beam": "here"}], (
+        "the failure was cached and the real drawings were never seen"
+    )
+
+    third = G.page_drawings(page)   # the success IS cached - no third get_drawings
+    assert third == second
+    assert page.calls == 2, "the success should be memoised, the failure should not"
+
+
+def test_a_successful_empty_drawing_read_is_still_cached():
+    """A page that genuinely has no drawings returns [] from get_drawings()
+    without raising, and THAT empty list is a real answer worth memoising - the
+    fix must not turn every blank page into a re-parse on each staff."""
+
+    class _BlankPage:
+        def __init__(self):
+            self.calls = 0
+
+        def get_drawings(self):
+            self.calls += 1
+            return []
+
+    page = _BlankPage()
+    G._DRAWINGS_CACHE.pop(page, None)
+    assert G.page_drawings(page) == []
+    assert G.page_drawings(page) == []
+    assert page.calls == 1, "a genuine empty read is memoised, not repeated"

--- a/server/tests/test_tabextract.py
+++ b/server/tests/test_tabextract.py
@@ -1491,6 +1491,46 @@ def test_a_staff_whose_heads_all_found_a_stem_is_still_fully_read(monkeypatch):
     assert src.provenance == tabextract.PROV_GLYPHS
 
 
+def test_a_staff_with_stem_bearing_heads_but_no_stems_at_all_is_degraded(monkeypatch):
+    """Issue #91: a staff that decoded stem-bearing noteheads (a half, filled,
+    x or diamond head) yet found ZERO stems anywhere is physically impossible
+    in standard notation - every one of those heads is drawn with a stem, so
+    the stem/beam vector pass failed for the whole staff and nothing on it was
+    read from a stem, flag or beam. no_stem_noteheads cannot see this when the
+    heads are half notes (it counts only the quarter-or-shorter heads whose
+    value needs a stem), so such a staff used to report "high - decoded
+    directly from the notehead/stem/flag/beam/dot glyphs" at full confidence.
+    It is now degraded."""
+    src = _resolve_with_stats(monkeypatch, _stats(
+        stem_count=0, stem_bearing_noteheads=40, no_stem_noteheads=0))
+    assert src.provenance == tabextract.PROV_GLYPHS_DEGRADED
+    assert src.uses_glyphs, "the notehead shapes were still read - not thrown back to spacing"
+    assert "40 stem-bearing notehead(s)" in src.detail
+    assert "no stems on it at all" in src.detail
+
+
+def test_a_stemless_staff_of_only_whole_notes_stays_fully_read(monkeypatch):
+    """A whole note carries no stem by definition, so a staff of nothing but
+    whole notes legitimately finds zero stems and must NOT be degraded - the
+    gate keys on stem-BEARING heads, not on stem_count alone, or every
+    whole-note staff in the library would degrade for a stem it never had."""
+    src = _resolve_with_stats(monkeypatch, _stats(
+        stem_count=0, stem_bearing_noteheads=0, no_stem_noteheads=0))
+    assert src.provenance == tabextract.PROV_GLYPHS
+
+
+def test_the_stemless_staff_gate_sits_after_the_no_stem_gate(monkeypatch):
+    """A staff with FILLED stemless heads is reported through the
+    no_stem_noteheads branch (which names the affected note count), not the
+    whole-staff stemless one, even when it also happens to have zero stems -
+    the more specific reason wins. Pinned so a reordering is caught here."""
+    src = _resolve_with_stats(monkeypatch, _stats(
+        stem_count=0, stem_bearing_noteheads=5, no_stem_noteheads=5))
+    assert src.provenance == tabextract.PROV_GLYPHS_DEGRADED
+    assert "no stem this" in src.detail  # the no_stem_noteheads wording
+    assert "no stems on it at all" not in src.detail
+
+
 def test_the_no_stem_gate_sits_at_the_end_of_the_resolution_ladder(monkeypatch):
     """`no_stem_noteheads` is checked LAST, after every unknown-vocabulary
     branch, and that ordering is deliberate rather than incidental: a staff
@@ -1550,6 +1590,54 @@ def test_overfull_bars_are_reported_and_cap_the_confidence():
     assert any("1 of 50 bar(s) hold more" in x for x in w2)
     assert c2.startswith("medium"), c2
     assert not c2.startswith("low"), "one bar in fifty is not a condemned score"
+
+
+def test_overfull_on_a_spacing_only_document_does_not_blame_merged_voices():
+    """Issue #91: the overfull-bar warning used to explain every overfull bar
+    the same way - two voices the stems did not separate, or a missed flag -
+    regardless of how the durations were obtained. A document read ENTIRELY
+    from the spacing heuristic never read a stem, a voice or a flag, so that
+    explanation is false for it: its overflow is the heuristic rounding each
+    normalised column to a notatable duration on its own. The warning must say
+    THAT, not blame voices that were never separated."""
+    spacing_only = collections.Counter({tabextract.PROV_SPACING: 5})
+    w, _c = tabextract._rhythm_report(
+        spacing_only, {}, tabextract._BarConformance(14, 0, 14, 16))
+    overfull = [x for x in w if "hold more than their time signature" in x]
+    assert len(overfull) == 1, w
+    assert "two voices" not in overfull[0]
+    assert "concurrent voices" not in overfull[0]
+    assert "flattened into one" not in overfull[0]
+    assert "spacing between note columns" in overfull[0]
+    assert "rounded to a notatable duration" in overfull[0]
+
+
+def test_overfull_on_a_glyph_decoded_document_still_names_merged_voices():
+    """The converse of the test above: where a staff WAS glyph-decoded, merged
+    voices and missed flags are the real causes, and the warning must keep
+    saying so. Only the pure-spacing case swaps the explanation."""
+    glyph = collections.Counter({tabextract.PROV_GLYPHS: 5})
+    w, _c = tabextract._rhythm_report(
+        glyph, {}, tabextract._BarConformance(3, 0, 3, 16))
+    overfull = [x for x in w if "hold more than their time signature" in x]
+    assert len(overfull) == 1, w
+    assert "two voices" in overfull[0]
+    assert "spacing between note columns" not in overfull[0]
+
+
+def test_a_whole_staff_with_no_stems_found_is_disclosed(monkeypatch):
+    """Issue #91: staves_stemless reaches the warning prose so a reader is told
+    a whole notation staff's stem layer came up empty, distinct from the
+    per-note no_stem count."""
+    glyph = collections.Counter({tabextract.PROV_GLYPHS: 4,
+                                 tabextract.PROV_GLYPHS_DEGRADED: 1})
+    w, _c = tabextract._rhythm_report(glyph, {}, staves_stemless=2)
+    hits = [x for x in w if "no stem was found anywhere on the staff" in x]
+    assert len(hits) == 1, w
+    assert "2 notation staff system(s)" in hits[0]
+    # And nothing when there are none.
+    w2, _c2 = tabextract._rhythm_report(glyph, {}, staves_stemless=0)
+    assert not any("no stem was found anywhere on the staff" in x for x in w2)
 
 
 def test_bar_quarters_accounts_for_dots():

--- a/web/src/lib/disclosures.js
+++ b/web/src/lib/disclosures.js
@@ -107,6 +107,13 @@ export const DISCLOSURE_ROWS = [
   // counted here.
   { key: "notes_no_stem", label: "Noteheads read with no stem (quarter or shorter)" },
   { key: "staves_no_stem", label: "Staves with a stemless notehead" },
+  // A whole notation staff whose stem/beam vector pass found NO stems at all,
+  // though it decoded noteheads that must carry one (issue #91). Stronger than
+  // the row above: not "one head lost its stem" but "no stem, flag or beam
+  // anywhere on the staff was read", so its durations came from the notehead
+  // shapes alone and the staff is degraded rather than reported as read
+  // directly from its glyphs.
+  { key: "staves_stemless", label: "Staves with stem-bearing noteheads but no stems found at all" },
   // HOW THE DURATIONS WERE OBTAINED (issue #117). tabextract.py counted both
   // of these on every extraction from the start, inside `rhythm_provenance` -
   // a field nothing stores, nothing returns and no interface code reads - so

--- a/web/tests/disclosure-keys.json
+++ b/web/tests/disclosure-keys.json
@@ -17,6 +17,7 @@
   "staves_dots_unassigned",
   "staves_no_stem",
   "staves_spacing_rhythm",
+  "staves_stemless",
   "systems_unread",
   "tie_ends_unpaired",
   "unison_digits_shared"


### PR DESCRIPTION
Closes #91.

Three places where the decoder already held the evidence that its answer was unreliable and reported confidence anyway. Each was reproduced on current main before fixing.

## 1. A staff with stem-bearing noteheads but zero stems (was full confidence)

`decode_note_events` wrote `stem_count` and read it nowhere. A staff of half notes with **no stems anywhere** is physically impossible — every half note carries a stem — so the whole stem/beam vector pass failed, yet the staff reported "high — decoded directly from the notehead/stem/flag/beam/dot glyphs". `no_stem_noteheads` structurally cannot catch this: it counts only quarter-or-shorter heads (a half note's value comes from the head shape, so it is excluded), so a half-note staff reached full confidence with `no_stem_noteheads == 0`.

Reproduced: a library score p1 — 40 half notes, 0 stems, provenance `glyphs` (full confidence). Library-wide, 34 zero-stem staves reported full confidence; 7 of them carried stem-bearing (half-note) heads.

Fix: a new `stem_bearing_noteheads` stat gates a degrade in `_resolve_rhythm_source`, and a `staves_stemless` disclosure counter is wired the full way — ExtractionResult → to_dict → `_BAR_KEYS` → confidence_json → TranscriptionOut → DISCLOSURE_ROWS → the vendored disclosure-keys mirror. A staff of only whole notes finds zero stems legitimately and stays fully read (the gate keys on stem-*bearing* heads, not on `stem_count` alone).

## 2. A transient drawing failure was cached forever

`page_drawings` stored the exception's empty list, so one malformed content stream reported no stems, no beams and no barlines for the rest of the process — at the same full confidence a genuinely blank page earns. Reproduced with a page whose `get_drawings()` raises once then succeeds: the failure was cached and the real drawings were never seen. Fix: cache successes only; a failure returns `[]` and is retried. A genuine empty read is still memoised.

## 3. A spacing-only document's overfull bars blamed merged voices

The overfull-bar warning explained every overfull bar as "voices the stems do not separate" or a missed flag — false for a document read *entirely* from note spacing, where no stem, voice or flag was ever read. Reproduced: `Tarrega-Estudio-Em-Werner.pdf` (provenance `{spacing: 5}`, 14/16 overfull) received the merged-voices warning. Fix: the explanation is conditional on provenance — a pure-spacing document is told its normalised columns each rounded to a notatable duration independently (five even columns in 4/4 each round to a quarter and sum to five). The confidence string itself was already honest via `_relabel`.

## Related note (does not reproduce)

A bar-length rest rounding *longer* than its bar in 3/4, 6/8, 7/8: #163's `_reduce_overlong_rests` already spells those budgets (`_single_notatable_rest` supports double dots, so 7/8's 3.5 is a double-dotted half; 3/4 and 6/8 are dotted halves), and the empty-bar builders use `_rest_beats_for`, which decomposes to the exact budget for every meter. A full-library scan found **zero** bars where a rest exceeds its bar. No code change; reported for the record.

## Verification

- Reproduced each signal on current main, then confirmed the fix routes it (per-signal, above).
- **Byte-identity across all 297 library PDFs**: emitted musicxml, alphatex and every note/beat/bar count are identical before and after. Only confidence labels, provenance counts, warnings and the new disclosure move — 16 documents get honest label changes (7 staves newly degraded; 9 already-degraded staves additionally disclosed as stemless; 1 document drops from high to degraded).
- New regression tests for all three signals; each was mutation-tested (reverting the fix turns the test red).
- Full server suite: 1193 passed, 3 skipped (all MusicXML-XSD, which skip without `FERMATA_MUSICXML_XSD` — no schema on disk). Disclosure-key mirror guards (server + web) consistent.
