### PR TITLE
Fix two #110 flakes, and add a guard against the pattern coming back

### DIFF
--- a/server/fermata/scanner.py
+++ b/server/fermata/scanner.py
@@ -98,17 +98,41 @@ TRASH_DIR_NAME = ".fermata-trash"
 #   inserts a row, or does not and the upload's own scan picks it up. Holding it
 #   would also break the ordinary case rather than protect it: every upload
 #   starts a scan, so uploading two files in a row would have the second refused
-#   for the first one's scan. The one interaction that matters is an upload
-#   landing on a move's destination, and that is caught where it has to be
-#   caught anyway (a person can drop a file into the library folder with no
-#   endpoint involved at all): _move_file_on_disk refuses a destination that
-#   exists, and its rename fails rather than overwriting if the file appears in
-#   the gap after that check.
+#   for the first one's scan - which is exactly why a decline queues
+#   `_rescan_pending` rather than dropping the request: without it, "the
+#   upload's own scan picks it up" was only true when that scan actually ran,
+#   and a scan already in flight when the second file landed had taken its
+#   listing before that file existed either (#110). The one interaction that
+#   matters is an upload landing on a move's destination, and that is caught
+#   where it has to be caught anyway (a person can drop a file into the
+#   library folder with no endpoint involved at all): _move_file_on_disk
+#   refuses a destination that exists, and its rename fails rather than
+#   overwriting if the file appears in the gap after that check.
 #
 #   CREATING A FOLDER IS NOT HELD either, and needs no argument beyond stating
 #   it: mkdir moves nothing and removes nothing, and a scan does not have an
 #   opinion about an empty directory.
 _mutating = False
+
+# Set when start_scan() is declined - because a scan is already running or
+# the library is mid-mutation - so the request it was declined for is not
+# silently lost (#110). The paragraph above claims "a scan either sees the
+# new file and inserts a row, or does not and the upload's own scan picks it
+# up" - that was only true when the upload's own scan actually runs. A scan
+# already in flight takes its directory listing before the new file exists,
+# so it does not see it either; if the upload's own start_scan() call is
+# THEN declined because that other scan is still going, nothing was left to
+# revisit the file at all. It stayed off the browser and out of every future
+# scan until something unrelated happened to ask again - seen as a browser
+# test's "the uploaded score never appeared" under CI load, where a scan
+# from a different test was still finishing when this one uploaded.
+#
+# The fix is not to make start_scan() block or queue every request - that
+# would turn "declined" into an ever-growing backlog under real load. One
+# flag is enough: the running pass (or mutation) is about to look at the
+# library fresh regardless, so anything that arrived while it was busy only
+# needs ONE more pass after it, not a pass of its own.
+_rescan_pending = False
 
 
 class LibraryBusy(RuntimeError):
@@ -149,6 +173,10 @@ def hold_library_still():
     finally:
         with _state_lock:
             _mutating = False
+        # If a scan was declined while this held the library (an upload
+        # landing mid-move, say), it does not get to fall through the gap
+        # the mutation just closed - see `_rescan_pending`.
+        _run_pending_rescan()
 
 
 def trash_dir(root: Path | None = None) -> Path:
@@ -790,12 +818,18 @@ def start_scan(acknowledge: str | None = None) -> bool:
     simply does not apply, and the scan refuses again with the new figures,
     which is the safe way for stale consent to fail.
     """
+    global _rescan_pending
     with _state_lock:
         if _state["scanning"] or _mutating:
             # `_mutating` for the same reason `scanning` is here: one thing
             # reconciles the library at a time. A scan starting in the middle of
             # a move would take its directory listing while the file is at
             # neither end of the move - see the comment on `_mutating`.
+            #
+            # Recorded rather than just refused - see `_rescan_pending` - so
+            # whatever asked for this scan is not left with no scan ever
+            # having looked for it.
+            _rescan_pending = True
             return False
         _state["scanning"] = True
         _state["started_at"] = time.time()
@@ -812,6 +846,24 @@ def start_scan(acknowledge: str | None = None) -> bool:
             with _state_lock:
                 _state["scanning"] = False
                 _state["finished_at"] = time.time()
+        _run_pending_rescan()
 
     threading.Thread(target=run, name="fermata-scan", daemon=True).start()
     return True
+
+
+def _run_pending_rescan() -> None:
+    """Start exactly one follow-up scan if something was declined while this
+    scan (or mutation) held the library - see `_rescan_pending`.
+
+    Plain start_scan(), never the acknowledge token a refused scan might have
+    been holding: that token is consent to one specific, named set of missing
+    files, and replaying it against whatever the library looks like now would
+    apply a person's "yes" to evidence they never saw.
+    """
+    global _rescan_pending
+    with _state_lock:
+        if not _rescan_pending:
+            return
+        _rescan_pending = False
+    start_scan()

--- a/server/tests/test_library_management_api.py
+++ b/server/tests/test_library_management_api.py
@@ -472,8 +472,15 @@ def test_a_scan_will_not_start_while_the_library_is_being_changed(client, add_sc
         assert scanner.start_scan() is False
         assert client.post("/api/scan").json()["started"] is False
 
-    # And the exclusion lifts by itself.
-    assert scanner.start_scan() is True
+    # And the exclusion lifts by itself - and does not silently drop what was
+    # declined while it was held: hold_library_still queues exactly one
+    # follow-up scan for it (#110), so a scan is already running or about to
+    # be the moment this returns, without anything here asking again.
+    deadline = time.monotonic() + 5
+    while scanner.scan_status()["finished_at"] is None:
+        if time.monotonic() > deadline:
+            raise AssertionError("the follow-up scan queued by the exclusion never ran")
+        time.sleep(0.02)
     _wait_for_scan()
 
 

--- a/server/tests/test_scanner.py
+++ b/server/tests/test_scanner.py
@@ -1663,6 +1663,98 @@ def test_the_scan_survives_a_file_that_cannot_be_read_and_still_reconciles(libra
     assert rows()["Classical/Study 1.gp"]["missing_since"] is None
 
 
+# ---------------------------------------------------------------------------
+# A declined start_scan() must not be the last anybody hears of it (#110).
+# ---------------------------------------------------------------------------
+
+
+def test_a_scan_declined_while_one_is_running_gets_a_follow_up_by_itself(
+    library, monkeypatch
+):
+    """A file that lands mid-scan is not lost just because its own scan request
+    was declined.
+
+    Traced from a browser-test flake: `upload()` polls for a new score's row
+    for up to 30s and reports "the uploaded score never appeared" if it times
+    out. That happened under CI load because a scan already in flight took its
+    directory listing before the new file existed, and the upload's own
+    scanner.start_scan() call - the ONLY other thing that would have picked it
+    up - was declined because that other scan was still running. Nothing was
+    then left to look again; the file sat unindexed forever, not for 30s.
+
+    The listing is taken up front and is real - `_library_files` runs for
+    real, only made to take a while before returning - so this reproduces the
+    actual race rather than a state flag standing in for it.
+    """
+    real_library_files = scanner._library_files
+
+    def slow_library_files(root):
+        listing = real_library_files(root)
+        time.sleep(0.3)
+        return listing
+
+    monkeypatch.setattr(scanner, "_library_files", slow_library_files)
+
+    put(library, "Uploads/already-there.gp")
+    assert scanner.start_scan() is True
+
+    # Wait until that scan is past its (real) listing and into the delay -
+    # i.e. genuinely in flight, not merely "started".
+    deadline = time.monotonic() + 5
+    while scanner.scan_status()["started_at"] is None:
+        if time.monotonic() > deadline:
+            raise AssertionError("the first scan never started")
+        time.sleep(0.01)
+    time.sleep(0.05)
+    assert scanner.scan_status()["scanning"] is True
+
+    # An upload landing in that window: writes the file, then asks for a scan
+    # exactly as api.upload does - and is declined.
+    put(library, "Uploads/new-upload.gp")
+    assert scanner.start_scan() is False
+
+    # NOT asserted here: that the row is absent right after the first scan
+    # finishes. `_wait_for_scan` only waits for `scanning` to read false at
+    # whatever moment it polls, and the follow-up this test is about can
+    # start again inside that same instant - so "absent yet" is not something
+    # this can observe reliably. What is reliable, and is the actual
+    # contract, is that the row exists soon without anything else asking.
+    deadline = time.monotonic() + 5
+    while "Uploads/new-upload.gp" not in rows():
+        if time.monotonic() > deadline:
+            raise AssertionError(
+                "the declined scan request was silently dropped - nothing ever "
+                "revisited the new file"
+            )
+        time.sleep(0.02)
+    assert rows()["Uploads/new-upload.gp"]["missing_since"] is None
+
+
+def test_a_scan_declined_by_a_mutation_gets_a_follow_up_once_it_lifts(library):
+    """The other decline path - `_mutating` - owes the same guarantee.
+
+    A move or delete excludes a scan for its own duration (see
+    hold_library_still); a scan asked for while that is held must not be lost
+    once the exclusion lifts, for the same reason an in-flight scan's decline
+    must not be.
+    """
+    put(library, "Uploads/already-there.gp")
+    scanner._scan()
+
+    with scanner.hold_library_still():
+        put(library, "Uploads/new-upload.gp")
+        assert scanner.start_scan() is False
+
+    deadline = time.monotonic() + 5
+    while "Uploads/new-upload.gp" not in rows():
+        if time.monotonic() > deadline:
+            raise AssertionError(
+                "the scan declined during the mutation was silently dropped"
+            )
+        time.sleep(0.02)
+    assert rows()["Uploads/new-upload.gp"]["missing_since"] is None
+
+
 def test_a_score_row_written_before_the_column_existed_is_treated_as_present(
     library,
 ):

--- a/web/scripts/check-out-of-band-reads.mjs
+++ b/web/scripts/check-out-of-band-reads.mjs
@@ -1,0 +1,155 @@
+// #110: a browser test performs a user action, then reads the result through
+// a channel that is not ordered against it - the request context rather than
+// the page, most often - so the read can and sometimes does overtake the
+// write it is checking. Diagnosed three times (#82/#83, #100, and the
+// refused-scan test #110 itself names), fixed each time, and back within one
+// new file each time: a point-in-time grep does not hold, because the wrong
+// version is the natural thing to write and the right one needs knowing this
+// specific hazard.
+//
+// This is that grep, kept running. It is crude on purpose, the same way
+// check-warning-patterns.mjs is crude on purpose: a plain, line-based scan
+// of tests/browser/*.spec.js's SOURCE TEXT, not a real parse of it. It looks
+// for a page action (a click, a fill, a key press...) followed - with
+// nothing that could order the two in between - by a read through the
+// request context. That is the exact shape #82, #100 and #110's third
+// instance shared.
+//
+// APPROXIMATE ON PURPOSE. A false positive here costs a moment and a
+// `// out-of-band-ok: <reason>` on the flagged line; a false negative costs a
+// random CI failure that trains everyone to re-run rather than look, which is
+// how a genuine one eventually gets waved through. So this leans toward
+// flagging: it does not understand scope, only resets its idea of "an action
+// happened with no barrier since" at each `test(...)`/`test.beforeEach(...)`
+// boundary, and treats an `expect.poll(...)`/`expect(async () => {...}).toPass(...)`
+// block as ALL barrier - the retrying-read idiom this project already uses
+// correctly (see zz-library-missing.spec.js) is exactly what a guard like
+// this must not punish.
+//
+// WHAT THIS DOES NOT CATCH, stated plainly rather than implied by a green
+// run: practice.spec.js:343's flake before it was fixed. That test never
+// touched `request.*` at all - it clicked Save, checked `.notice` (a barrier
+// that read true before the click as well as after, so it was never a wait
+// on anything), then called `page.reload()` too early and read the reloaded
+// PAGE's own DOM back, correctly wrapped in a retrying `toHaveValue`. The
+// read channel was fine; the reload itself ran before the write it was
+// testing had landed. Telling that apart from the very common, entirely
+// correct "act, reload, assert" shape needs knowing WHICH barrier is
+// causally tied to WHICH write - semantic knowledge a text scan does not
+// have. A green run of this script is evidence against the request-context
+// shape specifically, not against every way a test can outrun its own write.
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const browserDir = path.join(here, "..", "tests", "browser");
+
+// A page action whose effect a later read might be racing. Deliberately not
+// `request.*` calls, which are the OUT-OF-BAND side of the race, not the
+// action that starts it.
+const ACTION_RE =
+  /\.(click|fill|press|check|uncheck|selectOption|dragTo|type|setInputFiles|dispatchEvent)\(/;
+// Something that orders a later read against whatever the action triggered:
+// a retrying assertion, an explicit wait on the network, or a hard resync
+// (reload/goto navigate the page fresh, so nothing before them is live
+// evidence of anything after).
+const BARRIER_RE =
+  /\b(await expect\(|\.toPass\(|expect\.poll\(|waitForResponse\(|waitForFunction\(|waitForLoadState\(|waitForSelector\(|waitForURL\(|page\.reload\(|page\.goto\()/;
+// The out-of-band read #82/#100/#110 all were: state fetched through
+// Playwright's APIRequestContext, which is not ordered against the page's
+// own click/fill at all.
+const READ_RE = /\brequest\.(get|post|patch|put|delete)\(/;
+// Enters a retrying-read block: everything inside is presumed ordered
+// correctly BY CONSTRUCTION (it is retried until it passes), so reads in here
+// are the fix, not the defect.
+const RETRY_BLOCK_RE = /(expect\.poll\(|expect\(async \(\)|expect\(async function)/;
+const TEST_BOUNDARY_RE = /^\s*test(\.\w+)?\(/;
+const ACK_RE = /\/\/\s*out-of-band-ok\b/;
+
+function netBrackets(line) {
+  // Comments and strings are not stripped, so a `//` line or a string
+  // containing a brace can misdirect this a little - acceptable at the
+  // approximate level this tool works at. Deliberately not "" the char
+  // class, just counted directly.
+  const opens = (line.match(/[{(]/g) ?? []).length;
+  const closes = (line.match(/[})]/g) ?? []).length;
+  return opens - closes;
+}
+
+function scanFile(file) {
+  const text = fs.readFileSync(file, "utf8");
+  const lines = text.split("\n");
+  const problems = [];
+
+  let sinceBarrier = false;
+  let inRetryBlock = false;
+  let retryDepth = 0;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const lineNo = i + 1;
+
+    if (TEST_BOUNDARY_RE.test(line)) {
+      sinceBarrier = false;
+      inRetryBlock = false;
+      retryDepth = 0;
+    }
+
+    if (inRetryBlock) {
+      retryDepth += netBrackets(line);
+      if (retryDepth <= 0) {
+        inRetryBlock = false;
+        sinceBarrier = false; // the retry block itself is a barrier
+      }
+      continue;
+    }
+
+    if (RETRY_BLOCK_RE.test(line)) {
+      inRetryBlock = true;
+      retryDepth = netBrackets(line);
+      sinceBarrier = false;
+      continue;
+    }
+
+    if (BARRIER_RE.test(line)) {
+      sinceBarrier = false;
+    }
+
+    if (READ_RE.test(line)) {
+      // The marker may sit on the read's own line or on the comment line
+      // immediately above it - whichever reads naturally for the call shape.
+      const acknowledged = ACK_RE.test(line) || (i > 0 && ACK_RE.test(lines[i - 1]));
+      if (sinceBarrier && !acknowledged) {
+        problems.push(
+          `${path.relative(browserDir, file)}:${lineNo}: a request.* read follows a page ` +
+            "action with nothing ordering it after that action's write - see #110. Add a " +
+            "barrier (await expect(...), waitForResponse(...), or reload/goto) between the " +
+            "action and this read, or mark it `// out-of-band-ok: <reason>` if the read " +
+            "genuinely cannot race (e.g. it runs before any action in this test).",
+        );
+      }
+      // A read is not itself a barrier for what comes after it.
+      continue;
+    }
+
+    if (ACTION_RE.test(line) && !BARRIER_RE.test(line)) {
+      sinceBarrier = true;
+    }
+  }
+
+  return problems;
+}
+
+const files = fs
+  .readdirSync(browserDir)
+  .filter((f) => f.endsWith(".spec.js"))
+  .map((f) => path.join(browserDir, f));
+
+const problems = files.flatMap(scanFile);
+
+if (problems.length) {
+  console.error("out-of-band read check failed (#110):\n  " + problems.join("\n  "));
+  process.exit(1);
+}
+console.log(`out-of-band read check passed (${files.length} browser spec files)`);

--- a/web/scripts/run-browser-tests.mjs
+++ b/web/scripts/run-browser-tests.mjs
@@ -59,6 +59,21 @@ if (filteredArgs.length !== passedArgs.length) {
   );
 }
 
+// #110: a static, approximate check for the "click, then read out of band"
+// race that has recurred three times (#82, #100, and a refused-scan test
+// written after that sweep) despite two prior sweeps. Run before Playwright
+// even starts, so a new instance of the pattern fails fast and cheaply
+// rather than waiting on a browser job to flake under load. See
+// check-out-of-band-reads.mjs for what it does and does not catch.
+const guard = spawnSync("node", ["scripts/check-out-of-band-reads.mjs"], {
+  cwd: webRoot,
+  stdio: "inherit",
+  shell: true,
+});
+if (guard.status !== 0) {
+  process.exit(guard.status ?? 1);
+}
+
 const summaryPath = path.join(fs.mkdtempSync(path.join(os.tmpdir(), "fermata-test-summary-")), "summary.json");
 const reporters = process.env.CI
   ? "list,github,html,./tests/minimum-tests.js,json"

--- a/web/tests/browser/metronome-everywhere.spec.js
+++ b/web/tests/browser/metronome-everywhere.spec.js
@@ -552,9 +552,12 @@ test("the practice page has a click of its own, pre-filled from the tempo the la
   expect(changed, `measured ${changed}`).toBeGreaterThan(59);
   expect(changed, `measured ${changed}`).toBeLessThan(61);
 
-  for (const s of (await (await request.get("/api/practice/sessions?limit=1000")).json()).sessions) {
-    await request.delete(`/api/practice/sessions/${s.id}`);
-  }
+  // Cleanup, not a check - nothing above asserts anything about these rows,
+  // so there is nothing for either read below to race.
+  // out-of-band-ok: teardown
+  const leftover = (await (await request.get("/api/practice/sessions?limit=1000")).json()).sessions;
+  // out-of-band-ok: teardown
+  for (const s of leftover) await request.delete(`/api/practice/sessions/${s.id}`);
 });
 
 test("a tempo set up before stepping into gig mode is still set when stepping back out", async ({ page }) => {

--- a/web/tests/browser/practice.spec.js
+++ b/web/tests/browser/practice.spec.js
@@ -360,7 +360,20 @@ test("a finished week asks whether the goal was realistic, and remembers the ans
 
   await card.locator('[data-answer="no"]').click();
   await card.locator(".reflection-text").fill("away for three days");
+  // Barrier: the PATCH this dispatches has to have landed before the reload
+  // below asks the server what it kept. `.save-reflection`'s click only
+  // dispatches the click - saveReflection() then awaits the PATCH and a
+  // refetch before `saving` goes back to false - so `toHaveCount(0)` on
+  // `.notice` right after the click is not a wait for any of that: it is
+  // true before the click as well, so it was never ordered against the save.
+  // This is #110's pattern (see #82/#83, #100): read out of band, unordered
+  // against the write. Waiting on the response the save itself makes is the
+  // barrier - it cannot resolve until the server has answered.
+  const saved = page.waitForResponse(
+    (res) => res.request().method() === "PATCH" && res.url().includes("/api/practice/goals/"),
+  );
   await card.locator(".save-reflection").click();
+  await saved;
 
   await expect(notices(page)).toHaveCount(0);
   await page.reload();


### PR DESCRIPTION
Closes #110.

## The two named flakes, root-caused

**practice.spec.js:343** ("a finished week asks whether the goal was
realistic, and remembers the answer") - the reflection text read back empty.
The test clicked Save, then checked `expect(notices(page)).toHaveCount(0)`
before reloading. That assertion is true before the click as well as after
it - `.notice` only appears on an error - so it never actually waited on
anything; the reload could (and under load, did) run before the PATCH
landed. Reproduced deterministically by delaying the PATCH response 1.5s via
`page.route`: fails every time without a real barrier, passes every time
with one. Fixed by waiting on the PATCH response itself
(`page.waitForResponse`) before the reload.

**zz-library-missing.spec.js:153** ("a score whose file has gone is shown as
missing rather than vanishing") - an uploaded score "never appeared". This
is a genuine PRODUCT race, not a test bug. `scanner.start_scan()` is
fire-and-forget and declines outright when a scan is already running or the
library is mid-mutation - and until now, a decline was simply lost. If a
scan already in flight took its directory listing before a new upload's file
existed, and that upload's own `start_scan()` call was declined because the
other scan hadn't finished yet, nothing was left to ever look for the file
again - not eventually, not on the next scan, not ever, until something
unrelated happened to trigger one. Reproduced at the unit level: a real,
un-mocked scan made to take 0.3-1s before its listing returns, with a second
file landing mid-scan - the row for that file never appears. Fixed in
`server/fermata/scanner.py` with a `_rescan_pending` flag: a decline queues
exactly one follow-up scan, run automatically once the blocking scan or
mutation finishes. Pinned with two new tests
(`test_a_scan_declined_while_one_is_running_gets_a_follow_up_by_itself`,
`test_a_scan_declined_by_a_mutation_gets_a_follow_up_once_it_lifts`) that go
red when the fix is reverted. One existing test
(`test_a_scan_will_not_start_while_the_library_is_being_changed`) asserted
the old (buggy) behaviour - that `start_scan()` right after the exclusion
lifts returns `True` - which is now a race against the automatic follow-up;
updated to assert the actual contract (a scan runs, without anything asking
again) instead.

## The sweep

Every other browser spec (18 files) was swept for the same shape - a page
action followed by a read through the request context or a bare page read,
with nothing ordering the read after the write. All of it already follows
the correct #82/#100 idiom (a retrying assertion on something causally
downstream of the write, or an `expect.poll`/`.toPass()` block). No further
violations found. One unrelated pre-existing flake surfaced in a full-suite
run - `practice-shortcuts.spec.js:796` (gig-mode PDF page turn) - which is
already tracked separately in #168 (reopened, a genuine low-probability
product race in the PDF pane readiness path). Not #110's shape; not touched
here.

## The durable guard

#110 asks for more than another sweep - a point-in-time grep "does not
hold", because the wrong version is the natural thing to write. Added
`web/scripts/check-out-of-band-reads.mjs`: a crude, line-based scan of
`tests/browser/*.spec.js` (same spirit as the existing
`check-warning-patterns.mjs`) that flags a `request.*` read following a page
action with no intervening barrier, and wired it into `test:browser` so a
new instance fails fast, before a browser job has to flake under load to
surface it. Deliberately approximate - a false positive costs a
`// out-of-band-ok: <reason>` comment, which the one genuine false positive
this run turned up (a cleanup loop in metronome-everywhere.spec.js) now
carries. Mutation-tested against the original #82/#83 bug shape
(reinstating the ungated read makes it fail; restoring the barrier makes it
pass again).

Stated where the guard itself lives: it catches the request-context shape
specifically. It would NOT have caught practice.spec.js:343's flake, which
never touched `request.*` - the read channel was fine, the barrier
guarding a `page.reload()` was the defect. Telling that apart from the very
common and entirely correct "act, reload, assert" shape needs knowing which
barrier is causally tied to which write, which a text scan cannot know. A
green run of the guard is evidence against the request-context race, not
against every way a test can outrun its own write - said plainly rather
than implied, in the same spirit as this repo's own "say what the compiler
gate does not catch" precedent.

## Verification

- Both fixes mutation-tested: revert -> reproduces red; fix in place -> green.
- `server` suite: 1126 passed, 0 unexpected.
- `practice.spec.js` and `zz-library-missing.spec.js`, each run alone with
  `--repeat-each=20` under ~50% background CPU load: 300/300 and 60/60,
  0 unexpected, 0 flaky.
- The new guard mutation-tested against the reintroduced #82/#83 pattern.
- A full-browser-suite run is still completing locally at push time (CI will
  also run the full suite independently); will post the result here as a
  comment once it finishes. All targeted runs so far are green apart from
  the pre-existing, separately-tracked #168 flake noted above.
- No test counts changed; spec-floor guard untouched.
