### PR TITLE
Number segnos so a numbered D.S. names a distinct place (#167)

### DIFF
--- a/server/fermata/glyph_rhythm.py
+++ b/server/fermata/glyph_rhythm.py
@@ -3971,6 +3971,37 @@ def navigation_glyph_events(page):
                   key=lambda e: e.x0)
 
 
+def navigation_digit_events(page):
+    """Every music-font digit drawn on this page, x-sorted.
+
+    A numbered segno prints its number as a music-font digit at the sign's
+    lower right, and some scores number a coda the same way (the digit to the
+    sign's left, "1 ⊕ Coda") rather than as the text word "Coda 1" - and the
+    caller folds the digit adjacent to a segno or coda sign into that sign's
+    number (tabextract._read_navigation_marks). The value is the
+    printed digit itself: Finale's Maestro draws '1' as GID 16 and '2' as GID
+    17, and MAESTRO_GID_MAP resolves each to `digit1`/`digit2` from the
+    rendered outline, so there is no font-encoding offset to trust - the
+    category IS the printed number (DIGIT_CATS maps it back to the integer).
+
+    Returned whole-page like navigation_glyph_events, because the digit that
+    belongs to a segno is decided by geometry against that sign, not by any
+    band this module knows. The page's other music-font digits (a stacked
+    time signature, chiefly) come back too and the caller discards them by the
+    same adjacency test the coda label fold uses.
+
+    digit0 is not in MAESTRO_GID_MAP (Finale embeds only glyphs a score
+    actually uses, and no sampled page needed a '0' - see the map's own note),
+    so a hypothetical segno numbered 10 or 20 would arrive with its '0'
+    uncategorised. No library score numbers a segno past 2, and the fold reads
+    a single adjacent digit, so this is the same documented gap the meter
+    reader carries, not a wrong answer waiting on these files.
+    """
+    glyphs = extract_glyph_events(page)
+    return sorted((e for e in glyphs.events if e.category in DIGIT_CATS),
+                  key=lambda e: e.x0)
+
+
 # ---------------------------------------------------------------------------
 # Key signature
 # ---------------------------------------------------------------------------

--- a/server/fermata/tabextract.py
+++ b/server/fermata/tabextract.py
@@ -1850,6 +1850,14 @@ NAV_BAND_SPACES = 12.0
 # that draw the sign in the music font and the word in a text font a little
 # apart - measured at up to 1.6 sign-heights in the library.
 NAV_LABEL_GAP_HEIGHTS = 3.0
+# How far off a sign's own baseline a music-font digit may sit and still be
+# read as that sign's printed NUMBER (see the digit fold in
+# _read_navigation_marks), as a fraction of the sign's drawn height. The
+# number digit is drawn ON the baseline - measured at a vertical offset of 0.0
+# across every numbered segno and coda in the library - so this is deliberately
+# tight: a stacked time signature at the same system's start sits a whole sign
+# height or more off the baseline, and half a height cleanly separates the two.
+NAV_SIGN_DIGIT_BASELINE_HEIGHTS = 0.5
 # How close a bar boundary has to be to an instruction's own text before
 # that boundary is taken as the barline the instruction fires on, in TAB
 # staff spaces (the staff the bar grid belongs to). Measured over the
@@ -2067,6 +2075,52 @@ def _read_navigation_marks(page):
                for x0, y0, x1, y1 in tocoda_boxes):
             continue
         signs.append(_NavMark(ev.category, "", ev.x0, ev.y0, ev.x1, ev.y1))
+
+    # Fold a sign's printed NUMBER, drawn as a music-font digit beside it,
+    # into the sign. A numbered segno (𝄋) carries a bold digit at its lower
+    # right and a numbered "D.S. 1"/"D.S. 2" then names one segno or the
+    # other; some scores number their codas the same way, printing the digit
+    # to the sign's LEFT ("1 ⊕ Coda"). Both digits are drawn in the SAME music
+    # font as the sign, so each reaches us as a digit glyph event whose
+    # category is the printed number ITSELF - Maestro's '1' is GID 16 ->
+    # `digit1`, its '2' is GID 17 -> `digit2`, each read from the rendered
+    # outline (glyph.navigation_digit_events, DIGIT_CATS). No text-layer
+    # reading is trusted for this: the same digits reach the text layer fused
+    # to the sign glyph and offset by one ("1 ⊕ Coda" arrives as "1⊕Coda"
+    # whose leading char is a '1' for a printed 2), so a text digit would
+    # silently mislabel. The glyph carries the number with no offset.
+    #
+    # The digit sits against the sign on the sign's own baseline (measured
+    # across the five numbered files in the library at a gap of 0.0-0.09
+    # sign-heights, on either side). A page's OTHER music-font digits - a
+    # stacked time signature, chiefly - sit at the staff's left edge, well off
+    # the sign's baseline, so requiring the digit to share the baseline
+    # (within half the sign's height) discards them; the closest qualifying
+    # digit wins where more than one survives, and the side it sits on is not
+    # constrained because a segno numbers to its right and a coda to its left.
+    # Measured over the whole library this numbers exactly the segno and coda
+    # signs whose pages print a digit against them and no others - the FF
+    # codas that print "Coda 1"/"Coda 2" as words carry no adjacent digit
+    # glyph and are left for the coda LABEL fold below to number from the text.
+    #
+    # An unnumbered lone sign (the library's D.S.-with-one-segno scores) has
+    # no adjacent digit and keeps number=None, which _resolve_nav_marks reads
+    # as the single-sign case.
+    digit_events = glyph.navigation_digit_events(page)
+    for sign in signs:
+        height = max(sign.y1 - sign.y0, 1.0)
+        owner_digit = None
+        best_gap = None
+        for d in digit_events:
+            if abs(d.y0 - sign.y0) > height * NAV_SIGN_DIGIT_BASELINE_HEIGHTS:
+                continue
+            gap = max(d.x0 - sign.x1, sign.x0 - d.x1, 0.0)
+            if gap > height * NAV_LABEL_GAP_HEIGHTS:
+                continue
+            if best_gap is None or gap < best_gap:
+                owner_digit, best_gap = d, gap
+        if owner_digit is not None:
+            sign.number = glyph.DIGIT_CATS[owner_digit.category]
 
     # Fold a coda LABEL into the sign it labels. The label supplies the
     # NUMBER; the sign keeps the POSITION, which is the half that has to be
@@ -2349,18 +2403,21 @@ def _resolve_nav_marks(anchored, refused=()):
     there, so `dacapo` never needs a mark to point at.
     """
     codas = {}
-    segno = None
+    segnos = {}
     fine = None
     for bar, mark in anchored:
         if mark.kind == "coda":
             codas.setdefault(mark.number, bar)
-        elif mark.kind == "segno" and segno is None:
-            segno = bar
+        elif mark.kind == "segno":
+            segnos.setdefault(mark.number, bar)
         elif mark.kind == "fine" and fine is None:
             fine = bar
 
     def coda_id(number):
         return "coda" if number is None else f"coda{number}"
+
+    def segno_id(number):
+        return "segno" if number is None else f"segno{number}"
 
     directions = {}
     unresolved = []
@@ -2370,7 +2427,8 @@ def _resolve_nav_marks(anchored, refused=()):
 
     for bar, mark in sorted(anchored, key=lambda pair: (pair[0], pair[1].kind)):
         if mark.kind == "segno":
-            add(bar, "before", {"symbol": "segno", "sound": {"segno": "segno"}})
+            sid = segno_id(mark.number)
+            add(bar, "before", {"symbol": "segno", "sound": {"segno": sid}})
         elif mark.kind == "coda":
             cid = coda_id(mark.number)
             add(bar, "before", {"symbol": "coda", "sound": {"coda": cid}})
@@ -2394,8 +2452,21 @@ def _resolve_nav_marks(anchored, refused=()):
             sound = None
             if mark.back_to == "start":
                 sound = {"dacapo": "yes"}
-            elif segno is not None:
-                sound = {"dalsegno": "segno"}
+            elif mark.number in segnos:
+                # A numbered "D.S. 1"/"D.S. 2" names the segno printing that
+                # same digit (see the segno-number fold in
+                # _read_navigation_marks). Its own parsed number decides the
+                # target, NOT reading order: "Agnea, the Dancer" prints its
+                # segno "2" on the higher system and its segno "1" lower, so a
+                # by-appearance id would send both jumps to the wrong sign.
+                sound = {"dalsegno": segno_id(mark.number)}
+            elif mark.number is None and len(segnos) == 1:
+                # A lone unnumbered "D.S." on a score with one segno names it
+                # (numbered or not), the same fallback the unnumbered "To
+                # Coda" takes for a single coda. Two numbered segnos with an
+                # unnumbered D.S. name neither unambiguously, so no sound is
+                # attached and the bar is disclosed below.
+                sound = {"dalsegno": segno_id(next(iter(segnos)))}
             # The second half of the instruction ("al Coda", "al Fine")
             # names where to STOP, and MusicXML carries that on the Coda or
             # Fine mark itself rather than on the jump - so a jump whose

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -133,6 +133,25 @@ _FIXTURE_RELATIVE_PATHS = {
     # adversarial review, blocker 2).
     "victory_fanfare": (
         "Patreon/John Oeth/Final Fantasy/FF VII/Victory Fanfare (Final Fantays VII).pdf"),
+    # Two numbered segnos and two numbered D.S. jumps (issue #167): the page
+    # draws a segno printing "1" at bar 16 and one printing "2" at bar 32, and
+    # "D.S. 1"/"D.S. 2" then name one each. Before #167 both segno signs and
+    # both jumps emitted the single shared id "segno", so a numbered D.S.
+    # landed at whichever segno a reader found first.
+    "melodies_of_life": (
+        "Patreon/John Oeth/Final Fantasy/FF IX/Melodies of Life (Final Fantasy IX).pdf"),
+    # The adversarial case for #167: this page prints its segno "2" on the
+    # HIGHER system (bar 2) and its segno "1" LOWER (bar 10), so numbering by
+    # appearance order gets both backwards. The id has to come from the
+    # printed digit, which is what this fixture proves.
+    "agnea_the_dancer": (
+        "Patreon/John Oeth/Octopath Traveler/Agnea, the Dancer (Octopath Traveler II).pdf"),
+    # Numbered codas drawn as a music-font digit BEFORE the sign ("1 (sign)
+    # Coda" @19, "2 (sign) Coda" @27) rather than as the word "Coda 1" (issue
+    # #167). Also the "To Coda 1 & 2" @10 that names both, which a single-id
+    # tocoda cannot express and so is disclosed.
+    "hinata_vs_neji": (
+        "Patreon/John Oeth/Anime/Naruto/Hinata vs Neji (Naruto).pdf"),
     # Two thick strokes ("tHHt") with no repeat dots found anywhere nearby -
     # neither resolved to a direction nor unread for want of a thick stroke,
     # just two thick strokes and nothing beside them (issue #134 adversarial
@@ -468,6 +487,33 @@ def victory_fanfare_pdf() -> Path:
     if p is None:
         skip_without_library(
             "FERMATA_TEST_LIBRARY not set (or missing 'Victory Fanfare' fixture)")
+    return p
+
+
+@pytest.fixture
+def melodies_of_life_pdf() -> Path:
+    p = _fixture_path("melodies_of_life")
+    if p is None:
+        skip_without_library(
+            "FERMATA_TEST_LIBRARY not set (or missing 'Melodies of Life' fixture)")
+    return p
+
+
+@pytest.fixture
+def agnea_the_dancer_pdf() -> Path:
+    p = _fixture_path("agnea_the_dancer")
+    if p is None:
+        skip_without_library(
+            "FERMATA_TEST_LIBRARY not set (or missing 'Agnea, the Dancer' fixture)")
+    return p
+
+
+@pytest.fixture
+def hinata_vs_neji_pdf() -> Path:
+    p = _fixture_path("hinata_vs_neji")
+    if p is None:
+        skip_without_library(
+            "FERMATA_TEST_LIBRARY not set (or missing 'Hinata vs Neji' fixture)")
     return p
 
 

--- a/server/tests/test_tabextract.py
+++ b/server/tests/test_tabextract.py
@@ -3177,6 +3177,88 @@ def test_victory_fanfare_resolves_its_ds_to_the_segno_the_page_draws(
     assert result.nav_marks_unresolved == 0
 
 
+def test_melodies_of_life_numbers_its_two_segnos_and_their_two_ds_jumps(
+        melodies_of_life_pdf):
+    """Issue #167 on a real score. The page draws a segno printing a bold "1"
+    at bar 16 and one printing "2" at bar 32, and "D.S. 1"/"D.S. 2" send the
+    player to one each. Before #167 every segno sign emitted the single shared
+    id "segno" and every "D.S." emitted `dalsegno="segno"`, so both jumps
+    landed at whichever segno a reader found first - the segno side of the bug
+    the coda side (coda1/coda2, resolved here too) never had.
+
+    The number is read from the music-font digit drawn against the sign, not
+    from the text layer: the same digit reaches the text fused to the sign and
+    offset by one, so a text reading would mislabel."""
+    result = tabextract.extract(melodies_of_life_pdf)
+    assert result.extractable
+    from test_engraved_fixtures import _navigation_structure
+    assert _navigation_structure(result.musicxml) == {
+        16: [("before", "segno", {"segno": "segno1"})],
+        32: [("before", "segno", {"segno": "segno2"})],
+        40: [("after", "To Coda 1", {"tocoda": "coda1"})],
+        45: [("after", "To Coda 2", {"tocoda": "coda2"})],
+        54: [("after", "D.S. 1", {"dalsegno": "segno1"})],
+        55: [("before", "coda", {"coda": "coda1"}),
+             ("after", "D.S. 2", {"dalsegno": "segno2"})],
+        56: [("before", "coda", {"coda": "coda2"})],
+    }
+    assert result.nav_marks_unresolved == 0
+
+
+def test_agnea_numbers_its_segnos_by_the_printed_digit_not_reading_order(
+        agnea_the_dancer_pdf):
+    """The adversarial case for #167, and the reason the id must come from the
+    printed digit rather than from appearance order. This page draws its segno
+    printing "2" on the HIGHER system (bar 2) and its segno printing "1" LOWER
+    (bar 10), so numbering the signs top-to-bottom gets both backwards. The
+    bar-2 sign is segno2 and the bar-10 sign is segno1, and "D.S. 2"/"D.S. 1"
+    resolve to segno2/segno1 accordingly - by their own parsed number, not by
+    which sign the page draws first."""
+    result = tabextract.extract(agnea_the_dancer_pdf)
+    assert result.extractable
+    from test_engraved_fixtures import _navigation_structure
+    structure = _navigation_structure(result.musicxml)
+    assert structure[2] == [("before", "segno", {"segno": "segno2"})]
+    assert structure[10] == [("before", "segno", {"segno": "segno1"})]
+    assert structure[35] == [("after", "D.S. 2 al Coda", {"dalsegno": "segno2"})]
+    assert structure[51] == [("after", "D.S. 1", {"dalsegno": "segno1"})]
+    # The higher segno on the page reaches the LOWER id, which a by-appearance
+    # scheme could never produce - this is the whole point of the fixture.
+    assert structure[2][0][2]["segno"] == "segno2"
+    assert result.nav_marks_unresolved == 0
+
+
+def test_hinata_numbers_its_codas_from_the_sign_digit_and_discloses_the_two_target_to_coda(
+        hinata_vs_neji_pdf):
+    """Issue #167's coda shape. This page numbers its codas as a music-font
+    digit drawn to the LEFT of the sign ("1 (sign) Coda" at bar 19, "2 (sign)
+    Coda" at bar 27) rather than as the word "Coda 1", so the coda LABEL fold
+    - which reads a leading digit in a text line as the system's bar number -
+    left both as the shared id "coda". Read from the digit glyph they are
+    coda1 and coda2.
+
+    Its lone unnumbered "D.S." still resolves against its single unnumbered
+    segno (both plain "segno"), which is the fallback a numbered scheme must
+    keep. And its "To Coda 1 & 2" at bar 10 names BOTH codas from one mark,
+    which MusicXML's single-id `tocoda` cannot express: now that the two codas
+    are distinct rather than collapsed onto one, the instruction goes out as
+    the words the page prints with no playback jump, and its bar is disclosed
+    (nav_marks_unresolved) with a stated reason rather than silently pointed
+    at half of what the page says."""
+    result = tabextract.extract(hinata_vs_neji_pdf)
+    assert result.extractable
+    from test_engraved_fixtures import _navigation_structure
+    structure = _navigation_structure(result.musicxml)
+    assert structure[19] == [("before", "coda", {"coda": "coda1"})]
+    assert structure[27] == [("before", "coda", {"coda": "coda2"})]
+    assert structure[11] == [("before", "segno", {"segno": "segno"})]
+    assert structure[26] == [("after", "D.S.", {"dalsegno": "segno"})]
+    # The two-target "To Coda" is written as words with no sound, and disclosed.
+    assert structure[10] == [("after", "To Coda 1 & 2", None)]
+    assert result.nav_marks_unresolved == 1
+    assert result.nav_marks_unresolved_bars == [10]
+
+
 def test_two_thick_strokes_with_no_readable_dots_emit_heavy_heavy_not_nothing(
         tarrega_estudio_em_pdf):
     """Item 6 (issue #134 adversarial review): a barline group of two-or-more
@@ -3358,6 +3440,8 @@ def test_a_coda_label_gives_its_number_to_the_sign_it_labels_not_a_mark_of_its_o
     sign = tabextract._NavMark("coda", "", 392.3, 609.3, 402.2, 629.8)
     monkeypatch.setattr(tabextract.glyph, "navigation_glyph_events",
                         lambda page: [_FakeGlyph(sign)])
+    monkeypatch.setattr(tabextract.glyph, "navigation_digit_events",
+                        lambda page: [])
     monkeypatch.setattr(tabextract, "_text_lines", lambda page: [
         # The bar number, the sign and the label, in one line - the sign's
         # own box sits INSIDE this line's box.
@@ -3385,6 +3469,8 @@ def test_the_sign_printed_inside_a_to_coda_is_that_instructions_glyph_not_a_coda
     sign = tabextract._NavMark("coda", "", 244.29, 345.18, 254.17, 365.68)
     monkeypatch.setattr(tabextract.glyph, "navigation_glyph_events",
                         lambda page: [_FakeGlyph(sign)])
+    monkeypatch.setattr(tabextract.glyph, "navigation_digit_events",
+                        lambda page: [])
     monkeypatch.setattr(tabextract, "_text_lines", lambda page: [
         ("To Coda", 197.1, 327.58, 254.17, 377.51),
     ])
@@ -3401,6 +3487,8 @@ def test_a_coda_sign_beside_a_to_coda_rather_than_inside_it_is_still_a_coda(
     sign = tabextract._NavMark("coda", "", 417.9, 616.59, 427.78, 637.09)
     monkeypatch.setattr(tabextract.glyph, "navigation_glyph_events",
                         lambda page: [_FakeGlyph(sign)])
+    monkeypatch.setattr(tabextract.glyph, "navigation_digit_events",
+                        lambda page: [])
     monkeypatch.setattr(tabextract, "_text_lines", lambda page: [
         ("To Coda", 197.1, 327.58, 254.17, 377.51),
     ])
@@ -3416,10 +3504,20 @@ class _FakeGlyph:
         self.x0, self.y0, self.x1, self.y1 = mark.x0, mark.y0, mark.x1, mark.y1
 
 
+class _FakeDigit:
+    """A music-font digit glyph event, for the sign-number fold."""
+
+    def __init__(self, category, x0, y0, x1, y1):
+        self.category = category
+        self.x0, self.y0, self.x1, self.y1 = x0, y0, x1, y1
+
+
 def test_a_coda_label_with_no_sign_near_it_is_still_a_coda(monkeypatch):
     """One library file draws its coda in a font this decoder does not
     recognise and prints only the word, so the word alone has to be enough."""
     monkeypatch.setattr(tabextract.glyph, "navigation_glyph_events",
+                        lambda page: [])
+    monkeypatch.setattr(tabextract.glyph, "navigation_digit_events",
                         lambda page: [])
     monkeypatch.setattr(tabextract, "_text_lines", lambda page: [
         ("Coda", 76.0, 610.0, 104.0, 623.0),
@@ -4002,6 +4100,83 @@ def test_a_numbered_to_coda_names_the_coda_that_carries_the_same_number():
     assert unresolved == []
 
 
+def test_a_numbered_ds_names_the_segno_that_carries_the_same_number():
+    """The segno side of the same numbering (issue #167), mirroring the coda
+    test above. A "D.S. 1"/"D.S. 2" names the segno printing that same digit,
+    each resolving to `dalsegno="segno1"`/`"segno2"` and each segno sign
+    emitting the matching `segno="segno1"`/`"segno2"`.
+
+    The target is chosen by the JUMP's own parsed number, NOT by which segno
+    was anchored first: here segno2 is anchored (bar 2) BEFORE segno1 (bar 10),
+    the reverse-order shape Agnea draws, and "D.S. 1" still resolves to
+    segno1. Before #167 both signs and both jumps shared the single id
+    "segno", so a numbered D.S. could not name distinct places at all."""
+    segno2 = tabextract._NavMark("segno", "", 40.0, 0, 52.0, 5, number=2)
+    segno1 = tabextract._NavMark("segno", "", 40.0, 0, 52.0, 5, number=1)
+    ds1 = tabextract._NavMark("jump", "D.S. 1", 100.0, 0, 150.0, 5,
+                              back_to="segno", number=1)
+    ds2 = tabextract._NavMark("jump", "D.S. 2", 100.0, 0, 150.0, 5,
+                              back_to="segno", number=2)
+    directions, unresolved, _refused = tabextract._resolve_nav_marks(
+        [(2, segno2), (10, segno1), (54, ds1), (55, ds2)])
+    assert unresolved == []
+    assert directions[2]["before"] == [
+        {"symbol": "segno", "sound": {"segno": "segno2"}}]
+    assert directions[10]["before"] == [
+        {"symbol": "segno", "sound": {"segno": "segno1"}}]
+    assert directions[54]["after"] == [
+        {"words": "D.S. 1", "sound": {"dalsegno": "segno1"}}]
+    assert directions[55]["after"] == [
+        {"words": "D.S. 2", "sound": {"dalsegno": "segno2"}}]
+
+    # A lone unnumbered D.S. still names a single unnumbered segno - the
+    # fallback the numbered scheme must keep (Hinata's shape).
+    segno = tabextract._NavMark("segno", "", 40.0, 0, 52.0, 5)
+    plain = tabextract._NavMark("jump", "D.S.", 100.0, 0, 150.0, 5, back_to="segno")
+    directions, unresolved, _refused = tabextract._resolve_nav_marks(
+        [(1, segno), (11, plain)])
+    assert unresolved == []
+    assert directions[1]["before"] == [
+        {"symbol": "segno", "sound": {"segno": "segno"}}]
+    assert directions[11]["after"] == [
+        {"words": "D.S.", "sound": {"dalsegno": "segno"}}]
+
+    # A numbered D.S. whose numbered segno the page does not draw resolves to
+    # nothing and is disclosed, rather than guessing the other segno.
+    _d, unresolved, _refused = tabextract._resolve_nav_marks(
+        [(2, segno2), (54, ds1)])
+    assert unresolved == [54], "D.S. 1 with no segno1 on the page"
+    assert _d[54]["after"] == [{"words": "D.S. 1", "sound": None}]
+
+
+def test_a_signs_printed_number_is_read_from_the_music_font_digit_beside_it(monkeypatch):
+    """The digit fold in _read_navigation_marks (issue #167). A segno numbers
+    to its RIGHT and a coda numbers to its LEFT, each as a music-font digit on
+    the sign's own baseline, and the sign takes that digit's value as its
+    number. A page's OTHER music-font digits - a stacked time signature at the
+    system's start - sit well off the sign's baseline and must NOT be folded
+    in, which is what keeps this from reading a meter as a sign number."""
+    segno = tabextract._NavMark("segno", "", 74.0, 40.0, 85.0, 60.0)
+    coda = tabextract._NavMark("coda", "", 93.0, 620.0, 103.0, 640.0)
+    monkeypatch.setattr(tabextract.glyph, "navigation_glyph_events",
+                        lambda page: [_FakeGlyph(segno), _FakeGlyph(coda)])
+    monkeypatch.setattr(tabextract, "_text_lines", lambda page: [])
+    monkeypatch.setattr(tabextract.glyph, "navigation_digit_events", lambda page: [
+        # The segno's "1", just to its right on its baseline.
+        _FakeDigit("digit1", 87.0, 40.0, 97.0, 60.0),
+        # The coda's "2", just to its left on its baseline.
+        _FakeDigit("digit2", 82.0, 620.0, 92.0, 640.0),
+        # A stacked time signature "6"/"8" at the system's left edge - a whole
+        # sign-height off the coda's baseline, so neither is the coda's number.
+        _FakeDigit("digit6", 60.0, 596.0, 70.0, 610.0),
+        _FakeDigit("digit8", 60.0, 610.0, 70.0, 624.0),
+    ])
+    marks = {(m.kind, m.y0): m.number
+             for m in tabextract._read_navigation_marks(object())}
+    assert marks[("segno", 40.0)] == 1
+    assert marks[("coda", 620.0)] == 2
+
+
 def test_a_refused_coda_changes_the_disclosure_wording_and_not_a_single_count():
     """One root cause, two counters, one sentence that says which.
 
@@ -4463,10 +4638,22 @@ def test_library_wide_repeat_structure_leaves_conformance_untouched(library_root
     # issue #154 let its segno be read at all; between the two changes it
     # now both reads its segno and holds the bars its coda names.
     #
+    # 7 -> 8 (issue #167): Hinata vs Neji (Naruto) numbers its two codas as
+    # music-font digits drawn against the sign ("1 (sign) Coda" / "2 (sign)
+    # Coda"), which are now read as coda1 and coda2. Its "To Coda 1 & 2" @10
+    # names BOTH of them, which MusicXML's single-id `tocoda` cannot express,
+    # so - now that the two codas are distinct rather than collapsed onto one
+    # unnumbered "coda" - the instruction goes out as the words the page
+    # prints with no jump and its bar is disclosed, the same way every "To
+    # Coda <list>" already is on a score with more than one coda. Bar 10 is
+    # the 8th such bar. Measured score by score against this branch's parent,
+    # this file and the four numbered-segno files below are the only five
+    # whose navigation output moves at all; nothing else in the library does.
+    #
     # 0 unanchored. Not "near zero" - the library now holds no navigation
     # mark at all that was read off a page and has no bar to name, because
     # the systems those marks were drawn over are read.
-    assert totals["nav_marks_unresolved"] == 7
+    assert totals["nav_marks_unresolved"] == 8
     assert totals["nav_marks_unanchored"] == 0
     # What all of that costs the score a reader actually sees. On this
     # branch's parent the library reports 263 scores at `structure` high, 29


### PR DESCRIPTION
Closes #167.

## The bug

A numbered `D.S. 1` / `D.S. 2` has to send the player to a distinct segno, but every segno sign emitted the one shared id `segno` and every `<sound dalsegno>` emitted `dalsegno="segno"`, so both jumps resolved to whichever segno a reader found first. The coda side of the same scores already numbers correctly (`coda1`/`coda2`); this gives the segno side the same treatment.

## How a sign's number is read

From the **music-font digit drawn against the sign** — to a segno's right, to a coda's left — taken at face value. Finale's Maestro draws `1` as GID 16 and `2` as GID 17, each resolved to `digit1`/`digit2` from the rendered glyph outline, so the printed number IS the category and no font-encoding offset is trusted. The same digits also reach the text layer *fused to the sign glyph and offset by one* (`1 (sign) Coda` arrives as text `1(sign)Coda` whose leading char is a `1` for a printed **2**), which is exactly why the text reading is not used.

A digit is folded only when it sits on the sign's own baseline (within half the sign's height), which separates the number from a stacked time signature at the same system's start.

`_resolve_nav_marks` then chooses the id: `segno_id(n)` mirrors `coda_id(n)`, each segno sign emits `segno<n>`, and each `D.S.` resolves by **its own parsed number** — not by which segno was anchored first. The single-unnumbered-segno fallback is kept so a lone `D.S.` still resolves.

The same fold numbers a coda drawn as `1 (sign) Coda` / `2 (sign) Coda` (Score E), which the coda label fold missed because it reads a leading text digit as the system's bar number. With those two codas now distinct, that score's `To Coda 1 & 2` — which names both from one mark, something a single-id `tocoda` cannot express — goes out as words with no jump and its bar is disclosed, the same way every `To Coda <list>` already is.

## Result, measured

Per-score navigation output across the full 297-file library, keyed by full relative path, branch vs parent:

| file | before | after |
|---|---|---|
| Score A | segno@16/32 both `segno`; D.S.1@54/D.S.2@55 both `dalsegno=segno` | `segno1`/`segno2`; `segno1`/`segno2` |
| Score B | both `segno`; both `dalsegno=segno` | `segno1`/`segno2`; `segno1`/`segno2` |
| Score C | both `segno`; both `dalsegno=segno` | `segno1`/`segno2`; `segno1`/`segno2` |
| Score D (reverse order) | both `segno`; both `dalsegno=segno` | segno@2 **`segno2`**, segno@10 **`segno1`**; D.S.2@35 `segno2`, D.S.1@51 `segno1` |
| Score E | codas@19/27 both `coda`; To Coda@10 → `tocoda=coda` | `coda1`/`coda2`; To Coda@10 disclosed (unresolved), lone D.S. still `segno` |

**Exactly these five scores move; the other 292 are byte-identical.** Score D is the decisive case: it prints its segno `2` on the higher system and its segno `1` lower, so a by-appearance scheme would get both backwards — the id comes from the printed digit.

## Tests

- Integration tests on Score A (two numbered segnos + two D.S.), Score D (the reverse-order case), and Score E (digit-glyph codas + disclosed two-target To Coda).
- Unit tests for `_resolve_nav_marks` segno numbering (incl. the reverse-order and single-unnumbered fallback) and for the `_read_navigation_marks` digit fold (incl. that a stacked time signature is not folded).
- The library-wide nav pin updates by one: `nav_marks_unresolved` 7 → 8 (Score E's To Coda bar 10). Every other aggregate — coda signs 150, segno signs 88, directions 570, structure high/medium/low — is unchanged.