### PR TITLE
Pin that a library score's side-by-side systems are read (#87)

### DIFF
--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -121,6 +121,15 @@ _FIXTURE_RELATIVE_PATHS = {
     # got a chance to place it.
     "lenna_theme": (
         "Patreon/John Oeth/Final Fantasy/FF V/Lenna_s Theme (Final Fantasy V).pdf"),
+    # Issue #87, which is the same bug as #152 on a sibling of Lenna's Theme:
+    # page 1's last two bands each print two systems side by side, ruled 0.6pt
+    # apart in y so their lines interleave. Before #152's column split those
+    # bands came back as a 10-line and a 12-line group and were discarded whole,
+    # the "anomaly lines=10/12" the issue reports. This fixture pins that the
+    # named score's side-by-side systems are read, so #87 cannot silently
+    # regress - see test_sorrows_of_parting_reads_its_side_by_side_systems.
+    "sorrows_of_parting": (
+        "Patreon/John Oeth/Final Fantasy/FF V/Sorrows of Parting (Final Fantasy V).pdf"),
     # A "2." bracket with no matching "1." anywhere - genuinely, not from a
     # dropped candidate: the only mark near where a "1." would be sits 1.93
     # std-staff-spaces from the nearest barline, well outside every genuine
@@ -478,6 +487,15 @@ def lenna_theme_pdf() -> Path:
     p = _fixture_path("lenna_theme")
     if p is None:
         skip_without_library("FERMATA_TEST_LIBRARY not set (or missing Lenna's Theme fixture)")
+    return p
+
+
+@pytest.fixture
+def sorrows_of_parting_pdf() -> Path:
+    p = _fixture_path("sorrows_of_parting")
+    if p is None:
+        skip_without_library(
+            "FERMATA_TEST_LIBRARY not set (or missing 'Sorrows of Parting' fixture)")
     return p
 
 

--- a/server/tests/test_tabextract.py
+++ b/server/tests/test_tabextract.py
@@ -3116,6 +3116,65 @@ def test_lennas_theme_reads_a_volta_that_opens_a_system(lenna_theme_pdf):
     assert loaded["tickLookup"] == expected_order
 
 
+def test_sorrows_of_parting_reads_its_side_by_side_systems(sorrows_of_parting_pdf):
+    """Issue #87 on the score it names. The report reads its page 1 as two
+    staves each drawn with every line stroked twice:
+
+        anomaly lines=10  ys=[663.4, 664.1, 668.6, 669.2, 673.7, 674.3,
+                               678.8, 679.5, 683.9, 684.6]
+                          gaps=[0.7, 4.5, 0.6, 4.5, 0.6, 4.5, 0.7, 4.4, 0.7]
+        anomaly lines=12  gaps=[0.4, 7.3, 0.4, 7.2, 0.5, 7.2, 0.5, 7.2,
+                                0.4, 7.3, 0.4]
+
+    The lines are not doubled. Those ten y values are TWO five-line systems
+    printed side by side on one band - a left system at x 54.0-306.0 (y
+    663.4, 668.6, 673.7, 678.8, 683.9) and a right one at x 348.3-575.5 (y
+    664.1, 669.2, 674.3, 679.5, 684.6), ruled 0.6-0.7pt lower. Interleaved by
+    y alone they read as one 10-line group; the twelve are the same shape one
+    band down, a pair of side-by-side SIX-line tab systems at ~7.7pt spacing.
+    So #87 is the same bug as #152, and _band_columns (which splits a band
+    into its x-overlapping columns before the lines are counted) is what
+    already fixes it - reverting that split returns the two anomalies above,
+    gaps and all. This pins that the named score is read, so #87 cannot
+    silently regress behind #152's coverage on Lenna's Theme (a sibling in
+    the same folder and exporter - see
+    test_lennas_theme_reads_a_volta_that_opens_a_system).
+    """
+    page = fitz.open(sorrows_of_parting_pdf)[0]
+    staves, anomalies = tabextract._detect_staves(page)
+    # Every band is read; nothing is thrown away as an unexpected line count.
+    assert anomalies == []
+    assert len(staves) == 12
+
+    # The two bands the issue reports are the last standard band and the last
+    # tab band, each split into a left and a right column rather than counted
+    # as one doubled group. Grouped by band, the page's last standard band
+    # holds two 5-line staves and its last tab band two 6-line staves.
+    by_band = collections.defaultdict(list)
+    for s in staves:
+        by_band[s.band].append(s)
+    standard_bands = [b for b, ss in by_band.items()
+                      if all(s.kind == "standard" for s in ss)]
+    tab_bands = [b for b, ss in by_band.items()
+                 if all(s.kind == "tab" for s in ss)]
+    last_std = by_band[max(standard_bands)]
+    last_tab = by_band[max(tab_bands)]
+    assert [s.kind for s in last_std] == ["standard", "standard"]
+    assert [len(s.line_ys) for s in last_std] == [5, 5]
+    assert [s.kind for s in last_tab] == ["tab", "tab"]
+    assert [len(s.line_ys) for s in last_tab] == [6, 6]
+    # The left column ends before the right one begins - the tell that they
+    # are two systems, not one line drawn twice (a doubled line shares its x).
+    left_std, right_std = sorted(last_std, key=lambda s: s.x0)
+    assert left_std.x1 < right_std.x0
+
+    # And the music of those recovered systems decodes rather than being lost.
+    result = tabextract.extract(sorrows_of_parting_pdf)
+    assert result.extractable
+    assert result.bars == 20
+    assert result.systems_unread == 0
+
+
 def test_an_incomplete_ending_run_alone_downgrades_structure_confidence(victory_fanfare_pdf):
     """Blocker 2 (issue #134 adversarial review): `structure_issues` (~the
     confidence sum near musicxml build in tabextract.py) used to omit


### PR DESCRIPTION
Closes #87.

## What #87 turns out to be

Issue #87 reports that page 1 of *a library score* reads as two staves each drawn with every line stroked twice, discarded whole as `anomaly lines=10` and `anomaly lines=12` with alternating small (0.4-0.7pt) and large (4.5 / 7.2pt) gaps.

The lines are **not** doubled. The raw horizontal primitives show each anomaly is **two systems printed side by side on one band**, ruled 0.6-0.7pt apart in y so their lines interleave:

- left system at x `54.0-306.0`, y `663.4, 668.6, 673.7, 678.8, 683.9`
- right system at x `348.3-575.5`, y `664.1, 669.2, 674.3, 679.5, 684.6`

Counted by y alone they read as one 10-line group; the twelve are the same shape one band down, a pair of side-by-side six-line tab systems at ~7.7pt spacing. The alternating-gap "signature" is the 0.6pt engraving offset between the two systems, not a doubled stroke.

**So #87 is the same bug as #152.** `_band_columns` - which splits a band into its x-overlapping columns before the lines are counted (merged 2026-08-28) - already fixes it. On current `main`, that score's page 1 reads as **12 staves, 0 anomalies**, and the score decodes to its **20 bars / 170 notes** with nothing discarded.

Proof it is the same bug: reverting the column split (`_band_columns` -> one column per band) reproduces both anomalies of #87 character-for-character, gaps and all:

```
lines=10 gaps=[0.7, 4.5, 0.6, 4.5, 0.6, 4.5, 0.7, 4.4, 0.7]
lines=12 gaps=[0.4, 7.3, 0.4, 7.2, 0.5, 7.2, 0.5, 7.2, 0.4, 7.3, 0.4]
```

A library-wide sweep of all 297 PDFs (every page) finds **no** true same-x line doubling anywhere: 131 anomalies across 28 files, of which 129 are single-line rules and 2 are seven-line groups, and **none has any consecutive gap below 2.0pt**. There is no staff in the library whose lines are drawn twice, so no vertical merge tolerance is warranted - adding one would only risk collapsing legitimately-distinct lines on normal scores for a case that does not occur.

## What this PR does

No decode-core change (`tabextract.py` is byte-identical to `main`). It adds a regression test pinning the named score, so #87 cannot silently regress behind #152's existing coverage on a sibling score in the same folder and exporter. The test asserts page 1 reads as 12 staves with no anomaly, that the last standard and tab bands each split into two columns (5+5 and 6+6 lines) with the left column ending before the right begins, and that the score decodes to 20 bars with no system left unread.

Mutation-tested: reverting `_band_columns` reds the test at `assert anomalies == []`; restoring turns it green.

## Verification

- New test passes; full `test_tabextract.py` 221 passed / 9 skipped (the 9 are web/node_modules alphaTab-importer skips; `FERMATA_TEST_LIBRARY` was set, all real-library tests ran).
- `test_disclosure_keys.py` passes; no disclosure counter added, so no six-hop wiring needed.
- `test_every_route_has_exactly_the_expected_operation_count` still passes - no routes added.