### PR TITLE
Note editor: keyboard core loop (arrows, digit-sets-fret, backspace) (#186)

### DIFF
--- a/web/src/lib/TabViewer.svelte
+++ b/web/src/lib/TabViewer.svelte
@@ -185,6 +185,17 @@
   let redoStack = $state([]);
   let overlay = $state(null);
 
+  // The keyboard core loop's two-digit fret entry (#186). Typing a digit with a
+  // note selected sets its fret immediately (so "1" then a pause commits fret
+  // 1); a second digit that follows within TWO_DIGIT_MS on the SAME note
+  // extends it to a two-digit fret ("1" then a quick "2" = fret 12). Plain
+  // (non-reactive) state - nothing renders from it, it only remembers the last
+  // digit long enough to decide extend-vs-fresh at the next keypress, decided
+  // by a timestamp compare rather than a timer that could outlive the note.
+  // null between entries.
+  const TWO_DIGIT_MS = 600;
+  let fretEntry = null;
+
   function canEditNotes() {
     return editable && format === "musicxml" && tex != null;
   }
@@ -209,6 +220,9 @@
     divergenceOk = true;
     overlay = null;
     editWarn = "";
+    // A fresh selection (or none) starts a fresh two-digit fret window - a
+    // digit typed on a new note must never extend the last note's fret.
+    fretEntry = null;
   }
 
   function enterEdit() {
@@ -243,6 +257,7 @@
     const ord = view.editor.hitTest(clientX, clientY);
     if (ord == null) return;
     editWarn = "";
+    fretEntry = null;
     selectedOrdinal = ord;
     refreshSelection();
   }
@@ -330,6 +345,81 @@
 
   function changeDuration(type) {
     applyEdit(() => doc.setDurationType(selectedOrdinal, type), "That duration can't be written for this note.");
+  }
+
+  // ----------------------------------------------- the keyboard core loop (#186)
+  //
+  // Arrows move the selection, a digit sets the fret, Backspace deletes - all on
+  // the window key handler beside the transport shortcuts (see onKey), claimed
+  // only while a note is selected so the same keys still drive the transport and
+  // the staff-profile switch when it is not. NO key here starts playback: moving
+  // the selection is a document-model walk, not a transport seek, and the
+  // transport stays live throughout (Space still plays, even mid-edit).
+
+  // Move the selection note-to-note (kind "note") or bar-to-bar (kind
+  // "measure"), the editor's two arrow granularities - the same split the
+  // transport's own arrows make (a beat, and a whole bar). No playback: this
+  // only re-reads a different note into the selection.
+  function moveSelection(kind, direction) {
+    if (selectedOrdinal == null || !doc) return;
+    // Moving off the note ends its two-digit fret window.
+    fretEntry = null;
+    const target = kind === "measure" ? doc.stepMeasure(selectedOrdinal, direction) : doc.stepNote(selectedOrdinal, direction);
+    if (target == null || target === selectedOrdinal) return;
+    editWarn = "";
+    selectedOrdinal = target;
+    refreshSelection();
+  }
+
+  // A digit typed with a note selected. Sets the fret to that digit at once; a
+  // second digit within TWO_DIGIT_MS on the same note extends it to two digits
+  // (see fretEntry's declaration). Both paths write through the same
+  // applyEdit/doc.setFret the panel's Fret field uses, so the exact same
+  // writable-pitch bound (Rule 11, MIDI 12-131 / octaves 0-9) refuses an
+  // out-of-range fret here too - a two-digit value that would exceed it is
+  // refused, the already-committed single digit left in place.
+  const FRET_REFUSAL = "That fret would put the note outside the pitch range MusicXML can write (octaves 0–9).";
+  function typeFretDigit(d) {
+    if (selectedOrdinal == null || !doc) return;
+    const now = typeof performance !== "undefined" ? performance.now() : Date.now();
+    const extend = fretEntry && fretEntry.ordinal === selectedOrdinal && now - fretEntry.at <= TWO_DIGIT_MS;
+    if (extend) {
+      const combined = fretEntry.value * 10 + d;
+      // A two-digit fret is complete - a third digit starts a fresh entry
+      // rather than building a three-digit number no fretboard has.
+      fretEntry = null;
+      applyEdit(() => doc.setFret(selectedOrdinal, combined), FRET_REFUSAL);
+    } else {
+      fretEntry = { ordinal: selectedOrdinal, value: d, at: now };
+      applyEdit(() => doc.setFret(selectedOrdinal, d), FRET_REFUSAL);
+    }
+  }
+
+  // Backspace deletes the selected note by turning it into a rest (doc.deleteNote
+  // - see its comment for why a rest, not a removal). The delete shifts every
+  // ordinal after it, so the model is rebuilt from the new text (as undo's
+  // restore does) rather than trusting the in-place ordinal map; the note that
+  // slid into the selected slot stays selected, or the selection clears if the
+  // deleted note was the last one.
+  async function deleteSelected() {
+    if (selectedOrdinal == null || !doc || !view) return;
+    fretEntry = null;
+    const before = doc.text();
+    if (!doc.deleteNote(selectedOrdinal)) {
+      editWarn = "That note can't be deleted.";
+      return;
+    }
+    const after = doc.text();
+    if (after === before) return;
+    editWarn = "";
+    undoStack = [...undoStack, before];
+    redoStack = [];
+    dirty = true;
+    doc = createDocument(after);
+    editStringCount = doc.stringCount;
+    await view.editor.reload(after);
+    if (doc.noteAt(selectedOrdinal)) refreshSelection();
+    else clearSelection();
   }
 
   async function restore(text) {
@@ -679,6 +769,46 @@
       // for L/N/C, a rapid double-toggle that looks like nothing happened).
       return;
     }
+    // The keyboard core loop (#186) shares this one window handler with the
+    // transport and the staff-profile switch, and must not fight them. The
+    // arbitration rule: the editor claims arrows, digits and Backspace ONLY
+    // while a note is selected (editMode && selectedOrdinal != null); in every
+    // other state those keys fall through untouched to the switch below. So a
+    // digit sets the selected note's fret when one is selected and switches the
+    // staff profile when none is (keys "1"/"2"/"3" there); Backspace deletes the
+    // selected note when one is selected and stops the transport when none is;
+    // arrows move the selection when one is selected and move the playback
+    // cursor when none is. Every claimed key returns here, so it is handled once
+    // and never also by the switch. Space, L, S, N, C, T are never claimed - so
+    // the transport stays fully live while editing (a correction can be heard
+    // the instant it is made), which is why a note stays selected through it.
+    if (editMode && selectedOrdinal != null) {
+      switch (e.key) {
+        case "ArrowLeft":
+        case "ArrowRight":
+          e.preventDefault();
+          moveSelection("note", e.key === "ArrowRight" ? 1 : -1);
+          return;
+        case "ArrowUp":
+        case "ArrowDown":
+          e.preventDefault();
+          moveSelection("measure", e.key === "ArrowDown" ? 1 : -1);
+          return;
+        case "Backspace":
+          e.preventDefault();
+          deleteSelected();
+          return;
+        default:
+          if (e.key.length === 1 && e.key >= "0" && e.key <= "9") {
+            e.preventDefault();
+            typeFretDigit(Number(e.key));
+            return;
+          }
+          // Not an editor key (Space, L, S, ...): end any open two-digit fret
+          // window and let the transport/profile switch below handle it.
+          fretEntry = null;
+      }
+    }
     switch (e.key) {
       case " ":
         // A focused BUTTON owns Space already - see isButtonLikeTarget.
@@ -1008,10 +1138,10 @@
 
   <!-- Selecting a note is a spatial gesture: the click is hit-tested against
        the rendered note-head positions, which have no keyboard analogue here.
-       Note-to-note keyboard navigation (arrow keys, digit-sets-fret) is the
-       note-entry work #10 defers to a follow-up; when it lands it belongs on
-       the window key handler beside the transport shortcuts, not as a keydown
-       twin of this container's click. The staff itself is not a control. -->
+       Note-to-note keyboard navigation (arrow keys, digit-sets-fret, Backspace)
+       arrived in #186 and lives on the window key handler beside the transport
+       shortcuts (see onKey's arbitration comment), not as a keydown twin of
+       this container's click. The staff itself is not a control. -->
   <!-- svelte-ignore a11y_click_events_have_key_events -->
   <!-- svelte-ignore a11y_no_static_element_interactions -->
   <div

--- a/web/src/lib/editor/document.js
+++ b/web/src/lib/editor/document.js
@@ -103,6 +103,25 @@ export function createDocument(xml) {
   // are skipped by both, consistently.
   const noteEls = [...doc.getElementsByTagName("note")].filter((n) => !isRest(n));
 
+  // The `<measure number>` each sounding note sits in, indexed by ordinal - the
+  // model's coarse navigation unit. The keyboard core loop (#186) steps the
+  // selection note-to-note along this array (an ordinal +/- 1) and bar-to-bar
+  // across it (the next/previous measure), mirroring the transport's own two
+  // arrow granularities (a beat, and a whole bar - see score-render.js's
+  // moveCursorBeat / moveCursorBar). Read once here rather than walked on every
+  // keypress. `closest` is a DOM method the parsed elements carry.
+  const measureNums = noteEls.map((el) => {
+    const m = el.closest ? el.closest("measure") : null;
+    const n = m ? Number(m.getAttribute("number")) : NaN;
+    return Number.isFinite(n) ? n : null;
+  });
+  // The distinct measures in document order, so bar-to-bar stepping works even
+  // when measure numbers are not a contiguous 1..N run (a pickup numbered 0, a
+  // repeat that re-uses a number): the neighbour is the adjacent entry HERE,
+  // not measureNum +/- 1.
+  const measureOrder = [];
+  for (const n of measureNums) if (n != null && !measureOrder.includes(n)) measureOrder.push(n);
+
   function describe(el, ordinal) {
     const tech = technicalOf(el);
     const string = tech ? Number(tagText(tech, "string")) : null;
@@ -121,7 +140,45 @@ export function createDocument(xml) {
       type,
       dots,
       midi,
+      measure: measureNums[ordinal] ?? null,
     };
+  }
+
+  /**
+   * The ordinal of the sounding note one step forward (direction > 0) or back
+   * (direction < 0) in document order, or null at (or past) either end - the
+   * keyboard core loop's note-to-note move (#186). Pure: it reports where the
+   * caller's selection should go, it does not touch the document.
+   */
+  function stepNote(ordinal, direction) {
+    if (!Number.isInteger(ordinal)) return null;
+    const next = ordinal + (direction > 0 ? 1 : -1);
+    return next >= 0 && next < noteEls.length ? next : null;
+  }
+
+  /**
+   * The ordinal of the sounding note in the adjacent measure (direction > 0
+   * next, < 0 previous) at the same position within that measure - the
+   * keyboard core loop's bar-to-bar move (#186). When the target measure holds
+   * fewer notes, the last note in it; when there is no adjacent measure with a
+   * sounding note, null. Pure, like stepNote.
+   */
+  function stepMeasure(ordinal, direction) {
+    const here = measureNums[ordinal];
+    if (here == null) return null;
+    const at = measureOrder.indexOf(here);
+    const target = measureOrder[at + (direction > 0 ? 1 : -1)];
+    if (target == null) return null;
+    // The selected note's index within its own measure, and every ordinal in
+    // the target measure - so the move lands on the same-numbered note there.
+    let indexInMeasure = 0;
+    const inTarget = [];
+    for (let i = 0; i < noteEls.length; i++) {
+      if (measureNums[i] === here && i < ordinal) indexInMeasure += 1;
+      if (measureNums[i] === target) inTarget.push(i);
+    }
+    if (inTarget.length === 0) return null;
+    return inTarget[Math.min(indexInMeasure, inTarget.length - 1)];
   }
 
   function soundingNotes() {
@@ -232,6 +289,35 @@ export function createDocument(xml) {
     return true;
   }
 
+  /**
+   * Delete a sounding note by turning it into a rest (#186's Backspace) - the
+   * model's own notion of delete. This file's header pins rests as the notes
+   * that "keep their place in document order" and are "not offered as edit
+   * targets"; a deleted note becomes exactly that. Its `<duration>`, `<voice>`
+   * and `<type>` are kept and a `<rest/>` put where its `<pitch>` was, so the
+   * bar's arithmetic is unchanged - the note becomes the same length of silence
+   * in the same place, rather than the note being removed and the bar left
+   * short. On re-parse it drops out of `noteEls` (isRest filters it), so the
+   * ordinals after it close up by one - the caller rebuilds the model from the
+   * new text (as undo's restore does) rather than trust this in-place array.
+   * Returns true when the document changed.
+   */
+  function deleteNote(ordinal) {
+    const el = noteEls[ordinal];
+    if (!el || isRest(el)) return false;
+    // <rest> stands where <pitch>/<unpitched>/<rest> go in the schema: first,
+    // before <duration>. Drop the sounding-note-only children (<pitch>, the
+    // <notations> that carried <technical> string/fret, and any <accidental>)
+    // and insert <rest/> at the front.
+    for (const tag of ["pitch", "notations", "accidental"]) {
+      const child = firstChildTag(el, tag);
+      if (child) el.removeChild(child);
+    }
+    const rest = doc.createElement("rest");
+    el.insertBefore(rest, el.firstChild);
+    return true;
+  }
+
   function text() {
     const body = new XMLSerializer().serializeToString(root);
     // DOMParser drops the XML declaration; the server sniffs "starts with <"
@@ -246,9 +332,12 @@ export function createDocument(xml) {
     soundingNotes,
     noteAt,
     count: () => noteEls.length,
+    stepNote,
+    stepMeasure,
     setFret,
     setString,
     setDurationType,
+    deleteNote,
     text,
   };
 }

--- a/web/tests/browser/score-editor-keyboard-186.spec.js
+++ b/web/tests/browser/score-editor-keyboard-186.spec.js
@@ -1,0 +1,250 @@
+// The note editor's keyboard core loop (#186), end to end against the real
+// alphaTab render and the real editor/document.js parse - the same fixture and
+// stub the first-increment suite uses (score-editor.spec.js, fixtures/
+// editor-score.js), only the HTTP transport stubbed. Every assertion is on
+// state the app publishes onto the DOM (data-editor-* / data-score-* /
+// data-cursor-*) or the read-only geometry hook window.__scoreEditor, never on
+// an internal reached into.
+//
+// This increment adds, on the shared window key handler beside the transport
+// shortcuts: arrows move the SELECTION (note-to-note and bar-to-bar) starting no
+// playback; a digit sets the selected note's fret, a quick second digit
+// extending it to two digits; Backspace deletes the selected note (to a rest).
+// The arbitration under test is that the editor claims those keys ONLY while a
+// note is selected, so the number-key staff-profile switch and the transport
+// keep working when it is not.
+//
+// What each mutation would turn red, so this suite is falsifiable, not green by
+// construction:
+//   - drop the editor's arrow handling: ArrowRight moves the playback cursor
+//     instead of the selection -> "arrows move the selection" red (the
+//     selection does not change, and data-cursor-tick leaves 0).
+//   - drop the digit handling: a digit switches the profile instead of setting
+//     the fret -> "a digit sets the fret" and "a digit sets the fret, not the
+//     profile" red.
+//   - drop the two-digit window: "1" then "2" reads fret 2, not 12 -> the
+//     two-digit test red.
+//   - drop the writable-pitch bound reuse: a two-digit fret past B9 is written
+//     -> "a two-digit fret past the writable bound is refused" red.
+//   - drop the Backspace handling (or deleteNote): the sounding-note count
+//     stays 8 -> "Backspace deletes the selected note" red.
+//   - claim the keys unconditionally (ignore the selection guard): pressing a
+//     digit with nothing selected stops switching the profile -> "a number key
+//     still switches the staff profile" red.
+import { test, expect } from "@playwright/test";
+
+import { EDITOR_MUSICXML, stubEditorApi } from "./fixtures/editor-score.js";
+
+const wrap = (page) => page.locator(".staff-render .wrap");
+const host = (page) => page.locator(".staff-render .at-host");
+// Scoped to the transport row: the edit panel's Save button is also
+// button.primary, so a bare button.primary would match two elements in edit
+// mode. This is the Play/Pause button only.
+const playButton = (page) => page.locator(".staff-render .player button.primary");
+
+// Longer than the component's own two-digit window (TWO_DIGIT_MS = 600ms in
+// TabViewer.svelte) - the pause after which a second digit is a fresh
+// single-digit fret rather than an extension of the first.
+const PAST_TWO_DIGIT_WINDOW_MS = 900;
+
+async function renderedOk(page) {
+  await expect(host(page)).toHaveAttribute("data-score-render-ok", "true");
+}
+
+async function openEditor(page, content) {
+  const handle = await stubEditorApi(page, content);
+  await page.goto("/#/score/1");
+  await page.waitForSelector(".staff-render");
+  // Full-width staff, so the whole score is one active pane whose window key
+  // handler answers the keyboard (side-by-side would cede the arrows to the PDF
+  // pane - see TabViewer's `active` prop).
+  await page.getByRole("button", { name: "Staff", exact: true }).click();
+  await renderedOk(page);
+  await page.getByRole("button", { name: "Edit notes" }).click();
+  await expect(wrap(page)).toHaveAttribute("data-editor-active", "true");
+  // The notation-staff flip re-renders; wait until the geometry hook reports the
+  // whole score (8 sounding notes) is laid out before touching anything.
+  await expect.poll(() => page.evaluate(() => window.__scoreEditor?.noteCount() ?? 0)).toBe(8);
+  return handle;
+}
+
+async function selectNote(page, ordinal) {
+  const point = await page.evaluate((o) => window.__scoreEditor.headPoint(o), ordinal);
+  expect(point, `note ${ordinal} has a clickable head`).toBeTruthy();
+  await page.mouse.click(point.x, point.y);
+  await expect(wrap(page)).toHaveAttribute("data-editor-selected", String(ordinal));
+}
+
+test.describe("note editor keyboard core loop", () => {
+  test("arrow keys move the selection note-to-note and bar-to-bar, starting no playback", async ({ page }) => {
+    await openEditor(page, EDITOR_MUSICXML);
+    await selectNote(page, 0);
+    // Baseline transport: not playing, and wherever the playback cursor is
+    // parked (captured, not assumed - the point under test is that the arrows do
+    // not MOVE it, not where it starts).
+    await expect(playButton(page)).toHaveText(/Play/);
+    const tick0 = await host(page).getAttribute("data-cursor-tick");
+    const bar0 = await host(page).getAttribute("data-cursor-bar");
+
+    // ArrowRight -> the next note (ordinal 1, fret 2). The editor claimed the
+    // arrow, so the playback cursor did NOT advance and nothing began playing -
+    // the same key on the transport would have moved the beat cursor off tick0.
+    await page.keyboard.press("ArrowRight");
+    await expect(wrap(page)).toHaveAttribute("data-editor-selected", "1");
+    await expect(wrap(page)).toHaveAttribute("data-editor-selected-fret", "2");
+    await expect(host(page)).toHaveAttribute("data-cursor-tick", tick0 ?? "0");
+    await expect(playButton(page)).toHaveText(/Play/);
+
+    // ArrowLeft -> back to the first note.
+    await page.keyboard.press("ArrowLeft");
+    await expect(wrap(page)).toHaveAttribute("data-editor-selected", "0");
+
+    // ArrowDown -> the same position one bar on: measure 2's first note is
+    // ordinal 4, on string 2. The transport's own ArrowDown moves a WHOLE BAR of
+    // playback cursor (data-cursor-bar off bar0); this must not, since the
+    // editor owns the key while a note is selected.
+    await page.keyboard.press("ArrowDown");
+    await expect(wrap(page)).toHaveAttribute("data-editor-selected", "4");
+    await expect(wrap(page)).toHaveAttribute("data-editor-selected-string", "2");
+    await expect(host(page)).toHaveAttribute("data-cursor-bar", bar0 ?? "0");
+
+    // ArrowUp -> back to measure 1's first note.
+    await page.keyboard.press("ArrowUp");
+    await expect(wrap(page)).toHaveAttribute("data-editor-selected", "0");
+
+    // Still not playing, still parked where it began after all four arrows, and
+    // the document and render still agree about the selected note.
+    await expect(playButton(page)).toHaveText(/Play/);
+    await expect(host(page)).toHaveAttribute("data-cursor-tick", tick0 ?? "0");
+    await expect(wrap(page)).toHaveAttribute("data-editor-divergence-ok", "true");
+  });
+
+  test("typing a digit sets the selected note's fret", async ({ page }) => {
+    await openEditor(page, EDITOR_MUSICXML);
+    // Note 0: string 1 (E4), fret 0, MIDI 64.
+    await selectNote(page, 0);
+    await expect(wrap(page)).toHaveAttribute("data-editor-selected-midi", "64");
+    await page.keyboard.press("5");
+    // Fret 5 on the high E string sounds A4 = 69 = 64 + 5.
+    await expect(wrap(page)).toHaveAttribute("data-editor-selected-fret", "5");
+    await expect(wrap(page)).toHaveAttribute("data-editor-selected-midi", "69");
+    await expect(wrap(page)).toHaveAttribute("data-editor-divergence-ok", "true");
+    await expect(wrap(page)).toHaveAttribute("data-editor-dirty", "true");
+  });
+
+  test("two digits in quick succession set a two-digit fret", async ({ page }) => {
+    await openEditor(page, EDITOR_MUSICXML);
+    // Note 0: string 1 (E4 = 64). "1" then a quick "2" is fret 12, not 1 then 2.
+    await selectNote(page, 0);
+    await page.keyboard.press("1");
+    await page.keyboard.press("2");
+    await expect(wrap(page)).toHaveAttribute("data-editor-selected-fret", "12");
+    // fret 12 on the high E string sounds E5 = 76 = 64 + 12.
+    await expect(wrap(page)).toHaveAttribute("data-editor-selected-midi", "76");
+    await expect(wrap(page)).toHaveAttribute("data-editor-divergence-ok", "true");
+  });
+
+  test("the two-digit window expiring commits a single-digit fret", async ({ page }) => {
+    await openEditor(page, EDITOR_MUSICXML);
+    await selectNote(page, 0);
+    await page.keyboard.press("1");
+    // The single digit is committed at once.
+    await expect(wrap(page)).toHaveAttribute("data-editor-selected-fret", "1");
+    // Past the window, the next digit is a fresh single-digit fret, not an
+    // extension to 12.
+    await page.waitForTimeout(PAST_TWO_DIGIT_WINDOW_MS);
+    await page.keyboard.press("2");
+    await expect(wrap(page)).toHaveAttribute("data-editor-selected-fret", "2");
+    await expect(wrap(page)).toHaveAttribute("data-editor-divergence-ok", "true");
+  });
+
+  test("a two-digit fret past the writable bound is refused", async ({ page }) => {
+    await openEditor(page, EDITOR_MUSICXML);
+    // Note 4: string 2 (B3 = 59). Fret 9 sounds 68 (writable); a second "9"
+    // would make fret 99 = MIDI 158 = octave 12, which MusicXML's <octave> (0-9)
+    // cannot express (Rule 11) - the same writable-pitch bound the panel's Fret
+    // field enforces. The extension is refused; the committed single digit
+    // stays.
+    await selectNote(page, 4);
+    await page.keyboard.press("9");
+    await expect(wrap(page)).toHaveAttribute("data-editor-selected-fret", "9");
+    await page.keyboard.press("9");
+    await expect(wrap(page)).toHaveAttribute("data-editor-selected-fret", "9");
+    await expect(wrap(page)).toHaveAttribute("data-editor-warn", /octaves 0–9/);
+  });
+
+  test("Backspace deletes the selected note to a rest, re-rendering, guard green", async ({ page }) => {
+    const { saved } = await openEditor(page, EDITOR_MUSICXML);
+    // Note 2: string 1, fret 3 (G4), id n1-1-2-0.
+    await selectNote(page, 2);
+    await expect(wrap(page)).toHaveAttribute("data-editor-selected-fret", "3");
+    await expect(wrap(page)).toHaveAttribute("data-editor-divergence-ok", "true");
+
+    await page.keyboard.press("Backspace");
+    // One fewer sounding note: 8 -> 7, proving the delete re-imported and
+    // re-rendered rather than only mutating the document.
+    await expect.poll(() => page.evaluate(() => window.__scoreEditor?.noteCount() ?? 0)).toBe(7);
+    // The note that followed slid into ordinal 2 (old ordinal 3: A4, fret 5),
+    // still selected, and the document and render still agree about it (guard
+    // green after the operation).
+    await expect(wrap(page)).toHaveAttribute("data-editor-selected", "2");
+    await expect(wrap(page)).toHaveAttribute("data-editor-selected-fret", "5");
+    await expect(wrap(page)).toHaveAttribute("data-editor-divergence-ok", "true");
+    await expect(wrap(page)).toHaveAttribute("data-editor-dirty", "true");
+
+    // Persisted as a rest through the edited-transcription path - the model's
+    // own notion of delete (the note kept its place as silence).
+    await page.getByRole("button", { name: "Save", exact: true }).click();
+    await expect(wrap(page)).toHaveAttribute("data-editor-dirty", "false");
+    await expect.poll(() => saved.content).toContain("<rest");
+  });
+
+  test("a number key still switches the staff profile when no note is selected", async ({ page }) => {
+    await stubEditorApi(page, EDITOR_MUSICXML);
+    await page.goto("/#/score/1");
+    await page.waitForSelector(".staff-render");
+    await page.getByRole("button", { name: "Staff", exact: true }).click();
+    await renderedOk(page);
+    // Not in edit mode, nothing selected: the editor claims no keys, so the
+    // digits drive the staff-profile switch exactly as they did before #186.
+    // ("2" and "3" - this score's tab has no separate notation-only profile, so
+    // its options are tab and scoretab; "1" would be a no-op here.)
+    await page.keyboard.press("2");
+    await expect(host(page)).toHaveAttribute("data-score-profile", "tab");
+    await page.keyboard.press("3");
+    await expect(host(page)).toHaveAttribute("data-score-profile", "scoretab");
+  });
+
+  test("a number key sets the fret, not the profile, when a note is selected", async ({ page }) => {
+    await openEditor(page, EDITOR_MUSICXML);
+    // Edit mode forces the both-staves profile; hold that fixed as the control.
+    await expect(host(page)).toHaveAttribute("data-score-profile", "scoretab");
+    await selectNote(page, 0);
+    // "2" is the staff-profile "tab" key when nothing is selected - so if the
+    // digit leaked through with a note selected, the profile would flip to
+    // "tab". It must instead set the fret and leave the profile alone.
+    await page.keyboard.press("2");
+    await expect(wrap(page)).toHaveAttribute("data-editor-selected-fret", "2");
+    await expect(host(page)).toHaveAttribute("data-score-profile", "scoretab");
+  });
+
+  test("the transport still plays while a note is selected", async ({ page }) => {
+    await openEditor(page, EDITOR_MUSICXML);
+    await selectNote(page, 0);
+    // Editing does not disable playback: the transport is live with a note
+    // selected - Play starts it and Pause stops it (a correction can be heard
+    // the moment it is made), and the selection survives the round trip. (Driven
+    // through the Play control, not the Space key: after clicking a note the
+    // focus rests on a toolbar button, where Space is that button's own
+    // activation - the pre-existing #92 rule this feature deliberately leaves
+    // alone. What target 5 pins is that the transport stays enabled and works
+    // mid-edit, which the control exercises directly.)
+    await expect(playButton(page)).toBeEnabled();
+    await playButton(page).click();
+    await expect(playButton(page)).toHaveText(/Pause/, { timeout: 10_000 });
+    await expect(wrap(page)).toHaveAttribute("data-editor-selected", "0");
+    await playButton(page).click();
+    await expect(playButton(page)).toHaveText(/Play/);
+    await expect(wrap(page)).toHaveAttribute("data-editor-selected", "0");
+  });
+});

--- a/web/tests/spec-floors/browser-score-editor-keyboard-186.json
+++ b/web/tests/spec-floors/browser-score-editor-keyboard-186.json
@@ -1,0 +1,5 @@
+{
+  "file": "tests/browser/score-editor-keyboard-186.spec.js",
+  "count": 9,
+  "reason": "issue #186 the note editor's keyboard core loop on the shared window key handler: arrows move the selection note-to-note and bar-to-bar starting no playback (cursor and Play button unmoved), a digit sets the selected note's fret with a quick second digit extending it to two digits and the window expiring committing a single digit, a two-digit fret past the writable-pitch bound refused, Backspace deleting the selected note to a rest (8->7 sounding notes, guard green, persisted as a rest), and the arbitration proven both ways - a number key still switches the staff profile with nothing selected but sets the fret with a note selected - while the transport stays live and enabled (the Play control still starts and stops playback) mid-edit."
+}


### PR DESCRIPTION
Closes #186. Follow-up to #10: the editor's core loop now costs no mouse and no mode. All three gestures live on the existing window key handler, beside the transport shortcuts and the number-key staff-profile switch.

## What it does
- **Arrows move the selection.** Left/Right step note-to-note; Up/Down step bar-to-bar (the same two granularities the transport's own arrows use - a beat and a whole bar). No playback is started, and the playback cursor is not touched.
- **A digit sets the selected note's fret.** A second digit within a short window on the same note extends it to a two-digit fret ("1" then a quick "2" = fret 12; "1" then a pause = fret 1). The edit is written through the same `doc.setFret` / `applyEdit` path the Fret field uses, so the existing writable-pitch bound (Rule 11, MIDI 12-131 / octaves 0-9) refuses an out-of-range fret here too - a two-digit value past the bound is refused, the committed single digit left in place.
- **Backspace deletes the selected note** by turning it into a rest - the model's own notion of delete (this file's header pins rests as the notes that keep their place in document order and are not edit targets). Its duration/voice/type are kept and a `<rest/>` put where the pitch was, so the bar's arithmetic is unchanged. The document re-imports and re-renders; the sounding-note count drops by one and the note after it slides into the selection.

## Arbitration (the main integration risk)
The editor claims arrows, digits and Backspace **only while a note is selected** (`editMode && selectedOrdinal != null`). In every other state those keys fall through untouched: a digit switches the staff profile when nothing is selected and sets the fret when a note is; Backspace stops the transport when nothing is selected and deletes when a note is; arrows move the playback cursor when nothing is selected and the selection when a note is. Every claimed key returns, so it is handled once and never also by the transport switch. Space / L / S / N / C / T are never claimed - the transport stays fully live while editing, so a correction can be heard the instant it is made.

The two-digit window is 600ms, decided by a timestamp compare at each keypress rather than a timer that could outlive the note.

## Acceptance targets, as browser specs
`web/tests/browser/score-editor-keyboard-186.spec.js` (9 specs), against the real alphaTab render and the real document parse:
1. Arrows move the selection note-to-note and bar-to-bar; the playback cursor and Play button do not move.
2. A digit sets the fret; two quick digits set a two-digit fret; the window expiring commits a single digit; a two-digit fret past the writable bound is refused.
3. Backspace deletes to a rest - sounding-note count 8 -> 7, the divergence guard stays green, and the delete persists as a rest through the save path.
4. A number key still switches the staff profile with nothing selected, and sets the fret (not the profile) with a note selected - both states asserted.
5. The transport stays live and enabled while a note is selected.

Scope: `web/src/lib/TabViewer.svelte` and `web/src/lib/editor/document.js` only, plus the new spec and its spec-floor entry. No server changes.