### PR TITLE
Move a note from one voice to another in the note editor (#182)

### DIFF
--- a/web/src/lib/TabViewer.svelte
+++ b/web/src/lib/TabViewer.svelte
@@ -166,6 +166,14 @@
   let selType = $state(null);
   let selMidi = $state(null);
   let selNoteId = $state(null);
+  // The selected note's voice, its onset within that voice (in the document's
+  // divisions), and the voices its move control offers (#182). selRenderVoice is
+  // the SAME fact read back from the renderer, the voice half of the divergence
+  // cross-check below.
+  let selVoice = $state(null);
+  let selOnset = $state(null);
+  let selRenderVoice = $state(null);
+  let selVoiceOptions = $state([]);
   // The cross-check the evaluation asks for: the renderer's own read of the
   // selected note (through the importer and the positional map) against the
   // document's read of the same note. In this single-source-of-truth design
@@ -217,6 +225,8 @@
   function clearSelection() {
     selectedOrdinal = null;
     selFret = selString = selType = selMidi = selNoteId = null;
+    selVoice = selOnset = selRenderVoice = null;
+    selVoiceOptions = [];
     divergenceOk = true;
     overlay = null;
     editWarn = "";
@@ -275,7 +285,25 @@
     selType = d.type;
     selNoteId = d.id;
     selMidi = v?.midi ?? d.midi;
-    divergenceOk = !!v && v.mxString === d.string && v.fret === d.fret && v.midi === d.midi;
+    selVoice = d.voice;
+    selOnset = d.onset;
+    selRenderVoice = v?.voice ?? null;
+    // The voices this note can move to (#182): its own, the others its measure
+    // already sounds, and the next one up (so a new voice can be created), kept
+    // consecutive from 1 (Rule 6). At least [1, 2] so a monophonic bar can gain
+    // a second voice; capped so the list never runs away.
+    const upto = Math.min(4, Math.max(2, (d.measureVoices ?? 1) + 1));
+    selVoiceOptions = Array.from({ length: upto }, (_, i) => i + 1);
+    // The divergence oracle now also spans the voice a note landed in: the
+    // renderer's own read (v.voice) against the document's <voice> (d.voice).
+    // Guarded on v.voice being known so a renderer that does not report it never
+    // forces a false negative - it only ever tightens the check.
+    divergenceOk =
+      !!v &&
+      v.mxString === d.string &&
+      v.fret === d.fret &&
+      v.midi === d.midi &&
+      (v.voice == null || v.voice === d.voice);
     updateOverlay();
   }
 
@@ -345,6 +373,40 @@
 
   function changeDuration(type) {
     applyEdit(() => doc.setDurationType(selectedOrdinal, type), "That duration can't be written for this note.");
+  }
+
+  // Move the selected note into another voice (#182). Unlike a fret/string/
+  // duration edit, this is STRUCTURAL - it introduces a <backup> and a second
+  // voice, and the moved note's ordinal changes (its voice block now sits after
+  // the one it left), so this follows deleteSelected's shape rather than
+  // applyEdit's: rebuild the model from the new text and re-select the note at
+  // its NEW ordinal (which doc.moveToVoice returns) rather than trusting the
+  // in-place ordinal map. The move keeps the note's onset, so the same
+  // correction can be heard the instant it is made (the transport stays live).
+  async function changeVoice(value) {
+    const v = Number(value);
+    if (!Number.isInteger(v) || v < 1) return;
+    if (selectedOrdinal == null || !doc || !view) return;
+    if (v === selVoice) return; // choosing the note's own voice is a no-op
+    fretEntry = null;
+    const before = doc.text();
+    const newOrdinal = doc.moveToVoice(selectedOrdinal, v);
+    if (newOrdinal == null) {
+      editWarn = "That note can't be moved to that voice.";
+      return;
+    }
+    const after = doc.text();
+    if (after === before) return;
+    editWarn = "";
+    undoStack = [...undoStack, before];
+    redoStack = [];
+    dirty = true;
+    doc = createDocument(after);
+    editStringCount = doc.stringCount;
+    selectedOrdinal = newOrdinal;
+    await view.editor.reload(after);
+    if (doc.noteAt(selectedOrdinal)) refreshSelection();
+    else clearSelection();
   }
 
   // ----------------------------------------------- the keyboard core loop (#186)
@@ -488,6 +550,7 @@
           headRect: (ordinal) => v.editor.headRect(ordinal),
           headPoint: (ordinal) => v.editor.headPoint(ordinal),
           hitTest: (x, y) => v.editor.hitTest(x, y),
+          viewInfo: (ordinal) => v.editor.viewInfo(ordinal),
           noteCount: () => v.editor.noteCount(),
           boundsCount: () => v.editor.boundsCount(),
         };
@@ -892,6 +955,9 @@
   data-editor-selected-type={selType}
   data-editor-selected-midi={selMidi}
   data-editor-selected-note-id={selNoteId}
+  data-editor-selected-voice={selVoice}
+  data-editor-selected-onset={selOnset}
+  data-editor-render-voice={selRenderVoice}
   data-editor-divergence-ok={editMode ? divergenceOk : null}
   data-editor-dirty={dirty}
   data-editor-can-undo={undoStack.length > 0}
@@ -1111,6 +1177,17 @@
               {/if}
               {#each DURATION_TYPES as t}
                 <option value={t}>{t}</option>
+              {/each}
+            </select>
+          </label>
+          <label title="Move this note to another voice — the second voice (and its backup) is created if it does not exist yet">
+            Voice
+            <select value={String(selVoice ?? "")} onchange={(e) => changeVoice(e.target.value)}>
+              {#if selVoice != null && !selVoiceOptions.includes(selVoice)}
+                <option value={String(selVoice)}>{selVoice}</option>
+              {/if}
+              {#each selVoiceOptions as vopt}
+                <option value={String(vopt)}>{vopt}</option>
               {/each}
             </select>
           </label>

--- a/web/src/lib/editor/document.js
+++ b/web/src/lib/editor/document.js
@@ -51,6 +51,28 @@ function technicalOf(noteEl) {
   return notations ? firstChildTag(notations, "technical") : null;
 }
 
+// A chord member carries <chord/> as its first child (Rule 7); only the first
+// note of a chord advances the measure's time cursor.
+function hasChord(noteEl) {
+  return !!firstChildTag(noteEl, "chord");
+}
+
+// The integer <duration> of a <note>, <backup> or <forward> - what moves the
+// measure's time cursor. 0 when absent or unreadable, so the walk never adds a
+// NaN it can never recover from.
+function intDuration(el) {
+  const n = Number(tagText(el, "duration"));
+  return Number.isFinite(n) ? n : 0;
+}
+
+// A note's (or forward's) <voice> as a number, or null. This profile writes
+// voices as consecutive numeric strings from 1 (Rule 6), so a number is what
+// the model compares and orders them by.
+function voiceNumber(el) {
+  const n = Number(tagText(el, "voice"));
+  return Number.isFinite(n) ? n : null;
+}
+
 /**
  * Build the editable document from MusicXML text. Throws if the text is not
  * parseable XML or is not a score this profile writes (one part, a tab staff
@@ -122,6 +144,48 @@ export function createDocument(xml) {
   const measureOrder = [];
   for (const n of measureNums) if (n != null && !measureOrder.includes(n)) measureOrder.push(n);
 
+  // Each note's onset (in <divisions>) within its measure, and the set of
+  // voices its measure sounds - both read once here from a single per-measure
+  // time-cursor walk. MusicXML places notes on a per-measure cursor that each
+  // note's <duration> advances; a <backup> rewinds it and a <forward> advances
+  // it without a note. Because this profile returns the cursor to the measure
+  // start between voices (Rule 6), a note's onset counted from measure-start IS
+  // its onset within its own voice. The move-a-note-to-another-voice edit
+  // (#182) leans on exactly this arithmetic; describe() exposes onset so a
+  // moved note can be shown to keep the same onset in its new voice, and the
+  // voice set so the control knows which voices a note may move to.
+  const onsetByEl = new Map();
+  const voicesByMeasure = new Map(); // measureEl -> Set<voiceNum that sounds>
+  for (const measureEl of doc.getElementsByTagName("measure")) {
+    let cursor = 0;
+    let headOnset = 0;
+    const voices = new Set();
+    voicesByMeasure.set(measureEl, voices);
+    for (const child of measureEl.children) {
+      const tag = child.tagName;
+      if (tag === "backup") {
+        cursor -= intDuration(child);
+        continue;
+      }
+      if (tag === "forward") {
+        cursor += intDuration(child);
+        continue;
+      }
+      if (tag !== "note") continue;
+      const v = voiceNumber(child);
+      if (v != null && !isRest(child)) voices.add(v);
+      if (hasChord(child)) {
+        // A chord member shares the onset of its beat's first note and does not
+        // move the cursor (Rule 7).
+        onsetByEl.set(child, headOnset);
+      } else {
+        onsetByEl.set(child, cursor);
+        headOnset = cursor;
+        cursor += intDuration(child);
+      }
+    }
+  }
+
   function describe(el, ordinal) {
     const tech = technicalOf(el);
     const string = tech ? Number(tagText(tech, "string")) : null;
@@ -132,6 +196,8 @@ export function createDocument(xml) {
     const midi = pitchEl
       ? midiOfPitch(tagText(pitchEl, "step"), Number(tagText(pitchEl, "octave")), Number(tagText(pitchEl, "alter") ?? 0))
       : null;
+    const measureEl = el.closest ? el.closest("measure") : null;
+    const voices = measureEl ? voicesByMeasure.get(measureEl) : null;
     return {
       ordinal,
       id: el.getAttribute("id"),
@@ -141,6 +207,12 @@ export function createDocument(xml) {
       dots,
       midi,
       measure: measureNums[ordinal] ?? null,
+      // The note's own voice, its onset within that voice (both #182's proof
+      // that a moved note keeps its onset), and how many voices its measure
+      // already sounds (what the move control offers as targets).
+      voice: voiceNumber(el),
+      onset: onsetByEl.has(el) ? onsetByEl.get(el) : null,
+      measureVoices: voices ? voices.size : null,
     };
   }
 
@@ -318,6 +390,268 @@ export function createDocument(xml) {
     return true;
   }
 
+  // ------------------------------------------------ move a note to another voice (#182)
+  //
+  // Polyphonic tab is written one voice at a time, each voice after the first
+  // preceded by a <backup> that rewinds the cursor to the measure start (Rule
+  // 6), and every voice's notes and rests summing to the measure (Rule 8).
+  // Reassigning a note to another voice is therefore not a <voice> text swap: it
+  // moves the note out of one per-measure timeline and into another at the SAME
+  // onset, and both timelines have to stay full. The chosen mechanism rebuilds
+  // the measure's whole note stream from its voices' timelines, which keeps the
+  // backup arithmetic, Rule 8 and the onsets correct by construction rather than
+  // by patching. See moveToVoice for the per-case decisions.
+
+  // The plain type for a rest of `dur` divisions, or null when no undotted type
+  // expresses it exactly (a dotted-length gap) - in which case the rest is
+  // written with <duration> alone, which is valid and renders by its duration.
+  function typeForDuration(dur) {
+    for (const t of DURATION_TYPES) if (durationForType(t, divisions) === dur) return t;
+    return null;
+  }
+
+  // A fresh rest <note> filling `dur` divisions of silence in `voiceNum`. The
+  // schema's order for a rest note is (rest), duration, voice, type - the same
+  // order the emitter writes and the one this keeps.
+  function makeRest(dur, voiceNum) {
+    const note = doc.createElement("note");
+    note.appendChild(doc.createElement("rest"));
+    const d = doc.createElement("duration");
+    d.textContent = String(dur);
+    note.appendChild(d);
+    const v = doc.createElement("voice");
+    v.textContent = String(voiceNum);
+    note.appendChild(v);
+    const type = typeForDuration(dur);
+    if (type) {
+      const typeEl = doc.createElement("type");
+      typeEl.textContent = type;
+      note.appendChild(typeEl);
+    }
+    return note;
+  }
+
+  // Set a note's <voice> (Rule 6), creating it in its schema position (before
+  // <type>) if the note somehow lacked one.
+  function setVoiceEl(el, voiceNum) {
+    let v = firstChildTag(el, "voice");
+    if (!v) {
+      v = doc.createElement("voice");
+      const typeEl = firstChildTag(el, "type");
+      if (typeEl) el.insertBefore(v, typeEl);
+      else el.appendChild(v);
+    }
+    v.textContent = String(voiceNum);
+  }
+
+  // Add or drop a note's leading <chord/> (Rule 7): the first note of a beat
+  // carries none and every later member carries one, so a beat's noteheads are
+  // normalised by their position when the beat is written.
+  function setChordFlag(el, on) {
+    const existing = firstChildTag(el, "chord");
+    if (on && !existing) el.insertBefore(doc.createElement("chord"), el.firstChild);
+    if (!on && existing) el.removeChild(existing);
+  }
+
+  // Re-derive every note id in a measure from its position (Rule 17:
+  // n{measure}-{voice}-{onset}-{chord}, onset the 0-based beat index within the
+  // voice, chord the 0-based member index within the beat). Ids name a POSITION,
+  // not a note, so a structural edit that moves a note between voices has to
+  // recompute them for the whole measure - the profile makes this the editor's
+  // responsibility, not the emitter's.
+  function renumberMeasure(measureEl) {
+    const mnum = Number(measureEl.getAttribute("number"));
+    if (!Number.isFinite(mnum)) return;
+    const beatIdx = new Map();
+    const chordIdx = new Map();
+    for (const note of measureEl.getElementsByTagName("note")) {
+      const v = voiceNumber(note);
+      if (v == null) continue;
+      if (hasChord(note) && beatIdx.has(v)) {
+        chordIdx.set(v, (chordIdx.get(v) ?? 0) + 1);
+      } else {
+        beatIdx.set(v, beatIdx.has(v) ? beatIdx.get(v) + 1 : 0);
+        chordIdx.set(v, 0);
+      }
+      note.setAttribute("id", `n${mnum}-${v}-${beatIdx.get(v)}-${chordIdx.get(v)}`);
+    }
+  }
+
+  /**
+   * Move the sounding note at `ordinal` into voice `targetVoice`, keeping its
+   * onset. Returns the note's NEW ordinal (its voice block now sits after its
+   * old one, so the ordinal generally changes) or null when the move is refused
+   * or a no-op. The document is left untouched on a refusal.
+   *
+   * The decisions this makes, each stated so a reader need not reverse-engineer
+   * them from the arithmetic:
+   *
+   * - Onset is preserved. The note lands at the SAME onset in the new voice - a
+   *   note on beat 3 of voice 1 is on beat 3 of voice 2, not beat 1 - because
+   *   the whole measure is rebuilt from per-voice timelines and the note keeps
+   *   the onset its beat had.
+   * - A lone note leaves a rest behind. Removing it from its source voice would
+   *   leave a gap; that gap is filled with a rest of the same length, so the
+   *   source voice still spans the measure (Rule 8) and every later note keeps
+   *   its onset. The alternative - collapsing the gap - would move every note
+   *   after it earlier, which is not what "move THIS note" means.
+   * - A chord member splits off. Moving one notehead of a chord leaves the other
+   *   members sounding at that onset (no rest is inserted - the onset is still
+   *   occupied), and the moved note becomes a lone note at the same onset in the
+   *   target voice. If the moved note was the chord's written head, the next
+   *   member is promoted to head (its <chord/> dropped) so the source beat still
+   *   advances the cursor.
+   * - A new target voice is created full. When the target voice does not yet
+   *   exist in the measure it is introduced with its <backup> and filled with
+   *   rests around the moved note, so it too spans the measure. Voices stay
+   *   numbered consecutively from 1 (Rule 6): a target more than one past the
+   *   highest existing voice is refused.
+   * - An occupied target onset is refused. If the target voice already sounds
+   *   across the moved note's onset, the move is refused rather than guessing a
+   *   merge - the note is left where it was.
+   * - Inferred silence is not disturbed. A measure carrying a <forward> (Rule 14
+   *   deduced silence, which must not become a counted rest) is refused, since
+   *   the rest-filled rebuild cannot reproduce it faithfully.
+   */
+  function moveToVoice(ordinal, targetVoice) {
+    const mv = noteEls[ordinal];
+    if (!mv || isRest(mv)) return null;
+    if (!Number.isInteger(targetVoice) || targetVoice < 1) return null;
+    const measureEl = mv.closest ? mv.closest("measure") : null;
+    if (!measureEl) return null;
+    const srcVoice = voiceNumber(mv);
+    if (srcVoice == null || targetVoice === srcVoice) return null;
+    // Rule 14 inferred silence would be silently promoted to a counted rest by
+    // the rebuild below - refuse rather than corrupt the measure's arithmetic.
+    if (measureEl.getElementsByTagName("forward").length > 0) return null;
+
+    // The measure's note stream - its <note> and <backup> children, in order.
+    // A <direction>/<barline>/<print> before the first or after the last is left
+    // untouched; one INTERLEAVED between notes is refused, because the rebuild
+    // would not know where to put it back (a mid-voice mark is rare and this
+    // increment does not move it).
+    const kids = [...measureEl.children];
+    const streamIdx = [];
+    for (let i = 0; i < kids.length; i++) {
+      const t = kids[i].tagName;
+      if (t === "note" || t === "backup") streamIdx.push(i);
+    }
+    if (streamIdx.length === 0) return null;
+    const first = streamIdx[0];
+    const last = streamIdx[streamIdx.length - 1];
+    for (let i = first + 1; i < last; i++) {
+      const t = kids[i].tagName;
+      if (t !== "note" && t !== "backup") return null;
+    }
+
+    // Walk the stream into per-voice sounding beats and the measure's duration.
+    const soundingByVoice = new Map(); // vnum -> [{ onset, duration, notes: [el] }]
+    let cursor = 0;
+    let measureDur = 0;
+    let lastBeat = null;
+    for (let i = first; i <= last; i++) {
+      const el = kids[i];
+      if (el.tagName === "backup") {
+        cursor -= intDuration(el);
+        lastBeat = null;
+        continue;
+      }
+      const rest = isRest(el);
+      const dur = intDuration(el);
+      const v = voiceNumber(el);
+      if (hasChord(el) && lastBeat) {
+        if (!rest) lastBeat.notes.push(el);
+      } else {
+        const beat = { onset: cursor, duration: dur, notes: rest ? [] : [el] };
+        if (!rest && v != null) {
+          if (!soundingByVoice.has(v)) soundingByVoice.set(v, []);
+          soundingByVoice.get(v).push(beat);
+        }
+        cursor += dur;
+        if (cursor > measureDur) measureDur = cursor;
+        lastBeat = rest ? null : beat;
+      }
+    }
+    if (!(measureDur > 0)) return null;
+
+    // The moved note's beat in its source voice.
+    const srcBeats = soundingByVoice.get(srcVoice) || [];
+    const mvBeat = srcBeats.find((b) => b.notes.includes(mv));
+    if (!mvBeat) return null;
+    const onset = mvBeat.onset;
+    const duration = mvBeat.duration;
+
+    // Consecutive voice numbering (Rule 6): the target is at most one past the
+    // highest voice that sounds today.
+    let maxVoice = 0;
+    for (const v of soundingByVoice.keys()) if (v > maxVoice) maxVoice = v;
+    if (targetVoice > maxVoice + 1) return null;
+
+    // The target must be silent across the moved note's onset.
+    const tgtBeats = soundingByVoice.get(targetVoice) || [];
+    for (const b of tgtBeats) {
+      if (onset < b.onset + b.duration && b.onset < onset + duration) return null;
+    }
+
+    // Remove the note from its source beat; a beat left empty becomes silence
+    // (refilled as a rest below), a chord simply loses one member.
+    mvBeat.notes = mvBeat.notes.filter((n) => n !== mv);
+    if (mvBeat.notes.length === 0) {
+      soundingByVoice.set(
+        srcVoice,
+        srcBeats.filter((b) => b !== mvBeat),
+      );
+    }
+
+    // Add it to the target voice as a lone note at the same onset.
+    setChordFlag(mv, false);
+    tgtBeats.push({ onset, duration, notes: [mv] });
+    tgtBeats.sort((a, b) => a.onset - b.onset);
+    soundingByVoice.set(targetVoice, tgtBeats);
+
+    // Rebuild the whole note stream: every voice 1..max, each a full timeline of
+    // its sounding beats with the gaps between them (and before/after) filled by
+    // rests, and a <backup> to the measure start before every voice after the
+    // first.
+    const maxAfter = Math.max(maxVoice, targetVoice);
+    const newSeq = [];
+    for (let v = 1; v <= maxAfter; v++) {
+      if (v > 1) {
+        const backup = doc.createElement("backup");
+        const bd = doc.createElement("duration");
+        bd.textContent = String(measureDur);
+        backup.appendChild(bd);
+        newSeq.push(backup);
+      }
+      const beats = (soundingByVoice.get(v) || []).slice().sort((a, b) => a.onset - b.onset);
+      let pos = 0;
+      for (const beat of beats) {
+        if (beat.onset > pos) newSeq.push(makeRest(beat.onset - pos, v));
+        else if (beat.onset < pos) return null; // overlap - would corrupt the bar
+        beat.notes.forEach((n, idx) => {
+          setVoiceEl(n, v);
+          setChordFlag(n, idx > 0);
+        });
+        for (const n of beat.notes) newSeq.push(n);
+        pos = beat.onset + beat.duration;
+      }
+      if (pos < measureDur) newSeq.push(makeRest(measureDur - pos, v));
+    }
+
+    // Splice the rebuilt stream in where the old one was; leading/trailing
+    // non-stream siblings keep their place around it. The reused sounding notes
+    // are re-parented (detached then re-inserted) - insertBefore moves them.
+    const anchor = kids[last].nextSibling;
+    for (let i = first; i <= last; i++) measureEl.removeChild(kids[i]);
+    for (const el of newSeq) measureEl.insertBefore(el, anchor);
+
+    renumberMeasure(measureEl);
+
+    const nowSounding = [...doc.getElementsByTagName("note")].filter((n) => !isRest(n));
+    const newOrdinal = nowSounding.indexOf(mv);
+    return newOrdinal >= 0 ? newOrdinal : null;
+  }
+
   function text() {
     const body = new XMLSerializer().serializeToString(root);
     // DOMParser drops the XML declaration; the server sniffs "starts with <"
@@ -338,6 +672,7 @@ export function createDocument(xml) {
     setString,
     setDurationType,
     deleteNote,
+    moveToVoice,
     text,
   };
 }

--- a/web/src/lib/score-render.js
+++ b/web/src/lib/score-render.js
@@ -3073,10 +3073,16 @@ export function createScoreView(host, opts = {}) {
     if (!note) return null;
     const stringCount = note.beat?.voice?.bar?.staff?.tuning?.length ?? 0;
     const mxString = stringCount > 0 && note.string >= 1 ? stringCount + 1 - note.string : null;
+    // alphaTab numbers a bar's voices from 0; MusicXML from 1 (Rule 6). Mirrored
+    // here so the seam speaks the document's language - what lets TabViewer
+    // cross-check the voice a note landed in against the document's own <voice>
+    // after a voice reassignment (#182), the same way mxString is cross-checked.
+    const voiceIndex = note.beat?.voice?.index;
     return {
       mxString,
       fret: note.fret ?? null,
       midi: Number.isFinite(note.realValue) ? note.realValue : null,
+      voice: Number.isInteger(voiceIndex) ? voiceIndex + 1 : null,
     };
   }
 

--- a/web/tests/browser/fixtures/editor-score.js
+++ b/web/tests/browser/fixtures/editor-score.js
@@ -91,6 +91,56 @@ ${note("n2-1-3-0", "E", 0, 4, 2, 5)}
   </part>
 </score-partwise>`;
 
+// A one-measure score whose first beat is a two-note CHORD (Rule 7: the first
+// note carries no <chord>, the second carries <chord/>, both share one onset and
+// duration), for the move-a-note-to-another-voice edit (#182) to split. Standard
+// six-string tuning, 4/4, divisions 480.
+//
+//   ord  id          voice  onset  string  fret  pitch  midi   note
+//   0    n1-1-0-0    1      0      1       0     E4     64     chord head
+//   1    n1-1-0-1    1      0      2       0     B3     59     chord member
+//   2    n1-1-1-0    1      480    1       3     G4     67
+//   3    n1-1-2-0    1      960    2       3     D4     62
+//   4    n1-1-3-0    1      1440   1       5     A4     64
+//
+// Voice 1 sums to 480 × 4 = 1920, the 4/4 measure, so Rule 8 holds before any
+// edit. Moving the chord member (ord 1, B3) to voice 2 must leave the head (E4)
+// sounding at onset 0 and place B3 at onset 0 of the new voice.
+export const CHORD_MUSICXML = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list>
+    <score-part id="P1"><part-name>Guitar</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>480</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>TAB</sign><line>5</line></clef>${STAFF_DETAILS}
+      </attributes>
+      <note id="n1-1-0-0">
+        <pitch><step>E</step><octave>4</octave></pitch>
+        <duration>480</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <notations><technical><string>1</string><fret>0</fret></technical></notations>
+      </note>
+      <note id="n1-1-0-1">
+        <chord/>
+        <pitch><step>B</step><octave>3</octave></pitch>
+        <duration>480</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <notations><technical><string>2</string><fret>0</fret></technical></notations>
+      </note>
+${note("n1-1-1-0", "G", 0, 4, 1, 3)}
+${note("n1-1-2-0", "D", 0, 4, 2, 3)}
+${note("n1-1-3-0", "A", 0, 4, 1, 5)}
+    </measure>
+  </part>
+</score-partwise>`;
+
 // The same score with one note moved to a string the six-string staff does not
 // have (<string>7</string>) - the under-specified tab a directly uploaded or
 // hand-edited file can carry (issue #165). The editor never writes this; it is

--- a/web/tests/browser/score-editor-voices-182.spec.js
+++ b/web/tests/browser/score-editor-voices-182.spec.js
@@ -1,0 +1,244 @@
+// Moving a note between voices (#182), end to end against the real alphaTab
+// render and the real editor/document.js parse - the same fixture and stub the
+// first-increment suite uses (score-editor.spec.js, fixtures/editor-score.js),
+// only the HTTP transport stubbed. Every assertion is on state the app
+// publishes onto the DOM (data-editor-*) or the read-only geometry/model hook
+// window.__scoreEditor, or on the exact MusicXML persisted through the save
+// path - never on an internal reached into.
+//
+// The edit: the panel's Voice control reassigns the selected note to another
+// voice, introducing the <backup> and the second voice where one is needed and
+// keeping the note at the SAME onset. The document is rebuilt from its voices'
+// timelines, so the backup arithmetic, every voice's Rule 8 sum, and the
+// onsets stay correct by construction.
+//
+// What each mutation would turn red, so this suite is falsifiable, not green by
+// construction:
+//   - no-op doc.moveToVoice (return null): the Voice control refuses every move
+//     -> every test here red (the selection never lands in voice 2).
+//   - drop the <backup>/rest rebuild (write only the <voice> text): re-import
+//     puts the note at onset 0 of voice 2, not its old onset, and the per-voice
+//     sums stop equalling the measure -> "keeps its onset" and "arithmetic
+//     round-trips" red.
+//   - skip the source rest (collapse the gap): voice 1's later notes slide
+//     earlier, its sum drops below the measure -> "arithmetic round-trips" red.
+//   - mishandle the chord split (move the whole beat, or drop the head
+//     promotion): the head stops sounding at onset 0 -> "a chord member" red.
+import { test, expect } from "@playwright/test";
+
+import { EDITOR_MUSICXML, CHORD_MUSICXML, stubEditorApi } from "./fixtures/editor-score.js";
+
+const wrap = (page) => page.locator(".staff-render .wrap");
+const host = (page) => page.locator(".staff-render .at-host");
+const voiceSelect = (page) => page.locator(".edit-fields label", { hasText: "Voice" }).locator("select");
+const fretInput = (page) => page.locator(".edit-fields input");
+
+async function renderedOk(page) {
+  await expect(host(page)).toHaveAttribute("data-score-render-ok", "true");
+}
+
+// Opens the editor over `content` and waits until the whole score's `expected`
+// sounding notes are laid out - the barrier every read below waits behind.
+async function openEditor(page, content, expected) {
+  const handle = await stubEditorApi(page, content);
+  await page.goto("/#/score/1");
+  await page.waitForSelector(".staff-render");
+  // Full-width staff, so the whole score is one active pane and every note is on
+  // screen (side-by-side would give the staff half the width).
+  await page.getByRole("button", { name: "Staff", exact: true }).click();
+  await renderedOk(page);
+  await page.getByRole("button", { name: "Edit notes" }).click();
+  await expect(wrap(page)).toHaveAttribute("data-editor-active", "true");
+  await expect.poll(() => page.evaluate(() => window.__scoreEditor?.noteCount() ?? 0)).toBe(expected);
+  return handle;
+}
+
+async function selectNote(page, ordinal) {
+  const point = await page.evaluate((o) => window.__scoreEditor.headPoint(o), ordinal);
+  expect(point, `note ${ordinal} has a clickable head`).toBeTruthy();
+  await page.mouse.click(point.x, point.y);
+  await expect(wrap(page)).toHaveAttribute("data-editor-selected", String(ordinal));
+}
+
+// The per-voice sum of note+rest <duration> in a given measure of a MusicXML
+// string, computed in the page's own DOMParser - Rule 8's own arithmetic
+// (chord members counted once: a <chord/> note does not advance the cursor and
+// is not summed here). Returns { voices: {n: sum}, backups: [durations] }.
+async function measureShape(page, xml, measureNumber) {
+  return page.evaluate(
+    ({ xml, measureNumber }) => {
+      const doc = new DOMParser().parseFromString(xml, "application/xml");
+      const measures = [...doc.getElementsByTagName("measure")];
+      const m = measures.find((el) => el.getAttribute("number") === String(measureNumber));
+      const voices = {};
+      const backups = [];
+      const soundingVoices = new Set();
+      for (const child of m.children) {
+        if (child.tagName === "backup") {
+          const d = Number(child.getElementsByTagName("duration")[0]?.textContent);
+          backups.push(d);
+          continue;
+        }
+        if (child.tagName !== "note") continue;
+        const chord = !!child.getElementsByTagName("chord")[0];
+        const rest = !!child.getElementsByTagName("rest")[0];
+        const v = child.getElementsByTagName("voice")[0]?.textContent ?? "?";
+        const d = Number(child.getElementsByTagName("duration")[0]?.textContent) || 0;
+        if (!rest) soundingVoices.add(v);
+        if (!chord) voices[v] = (voices[v] ?? 0) + d;
+      }
+      return { voices, backups, soundingVoices: [...soundingVoices] };
+    },
+    { xml, measureNumber },
+  );
+}
+
+test.describe("note editor - move a note between voices", () => {
+  // Target 1 + part of 3: a note moved from voice 1 to voice 2 re-imports and
+  // re-renders in voice 2, at the SAME onset it had, with the divergence guard
+  // (now spanning the voice the note landed in) green.
+  test("a note moved to voice 2 keeps its onset and the guard stays green", async ({ page }) => {
+    await openEditor(page, EDITOR_MUSICXML, 8);
+    // Note 2 is G4, string 1 fret 3, voice 1, onset 960 (beat 3 of a 4/4 bar at
+    // divisions 480). Capture its onset from the app, not this comment.
+    await selectNote(page, 2);
+    await expect(wrap(page)).toHaveAttribute("data-editor-selected-voice", "1");
+    await expect(wrap(page)).toHaveAttribute("data-editor-selected-onset", "960");
+    await expect(wrap(page)).toHaveAttribute("data-editor-selected-fret", "3");
+
+    await voiceSelect(page).selectOption("2");
+
+    // Its voice block now sits after voice 1's, so the ordinal moved 2 -> 3.
+    await expect(wrap(page)).toHaveAttribute("data-editor-selected", "3");
+    await expect(wrap(page)).toHaveAttribute("data-editor-selected-voice", "2");
+    // Beat 3 of voice 1 is beat 3 of voice 2, NOT beat 1: the onset is unchanged.
+    await expect(wrap(page)).toHaveAttribute("data-editor-selected-onset", "960");
+    // Same note, unchanged: string 1, fret 3, G4 = MIDI 67.
+    await expect(wrap(page)).toHaveAttribute("data-editor-selected-fret", "3");
+    await expect(wrap(page)).toHaveAttribute("data-editor-selected-midi", "67");
+    // The document and the render agree, voice included.
+    await expect(wrap(page)).toHaveAttribute("data-editor-divergence-ok", "true");
+    await expect(wrap(page)).toHaveAttribute("data-editor-dirty", "true");
+    // The renderer's OWN read (a different path from the document's <voice>)
+    // also puts it in voice 2 - the voice half of the divergence cross-check.
+    const rv = await page.evaluate(() => window.__scoreEditor.viewInfo(3).voice);
+    expect(rv).toBe(2);
+    // No note was destroyed - it still sounds, just in another voice.
+    await expect.poll(() => page.evaluate(() => window.__scoreEditor?.noteCount() ?? 0)).toBe(8);
+  });
+
+  // Target 2: every voice's total duration is correct after the move, and
+  // re-importing the written MusicXML is stable (a second parse is identical).
+  test("the measure's arithmetic round-trips after the move", async ({ page }) => {
+    const { saved } = await openEditor(page, EDITOR_MUSICXML, 8);
+    await selectNote(page, 2);
+    await voiceSelect(page).selectOption("2");
+    await expect(wrap(page)).toHaveAttribute("data-editor-selected-voice", "2");
+
+    await page.getByRole("button", { name: "Save", exact: true }).click();
+    await expect(wrap(page)).toHaveAttribute("data-editor-dirty", "false");
+    await expect.poll(() => saved.content).not.toBeNull();
+
+    // Both voices of measure 1 fill the 4/4 bar (480 * 4 = 1920) - voice 1 as
+    // three notes and the rest left where the moved note was, voice 2 as the
+    // moved note between the rests that pad it to the bar. Rule 8 holds for each.
+    const shape = await measureShape(page, saved.content, 1);
+    expect(shape.voices["1"]).toBe(1920);
+    expect(shape.voices["2"]).toBe(1920);
+    // One backup, rewinding a whole measure to start voice 2 (Rule 6).
+    expect(shape.backups).toEqual([1920]);
+
+    // Re-importing the written MusicXML and re-emitting is stable: a second
+    // parse yields the identical per-voice arithmetic (no drift).
+    const again = await measureShape(page, saved.content, 1);
+    expect(again).toEqual(shape);
+  });
+
+  // Target 3: moving into a not-yet-existing second voice introduces the voice
+  // and its <backup>; the re-imported structure has two voices with the moved
+  // note in the second.
+  test("moving into a not-yet-existing voice introduces the second voice and its backup", async ({ page }) => {
+    const { saved } = await openEditor(page, EDITOR_MUSICXML, 8);
+    // Every note starts in voice 1; the fixture has no voice 2 at all.
+    const before = await measureShape(page, EDITOR_MUSICXML, 1);
+    expect(before.soundingVoices).toEqual(["1"]);
+    expect(before.backups).toEqual([]);
+
+    await selectNote(page, 2);
+    await voiceSelect(page).selectOption("2");
+    await expect(wrap(page)).toHaveAttribute("data-editor-selected-voice", "2");
+    await page.getByRole("button", { name: "Save", exact: true }).click();
+    await expect(wrap(page)).toHaveAttribute("data-editor-dirty", "false");
+    await expect.poll(() => saved.content).not.toBeNull();
+
+    const after = await measureShape(page, saved.content, 1);
+    // Two voices now sound where there was one, and a backup was introduced.
+    expect(after.soundingVoices.sort()).toEqual(["1", "2"]);
+    expect(after.backups).toEqual([1920]);
+    // The sounding note in the new voice 2 is the one that moved - G4, fret 3.
+    const movedFret = await page.evaluate((xml) => {
+      const doc = new DOMParser().parseFromString(xml, "application/xml");
+      const m = [...doc.getElementsByTagName("measure")].find((el) => el.getAttribute("number") === "1");
+      for (const n of m.getElementsByTagName("note")) {
+        if (n.getElementsByTagName("rest")[0]) continue;
+        if ((n.getElementsByTagName("voice")[0]?.textContent ?? "") === "2") {
+          return n.getElementsByTagName("fret")[0]?.textContent ?? null;
+        }
+      }
+      return null;
+    }, saved.content);
+    expect(movedFret).toBe("3");
+  });
+
+  // Target 4: a chord member moved out splits the chord - the moved note leaves
+  // as a lone note in the new voice at the same onset, the remaining members
+  // keep sounding at that onset in the source voice (the stated rule).
+  test("a chord member moved out splits the chord and keeps sounding in the new voice", async ({ page }) => {
+    await openEditor(page, CHORD_MUSICXML, 5);
+    // Ordinal 1 is the chord's SECOND note (B3, string 2 fret 0, voice 1, onset
+    // 0) - a member sharing the head's onset.
+    await selectNote(page, 1);
+    await expect(wrap(page)).toHaveAttribute("data-editor-selected-voice", "1");
+    await expect(wrap(page)).toHaveAttribute("data-editor-selected-onset", "0");
+    await expect(wrap(page)).toHaveAttribute("data-editor-selected-midi", "59");
+
+    await voiceSelect(page).selectOption("2");
+
+    // B3 is now a lone note in voice 2, still at onset 0, unchanged in pitch.
+    await expect(wrap(page)).toHaveAttribute("data-editor-selected-voice", "2");
+    await expect(wrap(page)).toHaveAttribute("data-editor-selected-onset", "0");
+    await expect(wrap(page)).toHaveAttribute("data-editor-selected-midi", "59");
+    await expect(wrap(page)).toHaveAttribute("data-editor-divergence-ok", "true");
+    // Nothing was destroyed by the split - all five noteheads still sound.
+    await expect.poll(() => page.evaluate(() => window.__scoreEditor?.noteCount() ?? 0)).toBe(5);
+
+    // The chord's head (E4) still sounds at onset 0 in voice 1: the chord shrank,
+    // it did not move. It is now ordinal 0 (voice 1's first note).
+    await selectNote(page, 0);
+    await expect(wrap(page)).toHaveAttribute("data-editor-selected-voice", "1");
+    await expect(wrap(page)).toHaveAttribute("data-editor-selected-onset", "0");
+    await expect(wrap(page)).toHaveAttribute("data-editor-selected-midi", "64");
+    await expect(wrap(page)).toHaveAttribute("data-editor-divergence-ok", "true");
+  });
+
+  // Target 5: the control performs the move and the earlier editor operations
+  // (#10 fret edit, its divergence guard) still work over a document that now
+  // carries two voices.
+  test("after a move, a fret edit on another note still works and the guard stays green", async ({ page }) => {
+    await openEditor(page, EDITOR_MUSICXML, 8);
+    await selectNote(page, 2);
+    await voiceSelect(page).selectOption("2");
+    await expect(wrap(page)).toHaveAttribute("data-editor-selected-voice", "2");
+
+    // A #10 fret edit on a still-voice-1 note (ordinal 0, E4) after the move:
+    // string 1, fret 0 -> fret 5 = A4 = MIDI 69, guard green over the now
+    // two-voice document.
+    await selectNote(page, 0);
+    await expect(wrap(page)).toHaveAttribute("data-editor-selected-voice", "1");
+    await fretInput(page).fill("5");
+    await fretInput(page).blur();
+    await expect(wrap(page)).toHaveAttribute("data-editor-selected-fret", "5");
+    await expect(wrap(page)).toHaveAttribute("data-editor-selected-midi", "69");
+    await expect(wrap(page)).toHaveAttribute("data-editor-divergence-ok", "true");
+  });
+});

--- a/web/tests/spec-floors/browser-score-editor-voices-182.json
+++ b/web/tests/spec-floors/browser-score-editor-voices-182.json
@@ -1,0 +1,5 @@
+{
+  "file": "tests/browser/score-editor-voices-182.spec.js",
+  "count": 5,
+  "reason": "issue #182 moving a note between voices: the Voice control reassigns the selected note to another voice, introducing the <backup> and the second voice where needed and keeping the note's onset. A note moved from voice 1 to voice 2 re-imports in voice 2 at the SAME onset with the divergence guard (now spanning the landed voice) green and no note destroyed; the measure's arithmetic round-trips (both voices sum to the 4/4 bar, one whole-measure backup, a second parse identical); moving into a not-yet-existing voice introduces that voice and its backup with the moved note the one that sounds in it; a chord member moved out splits the chord (the member leaves as a lone note in the new voice at the same onset, the head keeps sounding at that onset in the source voice); and a #10 fret edit on a still-voice-1 note keeps working with the guard green over the now two-voice document."
+}


### PR DESCRIPTION
Closes #182

Polyphonic guitar writing needs voices, and the automatic split can be wrong, so the note editor now lets a note move from one voice to another. Reassigning a note is not a `<voice>` text swap: the note leaves one per-measure timeline and joins another at the same onset, so the `<backup>` arithmetic and every voice's measure sum have to stay right.

## Mechanism

`editor/document.js` gains `moveToVoice(ordinal, targetVoice)`. It rebuilds the affected measure's whole note stream from its voices' timelines: it walks the measure's `<note>`/`<backup>` stream on a time cursor to recover each sounding beat's onset and duration, moves the selected note between voices, then re-serialises every voice `1..max` as a full timeline of its sounding beats with the gaps between them (and before/after) filled by rests, a `<backup>` of the whole measure before every voice after the first (Rule 6). Because each voice is written full, every voice's notes+rests sum to the measure (Rule 8) and onsets are correct by construction. Every note id in the measure is then re-derived from its new position (Rule 17 makes that the editor's job, not the emitter's).

### `<backup>`/`<forward>` arithmetic and the per-case decisions

- **Onset preserved.** The note lands at the same onset in the new voice (beat 3 of voice 1 is beat 3 of voice 2, not beat 1) — the whole measure is rebuilt from timelines and the note keeps the onset its beat had.
- **Source gap → rest.** A lone note removed from its source voice leaves a gap; that gap is filled with a rest of the same length, so the source voice stays full and every later note keeps its onset. The collapse alternative (sliding later notes earlier) is not what "move THIS note" means.
- **Chord member splits off.** Moving one notehead of a chord leaves the other members sounding at that onset in the source voice (no rest inserted — the onset is still occupied), and the moved note becomes a lone note at the same onset in the target voice. If the moved note was the written head, the next member is promoted to head (its `<chord/>` dropped) so the source beat still advances the cursor.
- **New target voice created full.** A not-yet-existing target voice is introduced with its `<backup>` and filled with rests around the moved note; voices stay numbered consecutively from 1 (a target more than one past the highest existing voice is refused).
- **Occupied target onset refused.** If the target voice already sounds across the moved note's onset, the move is refused rather than guessing a merge.
- **Inferred silence untouched.** A measure carrying a `<forward>` (Rule 14 deduced silence, which must not become a counted rest) is refused, since the rest-filled rebuild cannot reproduce it faithfully.

## The control

A **Voice** `<select>` in the edit panel, beside Fret/String/Duration. It offers the note's own voice, the other voices its measure sounds, and the next one up (so a second voice can be created). The move is structural (the note's ordinal changes), so it rebuilds the model and re-selects the note at its new ordinal — the same shape as #186's delete. The divergence guard now also spans the voice a note landed in: the renderer's own read (`viewInfo().voice`, alphaTab's 0-based voice index mirrored to MusicXML's 1-based) cross-checked against the document's `<voice>`, the same way the Rule 5 string mirror already is.

## Acceptance targets — proven as browser specs (`tests/browser/score-editor-voices-182.spec.js`, built dist)

1. A note moved from voice 1 to voice 2 re-imports in voice 2 at the same onset (960, beat 3), the divergence guard stays green, and no note is destroyed.
2. The measure's arithmetic round-trips: both voices of the bar sum to 1920 (the 4/4 measure), exactly one whole-measure backup, and a second parse of the written MusicXML is identical (no drift).
3. Moving into a not-yet-existing voice introduces the second voice and its backup; the re-imported structure has two sounding voices with the moved note the one that sounds in voice 2.
4. A chord member moved out splits the chord per the stated rule: it leaves as a lone note in voice 2 at onset 0 while the head keeps sounding at onset 0 in voice 1, guard green.
5. The Voice control performs the move, and a #10 fret edit on a still-voice-1 note keeps working with the guard green over the now two-voice document.

## Verification

- **Mutation test.** Neutered `moveToVoice` to a naive `<voice>` text swap (no `<backup>`/rest rebuild), rebuilt the dist, re-ran the new spec: **4 of 5 red** — targets 1–4 (onset preserved, arithmetic round-trip, backup introduced, chord split + guard). Target 5 stayed green because a relabel still changes the note's voice and the later fret edit on an unaffected note is genuinely independent of the backup arithmetic. Restored and rebuilt; all 5 green.
- **Full browser suite** (`node scripts/run-browser-tests.mjs`): **529 passed, 0 failed, 0 skipped**; spec-floor guard and out-of-band-read guard both pass (23 spec files). Existing #10 / #186 editor specs and the divergence-guard spec stay green.

## Spec floor

New per-file floor `tests/spec-floors/browser-score-editor-voices-182.json`, count 5.

Server untouched. Do not merge — for review.