### PR TITLE
Excuse a first-bar pickup from Rule 8 instead of demoting for it

### DIFF
--- a/server/fermata/api.py
+++ b/server/fermata/api.py
@@ -1577,7 +1577,19 @@ def _transcription_row(conn, score_id: int):
 # that already has its own dot, not one with nothing nearby (see
 # tabextract._rhythm_report / glyph._assign_dots).
 _BAR_KEYS = ("bars_overfull", "bars_short", "bars_defective", "bars_measured",
-             "bars_padded", "bars_unread", "notes_no_stem", "staves_no_stem",
+             "bars_padded", "bars_unread",
+             # `bars_anacrusis` (issue #174): how many bars a first-bar pickup
+             # let Rule 8 excuse. A Rule 8 CONFORMANCE figure, not a structural
+             # disclosure - it is the bars_short/bars_defective arithmetic
+             # itself, adjusted for a pickup that is normal notation rather than
+             # a misread, and is shown through the bar-count headline and the
+             # warning prose (which names `anacrusis_bars`) like its
+             # bars_padded / bars_unread neighbours, not the disclosures panel.
+             # So it is listed in test_disclosure_keys._RULE8_CONFORMANCE_KEYS
+             # and stays OFF the web mirror. It still has to survive a reload
+             # for the same reason the rest do: a reader reopening a stored
+             # transcription must see that a first bar was excused, and which.
+             "bars_anacrusis", "notes_no_stem", "staves_no_stem",
              # `staves_stemless` (issue #91): a notation staff whose stem/beam
              # vector pass found NO stems at all, though it decoded noteheads
              # that must carry one. A different, stronger fact than
@@ -1680,7 +1692,13 @@ _BAR_KEYS = ("bars_overfull", "bars_short", "bars_defective", "bars_measured",
 # resolved each way, but that field is not one this module stores or exposes
 # - only these bar-number lists carry the fact out to a consumer, and a bar
 # number is what a reader can carry back to the PDF.
-_BAR_LIST_KEYS = ("padded_bars", "unread_bars", "spacing_bars", "degraded_bars",
+_BAR_LIST_KEYS = ("padded_bars", "unread_bars",
+                   # WHICH bars a first-bar pickup excused (issue #174) - the
+                   # bar-number half of `bars_anacrusis`, named in the warning
+                   # prose so a reader can carry it back to the printed page and
+                   # confirm the excused bar really is a pickup.
+                   "anacrusis_bars",
+                   "spacing_bars", "degraded_bars",
                    # WHICH bars carried a repeat/volta mark that could not be
                    # read in full - the bar-number half of the repeats_unread
                    # / endings_unread / endings_truncated / form_marks_unanchored
@@ -1958,6 +1976,14 @@ def _store_extraction_result(score_id: int, result) -> dict:
             "bars_unread": result.bars_unread,
             "padded_bars": result.padded_bars,
             "unread_bars": result.unread_bars,
+            # bars_anacrusis / anacrusis_bars (issue #174): how many first-bar
+            # pickups Rule 8 excused, and which bars. Written here, the only
+            # path into storage, so a reader reopening a stored transcription
+            # still sees that a first bar was read as a pickup rather than
+            # counted against the meter - the round trip the structural guard
+            # in test_transcription_api.py checks by name.
+            "bars_anacrusis": result.bars_anacrusis,
+            "anacrusis_bars": result.anacrusis_bars,
             "inferred_rest_quarters": result.inferred_rest_quarters,
             "notes_no_stem": result.notes_no_stem,
             "staves_no_stem": result.staves_no_stem,

--- a/server/fermata/api_models.py
+++ b/server/fermata/api_models.py
@@ -628,6 +628,12 @@ class TranscriptionOut(BaseModel):
     bars_measured: int | None
     bars_padded: int | None
     bars_unread: int | None
+    # How many bars a first-bar pickup (anacrusis) let Rule 8 excuse (issue
+    # #174) - a deliberately short opening measure, lifted out of bars_short /
+    # bars_defective because it is normal notation, not a misread. `anacrusis_bars`
+    # below names which; both are reported so a reader can see and check the
+    # one assumption the exemption makes about the page.
+    bars_anacrusis: int | None
     notes_no_stem: int | None
     staves_no_stem: int | None
     # A notation staff whose stem/beam vector pass found no stems at all though
@@ -678,6 +684,9 @@ class TranscriptionOut(BaseModel):
     # _BAR_LIST_KEYS
     padded_bars: list[int] | None
     unread_bars: list[int] | None
+    # Which bars a first-bar pickup excused (issue #174) - the bar-number half
+    # of bars_anacrusis.
+    anacrusis_bars: list[int] | None
     spacing_bars: list[int] | None
     degraded_bars: list[int] | None
     repeats_unread_bars: list[int] | None

--- a/server/fermata/tabextract.py
+++ b/server/fermata/tabextract.py
@@ -308,6 +308,15 @@ class ExtractionResult:
     # here was read" - and they do count towards the reported confidence.
     bars_unread: int = 0
     unread_bars: list[int] = field(default_factory=list)
+    # Bars a first-bar pickup (anacrusis) let Rule 8 excuse, and which ones. A
+    # pickup is a deliberately short opening measure - normal notation, not a
+    # misread - so it is lifted out of bars_short / bars_defective rather than
+    # counted against the meter. Reported as data (not only in the warning
+    # prose) precisely because the exemption is an assumption about the page: a
+    # reader must be able to see WHICH bar was excused and check it. See
+    # _anacrusis_bars for the first/last pairing that has to hold.
+    bars_anacrusis: int = 0
+    anacrusis_bars: list[int] = field(default_factory=list)
     # Total tab / standard staff systems found across the whole document
     # (summed across pages) - same definition analyze() uses, not a
     # per-page maximum.
@@ -533,6 +542,8 @@ class ExtractionResult:
             "inferred_rest_quarters": self.inferred_rest_quarters,
             "bars_unread": self.bars_unread,
             "unread_bars": list(self.unread_bars),
+            "bars_anacrusis": self.bars_anacrusis,
+            "anacrusis_bars": list(self.anacrusis_bars),
             "tab_staff_count": self.tab_staff_count,
             "standard_staff_count": self.standard_staff_count,
             "pages_processed": self.pages_processed,
@@ -4528,6 +4539,78 @@ class _BarConformance(NamedTuple):
     # _rhythm_report), and a bar can be both - adding the two counts would
     # double-count it and could put the ratio over 1.
     defective_bars: tuple[int, ...] = ()
+    # How many bars a first-bar pickup (anacrusis) let Rule 8 excuse, and which
+    # ones (1-based). A pickup is a deliberately short FIRST bar - normal
+    # notation, not a misread - so it is lifted out of `short`/`defective`
+    # rather than counted against the meter. It is DISCLOSED here, and named in
+    # the warning prose, rather than being silently reclassified: the whole
+    # risk of the exemption is excusing a genuinely short first bar, so the
+    # assumption is made visible. See _anacrusis_bars for exactly when it fires.
+    anacrusis: int = 0
+    anacrusis_bars: tuple[int, ...] = ()
+
+
+def _anacrusis_bars(bar_info, last_index) -> tuple[int, ...]:
+    """Which bars a first-bar pickup lets Rule 8 excuse - a NEW rule, not a
+    loosening of the zero-tolerance gate #114 tightened.
+
+    `bar_info` is (index, min_voice, max_voice, budget) for every bar that had
+    BOTH a meter and at least one voice, in bar order. `last_index` is the
+    number of the score's final measure. Returns the bar numbers to lift out of
+    the defective count (empty when no pickup is recognised).
+
+    A pickup (anacrusis) is a deliberately short FIRST measure that a musician
+    reads as normal notation. The one failure mode to defend against is
+    excusing a genuinely misread first bar and handing a wrong score an
+    undeserved confidence, so this keys off the FIRST and LAST bars TOGETHER -
+    never a short first bar's own shape alone, which cannot tell a pickup from
+    a dropped note. Every one of these must hold:
+
+      - there are at least two measured bars, bar 1 is the score's actual first
+        measured bar, and the final MEASURED bar is the score's actual final
+        bar (a meterless or unread final bar disqualifies the score - the
+        "final measure" has to really be final);
+      - bar 1 and the final bar carry the SAME meter;
+      - bar 1 is short in EVERY voice - its LONGEST voice still falls under the
+        meter. One voice that fills the bar while another falls short is a
+        dropped note, not a pickup (this is the guard that keeps a bar like
+        [3.0, 4.0] in 4/4 defective), so the whole first bar has to be partial;
+      - the final bar CORROBORATES the pickup, in one of the two shapes a
+        printed anacrusis takes:
+          * it is a COMPLETE measure of the shared meter - the piece opens
+            mid-measure and closes on a full downbeat bar (the uncompensated
+            pickup these arrangements actually use); or
+          * it is itself short and bar 1's length plus the final bar's length
+            sum to exactly one measure - the compensated pairing, where the
+            beats missing from bar 1 are precisely the ones the final bar is
+            missing.
+
+    The compensated shape returns BOTH bars (the final bar's shortness is the
+    other half of the same pickup, not a defect); the uncompensated shape
+    returns bar 1 alone.
+    """
+    tol = 1e-6
+    if len(bar_info) < 2:
+        return ()
+    i1, min1, max1, b1 = bar_info[0]
+    iN, minN, maxN, bN = bar_info[-1]
+    # Bar 1 must be the real first bar and the final measured bar the real last
+    # bar; anything else means an unread/meterless bar sits at an end and the
+    # "first/last pairing" would be reading the wrong bars.
+    if i1 != 1 or iN != last_index or b1 != bN:
+        return ()
+    # Bar 1 short in every voice (longest voice under the meter). This is what
+    # separates a pickup from a dropped note in one voice of an otherwise full
+    # bar - the single most important guard here.
+    if not (max1 < b1 - tol):
+        return ()
+    final_complete = abs(minN - bN) <= tol and abs(maxN - bN) <= tol
+    if final_complete:
+        return (1,)
+    final_short = maxN < bN - tol
+    if final_short and abs((max1 + maxN) - bN) <= tol:
+        return (1, iN)
+    return ()
 
 
 def _bar_conformance(measures) -> _BarConformance:
@@ -4565,7 +4648,15 @@ def _bar_conformance(measures) -> _BarConformance:
     padded_bars = []
     defective_bars = []
     inferred_quarters = 0.0
+    # (index, min_voice, max_voice, budget) for every bar actually compared
+    # against a meter, so the pickup rule below can read the first and last
+    # bars back without a second pass. `last_index` is the score's final
+    # measure - meterless trailing bars included - so the rule can insist the
+    # final MEASURED bar really is the final bar.
+    bar_info = []
+    last_index = 0
     for index, (beats, ts) in enumerate(measures, start=1):
+        last_index = index
         # The padding accounting comes FIRST, before the meterless-bar skip: a
         # bar with no meter is not measured against one, but if it holds
         # inferred silence it still carries a `<forward>` into the file, and a
@@ -4590,9 +4681,23 @@ def _bar_conformance(measures) -> _BarConformance:
         short += under
         if over or under:
             defective_bars.append(index)
+        bar_info.append((index, min(voices), max(voices), budget))
+    # A first-bar pickup is normal notation, not a misread: lift it out of the
+    # short/defective counts the reported confidence is derived from, keeping
+    # a record of which bars for the disclosure. Only a bar that WAS defective
+    # is removed (a pickup is short by definition), and only in the short
+    # direction - the pickup rule never fires on an overfull bar.
+    anacrusis = _anacrusis_bars(bar_info, last_index)
+    excused = []
+    for bar in anacrusis:
+        if bar in defective_bars:
+            defective_bars.remove(bar)
+            short -= 1
+            excused.append(bar)
     return _BarConformance(overfull, short, len(defective_bars), counted,
                            len(padded_bars), tuple(padded_bars),
-                           inferred_quarters, tuple(defective_bars))
+                           inferred_quarters, tuple(defective_bars),
+                           len(excused), tuple(excused))
 
 
 def _overfull_bars(measures) -> tuple[int, int]:
@@ -4935,6 +5040,23 @@ def _rhythm_report(counts, details, conformance=None, unread_bars=(),
             "with each other; the inferred silence is NOT counted towards those bars adding up, and "
             "is written into the MusicXML as <forward> rather than as a rest so no consumer "
             "mistakes it for one the engraver printed"
+        )
+    # A recognised first-bar pickup (anacrusis) is DISCLOSED, never hidden: the
+    # whole risk of the exemption is excusing a genuinely short first bar, so
+    # the assumption is stated out loud with the bar named, the same way the
+    # padded/unread bars are. The count says how many bars were excused; the
+    # numbers say which, so a reader can check them against the printed page.
+    if conformance.anacrusis:
+        warnings.append(
+            f"{conformance.anacrusis} bar(s) were read as a pickup (anacrusis) and are NOT counted "
+            f"against the time signature. The bars are: {_bar_list(conformance.anacrusis_bars)}. A "
+            "pickup is a deliberately short measure that opens a piece - normal notation a musician "
+            "reads as a lead-in, not a mistake. It is recognised only from the FIRST and LAST bars "
+            "together: bar 1 falls short of the meter in every voice AND the final bar is a complete "
+            "measure of the same meter (or is itself short by exactly the beats bar 1 is missing, the "
+            "classical anacrusis pairing). A first bar that is short for any OTHER reason - one voice "
+            "short while another fills the bar, or a final bar that does not complete it - is still "
+            "counted as not adding up"
         )
     # A bar nothing was read from is reported SEPARATELY from the Rule 8 counts,
     # and deliberately so. It holds a whole bar of rests that do add up to its
@@ -6474,6 +6596,8 @@ def _extract(doc, pdf_path, time_signature: tuple[int, int] | None,
         inferred_rest_quarters=conformance.inferred_quarters,
         bars_unread=len(unread_bars),
         unread_bars=list(unread_bars),
+        bars_anacrusis=conformance.anacrusis,
+        anacrusis_bars=list(conformance.anacrusis_bars),
         tab_staff_count=tab_count,
         standard_staff_count=std_count,
         pages_processed=len(pages_with_tab),

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -35,6 +35,17 @@ _FIXTURE_RELATIVE_PATHS = {
     # chord: the figure notehead-to-stem attachment gets wrong, and an Opus
     # engraving, so it also exercises the side bearing that only that font has.
     "dalza": "Classical/PrimoGuitar Misc/Dalza-Recercar-Guitar-2019.pdf",
+    # Issue #174 anacrusis cases. Sad Song opens on a two-eighth-note pickup and
+    # is otherwise clean, so recognising the pickup takes it to zero defective
+    # bars. Singing Mountain opens on a one-beat pickup but ALSO carries an
+    # unrelated short bar (19), so recognising the pickup lifts bar 1 while its
+    # demotion remains. Far Promise is the adversarial non-pickup: its first bar
+    # is short in ONE voice while another fills it (a dropped note), and its
+    # final bar IS a complete measure - so the "wholly short" guard has to keep
+    # it defective even though the final-bar half of the pairing holds.
+    "sad_song": "Patreon/John Oeth/Super Mario/Sad Song (Super Mario RPG).pdf",
+    "singing_mountain": "Patreon/John Oeth/Chrono Trigger/Singing Mountain (Chrono Trigger).pdf",
+    "far_promise": "Patreon/John Oeth/Chrono Cross/Far Promise (Radical Dreamers).pdf",
     # Filled noteheads whose stems the vector pass never sees, on every one of
     # its notation staves. Nothing engraved in this repository reproduces that
     # - MuseScore draws every stem as a clean vector line, so all twelve
@@ -382,6 +393,30 @@ def dalza_pdf() -> Path:
     p = _fixture_path("dalza")
     if p is None:
         skip_without_library("FERMATA_TEST_LIBRARY not set (or missing Dalza fixture)")
+    return p
+
+
+@pytest.fixture
+def sad_song_pdf() -> Path:
+    p = _fixture_path("sad_song")
+    if p is None:
+        skip_without_library("FERMATA_TEST_LIBRARY not set (or missing 'Sad Song' fixture)")
+    return p
+
+
+@pytest.fixture
+def singing_mountain_pdf() -> Path:
+    p = _fixture_path("singing_mountain")
+    if p is None:
+        skip_without_library("FERMATA_TEST_LIBRARY not set (or missing 'Singing Mountain' fixture)")
+    return p
+
+
+@pytest.fixture
+def far_promise_pdf() -> Path:
+    p = _fixture_path("far_promise")
+    if p is None:
+        skip_without_library("FERMATA_TEST_LIBRARY not set (or missing 'Far Promise' fixture)")
     return p
 
 

--- a/server/tests/test_disclosure_keys.py
+++ b/server/tests/test_disclosure_keys.py
@@ -37,6 +37,13 @@ _VENDORED_PATH = (
 _RULE8_CONFORMANCE_KEYS = {
     "bars_overfull", "bars_short", "bars_defective", "bars_measured",
     "bars_padded", "bars_unread",
+    # `bars_anacrusis` (issue #174) is the Rule 8 arithmetic itself, adjusted
+    # for a first-bar pickup that is normal notation rather than a misread: it
+    # is how many bars were lifted out of bars_short / bars_defective. Shown
+    # through the bar-count headline and the warning prose (which names
+    # `anacrusis_bars`) exactly like bars_padded / bars_unread, not through the
+    # #155 disclosures panel, so it belongs here and stays off the web mirror.
+    "bars_anacrusis",
 }
 
 

--- a/server/tests/test_tabextract.py
+++ b/server/tests/test_tabextract.py
@@ -2053,31 +2053,152 @@ def test_bar_conformance_counts_both_directions():
     count existed before, so a bar with a note missing from it looked clean.
 
     The fields are (overfull, short, defective, counted, padded, padded_bars,
-    inferred_quarters, defective_bars)."""
+    inferred_quarters, defective_bars, anacrusis, anacrusis_bars). The two
+    trailing anacrusis fields (issue #174) are 0/() here: none of these cases
+    is a pickup - a single short bar is not (a pickup needs a first AND a
+    corroborating final bar), and the two-bar cases open on a FULL bar."""
     exact = [[(4, 0, [(1, 0)])] * 3]
     over = [[(4, 0, [(1, 0)])] * 4]
     short = [[(4, 0, [(1, 0)])] * 2]
-    assert tabextract._bar_conformance([(exact, (3, 4))]) == (0, 0, 0, 1, 0, (), 0.0, ())
-    assert tabextract._bar_conformance([(over, (3, 4))]) == (1, 0, 1, 1, 0, (), 0.0, (1,))
-    assert tabextract._bar_conformance([(short, (3, 4))]) == (0, 1, 1, 1, 0, (), 0.0, (1,))
+    assert tabextract._bar_conformance([(exact, (3, 4))]) == (0, 0, 0, 1, 0, (), 0.0, (), 0, ())
+    assert tabextract._bar_conformance([(over, (3, 4))]) == (1, 0, 1, 1, 0, (), 0.0, (1,), 0, ())
+    assert tabextract._bar_conformance([(short, (3, 4))]) == (0, 1, 1, 1, 0, (), 0.0, (1,), 0, ())
     # A bar with one voice over its meter and another under it is wrong ONCE.
     # overfull + short would count it twice and can exceed the bar count, which
     # is why `defective` is a field of its own.
     both = [[(4, 0, [(1, 0)])] * 4, [(4, 0, [(2, 0)])] * 2]
-    assert tabextract._bar_conformance([(both, (3, 4))]) == (1, 1, 1, 1, 0, (), 0.0, (1,))
+    assert tabextract._bar_conformance([(both, (3, 4))]) == (1, 1, 1, 1, 0, (), 0.0, (1,), 0, ())
     # A voice padded out to its meter with inferred silence is still SHORT by
     # what was missing, and the padding is reported separately: bar 2 here.
     padded = [[(4, 0, [(1, 0)])] * 3,
               [(4, 0, [(2, 0)]), (2, 0, musicxml.inferred_rest())]]
     assert tabextract._bar_conformance([(exact, (3, 4)), (padded, (3, 4))]) == (
-        0, 1, 1, 2, 1, (2,), 2.0, (2,))
+        0, 1, 1, 2, 1, (2,), 2.0, (2,), 0, ())
     # A bar with no meter is not measured against one, but its padding is still
     # counted: it carries a <forward> into the file either way, and a padded
     # count the file disagrees with is what this whole mechanism prevents.
     assert tabextract._bar_conformance([(padded, None)]) == (
-        0, 0, 0, 0, 1, (1,), 2.0, ())
+        0, 0, 0, 0, 1, (1,), 2.0, (), 0, ())
     # _overfull_bars keeps its old shape for the callers that want just that
     assert tabextract._overfull_bars([(over, (3, 4))]) == (1, 1)
+
+
+def test_a_first_bar_pickup_is_excused_from_rule_8_uncompensated():
+    """Issue #174: a deliberately short FIRST bar (an anacrusis / pickup) whose
+    piece closes on a COMPLETE final measure of the same meter is normal
+    notation, not a misread, so _bar_conformance lifts it out of the short and
+    defective counts and records it as an anacrusis instead."""
+    full = [[(4, 0, [(1, 0)])] * 3]        # one voice, 3.0 == a full 3/4 bar
+    pickup = [[(4, 0, [(1, 0)])]]          # one voice, 1.0 - short of the meter
+    c = tabextract._bar_conformance(
+        [(pickup, (3, 4)), (full, (3, 4)), (full, (3, 4))])
+    # Bar 1 was short in its only voice and the final bar is a complete measure,
+    # so bar 1 is the pickup: no short bar, no defective bar, one anacrusis.
+    assert (c.short, c.defective, c.defective_bars) == (0, 0, ())
+    assert (c.anacrusis, c.anacrusis_bars) == (1, (1,))
+
+
+def test_a_first_bar_pickup_is_excused_from_rule_8_compensated():
+    """The classical, compensated pairing: bar 1 is short AND the final bar is
+    short by exactly the beats bar 1 is missing, so the two sum to one measure
+    (Bella-Ciao is the real case - 2.0 + 2.0 in 4/4). BOTH bars are the pickup,
+    and both come out of the defective count."""
+    full = [[(4, 0, [(1, 0)])] * 4]        # 4.0 == a full 4/4 bar
+    pickup = [[(2, 0, [(1, 0)])]]          # 2.0 - short of 4/4
+    final = [[(2, 0, [(1, 0)])]]           # 2.0 - and 2.0 + 2.0 == 4.0
+    c = tabextract._bar_conformance(
+        [(pickup, (4, 4)), (full, (4, 4)), (final, (4, 4))])
+    assert (c.short, c.defective, c.defective_bars) == (0, 0, ())
+    assert (c.anacrusis, c.anacrusis_bars) == (2, (1, 3))
+
+
+def test_a_first_bar_short_in_only_one_voice_is_not_a_pickup():
+    """The central adversarial guard (issue #174): a first bar with one voice
+    that FILLS the meter and another that falls short is a dropped note, not a
+    pickup - even when the final bar is a complete measure, the shape that would
+    otherwise complete the pairing. It stays short and defective. This is the
+    _bar_conformance shape of the real Far Promise case."""
+    full = [[(4, 0, [(1, 0)])] * 4]
+    # voice 1 is 1.0, voice 2 fills the bar at 4.0 - the longest voice is NOT
+    # under the meter, so the bar is not wholly short.
+    dropped = [[(4, 0, [(1, 0)])], [(4, 0, [(2, 0)])] * 4]
+    c = tabextract._bar_conformance(
+        [(dropped, (4, 4)), (full, (4, 4)), (full, (4, 4))])
+    assert (c.short, c.defective, c.defective_bars) == (1, 1, (1,))
+    assert (c.anacrusis, c.anacrusis_bars) == (0, ())
+
+
+def test_a_short_first_bar_the_final_bar_does_not_complete_stays_defective():
+    """The other half of the adversarial guard: bar 1 IS wholly short, but the
+    final bar neither is a complete measure nor sums with bar 1 to one - so the
+    first/last pairing does not hold and bar 1 is still counted as not adding
+    up. A short first bar alone never earns the exemption."""
+    full = [[(4, 0, [(1, 0)])] * 3]
+    pickup = [[(4, 0, [(1, 0)])]]          # 1.0, wholly short
+    final = [[(4, 1, [(1, 0)])]]           # 1.5 (dotted quarter); 1.0 + 1.5 != 3.0
+    c = tabextract._bar_conformance(
+        [(pickup, (3, 4)), (full, (3, 4)), (final, (3, 4))])
+    # both the first and last bars are short, and NEITHER is excused
+    assert (c.short, c.defective, c.defective_bars) == (2, 2, (1, 3))
+    assert (c.anacrusis, c.anacrusis_bars) == (0, ())
+
+
+def test_a_single_short_bar_is_never_a_pickup():
+    """A pickup needs a first AND a corroborating final bar, so a lone short bar
+    - which is both - cannot be one. Guards against a one-bar score excusing its
+    only bar into looking clean."""
+    pickup = [[(4, 0, [(1, 0)])]]
+    c = tabextract._bar_conformance([(pickup, (3, 4))])
+    assert (c.short, c.defective, c.anacrusis) == (1, 1, 0)
+
+
+def test_the_pickup_exemption_is_disclosed_in_the_rhythm_warnings():
+    """The exemption is stated out loud, never silent (issue #174): the whole
+    risk is excusing a genuinely short first bar, so the assumption and the bar
+    it was made on reach the reader."""
+    conformance = tabextract._BarConformance(
+        overfull=0, short=0, defective=0, counted=3, anacrusis=1,
+        anacrusis_bars=(1,))
+    warnings, _confidence = tabextract._rhythm_report(
+        collections.Counter({tabextract.PROV_GLYPHS: 1}), {}, conformance)
+    assert any("pickup (anacrusis)" in w and "bars are: 1" in w for w in warnings)
+
+
+def test_sad_song_pickup_is_recognised_and_lifts_its_demotion(sad_song_pdf):
+    """Issue #174 target 1: Sad Song opens on a two-eighth-note pickup that was
+    its ONLY defective bar, so recognising it takes the score to zero defective
+    bars and its rhythm confidence from medium back to high."""
+    result = tabextract.extract(sad_song_pdf)
+    assert result.bars_anacrusis == 1
+    assert result.anacrusis_bars == [1]
+    assert result.bars_defective == 0
+    assert result.bars_short == 0
+    assert result.confidence["rhythm"].startswith("high")
+
+
+def test_singing_mountain_pickup_is_lifted_but_its_other_defect_remains(
+        singing_mountain_pdf):
+    """Issue #174 target 2: Singing Mountain opens on a one-beat pickup but also
+    carries an unrelated short bar (bar 19). The pickup is recognised - bar 1
+    leaves the defective count - while bar 19 keeps the score at medium."""
+    result = tabextract.extract(singing_mountain_pdf)
+    assert result.bars_anacrusis == 1
+    assert result.anacrusis_bars == [1]
+    # bar 19 is a genuine misread and stays defective
+    assert result.bars_defective == 1
+    assert result.confidence["rhythm"].startswith("medium")
+
+
+def test_far_promise_short_first_bar_is_not_excused_as_a_pickup(far_promise_pdf):
+    """Issue #174 adversarial non-fire on a real score: Far Promise's first bar
+    is short in one voice while another voice fills it (a dropped note), and its
+    final bar IS a complete measure - the shape that would complete the pairing.
+    The 'wholly short' guard keeps bar 1 defective and the demotion intact."""
+    result = tabextract.extract(far_promise_pdf)
+    assert result.bars_anacrusis == 0
+    assert result.anacrusis_bars == []
+    assert result.bars_defective == 2       # bars 1 and 16, both still counted
+    assert result.confidence["rhythm"].startswith("medium")
 
 
 def test_short_bars_are_reported_not_padded():
@@ -4346,6 +4467,7 @@ def test_library_wide_repeat_structure_leaves_conformance_untouched(library_root
         totals["bars_overfull"] += result.bars_overfull
         totals["bars_short"] += result.bars_short
         totals["bars_defective"] += result.bars_defective
+        totals["bars_anacrusis"] += result.bars_anacrusis
         totals["bars_padded"] += result.bars_padded
         totals["inferred_rest_quarters"] += result.inferred_rest_quarters
         totals["form_marks_unanchored"] += result.form_marks_unanchored
@@ -4553,10 +4675,27 @@ def test_library_wide_repeat_structure_leaves_conformance_untouched(library_root
     # right takes it out of bars_defective as well: bars_defective falls by 1
     # and bars_short does not move. Still no note, beat or bar moves - the rest
     # is relocated, not dropped or added.
-    assert totals["bars_overfull"] == 1535               # 1541 (#113) -> 1540 (#163) -> 1536 (#140) -> 1535 (#180, bar 16)
-    assert totals["bars_short"] == 4192                  # 4190 -> 4192 (#140); unmoved by #180
-    assert totals["bars_defective"] == 5299              # 5340; -1 at #180 (bar 16 was overfull-only)
-    assert totals["bars_padded"] == 3605                 # 3603 -> 3605 (#140)
+    assert totals["bars_overfull"] == 1535               # 1541 (#113) -> 1540 (#163) -> 1536 (#140) -> 1535 (#180, bar 16); unmoved by #174
+    # -40 at #174: a first-bar pickup (anacrusis) is normal notation, not a
+    # short bar, so _bar_conformance lifts it out of bars_short / bars_defective.
+    # 40 bars are excused across 38 scores (see bars_anacrusis below): 36 scores
+    # excuse their first bar alone, and Bella-Ciao and Peaceful Sleep (NieR
+    # Automata) each also excuse their FINAL bar, the compensated pairing where
+    # bar 1's length plus the final bar's length sum to one measure (Bella-Ciao:
+    # 2.0 + 2.0 in 4/4). Every excused bar was short in every voice, so
+    # bars_short and bars_defective each fall by exactly the same 40.
+    assert totals["bars_short"] == 4152                  # 4190 -> 4192 (#140) -> 4152 (#174, -40)
+    assert totals["bars_defective"] == 5259              # 5340; -1 at #180 (bar 16 overfull-only); -40 at #174 (pickups)
+    # Every excused pickup bar (issue #174) - the count that says how many bars
+    # bars_short and bars_defective each dropped by, and the disclosure a reader
+    # sees. Two of the 38 scores excuse two bars each (the compensated pairing
+    # above), so this is 40, not 38. Verified score by score against the printed
+    # pages for the classification movers: Sad Song (Super Mario RPG), the only
+    # score whose rhythm confidence this lifts from medium to high, is a
+    # two-eighth-note pickup; every other excused first bar leaves its score in
+    # the same rhythm band (it still carries other defects, or was already low).
+    assert totals["bars_anacrusis"] == 40
+    assert totals["bars_padded"] == 3605                 # 3603 -> 3605 (#140); unmoved by #174
     # 4897.875 before #162, 4899.875 after: Answers (Final Fantasy XIV
     # Endwalker) bar 45 held one quarter in each of its two voices in a bar read
     # a system early as 3/4. #162 puts that bar back on the running 4/4 it is


### PR DESCRIPTION
Closes #174

## The gap

Rule 8 (`_BarConformance` in `server/fermata/tabextract.py`) had no anacrusis model. A pickup measure - a deliberately short opening bar a musician reads as a lead-in, not a mistake - was scored exactly like a misread bar, so a score whose only unreliable bar was its pickup took the same rhythm-confidence demotion as one with a genuinely wrong bar.

## The rule (first/last pairing, never bar 1's shape alone)

A new rule - **not** a loosening of the zero-tolerance gate #114 tightened. `_bar_conformance` lifts bar 1 out of the `short`/`defective` counts only when **all** hold:

- there are >= 2 measured bars, bar 1 is the score's real first bar, and the final measured bar is the score's real last bar (a meterless/unread bar at either end disqualifies it);
- bar 1 and the final bar share a meter;
- **bar 1 is short in _every_ voice** (its longest voice under the meter) - the guard that separates a pickup from a dropped note;
- the final bar corroborates the pickup, in one of two shapes:
  - it is a **complete** measure of the shared meter (the *uncompensated* pickup these arrangements use - open mid-measure, close on a full downbeat bar), or
  - it is **itself short** and bar 1 + final bar sum to exactly one measure (the *compensated* pairing, e.g. Bella-Ciao's 2.0 + 2.0 in 4/4, in which the final bar is excused too).

## Why it can't fire on a misread

The single failure mode to defend against is excusing a genuinely short/misread first bar. The **wholly-short** guard does it: a first bar with one voice that fills the meter while another falls short is a dropped note - it stays defective even when its final bar is a complete measure (the shape that would otherwise complete the pairing). Real adversarial case **Score A**: bar 1 reads `[3.0, 4.0]` in 4/4, final bar is complete - it is **not** excused (`bars_anacrusis == 0`, `bars_defective == 2`, still `medium`).

## Disclosed, never silent

A new `bars_anacrusis` count and `anacrusis_bars` list carry which bars were excused through storage and the API (wired through `ExtractionResult`/`to_dict`/`confidence_json`/`_BAR_KEYS`+`_BAR_LIST_KEYS`/`TranscriptionOut`; it is a Rule 8 conformance figure like `bars_padded`, so it is listed in `_RULE8_CONFORMANCE_KEYS` and stays off the web disclosures panel). The rhythm warning names the excused bars and states the pairing it recognised.

## Measured on the configured library (293 extractable of 297)

- **Emitted output (musicxml + alphatex) byte-identical across all 297**, keyed by full relative path. Zero moves. This is a scoring change, not a note change.
- `bars_short` 4192 -> 4152, `bars_defective` 5299 -> 5259 (each -40), `bars_anacrusis` = 40 across 38 scores (36 excuse bar 1 alone; Bella-Ciao and Peaceful Sleep each also excuse their compensated final bar). `bars_overfull`, `bars_padded`, `inferred_rest_quarters` unmoved.
- **Rhythm-confidence moves: exactly two**, both page-verified pickups: **Score B** medium -> high (a two-eighth-note pickup that was its only defect -> zero defective bars), and **Score C** low -> medium (a one-beat pickup crossing the low/medium threshold; it keeps other defects). No non-pickup score's classification moves.
- **Score D**: pickup recognised (`bars_anacrusis == 1`), but bar 19 is a genuine unrelated misread, so `bars_defective` 2 -> 1 and it stays `medium`.
- Repeat-structure confidence census (`structure_high/medium/low` = 256/35/2) unchanged.

## Tests

Synthetic `_bar_conformance` unit tests (uncompensated fire, compensated fire excusing both bars, wholly-short guard, final-not-complementing, single-bar); a disclosure-warning test; and real-library tests for Score B, Score D, and the Score A adversarial non-fire. The library aggregate pins are updated with lineage comments. Mutation-tested: disabling the exemption reds the four pickup-recognition tests plus the aggregate pin, while every adversarial non-fire test stays green.
