### PR TITLE
Read a whole-measure rest as its own voice, not a beat on the arpeggio (#180)

### DIFF
--- a/server/fermata/tabextract.py
+++ b/server/fermata/tabextract.py
@@ -3632,6 +3632,68 @@ def _reduce_overlong_rests(voice, budget):
     return reduced
 
 
+def _measure_rest_beats(x, budget):
+    """One voice's worth of beats for a bar the voice is silent through -
+    a whole-measure rest, spelled as the silence the meter actually holds.
+
+    A single written rest where the meter is one a lone rest can spell (a
+    dotted-half in 3/4, a whole in 4/4), so the voice's beat count is one, the
+    way the page draws it; the rare meter no single rest equals (5/4) falls back
+    to the plain longest-first decomposition. NOT marked inferred: this silence
+    WAS printed, as a whole rest, so it is a read beat that counts towards the
+    bar (unlike _pad_voice_to_budget's meter-deduced filler).
+    """
+    cd = _single_notatable_rest(budget)
+    if cd is not None:
+        return [(x, cd[0], cd[1], [])]
+    return [(x + k, code, dots, [])
+            for k, (code, dots, _n) in enumerate(_rest_beats_for(budget))]
+
+
+def _separate_whole_measure_rest(live, budget):
+    """Lift a whole-measure rest out of a voice the sounding notes already fill
+    and into a silent voice of its own. Returns how many were lifted (issue
+    #180).
+
+    A whole rest is the whole-measure convention: drawn as a whole rest in any
+    meter, it says "this voice is silent for the whole bar". Where the melody
+    rests a bar the tablature arpeggiates through, the two are engraved as two
+    voices - but the tab staff carries no stems for the silent one, so
+    _assign_group_voices, which reads voices off stems, never makes it, and the
+    whole rest is placed (by _place_rest_clusters) in the ONE voice the arpeggio
+    does make. That voice already sums to the whole bar, so the rest stacks on
+    top of a full measure: Classical-Guitar-Method-Vol1 bar 16 is six eighths
+    filling 3/4 plus a whole rest, read as 7.0 quarters.
+
+    This is a mis-voicing, not the over-read #163 trims: #163 shortens a rest to
+    the room its voice has left, and here the voice has none, so shrinking the
+    rest would drop the written beat rather than shorten one (see
+    _reduce_overlong_rests, which declines exactly this case). So the rest is
+    moved into a voice of its own, spelled as the silence the measure holds - a
+    whole-measure rest against the accompaniment - and the accompaniment keeps
+    its own full bar.
+
+    Fires only on a plain whole rest (the whole-measure glyph) whose voice's
+    OTHER events already account for the whole bar. A partly-filled voice has
+    room and keeps #163's reduction, where the rest may be a genuine over-read;
+    it is left untouched here.
+    """
+    separated = 0
+    for voice in list(live):
+        for i, (x, code, dots, notes) in enumerate(voice):
+            if notes or code != 1 or dots:
+                continue  # not a plain whole rest - the whole-measure glyph
+            other = sum(_beat_quarters(c, d)
+                        for j, (_x, c, d, _n) in enumerate(voice) if j != i)
+            if other < budget - 1e-6:
+                continue  # room remains: #163's reduction owns this, not us
+            del voice[i]
+            live.append(_measure_rest_beats(x, budget))
+            separated += 1
+            break  # at most one whole-measure rest lifted per voice
+    return separated
+
+
 def _build_measure_beats_glyph(m_cols, m_lo, m_hi, note_events, note_xs, x_tol,
                                notation_spacing, budget=None):
     """Build one measure's VOICES from glyph-decoded note/rest events on the
@@ -3667,7 +3729,8 @@ def _build_measure_beats_glyph(m_cols, m_lo, m_hi, note_events, note_xs, x_tol,
     how much of each voice is silence; without it no rests are inferred.
 
     Returns (voices, unmatched_columns, unmatched_glyph_notes,
-    unison_digits_shared, overlong_rests_reduced): voices is a list of one or
+    unison_digits_shared, overlong_rests_reduced,
+    whole_measure_rests_separated): voices is a list of one or
     more beat lists, each a list of (duration_code, dots, notes) triples in x
     order ready for _fmt_beat; unmatched_columns is how many tab columns had no
     glyph note within x_tol; unmatched_glyph_notes is how many decoded
@@ -3676,7 +3739,10 @@ def _build_measure_beats_glyph(m_cols, m_lo, m_hi, note_events, note_xs, x_tol,
     digit their coincident twin's position was printed with instead (see
     _share_unison_digits) - an inference, disclosed rather than silent;
     overlong_rests_reduced is how many rests read longer than their bar were
-    trimmed to what it can hold (issue #163, see _reduce_overlong_rests).
+    trimmed to what it can hold (issue #163, see _reduce_overlong_rests);
+    whole_measure_rests_separated is how many whole-measure rests were lifted
+    out of a voice the sounding notes already filled into a silent voice of
+    their own (issue #180, see _separate_whole_measure_rest).
 
     Silence that had to be deduced from the meter is not reported here: the
     beats carry it themselves, as an InferredRest notes slot, which is what the
@@ -3752,8 +3818,16 @@ def _build_measure_beats_glyph(m_cols, m_lo, m_hi, note_events, note_xs, x_tol,
     # as short. A rest whose voice has no room left at all (the other events
     # already fill the bar) cannot shrink to a positive written value and is
     # left untouched here - see _reduce_overlong_rests.
+    # A whole rest sharing a bar with a voice that already fills it is not that
+    # voice's rest at all - it is a second, silent voice the tab staff drew no
+    # stems for, so the stem-based voice split never made it and the rest was
+    # stacked onto the accompaniment (issue #180). Lift it into its own voice
+    # before reducing or padding, so the arpeggio keeps its own full bar and the
+    # whole-measure rest is not then also seen as an over-read to trim.
+    whole_measure_rests_separated = 0
     overlong_rests_reduced = 0
     if budget:
+        whole_measure_rests_separated = _separate_whole_measure_rest(live, budget)
         for t in live:
             overlong_rests_reduced += _reduce_overlong_rests(t, budget)
 
@@ -3764,7 +3838,7 @@ def _build_measure_beats_glyph(m_cols, m_lo, m_hi, note_events, note_xs, x_tol,
 
     return ([[(code, dots, notes) for _x, code, dots, notes in t] for t in live],
             unmatched_columns, unmatched_glyph_notes, unison_digits_shared,
-            overlong_rests_reduced)
+            overlong_rests_reduced, whole_measure_rests_separated)
 
 
 def _voice_mean_y(groups):
@@ -4535,7 +4609,8 @@ def _rhythm_report(counts, details, conformance=None, unread_bars=(),
                    dots_unassigned_eliminated=0, dots_unassigned_staves=0,
                    coincident_unsplit_pairs=0, coincident_unsplit_staves=0,
                    unison_digits_shared=0, overlong_rests_reduced=0,
-                   overlong_rest_bars=()):
+                   overlong_rest_bars=(), whole_measure_rests_separated=0,
+                   whole_measure_rest_bars=()):
     """Derive the document's rhythm warnings and confidence string from the
     collected per-staff provenances - the single place that decides both, so
     they cannot drift out of step with each other or with the measure loop.
@@ -4593,6 +4668,12 @@ def _rhythm_report(counts, details, conformance=None, unread_bars=(),
     could hold, and the numbers of the bars they were in (issue #163, see
     _reduce_overlong_rests). Reported like the padded-bars warning: the count
     says how much, the bar numbers say where.
+
+    `whole_measure_rests_separated` / `whole_measure_rest_bars` are how many
+    whole-measure rests were lifted out of a voice the sounding notes already
+    filled into a silent voice of their own, and where (issue #180, see
+    _separate_whole_measure_rest). Disclosed the same way: the count says how
+    much, the bar numbers say which bars to check against the page.
     """
     conformance = conformance or _BarConformance(0, 0, 0, 0)
     prov_bars = prov_bars or {}
@@ -4776,6 +4857,23 @@ def _rhythm_report(counts, details, conformance=None, unread_bars=(),
             "the bar had room for beside the other events in their voice. The rest was engraved, "
             "so it is kept; its duration is inferred from the time signature rather than read from "
             f"the glyph, and may not be what the score printed.{where}"
+        )
+
+    # A whole-measure rest moved out of a voice the sounding notes already
+    # filled into a silent voice of its own (issue #180). Disclosed like the
+    # reductions above: the rest WAS engraved, as a whole rest meaning "this
+    # voice is silent for the bar", and this decoder read it as a second voice
+    # the tab staff drew no stems for - a reading a viewer of the page may want
+    # to confirm, especially where the melody and accompaniment interleave.
+    if whole_measure_rests_separated:
+        where = (f" The bars are: {_bar_list(sorted(whole_measure_rest_bars))}."
+                 if whole_measure_rest_bars else "")
+        warnings.append(
+            f"{whole_measure_rests_separated} whole-measure rest(s) shared a bar with a voice that "
+            "already fills it, and were read as a separate voice silent for the whole bar rather "
+            "than stacked onto the sounding one. The rest was engraved as a whole rest; that it "
+            "belongs to a second voice the tablature drew no stems for is this decoder's reading of "
+            f"the page.{where}"
         )
 
     # Bars that don't add up outrank how the durations were obtained: a
@@ -5703,6 +5801,12 @@ def _extract(doc, pdf_path, time_signature: tuple[int, int] | None,
     # names its own.
     overlong_rests_reduced_total = 0
     overlong_rest_bars = []
+    # Whole-measure rests lifted out of a voice the sounding notes already
+    # filled into a silent voice of their own (issue #180, see
+    # _separate_whole_measure_rest). A count and the bar numbers, disclosed the
+    # same way the overlong reductions above are.
+    whole_measure_rests_separated_total = 0
+    whole_measure_rest_bars = []
     # Augmentation-dot glyphs that bound to no note - a genuine anomaly (see
     # glyph.decode_note_events, dots_unassigned), summed the same way and
     # over the same de-duplicated decodes as no_stem_notes above.
@@ -5903,7 +6007,8 @@ def _extract(doc, pdf_path, time_signature: tuple[int, int] | None,
                 bar_ts = _ts_at(ts_timeline, page_idx, anchor_y, m_lo) or ts
                 measure_quarter_len = _measure_quarter_length(bar_ts)
                 if source.uses_glyphs:
-                    voices, unmatched_cols, unmatched_notes, shared_digits, overlong_reduced = (
+                    (voices, unmatched_cols, unmatched_notes, shared_digits,
+                     overlong_reduced, wm_rests_separated) = (
                         _build_measure_beats_glyph(
                             m_cols, m_lo, m_hi, source.note_events, source.note_xs,
                             x_tol, std_staff.spacing, measure_quarter_len,
@@ -5915,6 +6020,9 @@ def _extract(doc, pdf_path, time_signature: tuple[int, int] | None,
                     overlong_rests_reduced_total += overlong_reduced
                     if overlong_reduced:
                         overlong_rest_bars.append(staff_first_bar + i)
+                    whole_measure_rests_separated_total += wm_rests_separated
+                    if wm_rests_separated:
+                        whole_measure_rest_bars.append(staff_first_bar + i)
                     if len(voices) > 1:
                         multivoice_bars += 1
                     if not voices:
@@ -6032,6 +6140,8 @@ def _extract(doc, pdf_path, time_signature: tuple[int, int] | None,
         unison_digits_shared=unison_digits_shared_total,
         overlong_rests_reduced=overlong_rests_reduced_total,
         overlong_rest_bars=tuple(sorted(overlong_rest_bars)),
+        whole_measure_rests_separated=whole_measure_rests_separated_total,
+        whole_measure_rest_bars=tuple(sorted(whole_measure_rest_bars)),
     )
     warnings.extend(rhythm_warnings)
     # Font-level problems that weren't already the reason a staff degraded

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -232,6 +232,16 @@ _FIXTURE_RELATIVE_PATHS = {
     "rito_village": (
         "Patreon/John Oeth/The Legend of Zelda/TLOZ Breath of the Wild/"
         "Rito Village - Night (The Legend of Zelda Breath of the Wild).pdf"),
+    # Issue #180: bar 16 (the Scarborough Fair setting, last system on PDF page
+    # 84) prints a whole-measure rest in the melody staff - the melody is silent
+    # for the bar - over a six-eighth arpeggio in the tablature that fills the
+    # 3/4 bar on its own. The tab staff draws no stems for the silent melody, so
+    # the stem-based voice split never makes it, and the whole rest used to be
+    # stacked onto the arpeggio's voice, reading the bar as 7.0 quarters. Now
+    # read as two voices of 3.0. Nothing committed here reproduces a
+    # whole-measure rest sharing a bar with a voice that already fills it.
+    "classical_guitar_method_vol1": (
+        "Method Books/Classical-Guitar-Method-Vol1-2020.pdf"),
 }
 
 # Skips for want of a library are COUNTED HERE as they happen, rather than
@@ -611,6 +621,16 @@ def rito_village_pdf() -> Path:
     if p is None:
         skip_without_library(
             "FERMATA_TEST_LIBRARY not set (or missing 'Rito Village - Night' fixture)")
+    return p
+
+
+@pytest.fixture
+def classical_guitar_method_vol1_pdf() -> Path:
+    p = _fixture_path("classical_guitar_method_vol1")
+    if p is None:
+        skip_without_library(
+            "FERMATA_TEST_LIBRARY not set (or missing "
+            "Classical-Guitar-Method-Vol1 fixture)")
     return p
 
 

--- a/server/tests/test_tabextract.py
+++ b/server/tests/test_tabextract.py
@@ -4930,16 +4930,20 @@ def test_no_emitted_note_is_longer_than_the_bar_it_sits_in(library_root):
 
     The RESTS the same issue calls out as an adjacent class are counted
     separately here, because a rest longer than its bar is a rest fault, not a
-    note one. One remains:
+    note one. The list is now empty; both rests once here have been worked:
 
-      Classical-Guitar-Method-Vol1-2020, bar 16 - a whole rest that reads as
-      four quarters in a 3/4 bar. Read against the page it is a LEGITIMATE
-      whole-measure rest: the melody voice is silent for the bar while the
-      tablature plays a six-eighth arpeggio. The fault is that the two are
-      flattened into one voice, where the arpeggio already fills the 3/4 bar,
-      so #163's over-read reduction (below) has no room to shrink the rest into
-      and leaves it - this is a voice-separation defect awaiting its own issue,
-      not the confident duration over-read #163 fixes. See the assertion below.
+      Classical-Guitar-Method-Vol1-2020, bar 16 held a whole rest that read as
+      four quarters in a 3/4 bar. Read against the page (the Scarborough Fair
+      setting, "She once was a true love of mine" - the last system on PDF page
+      84) it is a LEGITIMATE whole-measure rest: the melody voice is silent for
+      the bar while the tablature plays a six-eighth arpeggio. The fault was
+      that the two were flattened into one voice, where the arpeggio already
+      fills the 3/4 bar, so #163's over-read reduction (below) had no room to
+      shrink the rest into and left it. #180 recognises it as its own silent
+      voice - a whole-measure rest against the arpeggio - so the bar now reads
+      as two voices of 3.0 each rather than one of 7.0, and it leaves this list.
+      See test_bar16_whole_measure_rest_reads_as_its_own_voice for the two-voice
+      pin.
 
       My Star (Final Fantasy XVI), bar 5 held a DOTTED whole rest - six quarters
       in a 4/4 bar, never the whole-measure convention (a plain undotted whole
@@ -4995,8 +4999,9 @@ def test_no_emitted_note_is_longer_than_the_bar_it_sits_in(library_root):
         "note(s) written longer than the bar they sit in (score, bar, meter, "
         f"type, dots): {impossible[:10]}"
         + (f" and {len(impossible) - 10} more" if len(impossible) > 10 else ""))
-    # One disclosed rest remains, pinned so it can neither multiply unnoticed
-    # nor be quietly fixed without this sentence going with it.
+    # The list is empty, and none may come back: a rest longer than its bar is
+    # impossible whatever the page says, so an exact empty list makes any new
+    # site name itself in the failure. Two rests were once here:
     #
     # My Star (Final Fantasy XVI) bar 5 held a DOTTED whole rest - six quarters
     # in a 4/4 bar, never the whole-measure convention (which is a plain whole
@@ -5005,19 +5010,88 @@ def test_no_emitted_note_is_longer_than_the_bar_it_sits_in(library_root):
     # quarters the bar has room for beside the chord, disclosed as an inferred
     # length. It is gone from this list as a result.
     #
-    # Classical-Guitar-Method-Vol1-2020 bar 16 stays. Read against the printed
-    # page (the Scarborough Fair setting, "She once was a true love of mine" -
-    # the last system on PDF page 84) its whole rest is a LEGITIMATE
-    # whole-measure rest: the melody voice is silent for the bar while the
-    # tablature plays a six-eighth arpeggio. The defect is that the two were flattened into one
-    # voice, where the arpeggio already fills the 3/4 bar and leaves the rest no
-    # room - a voice-separation fault, not the duration over-read #163 fixes, so
-    # #163's reduction correctly does not fire on it (shrinking it to the zero
-    # room left would drop a written beat rather than shorten one). Carried here
-    # until that separation is done under its own issue.
-    assert impossible_rests == [
-        ("Classical-Guitar-Method-Vol1-2020.pdf", "16", (3, 4), "whole", 0),
-    ], impossible_rests
+    # Classical-Guitar-Method-Vol1-2020 bar 16 held a whole rest that read as
+    # four quarters in a 3/4 bar. Read against the printed page (the Scarborough
+    # Fair setting, "She once was a true love of mine" - the last system on PDF
+    # page 84) it is a LEGITIMATE whole-measure rest: the melody voice is silent
+    # for the bar while the tablature plays a six-eighth arpeggio. The two were
+    # flattened into one voice, where the arpeggio already fills the 3/4 bar and
+    # left the rest no room - a voice-separation fault, not the duration
+    # over-read #163 fixes, so #163's reduction correctly did not fire on it
+    # (shrinking it to the zero room left would drop a written beat rather than
+    # shorten one). #180 lifts it into its own silent voice - a whole-measure
+    # rest against the arpeggio, spelled as the dotted-half the 3/4 bar holds -
+    # so the bar reads as two voices of 3.0 rather than one of 7.0, and it is
+    # gone from this list. See test_bar16_whole_measure_rest_reads_as_its_own_voice.
+    assert impossible_rests == [], impossible_rests
+
+
+def test_bar16_whole_measure_rest_reads_as_its_own_voice(
+        classical_guitar_method_vol1_pdf):
+    """Issue #180: a whole-measure rest sharing a bar with a voice that already
+    fills it is a second, silent voice - not a beat stacked onto the sounding
+    one.
+
+    Classical-Guitar-Method-Vol1 bar 16 (the Scarborough Fair setting, "She
+    once was a true love of mine" - the last system on PDF page 84) prints a
+    whole rest in the melody staff, hanging below the fourth line: the melody is
+    silent for the whole bar. The tablature underneath plays a six-eighth
+    arpeggio that fills the 3/4 bar on its own. Because the tab staff draws no
+    stems for the silent melody, the stem-based voice split (_assign_group_voices)
+    never makes a voice for it, and the whole rest was placed in the ONE voice
+    the arpeggio makes - stacking a four-quarter rest onto a bar the six eighths
+    already fill, so the bar read as 7.0 quarters in 3/4.
+
+    The fix separates it: the arpeggio keeps its own 3.0-quarter bar, and the
+    whole-measure rest becomes a voice of its own, silent for the bar, spelled
+    as the 3.0 quarters the meter holds (a dotted-half rest in 3/4 - a whole
+    rest means "the whole measure" in any meter, never four quarters in 3/4).
+    Neither voice exceeds the bar, and both sum to 3.0.
+    """
+    result = tabextract.extract(classical_guitar_method_vol1_pdf)
+    assert result.extractable and result.musicxml
+
+    type_quarters = {"breve": 8.0, "whole": 4.0, "half": 2.0, "quarter": 1.0,
+                     "eighth": 0.5, "16th": 0.25, "32nd": 0.125}
+    root = ET.fromstring(result.musicxml)
+    bar16 = None
+    for part in root.findall("part"):
+        for measure in part.findall("measure"):
+            if measure.get("number") == "16":
+                bar16 = measure
+                break
+        if bar16 is not None:
+            break
+    assert bar16 is not None, "bar 16 was not emitted"
+
+    # Sum each voice's WRITTEN durations (what _bar_conformance and any MusicXML
+    # tool reads), split by voice, and record the rest types each voice holds.
+    voice_quarters = {}
+    voice_rest_types = {}
+    for note in bar16.findall("note"):
+        written = type_quarters.get(note.findtext("type"))
+        if written is None:
+            continue
+        written *= 2 - 0.5 ** len(note.findall("dot"))
+        voice = note.findtext("voice") or "1"
+        voice_quarters[voice] = voice_quarters.get(voice, 0.0) + written
+        if note.find("rest") is not None:
+            voice_rest_types.setdefault(voice, []).append(
+                (note.findtext("type"), len(note.findall("dot"))))
+
+    # Two voices, each holding a full 3/4 bar - not one voice of 7.0.
+    assert len(voice_quarters) == 2, voice_quarters
+    for voice, q in voice_quarters.items():
+        assert abs(q - 3.0) < 1e-9, (voice, q, voice_quarters)
+
+    # One voice is the six-eighth arpeggio (no rests); the other is the
+    # whole-measure rest, spelled as the dotted-half the 3/4 bar holds rather
+    # than a whole rest that would read as four quarters again.
+    rests = [types for types in voice_rest_types.values() if types]
+    assert rests == [[("half", 1)]], voice_rest_types
+
+    # And it is disclosed, the same way #163's reductions are.
+    assert any("whole-measure rest" in w for w in result.warnings), result.warnings
 
 
 # ---------------------------------------------------------------------------

--- a/server/tests/test_tabextract.py
+++ b/server/tests/test_tabextract.py
@@ -4543,9 +4543,19 @@ def test_library_wide_repeat_structure_leaves_conformance_untouched(library_root
     # defective) because its OTHER voice was already short of the meter before
     # this change, which is why only bars_overfull moves and bars_short /
     # bars_defective do not. No note, beat or bar moves: a rest is neither.
-    assert totals["bars_overfull"] == 1536               # 1541 (#113) -> 1540 (#163) -> 1536 (#140, four harmonics)
-    assert totals["bars_short"] == 4192                  # 4190 -> 4192 (#140)
-    assert totals["bars_defective"] == 5300              # 5340; unmoved by #140
+    #
+    # 1536 before #180, 1535 after: Classical-Guitar-Method-Vol1 bar 16 held a
+    # six-eighth arpeggio filling its 3/4 bar with a whole rest stacked onto the
+    # same voice (7.0 quarters). #180 lifts that whole rest into its own silent
+    # voice - a whole-measure rest of 3.0 - so the arpeggio voice stops being
+    # overfull and both voices now sum to the meter. The bar was overfull but
+    # NOT short (its one voice held too much, none too little), so putting it
+    # right takes it out of bars_defective as well: bars_defective falls by 1
+    # and bars_short does not move. Still no note, beat or bar moves - the rest
+    # is relocated, not dropped or added.
+    assert totals["bars_overfull"] == 1535               # 1541 (#113) -> 1540 (#163) -> 1536 (#140) -> 1535 (#180, bar 16)
+    assert totals["bars_short"] == 4192                  # 4190 -> 4192 (#140); unmoved by #180
+    assert totals["bars_defective"] == 5299              # 5340; -1 at #180 (bar 16 was overfull-only)
     assert totals["bars_padded"] == 3605                 # 3603 -> 3605 (#140)
     # 4897.875 before #162, 4899.875 after: Answers (Final Fantasy XIV
     # Endwalker) bar 45 held one quarter in each of its two voices in a bar read
@@ -4578,7 +4588,13 @@ def test_library_wide_repeat_structure_leaves_conformance_untouched(library_root
     # directions and the pair is what says a dot was BOUND rather than merely
     # stopped being reported.
     #                                        before #111/#112 -> after
-    assert totals["dots"] == 9182                          # 8884
+    # +1 at #180: the whole-measure rest lifted out of Classical-Guitar-Method
+    # bar 16 is spelled as the 3.0 quarters the 3/4 bar holds, which is a DOTTED
+    # half rest - one emitted <dot />. Spelling it dotless would take two rests
+    # (a half plus a quarter) and move BEATS instead, which must not move; the
+    # single dotted rest keeps the beat count and adds exactly this one dot. It
+    # is bound to the rest, so dots_unassigned below does not move.
+    assert totals["dots"] == 9183                          # 8884 -> 9182 (#111/#112) -> 9183 (#180)
     assert totals["dots_unassigned"] == 1154                # 1280
     assert totals["dots_unassigned_no_candidate"] == 1144   # 1226
     assert totals["dots_unassigned_eliminated"] == 10       # 54


### PR DESCRIPTION
Closes #180

## The site

`Classical-Guitar-Method-Vol1-2020` bar 16 (the Scarborough Fair setting, "She once was a true love of mine" — the last system on PDF page 84) is a 3/4 bar. The melody staff prints a single **whole rest hanging below the fourth line**: the melody is silent for the whole bar. The tablature underneath plays a **six-eighth arpeggio** that fills the 3/4 bar on its own (0.5 × 6 = 3.0).

Read against the page these are **two voices**, but they were flattened into **one**: six eighths (3.0) plus a whole rest (4.0) = **7.0 quarters in a 3/4 bar**.

## Where the two staves' events combine, and why the rest was mis-voiced

`_build_measure_beats_glyph` (tabextract.py) groups a bar's noteheads by stem and splits them into voices with `_assign_group_voices`, which reads voices **off stems**. Rests are excluded from that grouping (`_stem_groups([n … if not n.is_rest])`), so a rest can never make a voice of its own. Here the silent melody voice consists *entirely* of a rest — the tab staff draws no stems for it — so `_assign_group_voices` makes **one** voice (the arpeggio), and the bar is monophonic.

`_place_rest_clusters`'s monophonic branch then appends the whole rest to that single voice: the rest is centred in the bar, at no decoded onset (`hit is None`), so it is kept as a beat and lands on top of the arpeggio that already fills the bar.

`_reduce_overlong_rests` (#163) cannot fix this: it shortens a rest to the room its voice has left, and this voice has none, so it correctly declines (shrinking the rest to the zero room left would drop a written beat rather than shorten one). The rest is **mis-voiced**, not over-read.

## The fix

New `_separate_whole_measure_rest(live, budget)`, run in `_build_measure_beats_glyph` before the #163 reduction and the padding: a plain whole rest (the whole-measure convention glyph) whose voice's **other events already account for the whole bar** is lifted out into a **silent voice of its own**, spelled as the silence the meter holds — a dotted-half rest in 3/4, since a whole rest means "the whole measure" in any meter, never four quarters in 3/4. The arpeggio keeps its own full bar.

It fires only on the exact case #163 declines (the voice already full); a partly-filled voice keeps #163's reduction, where the rest may be a genuine over-read.

Disclosed with its own count and bar numbers via `_rhythm_report`, the same document-level warning pattern #163's reductions use (no new per-bar disclosure key, so the six-hop structural guards are untouched).

## Bar 16 voice sums

| | before | after |
|---|---|---|
| voice 1 | 7.0 (six eighths + whole rest) | 3.0 (six eighths) |
| voice 2 | — | 3.0 (dotted-half whole-measure rest) |

## Library-wide counts (293 extractable scores, `FERMATA_TEST_LIBRARY` set)

| | before | after |
|---|---|---|
| notes | 99461 | 99461 (unchanged) |
| beats | 83365 | 83365 (unchanged) |
| bars | 10762 | 10762 (unchanged) |
| bars_overfull | 1536 | **1535** |
| bars_defective | 5300 | **5299** |

`notes`/`beats`/`bars` do not move — the rest is relocated, not dropped or added. `bars_overfull` and `bars_defective` each fall by one (bar 16 was overfull-only, so putting it right removes it from both). `dots` rises by one (a dotted-half rest carries one dot); spelling the rest as two dotless rests would instead have moved `beats`.

`impossible_rests` in `test_no_emitted_note_is_longer_than_the_bar_it_sits_in` was pinned to bar 16 as its **only** remaining entry; it is now **empty**.

## Non-regression sweep

Emitted MusicXML + alphaTex hashed per **full relative path** (297 entries, 293 extractable — 4 basenames collide across game folders, so basename-keying would silently collapse the set). **Exactly one** score's output moved: the target, `Method Books/Classical-Guitar-Method-Vol1-2020.pdf`. No other score in the library changed. Page 84 was rendered at 6× and read by eye: the melody's whole rest and the tab's six-eighth arpeggio are two voices, now separated correctly.

## Tests

- New `test_bar16_whole_measure_rest_reads_as_its_own_voice` pins the two-voice 3.0/3.0 reading and the disclosure.
- `test_no_emitted_note_is_longer_than_the_bar_it_sits_in`'s pin updated to the empty list, with the reasoning carried in the docstring/comment.
- Library-wide conformance pins moved with a documented reason.
- **Mutation test:** with separation disabled, both the regression test (`{'1': 7.0}`, asserts 2 voices) and the impossible-rests test (names `Classical-Guitar-Method-Vol1-2020.pdf 16 (3,4) whole 0`) go red; restored, both green.

Full `test_tabextract.py`: 221 passed, 9 skipped (web/node_modules absent). Route-count and disclosure-key structural guards pass (no routes added, no new bar-key).
