### PR TITLE
Validate an edited MusicXML transcription against the real schema when configured

### DIFF
--- a/server/fermata/api.py
+++ b/server/fermata/api.py
@@ -22,6 +22,7 @@ from fastapi import (
     UploadFile,
 )
 from fastapi.responses import FileResponse, Response
+from lxml import etree as lxml_etree
 from pydantic import BaseModel, Field, StrictInt
 
 from . import instruments, practice, scanner, trainer, transcribe_batch
@@ -2116,17 +2117,79 @@ def _sniff_transcription_format(content: str) -> str:
     return "musicxml" if content.lstrip().startswith("<") else "alphatex"
 
 
+# Cached as (path, parsed schema) rather than just the schema, so a changed
+# config.MUSICXML_XSD - which only happens in tests, via monkeypatch; a real
+# deployment sets the environment variable once, before Fermata starts -
+# invalidates the cache instead of going on serving whatever path was parsed
+# first. Parsing the schema is not cheap (it is hundreds of kilobytes with its
+# own imports to resolve), and PUT /scores/{id}/transcription would otherwise
+# pay that cost on every single save.
+_musicxml_schema_cache: tuple[str, "lxml_etree.XMLSchema"] | None = None
+
+
+def _musicxml_schema():
+    """The parsed MusicXML 4.0 schema named by config.MUSICXML_XSD, or None
+    when it is unset or does not name a file that is actually there.
+
+    None is the default-runtime answer, and it is what keeps
+    save_transcription's behaviour unchanged for every deployment that has
+    not opted in: no schema configured means _validate_musicxml_edit is a
+    no-op, exactly as this endpoint has always behaved. Loaded from disk only
+    - this never fetches anything - which matters because the schema's own
+    xsi:noNamespaceSchemaLocation names a remote URL that must not be
+    fetched on every request. See config.MUSICXML_XSD's comment for how a
+    deployment or CI run obtains a local copy.
+    """
+    global _musicxml_schema_cache
+    path = config.MUSICXML_XSD
+    if not path or not os.path.isfile(path):
+        return None
+    if _musicxml_schema_cache is None or _musicxml_schema_cache[0] != path:
+        _musicxml_schema_cache = (path, lxml_etree.XMLSchema(lxml_etree.parse(path)))
+    return _musicxml_schema_cache[1]
+
+
+def _validate_musicxml_edit(content: str) -> None:
+    """422 when a MusicXML edit is not well-formed XML, or is well-formed but
+    invalid against the real MusicXML 4.0 schema - belt-and-suspenders behind
+    the note editor's own client-side Rule 11 guard, against a hand-crafted
+    request (#188). Only called for `fmt == "musicxml"` - alphaTex is never
+    XSD-checked, there being no schema for it.
+
+    A no-op whenever _musicxml_schema() answers None, which is the entire
+    point: an unconfigured deployment must see no change in behaviour, so
+    this function raises nothing until FERMATA_MUSICXML_XSD names a real
+    local schema. Uses the exact same lxml.etree.XMLSchema.validate call as
+    tests/test_musicxml.py's test_validates_against_xsd, against the same
+    schema, rather than a second hand-rolled loader.
+    """
+    schema = _musicxml_schema()
+    if schema is None:
+        return
+    try:
+        doc = lxml_etree.fromstring(content.encode("utf-8"))
+    except lxml_etree.XMLSyntaxError as exc:
+        raise HTTPException(422, f"transcription is not well-formed XML: {exc}") from None
+    if not schema.validate(doc):
+        errors = "; ".join(f"line {e.line}: {e.message}" for e in schema.error_log)
+        raise HTTPException(
+            422, f"transcription does not validate against the MusicXML 4.0 schema: {errors}")
+
+
 @router.put(
     "/scores/{score_id}/transcription", tags=[TAG_TRANSCRIPTION], response_model=TranscriptionOut
 )
 def save_transcription(score_id: RowId, body: TranscriptionEditIn):
     """Save a hand edit, replacing any hand edit already stored - never the
     extraction. `format` is sniffed from the content when not given - see
-    _sniff_transcription_format."""
+    _sniff_transcription_format. A MusicXML edit is also checked against the
+    real schema when one is configured - see _validate_musicxml_edit."""
     fmt = body.format or _sniff_transcription_format(body.content)
     if fmt not in VALID_TRANSCRIPTION_FORMATS:
         raise HTTPException(
             422, f"format must be one of {sorted(VALID_TRANSCRIPTION_FORMATS)}")
+    if fmt == "musicxml":
+        _validate_musicxml_edit(body.content)
     with tx() as conn:
         _live_score_row(conn, score_id, "save a transcription for it")
         conn.execute(

--- a/server/fermata/config.py
+++ b/server/fermata/config.py
@@ -6,6 +6,21 @@ LIBRARY_DIR = Path(os.environ.get("FERMATA_LIBRARY", "./library")).resolve()
 CONFIG_DIR = Path(os.environ.get("FERMATA_CONFIG", "./config")).resolve()
 WEB_DIST = os.environ.get("FERMATA_WEB_DIST", "")
 
+# A local copy of the real MusicXML 4.0 schema (issue #188) - belt-and-
+# suspenders validation of a hand edit PUT to /scores/{id}/transcription,
+# on top of the note editor's own client-side Rule 11 guard. The schema is
+# not something Fermata can carry in the repository or fetch for itself: its
+# own xs:import elements name remote URLs, and a server that fetched them on
+# every save would be a network dependency nobody asked for. So this is empty
+# by default, which is a no-op - PUT accepts an edit exactly as it always
+# has - and only takes effect when it is pointed at a LOCAL file whose own
+# imports were already repointed to resolve locally too. See
+# tests/test_musicxml.py's test_validates_against_xsd, which validates the
+# emitter's own output against the same schema this names, and the "Fetch the
+# MusicXML schema" step in .github/workflows/ci.yml, which is how CI obtains
+# one without committing it.
+MUSICXML_XSD = os.environ.get("FERMATA_MUSICXML_XSD", "")
+
 CACHE_DIR = CONFIG_DIR / "cache"
 DB_PATH = CONFIG_DIR / "fermata.db"
 

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -14,18 +14,23 @@ dependencies = [
     "pymupdf>=1.24",
     "python-multipart>=0.0.9",
     "fonttools>=4.50",
+    # A schema-aware XML parser - the standard library has none. Two things
+    # need it: PUT /scores/{id}/transcription validating a hand edit against
+    # the real MusicXML 4.0 schema when FERMATA_MUSICXML_XSD names one (see
+    # config.MUSICXML_XSD and api.py's _musicxml_schema - #188), and
+    # tests/test_musicxml.py's test_validates_against_xsd checking the
+    # emitter's own output the same way. Both are opt-in - unset, nothing
+    # calls into lxml - but the import has to be real for a deployment that
+    # turns the check on, not merely present for pytest, which is why this is
+    # a core dependency and not a dev one. See
+    # docs/musicxml-tab-profile.md#checking-a-file.
+    "lxml>=5.0",
 ]
 
 [project.optional-dependencies]
 dev = [
     "pytest>=8.0",
     "httpx>=0.27",
-    # Validating emitted MusicXML against the real MusicXML 4.0 XSD, which
-    # needs a schema-aware parser - the standard library has none. The
-    # validation test skips unless FERMATA_MUSICXML_XSD points at a schema, so
-    # this is what makes running it possible rather than what triggers it.
-    # See docs/musicxml-tab-profile.md#checking-a-file.
-    "lxml>=5.0",
     # Validates GET /api/openapi.json against the OpenAPI 3.1 meta-schema -
     # see tests/test_api_docs.py. FastAPI generating SOME document is not the
     # same claim as the document being one a client's codegen can trust.

--- a/server/tests/test_transcription_api.py
+++ b/server/tests/test_transcription_api.py
@@ -13,12 +13,27 @@ runs against the library and still skips without it.
 import ast
 import inspect
 import json
+import os
 import textwrap
 
 import pytest
 from fastapi import HTTPException
 
 from fermata import api, db
+
+# A schema-valid minimal MusicXML document, used anywhere a test needs content
+# that sniffs (or is declared) as "musicxml" and must therefore survive
+# save_transcription's XSD check (#188) when FERMATA_MUSICXML_XSD is set -
+# which CI's "Fetch the MusicXML schema" step does for the whole test job, not
+# just tests/test_musicxml.py. `<score-partwise version="4.0"/>` alone is NOT
+# schema-valid (part-list is required), so it is a trap here specifically.
+MINIMAL_VALID_MUSICXML = (
+    '<?xml version="1.0" encoding="UTF-8"?>\n'
+    '<score-partwise version="4.0">'
+    '<part-list><score-part id="P1"><part-name>Music</part-name></score-part></part-list>'
+    '<part id="P1"><measure number="1"/></part>'
+    "</score-partwise>"
+)
 
 
 def test_edited_transcription_survives_re_extraction(app_env, extractable_pdf, monkeypatch, insert_score):
@@ -339,8 +354,8 @@ def test_an_edit_format_is_sniffed_when_the_client_does_not_say(app_env, insert_
     than assumed, because assuming wrong makes the transcription unrenderable."""
     conn = db.connect()
     score_id = insert_score(conn, "x.pdf")
-    xml = '<?xml version="1.0" encoding="UTF-8"?>\n<score-partwise version="4.0"/>'
-    saved = api.save_transcription(score_id, api.TranscriptionEditIn(content=xml))
+    saved = api.save_transcription(
+        score_id, api.TranscriptionEditIn(content=MINIMAL_VALID_MUSICXML))
     assert saved["format"] == "musicxml"
     tex = ":4 0.1 |"
     saved = api.save_transcription(score_id, api.TranscriptionEditIn(content=tex))
@@ -348,11 +363,17 @@ def test_an_edit_format_is_sniffed_when_the_client_does_not_say(app_env, insert_
 
 
 def test_an_explicit_edit_format_wins_over_the_sniff(app_env, insert_score):
+    """The client's stated format overrides what the content would sniff to -
+    content that starts with '<' and would otherwise sniff as musicxml is
+    stored as alphatex when the client says so, not reinterpreted. (Content
+    that sniffs the OTHER way and is forced to musicxml is exercised in
+    test_pasting_alphatex_over_a_musicxml_row_stores_it_as_alphatex, which
+    uses real MusicXML so it also clears the #188 schema check below.)"""
     conn = db.connect()
     score_id = insert_score(conn, "x.pdf")
     saved = api.save_transcription(
-        score_id, api.TranscriptionEditIn(content=":4 0.1 |", format="musicxml"))
-    assert saved["format"] == "musicxml"
+        score_id, api.TranscriptionEditIn(content="<not actually xml", format="alphatex"))
+    assert saved["format"] == "alphatex"
 
 
 def test_an_unknown_edit_format_is_rejected(app_env, insert_score):
@@ -362,6 +383,113 @@ def test_an_unknown_edit_format_is_rejected(app_env, insert_score):
         api.save_transcription(
             score_id, api.TranscriptionEditIn(content=":4 0.1 |", format="lilypond"))
     assert exc_info.value.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Server-side MusicXML validation of a hand edit (#188)
+# ---------------------------------------------------------------------------
+#
+# The note editor already guards Rule 11 (octaves 0-9, among other things)
+# client-side before a save is ever sent - this is belt-and-suspenders against
+# a hand-crafted PUT that skips the editor entirely. Validating needs the real
+# MusicXML 4.0 schema at runtime, which the repository does not carry (see
+# config.MUSICXML_XSD's comment), so - exactly like
+# tests/test_musicxml.py's test_validates_against_xsd - the test that proves
+# the 422 skips unless FERMATA_MUSICXML_XSD names a local copy. The test that
+# proves an unconfigured deployment is UNCHANGED needs no schema and never
+# skips: that is the default-runtime behaviour target.
+
+# A note whose octave is 10 - out of the schema's 0-9 range (issue #188's own
+# example, and the same Rule 11 case #10 the note editor already refuses
+# client-side) - inside an otherwise well-formed, schema-shaped document, so
+# what fails validation is specifically the octave, not a missing part-list
+# or the like.
+INVALID_MUSICXML_OUT_OF_RANGE_OCTAVE = (
+    '<?xml version="1.0" encoding="UTF-8"?>\n'
+    '<score-partwise version="4.0">'
+    '<part-list><score-part id="P1"><part-name>Music</part-name></score-part></part-list>'
+    '<part id="P1"><measure number="1">'
+    "<note><pitch><step>C</step><octave>10</octave></pitch>"
+    "<duration>4</duration><type>quarter</type></note>"
+    "</measure></part>"
+    "</score-partwise>"
+)
+
+
+def test_an_invalid_musicxml_edit_is_rejected_when_a_schema_is_configured(
+    app_env, insert_score, monkeypatch
+):
+    """A hand-crafted PUT carrying an out-of-range octave is refused with 422
+    and nothing is stored - the prior state (nothing) is unchanged - but only
+    once FERMATA_MUSICXML_XSD actually names a schema to check against."""
+    path = os.environ.get("FERMATA_MUSICXML_XSD")
+    if not path or not os.path.isfile(path):
+        pytest.skip("FERMATA_MUSICXML_XSD not set to a musicxml.xsd")
+    conn = db.connect()
+    score_id = insert_score(conn, "x.pdf")
+
+    with pytest.raises(HTTPException) as exc_info:
+        api.save_transcription(
+            score_id, api.TranscriptionEditIn(content=INVALID_MUSICXML_OUT_OF_RANGE_OCTAVE))
+    assert exc_info.value.status_code == 422
+
+    row = conn.execute(
+        "SELECT * FROM transcriptions WHERE score_id = ? AND source = 'edited'", (score_id,)
+    ).fetchone()
+    assert row is None
+
+
+def test_a_valid_musicxml_edit_is_stored_when_a_schema_is_configured(app_env, insert_score):
+    """The counterpart to the rejection test above: a well-formed, schema-valid
+    edit is still accepted (and stored) once FERMATA_MUSICXML_XSD is set -
+    the check does not merely reject everything."""
+    path = os.environ.get("FERMATA_MUSICXML_XSD")
+    if not path or not os.path.isfile(path):
+        pytest.skip("FERMATA_MUSICXML_XSD not set to a musicxml.xsd")
+    conn = db.connect()
+    score_id = insert_score(conn, "x.pdf")
+
+    saved = api.save_transcription(
+        score_id, api.TranscriptionEditIn(content=MINIMAL_VALID_MUSICXML))
+    assert saved["format"] == "musicxml"
+    row = conn.execute(
+        "SELECT * FROM transcriptions WHERE score_id = ? AND source = 'edited'", (score_id,)
+    ).fetchone()
+    assert row is not None
+
+
+def test_an_invalid_musicxml_edit_is_accepted_when_no_schema_is_configured(
+    app_env, insert_score, monkeypatch
+):
+    """The default-runtime target: with FERMATA_MUSICXML_XSD unset (or naming
+    nothing readable), save_transcription behaves exactly as it did before
+    #188 - the same out-of-range-octave body that a configured schema rejects
+    above is accepted and stored here. Needs no schema, so it never skips."""
+    monkeypatch.setattr(api.config, "MUSICXML_XSD", "")
+    conn = db.connect()
+    score_id = insert_score(conn, "x.pdf")
+
+    saved = api.save_transcription(
+        score_id, api.TranscriptionEditIn(content=INVALID_MUSICXML_OUT_OF_RANGE_OCTAVE))
+    assert saved["format"] == "musicxml"
+    row = conn.execute(
+        "SELECT * FROM transcriptions WHERE score_id = ? AND source = 'edited'", (score_id,)
+    ).fetchone()
+    assert row is not None
+    assert row["content"] == INVALID_MUSICXML_OUT_OF_RANGE_OCTAVE
+
+
+def test_an_alphatex_edit_is_unaffected_by_the_schema_check(app_env, insert_score):
+    """Only a MusicXML-formatted edit is ever run through the XSD - alphaTex
+    has no schema to check against, so it must be unaffected either way. Uses
+    whatever FERMATA_MUSICXML_XSD is (or is not) in this run rather than
+    forcing one, because the point is that alphatex bypasses the check
+    entirely - not that a schema happens to be present."""
+    conn = db.connect()
+    score_id = insert_score(conn, "x.pdf")
+    saved = api.save_transcription(
+        score_id, api.TranscriptionEditIn(content=":4 0.1 |", format="alphatex"))
+    assert saved["format"] == "alphatex"
 
 
 def test_pasting_alphatex_over_a_musicxml_row_stores_it_as_alphatex(
@@ -385,8 +513,8 @@ def test_pasting_alphatex_over_a_musicxml_row_stores_it_as_alphatex(
     assert api.get_transcription(score_id)["format"] == "alphatex"
 
     # and the reverse: MusicXML pasted over an alphatex row
-    xml = '<?xml version="1.0"?>\n<score-partwise version="4.0"/>'
-    saved = api.save_transcription(score_id, api.TranscriptionEditIn(content=xml))
+    saved = api.save_transcription(
+        score_id, api.TranscriptionEditIn(content=MINIMAL_VALID_MUSICXML))
     assert saved["format"] == "musicxml"
 
 


### PR DESCRIPTION
Closes #188

## What

`PUT /scores/{id}/transcription` stored a hand edit verbatim and never
re-validated it - the note editor guards Rule 11 client-side, but a
hand-crafted request could send anything. This adds a server-side check as
belt-and-suspenders behind that guard.

## Design (matches the design tension the issue names)

The MusicXML 4.0 schema cannot live in the repository (too large) or be
fetched over the network on every save (its own `xs:import` elements name
remote URLs). So the check is opt-in, reusing the exact mechanism
`tests/test_musicxml.py`'s `test_validates_against_xsd` already established:

- `FERMATA_MUSICXML_XSD` unset, or not naming a readable file: `save_transcription`
  behaves exactly as it does today - no change for any existing deployment.
- `FERMATA_MUSICXML_XSD` set to a local schema (as CI's "Fetch the MusicXML
  schema" step already sets it for the whole server test job) AND the edited
  body sniffs/declares as `musicxml`: the body is validated with the same
  `lxml.etree.XMLSchema(...).validate(...)` call the emitter test uses,
  against the same schema - not a second hand-rolled loader - and rejected
  with 422 on failure.
- alphaTex edits are never XSD-checked; there is no schema for them.

The schema is loaded from disk only (`lxml_etree.parse(path)`), never
fetched: verified that neither an `xsi:noNamespaceSchemaLocation` hint in a
submitted body nor a DOCTYPE external entity triggers a network call.

`lxml` moves from a dev-only dependency to a core one, since `api.py` (not
just tests) now conditionally imports it. It was already installed for
`tests/test_musicxml.py`; this makes it available to the request path
without a lazy/guarded import that could silently no-op a deployment that
believed it had turned validation on.

## Tests

Added to `tests/test_transcription_api.py`:
- `test_an_invalid_musicxml_edit_is_rejected_when_a_schema_is_configured` -
  an out-of-range `<octave>10</octave>` (Rule 11 case #10) is refused 422 and
  nothing is stored. Skip-gated on `FERMATA_MUSICXML_XSD`, exactly like the
  emitter's own schema test.
- `test_a_valid_musicxml_edit_is_stored_when_a_schema_is_configured` - the
  counterpart: a schema-valid edit still saves. Also skip-gated.
- `test_an_invalid_musicxml_edit_is_accepted_when_no_schema_is_configured` -
  the same invalid body is accepted when no schema is configured. Never
  skips; needs no schema.
- `test_an_alphatex_edit_is_unaffected_by_the_schema_check` - alphaTex
  bypasses the check either way.

Also fixed three existing tests that used a schema-invalid MusicXML stub
(`<score-partwise version="4.0"/>`, missing the required `part-list`) or
forced `format="musicxml"` onto content that isn't XML at all - both now
caught by the new check, and would otherwise fail under CI, which already
sets `FERMATA_MUSICXML_XSD` for the entire server test job.

## Verified locally

Fetched the same MusicXML 4.0 schema CI fetches (from the tagged W3C
release, with `xml.xsd`/`xlink.xsd` repointed locally, same as the CI step)
to exercise both branches:
- Without `FERMATA_MUSICXML_XSD`: full server suite passes, identical to the
  pre-change baseline (same 1 pre-existing, order-dependent failure in
  `test_engraved_fixtures.py` unrelated to this change - confirmed present
  on `origin/main` before this branch's changes too).
- With `FERMATA_MUSICXML_XSD` set: full server suite passes (1178 passed vs
  1171 without, since the two schema-gated emitter tests and the four new
  ones now run instead of skipping); no regressions.
- Mutation test: reverted the `_validate_musicxml_edit` call in
  `save_transcription`, confirmed `test_an_invalid_musicxml_edit_is_rejected_when_a_schema_is_configured`
  goes red (`DID NOT RAISE HTTPException`), restored, confirmed green again.
- `test_every_route_has_exactly_the_expected_operation_count` still passes
  unchanged - no new route was added.
- Confirmed no network call: a submitted body's own
  `xsi:noNamespaceSchemaLocation` pointing at an unreachable host returns
  instantly, and a DOCTYPE external entity is refused as a syntax error
  rather than dereferenced.