### PR TITLE
Enter dotted durations and ties in the note editor (#183)

### DIFF
--- a/web/src/lib/TabViewer.svelte
+++ b/web/src/lib/TabViewer.svelte
@@ -164,6 +164,12 @@
   let selFret = $state(null);
   let selString = $state(null);
   let selType = $state(null);
+  // The selected note's augmentation dots (0/1/2) and whether it is tied into
+  // the next note (#183). Both are read back from the document on each selection
+  // and drive the Dots select and the Tie toggle below.
+  let selDots = $state(0);
+  let selTieStart = $state(false);
+  let selTieStop = $state(false);
   let selMidi = $state(null);
   let selNoteId = $state(null);
   // The selected note's voice, its onset within that voice (in the document's
@@ -225,6 +231,8 @@
   function clearSelection() {
     selectedOrdinal = null;
     selFret = selString = selType = selMidi = selNoteId = null;
+    selDots = 0;
+    selTieStart = selTieStop = false;
     selVoice = selOnset = selRenderVoice = null;
     selVoiceOptions = [];
     divergenceOk = true;
@@ -283,6 +291,9 @@
     selFret = d.fret;
     selString = d.string;
     selType = d.type;
+    selDots = d.dots ?? 0;
+    selTieStart = !!d.tieStart;
+    selTieStop = !!d.tieStop;
     selNoteId = d.id;
     selMidi = v?.midi ?? d.midi;
     selVoice = d.voice;
@@ -373,6 +384,31 @@
 
   function changeDuration(type) {
     applyEdit(() => doc.setDurationType(selectedOrdinal, type), "That duration can't be written for this note.");
+  }
+
+  // Set the selected note's augmentation dots (#183). Non-structural in the same
+  // sense a duration change is - the ordinal is unchanged - so it goes through
+  // the same applyEdit that a fret/string/duration change does: mutate the
+  // document, re-import, re-render, re-read. setDots keeps <duration> exactly
+  // consistent with <type> + the <dot/>(s), which is what the re-import agrees
+  // with; a value that cannot be written as a whole number of divisions (or a
+  // tuplet member, whose sounding duration is scaled) is refused.
+  function changeDots(value) {
+    const v = Number(value);
+    if (!Number.isInteger(v) || v < 0 || v > 2) return;
+    applyEdit(() => doc.setDots(selectedOrdinal, v), "That dotted value can't be written for this note.");
+  }
+
+  // Toggle a tie from the selected note to the next one (#183). Both notes
+  // change (the start on this one, the stop on its partner) but neither is added
+  // or removed, so the ordinal is stable and applyEdit's re-import/re-render is
+  // enough. A tie to a different pitch, or across a gap, is refused (setTie
+  // returns false) with the stated message.
+  function toggleTie() {
+    applyEdit(
+      () => doc.setTie(selectedOrdinal, !selTieStart),
+      "A tie needs the next note to be the same pitch and directly follow this one.",
+    );
   }
 
   // Move the selected note into another voice (#182). Unlike a fret/string/
@@ -953,6 +989,9 @@
   data-editor-selected-fret={selFret}
   data-editor-selected-string={selString}
   data-editor-selected-type={selType}
+  data-editor-selected-dots={selectedOrdinal != null ? selDots : null}
+  data-editor-selected-tie-start={selectedOrdinal != null ? selTieStart : null}
+  data-editor-selected-tie-stop={selectedOrdinal != null ? selTieStop : null}
   data-editor-selected-midi={selMidi}
   data-editor-selected-note-id={selNoteId}
   data-editor-selected-voice={selVoice}
@@ -1180,6 +1219,22 @@
               {/each}
             </select>
           </label>
+          <label title="Augmentation dots — a dot adds half the note's value again (a dotted quarter is 1.5× a quarter)">
+            Dots
+            <select value={String(selDots)} onchange={(e) => changeDots(e.target.value)}>
+              <option value="0">none</option>
+              <option value="1">dotted</option>
+              <option value="2">double</option>
+            </select>
+          </label>
+          <button
+            class="tie-toggle"
+            class:on={selTieStart}
+            onclick={toggleTie}
+            title="Tie this note to the next — they must be the same pitch and directly follow one another, so the two read as one held note"
+          >
+            {selTieStart ? "Tied →" : "Tie →"}
+          </button>
           <label title="Move this note to another voice — the second voice (and its backup) is created if it does not exist yet">
             Voice
             <select value={String(selVoice ?? "")} onchange={(e) => changeVoice(e.target.value)}>
@@ -1489,6 +1544,17 @@
 
   .edit-fields input {
     width: 64px;
+  }
+
+  .edit-fields .tie-toggle {
+    align-self: center;
+    padding: 5px 12px;
+  }
+
+  .edit-fields .tie-toggle.on {
+    background: var(--brass);
+    color: #241d0f;
+    font-weight: 600;
   }
 
   .edit-actions {

--- a/web/src/lib/editor/document.js
+++ b/web/src/lib/editor/document.js
@@ -16,6 +16,7 @@
 // unit-tested on its own.
 import {
   DURATION_TYPES,
+  durationForDots,
   durationForType,
   isWritablePitch,
   midiForStringFret,
@@ -55,6 +56,21 @@ function technicalOf(noteEl) {
 // note of a chord advances the measure's time cursor.
 function hasChord(noteEl) {
   return !!firstChildTag(noteEl, "chord");
+}
+
+// The <tie type=> sound element of the given type on a note, or null (#183). A
+// note carries up to two: a note held into AND out of has both a stop (from the
+// previous note) and a start (into the next). This is the SOUND half of a tie;
+// the <tied> notation half lives in <notations>.
+function firstTie(noteEl, type) {
+  for (const child of noteEl.children) {
+    if (child.tagName === "tie" && child.getAttribute("type") === type) return child;
+  }
+  return null;
+}
+
+function hasTie(noteEl, type) {
+  return !!firstTie(noteEl, type);
 }
 
 // The integer <duration> of a <note>, <backup> or <forward> - what moves the
@@ -156,9 +172,15 @@ export function createDocument(xml) {
   // voice set so the control knows which voices a note may move to.
   const onsetByEl = new Map();
   const voicesByMeasure = new Map(); // measureEl -> Set<voiceNum that sounds>
+  // measureEl -> the measure's total duration (its highest cursor). A tie whose
+  // partner is the first note of the next measure (a cross-barline tie, #183)
+  // needs to know this note reaches its own measure's end; read once here from
+  // the same walk rather than re-derived per keypress.
+  const measureDurByEl = new Map();
   for (const measureEl of doc.getElementsByTagName("measure")) {
     let cursor = 0;
     let headOnset = 0;
+    let measureDur = 0;
     const voices = new Set();
     voicesByMeasure.set(measureEl, voices);
     for (const child of measureEl.children) {
@@ -169,6 +191,7 @@ export function createDocument(xml) {
       }
       if (tag === "forward") {
         cursor += intDuration(child);
+        if (cursor > measureDur) measureDur = cursor;
         continue;
       }
       if (tag !== "note") continue;
@@ -182,8 +205,10 @@ export function createDocument(xml) {
         onsetByEl.set(child, cursor);
         headOnset = cursor;
         cursor += intDuration(child);
+        if (cursor > measureDur) measureDur = cursor;
       }
     }
+    measureDurByEl.set(measureEl, measureDur);
   }
 
   function describe(el, ordinal) {
@@ -213,6 +238,11 @@ export function createDocument(xml) {
       voice: voiceNumber(el),
       onset: onsetByEl.has(el) ? onsetByEl.get(el) : null,
       measureVoices: voices ? voices.size : null,
+      // Whether this note is tied INTO the next note (a tie starts here) and/or
+      // OUT of the previous one (a tie stops here) - #183. The control reflects
+      // and toggles the start; the stop is shown so a tied pair reads as one.
+      tieStart: hasTie(el, "start"),
+      tieStop: hasTie(el, "stop"),
     };
   }
 
@@ -358,6 +388,178 @@ export function createDocument(xml) {
     }
     typeEl.textContent = type;
     for (const dot of [...el.children].filter((c) => c.tagName === "dot")) el.removeChild(dot);
+    return true;
+  }
+
+  /**
+   * Set a sounding note's augmentation dots to `dots` (0, 1 or 2), keeping its
+   * written `<type>` and recomputing `<duration>` so the two stay consistent
+   * (#183). A dot adds half the value again: a dotted quarter is 1.5x a quarter,
+   * a double-dotted quarter 1.75x (see durationForDots). Writes exactly `dots`
+   * `<dot/>` elements in their schema position (immediately after `<type>`,
+   * before `<accidental>`/`<notations>`) and the matching `<duration>`.
+   *
+   * Structural like setDurationType - it changes the bar's arithmetic, so the
+   * caller re-imports the whole document rather than trusting an in-place tweak.
+   * Returns true when the document changed. Refuses (leaving the note untouched)
+   * when the note has no `<type>` to scale, when the dotted value is not a whole
+   * number of divisions, or when the note carries a `<time-modification>`: a
+   * tuplet member's sounding duration is its written value scaled by the tuplet
+   * ratio too, and writing a dot-only duration over that would be inconsistent -
+   * tuplets are a stated follow-on (see the PR), so a dotted tuplet is refused
+   * here rather than written wrong.
+   */
+  function setDots(ordinal, dots) {
+    const el = noteEls[ordinal];
+    if (!el || !Number.isInteger(dots) || dots < 0 || dots > 2) return false;
+    if (firstChildTag(el, "time-modification")) return false;
+    const type = tagText(el, "type");
+    if (!type) return false;
+    const value = durationForDots(type, divisions, dots);
+    if (value == null) return false;
+    const durationEl = firstChildTag(el, "duration");
+    const typeEl = firstChildTag(el, "type");
+    if (!durationEl || !typeEl) return false;
+    // Drop whatever dots the note had, then write the new count immediately after
+    // <type> (the schema's home for <dot>), so a change from two dots to one, or
+    // to none, lands correctly rather than accreting.
+    for (const dot of [...el.children].filter((c) => c.tagName === "dot")) el.removeChild(dot);
+    let anchor = typeEl;
+    for (let i = 0; i < dots; i++) {
+      const dot = doc.createElement("dot");
+      anchor.insertAdjacentElement?.("afterend", dot) ?? el.appendChild(dot);
+      anchor = dot;
+    }
+    durationEl.textContent = String(value);
+    return true;
+  }
+
+  // ------------------------------------------------------------------- ties (#183)
+  //
+  // A tie makes two same-pitch notes read as ONE held note: the first carries a
+  // <tie type="start"/> (and <tied type="start"/> notation), the second a
+  // matching stop. This profile writes BOTH the sound element (<tie>, a child of
+  // <note>) and the notation (<tied>, in <notations>), start on the first note
+  // and stop on the second, so a validating consumer and the renderer agree.
+
+  // The sounding note this note would tie TO: the next note in document order in
+  // the SAME voice that is contiguous with it (its onset is exactly where this
+  // note ends) - either the immediately-following beat in the same measure, or
+  // the first beat of the next measure when this note reaches its own measure's
+  // end (a cross-barline tie). Chord beats are not offered (see setTie). Returns
+  // { el, ordinal } or null. Pitch is NOT checked here - setTie adds that only
+  // when starting a tie, so a tie can still be REMOVED after a fret edit spoils
+  // the match.
+  function tieNext(ordinal) {
+    const el = noteEls[ordinal];
+    if (!el || isRest(el) || hasChord(el)) return null;
+    const voice = voiceNumber(el);
+    const onset = onsetByEl.get(el);
+    const dur = intDuration(el);
+    const measureEl = el.closest ? el.closest("measure") : null;
+    if (voice == null || onset == null || !measureEl) return null;
+    for (let i = ordinal + 1; i < noteEls.length; i++) {
+      const cand = noteEls[i];
+      // Skip a chord member (it shares its head's onset); the head is what a tie
+      // would attach to, and it precedes its members in document order.
+      if (hasChord(cand)) continue;
+      if (voiceNumber(cand) !== voice) continue;
+      const candMeasure = cand.closest ? cand.closest("measure") : null;
+      const candOnset = onsetByEl.get(cand);
+      if (candMeasure === measureEl) {
+        // Same measure: the partner must start exactly where this note ends. A
+        // non-contiguous next note means a gap (a rest) sits between them, which
+        // a tie must not span.
+        return candOnset === onset + dur ? { el: cand, ordinal: i } : null;
+      }
+      // A later measure: only the first beat of it, and only when this note runs
+      // to its own measure's end, is contiguous across the barline.
+      if (candOnset === 0 && onset + dur === measureDurByEl.get(measureEl)) {
+        return { el: cand, ordinal: i };
+      }
+      return null;
+    }
+    return null;
+  }
+
+  // Write (or ensure) the <tie> sound element and <tied> notation of `type`
+  // ("start"/"stop") on a note. <tie> sits after <duration> (its schema home,
+  // before <voice>); <tied> goes in <notations> (created if absent), before the
+  // <technical> that carries string/fret.
+  function writeTie(el, type) {
+    if (!firstTie(el, type)) {
+      const tie = doc.createElement("tie");
+      tie.setAttribute("type", type);
+      const durationEl = firstChildTag(el, "duration");
+      if (durationEl) durationEl.insertAdjacentElement?.("afterend", tie) ?? el.appendChild(tie);
+      else el.appendChild(tie);
+    }
+    let notations = firstChildTag(el, "notations");
+    if (!notations) {
+      notations = doc.createElement("notations");
+      el.appendChild(notations);
+    }
+    const already = [...notations.children].some((c) => c.tagName === "tied" && c.getAttribute("type") === type);
+    if (!already) {
+      const tied = doc.createElement("tied");
+      tied.setAttribute("type", type);
+      notations.insertBefore(tied, notations.firstChild);
+    }
+  }
+
+  // Remove the <tie> sound element and <tied> notation of `type` from a note.
+  function removeTie(el, type) {
+    const tie = firstTie(el, type);
+    if (tie) el.removeChild(tie);
+    const notations = firstChildTag(el, "notations");
+    if (notations) {
+      for (const c of [...notations.children]) {
+        if (c.tagName === "tied" && c.getAttribute("type") === type) notations.removeChild(c);
+      }
+    }
+  }
+
+  /**
+   * Tie the sounding note at `ordinal` to the next note (`on` true), or remove
+   * that tie (`on` false). Returns true when the document changed (#183).
+   *
+   * The decisions, stated so a reader need not infer them:
+   * - A tie joins THIS note to the NEXT one. "Next" is the next sounding note in
+   *   the same voice that is contiguous with this one - the following beat in the
+   *   measure, or the first beat of the next measure when this note reaches the
+   *   barline. A gap (a rest) between them, or the next note being in another
+   *   voice, means there is nothing to tie to and the request is refused.
+   * - The two notes must be the SAME pitch. A tie sustains one pitch; joining two
+   *   different pitches is a slur, not a tie, and is refused with the document
+   *   untouched (so the field can be corrected).
+   * - Chord beats are not offered. A tie on a chord member (or from a chord) would
+   *   have to pair every voice of the chord; this increment refuses it.
+   * - It can be removed. Toggling a started tie off drops both the start on this
+   *   note and the stop on its partner, found structurally (by the tie, not by
+   *   re-matching the pitch), so a later fret edit cannot orphan the stop.
+   */
+  function setTie(ordinal, on) {
+    const el = noteEls[ordinal];
+    if (!el || isRest(el) || hasChord(el)) return false;
+    const startsHere = hasTie(el, "start");
+    if (on) {
+      if (startsHere) return false; // already tied to the next note - a no-op
+      const next = tieNext(ordinal);
+      if (!next) return false;
+      const here = describe(el, ordinal).midi;
+      const there = describe(next.el, next.ordinal).midi;
+      if (here == null || there == null || here !== there) return false;
+      writeTie(el, "start");
+      writeTie(next.el, "stop");
+      return true;
+    }
+    if (!startsHere) return false; // nothing to remove
+    const next = tieNext(ordinal);
+    removeTie(el, "start");
+    // Remove the partner's stop too. tieNext finds it structurally (contiguity,
+    // not pitch), so an edit that changed the note's pitch after it was tied
+    // still lets the pair be untied cleanly.
+    if (next) removeTie(next.el, "stop");
     return true;
   }
 
@@ -671,6 +873,8 @@ export function createDocument(xml) {
     setFret,
     setString,
     setDurationType,
+    setDots,
+    setTie,
     deleteNote,
     moveToVoice,
     text,

--- a/web/src/lib/editor/notes.js
+++ b/web/src/lib/editor/notes.js
@@ -149,3 +149,29 @@ export function durationForType(type, divisions) {
   const value = q * divisions;
   return Number.isInteger(value) ? value : null;
 }
+
+/**
+ * The `<duration>` value for a note of the given `<type>` carrying `dots`
+ * augmentation dots (#183). A dot adds half the value again, a second dot half
+ * of THAT again: one dot is 3/2 the plain value, two dots 7/4 - in general the
+ * multiplier is (2^(dots+1) - 1) / 2^dots. So a dotted quarter is 1.5x a
+ * quarter and a double-dotted quarter 1.75x, and the written `<dot/>`
+ * element(s) and this `<duration>` stay exactly consistent (the divergence the
+ * re-import round-trip checks for).
+ *
+ * `dots` is 0, 1 or 2 - the values this increment writes. Returns null when the
+ * plain type has no duration at this divisions (see durationForType), when the
+ * dotted value is not a whole number of units (a dotted 16th against a divisions
+ * too coarse to halve again), or when `dots` is outside 0..2 - in every such
+ * case the caller keeps the note as it was rather than writing a rounded,
+ * wrong duration.
+ */
+export function durationForDots(type, divisions, dots = 0) {
+  if (!Number.isInteger(dots) || dots < 0 || dots > 2) return null;
+  const base = durationForType(type, divisions);
+  if (base == null) return null;
+  const numerator = 2 ** (dots + 1) - 1; // 1, 3, 7
+  const denominator = 2 ** dots; //          1, 2, 4
+  const value = (base * numerator) / denominator;
+  return Number.isInteger(value) ? value : null;
+}

--- a/web/tests/browser/score-editor-rhythm-183.spec.js
+++ b/web/tests/browser/score-editor-rhythm-183.spec.js
@@ -1,0 +1,297 @@
+// Dotted durations and ties (#183), end to end against the real alphaTab render
+// and the real editor/document.js parse - the same fixture and stub the
+// first-increment suite uses (score-editor.spec.js, fixtures/editor-score.js),
+// only the HTTP transport stubbed. Every assertion is on state the app
+// publishes onto the DOM (data-editor-*), the read-only geometry/model hook
+// window.__scoreEditor, or the exact MusicXML persisted through the save path -
+// never on an internal reached into.
+//
+// The two edits this covers (tuplets are a stated follow-on - see the PR):
+//   - Dots: the Dots control sets a note's augmentation dots, writing the
+//     <dot/>(s) AND a <duration> that stays exactly consistent (a dotted quarter
+//     is 720 against divisions 480, a double-dotted quarter 840). The re-import
+//     agrees and the bar arithmetic holds when the dotted note and the shortened
+//     one it borrows from still sum to the space they replaced.
+//   - Ties: the Tie control joins the selected note to the next one so the two
+//     read as ONE held note, writing <tie> (sound) AND <tied> (notation),
+//     type="start" on the first and "stop" on the second. The two must be the
+//     same pitch; a tie to a different pitch is refused. It can be removed.
+//
+// What each mutation would turn red, so this suite is falsifiable, not green by
+// construction:
+//   - omit the <dot/> while keeping the longer <duration> (or vice versa): the
+//     re-imported dot count stops matching, and the "writes the dot" assertions
+//     on the persisted MusicXML go red.
+//   - compute the dotted <duration> as the plain value (drop the *3/2): the bar
+//     no longer sums to 1920 -> "the bar still sums" red, and the persisted
+//     <duration> assertion red.
+//   - drop either the <tie> or the <tied> (or a matching start/stop): the
+//     persisted-MusicXML tie assertions go red.
+//   - skip the same-pitch guard (tie to any next note): the "refused" test's
+//     expectation that nothing was written, and dirty stayed false, goes red.
+import { test, expect } from "@playwright/test";
+
+import { EDITOR_MUSICXML, stubEditorApi } from "./fixtures/editor-score.js";
+
+const wrap = (page) => page.locator(".staff-render .wrap");
+const host = (page) => page.locator(".staff-render .at-host");
+const fretInput = (page) => page.locator(".edit-fields input");
+const durationSelect = (page) => page.locator(".edit-fields label", { hasText: "Duration" }).locator("select");
+const dotsSelect = (page) => page.locator(".edit-fields label", { hasText: "Dots" }).locator("select");
+const tieButton = (page) => page.locator(".edit-fields .tie-toggle");
+
+async function renderedOk(page) {
+  await expect(host(page)).toHaveAttribute("data-score-render-ok", "true");
+}
+
+// Opens the editor over `content` and waits until the whole score's `expected`
+// sounding notes are laid out - the barrier every read below waits behind.
+async function openEditor(page, content, expected) {
+  const handle = await stubEditorApi(page, content);
+  await page.goto("/#/score/1");
+  await page.waitForSelector(".staff-render");
+  await page.getByRole("button", { name: "Staff", exact: true }).click();
+  await renderedOk(page);
+  await page.getByRole("button", { name: "Edit notes" }).click();
+  await expect(wrap(page)).toHaveAttribute("data-editor-active", "true");
+  await expect.poll(() => page.evaluate(() => window.__scoreEditor?.noteCount() ?? 0)).toBe(expected);
+  return handle;
+}
+
+async function selectNote(page, ordinal) {
+  const point = await page.evaluate((o) => window.__scoreEditor.headPoint(o), ordinal);
+  expect(point, `note ${ordinal} has a clickable head`).toBeTruthy();
+  await page.mouse.click(point.x, point.y);
+  await expect(wrap(page)).toHaveAttribute("data-editor-selected", String(ordinal));
+}
+
+// The per-voice sum of note+rest <duration> in a measure of a MusicXML string,
+// computed in the page's own DOMParser - Rule 8's own arithmetic (chord members
+// counted once). Returns { voices: {n: sum} }.
+async function measureShape(page, xml, measureNumber) {
+  return page.evaluate(
+    ({ xml, measureNumber }) => {
+      const doc = new DOMParser().parseFromString(xml, "application/xml");
+      const m = [...doc.getElementsByTagName("measure")].find((el) => el.getAttribute("number") === String(measureNumber));
+      const voices = {};
+      for (const child of m.children) {
+        if (child.tagName !== "note") continue;
+        if (child.getElementsByTagName("chord")[0]) continue;
+        const v = child.getElementsByTagName("voice")[0]?.textContent ?? "?";
+        const d = Number(child.getElementsByTagName("duration")[0]?.textContent) || 0;
+        voices[v] = (voices[v] ?? 0) + d;
+      }
+      return { voices };
+    },
+    { xml, measureNumber },
+  );
+}
+
+// Everything the rhythm edits touch on ONE note of a MusicXML string, read by
+// its Rule 17 id (which setDots/setTie never renumber): its <type>, its <dot/>
+// count, its <duration>, the <tie> sound types it carries, and the <tied>
+// notation types. A DIRECT child <tie> only (not a nested one), so the sound
+// half is counted where the schema puts it.
+async function noteById(page, xml, id) {
+  return page.evaluate(
+    ({ xml, id }) => {
+      const doc = new DOMParser().parseFromString(xml, "application/xml");
+      const note = [...doc.getElementsByTagName("note")].find((n) => n.getAttribute("id") === id);
+      if (!note) return null;
+      const ties = [...note.children].filter((c) => c.tagName === "tie").map((c) => c.getAttribute("type"));
+      const notations = [...note.children].find((c) => c.tagName === "notations");
+      const tied = notations
+        ? [...notations.children].filter((c) => c.tagName === "tied").map((c) => c.getAttribute("type"))
+        : [];
+      return {
+        type: note.getElementsByTagName("type")[0]?.textContent ?? null,
+        dots: [...note.children].filter((c) => c.tagName === "dot").length,
+        duration: Number(note.getElementsByTagName("duration")[0]?.textContent) || 0,
+        ties: ties.sort(),
+        tied: tied.sort(),
+      };
+    },
+    { xml, id },
+  );
+}
+
+async function save(page) {
+  await page.getByRole("button", { name: "Save", exact: true }).click();
+  await expect(wrap(page)).toHaveAttribute("data-editor-dirty", "false");
+}
+
+test.describe("note editor - dotted durations (#183)", () => {
+  // Target 1: a note set to dotted writes the <dot/> and a <duration> that
+  // round-trips; re-import shows the dotted value; guard green; the bar
+  // arithmetic is correct.
+  test("a dotted quarter writes the dot and a round-tripping duration, and the bar still sums", async ({ page }) => {
+    const { saved } = await openEditor(page, EDITOR_MUSICXML, 8);
+
+    // Shorten note 1 (a quarter, 480) to an eighth (240), then dot note 0's
+    // quarter (480 -> 720). 720 + 240 = 960 = the two quarters they replaced, so
+    // voice 1 still fills the 4/4 bar (720 + 240 + 480 + 480 = 1920).
+    await selectNote(page, 1);
+    await durationSelect(page).selectOption("eighth");
+    await expect(wrap(page)).toHaveAttribute("data-editor-selected-type", "eighth");
+
+    await selectNote(page, 0);
+    await expect(wrap(page)).toHaveAttribute("data-editor-selected-type", "quarter");
+    await expect(wrap(page)).toHaveAttribute("data-editor-selected-dots", "0");
+    await dotsSelect(page).selectOption("1");
+
+    // Re-imported: the document shows one dot, the pitch is undisturbed, the two
+    // reads still agree.
+    await expect(wrap(page)).toHaveAttribute("data-editor-selected-dots", "1");
+    await expect(wrap(page)).toHaveAttribute("data-editor-selected-type", "quarter");
+    await expect(wrap(page)).toHaveAttribute("data-editor-selected-midi", "64");
+    await expect(wrap(page)).toHaveAttribute("data-editor-divergence-ok", "true");
+    await expect(wrap(page)).toHaveAttribute("data-editor-dirty", "true");
+    await expect.poll(() => page.evaluate(() => window.__scoreEditor?.noteCount() ?? 0)).toBe(8);
+
+    await save(page);
+    await expect.poll(() => saved.content).not.toBeNull();
+
+    // The persisted note carries exactly one <dot/> and the dotted <duration>.
+    const n0 = await noteById(page, saved.content, "n1-1-0-0");
+    expect(n0).toMatchObject({ type: "quarter", dots: 1, duration: 720 });
+
+    // The bar's voice 1 still sums to the 4/4 measure (720 + 240 + 480 + 480).
+    const shape = await measureShape(page, saved.content, 1);
+    expect(shape.voices["1"]).toBe(1920);
+
+    // A second parse of what was written is identical - no drift on re-import.
+    const again = await measureShape(page, saved.content, 1);
+    expect(again).toEqual(shape);
+  });
+
+  // Target 1 (double dot): two <dot/>s and 7/4 the duration, re-imported.
+  test("a double-dotted quarter writes two dots and 7/4 the duration", async ({ page }) => {
+    const { saved } = await openEditor(page, EDITOR_MUSICXML, 8);
+    await selectNote(page, 0);
+    await dotsSelect(page).selectOption("2");
+    await expect(wrap(page)).toHaveAttribute("data-editor-selected-dots", "2");
+    await expect(wrap(page)).toHaveAttribute("data-editor-selected-midi", "64");
+    await expect(wrap(page)).toHaveAttribute("data-editor-divergence-ok", "true");
+
+    await save(page);
+    await expect.poll(() => saved.content).not.toBeNull();
+    // 480 * 7/4 = 840, with two dots.
+    const n0 = await noteById(page, saved.content, "n1-1-0-0");
+    expect(n0).toMatchObject({ type: "quarter", dots: 2, duration: 840 });
+
+    // Setting it back to none drops both dots and restores the plain duration.
+    await selectNote(page, 0);
+    await dotsSelect(page).selectOption("0");
+    await expect(wrap(page)).toHaveAttribute("data-editor-selected-dots", "0");
+    await save(page);
+    const n0b = await noteById(page, saved.content, "n1-1-0-0");
+    expect(n0b).toMatchObject({ type: "quarter", dots: 0, duration: 480 });
+  });
+});
+
+test.describe("note editor - ties (#183)", () => {
+  // Target 3 (refusal half): a tie to a different pitch is refused, the document
+  // untouched.
+  test("a tie to a different pitch is refused and nothing is written", async ({ page }) => {
+    await openEditor(page, EDITOR_MUSICXML, 8);
+    // Note 0 is E4 (fret 0); the next note (1) is F#4 (fret 2) - a different
+    // pitch, so it cannot be tied.
+    await selectNote(page, 0);
+    await expect(wrap(page)).toHaveAttribute("data-editor-selected-midi", "64");
+    await tieButton(page).click();
+
+    // Refused: a warning is shown, no tie is on the note, and nothing changed.
+    await expect(wrap(page)).toHaveAttribute("data-editor-warn", /same pitch/);
+    await expect(wrap(page)).toHaveAttribute("data-editor-selected-tie-start", "false");
+    await expect(wrap(page)).toHaveAttribute("data-editor-dirty", "false");
+    await expect(wrap(page)).toHaveAttribute("data-editor-divergence-ok", "true");
+  });
+
+  // Target 3 (main): two same-pitch notes tied read as one held note on
+  // re-import - <tie>+<tied> start on the first, stop on the second - guard
+  // green, no note destroyed, bar arithmetic unchanged.
+  test("two same-pitch notes are tied and read as one held note", async ({ page }) => {
+    const { saved } = await openEditor(page, EDITOR_MUSICXML, 8);
+    // Make note 1 the SAME pitch as note 0: fret 2 (F#4) -> fret 0 (E4).
+    await selectNote(page, 1);
+    await fretInput(page).fill("0");
+    await fretInput(page).blur();
+    await expect(wrap(page)).toHaveAttribute("data-editor-selected-midi", "64");
+
+    // Tie note 0 to note 1 (both E4, contiguous in measure 1).
+    await selectNote(page, 0);
+    await tieButton(page).click();
+    await expect(wrap(page)).toHaveAttribute("data-editor-selected-tie-start", "true");
+    await expect(wrap(page)).toHaveAttribute("data-editor-divergence-ok", "true");
+    await expect(wrap(page)).toHaveAttribute("data-editor-dirty", "true");
+    // The partner reads back as tied INTO from the previous note.
+    await selectNote(page, 1);
+    await expect(wrap(page)).toHaveAttribute("data-editor-selected-tie-stop", "true");
+    await expect(wrap(page)).toHaveAttribute("data-editor-selected-tie-start", "false");
+    // Nothing was destroyed - both notes still sound.
+    await expect.poll(() => page.evaluate(() => window.__scoreEditor?.noteCount() ?? 0)).toBe(8);
+
+    await save(page);
+    await expect.poll(() => saved.content).not.toBeNull();
+    // Both the sound (<tie>) and notation (<tied>) halves, start on the first
+    // note and stop on the second.
+    const first = await noteById(page, saved.content, "n1-1-0-0");
+    const second = await noteById(page, saved.content, "n1-1-1-0");
+    expect(first.ties).toEqual(["start"]);
+    expect(first.tied).toEqual(["start"]);
+    expect(second.ties).toEqual(["stop"]);
+    expect(second.tied).toEqual(["stop"]);
+    // A tie changes no duration, so the bar still sums to the 4/4 measure.
+    const shape = await measureShape(page, saved.content, 1);
+    expect(shape.voices["1"]).toBe(1920);
+  });
+
+  // Target 3 (removable): a tie can be toggled off, dropping both halves on both
+  // notes.
+  test("a tie can be removed again", async ({ page }) => {
+    const { saved } = await openEditor(page, EDITOR_MUSICXML, 8);
+    await selectNote(page, 1);
+    await fretInput(page).fill("0");
+    await fretInput(page).blur();
+    await selectNote(page, 0);
+    await tieButton(page).click();
+    await expect(wrap(page)).toHaveAttribute("data-editor-selected-tie-start", "true");
+
+    // Toggle it off.
+    await tieButton(page).click();
+    await expect(wrap(page)).toHaveAttribute("data-editor-selected-tie-start", "false");
+    await save(page);
+    await expect.poll(() => saved.content).not.toBeNull();
+    const first = await noteById(page, saved.content, "n1-1-0-0");
+    const second = await noteById(page, saved.content, "n1-1-1-0");
+    expect(first.ties).toEqual([]);
+    expect(first.tied).toEqual([]);
+    expect(second.ties).toEqual([]);
+    expect(second.tied).toEqual([]);
+  });
+
+  // Target 4: the existing #10 fret edit and the divergence guard still work
+  // over a document now carrying a dot and a tie.
+  test("after a dot and a tie, a fret edit still works and the guard stays green", async ({ page }) => {
+    await openEditor(page, EDITOR_MUSICXML, 8);
+    // A dot on note 3, a tie between notes 0 and 1 (same pitch first).
+    await selectNote(page, 3);
+    await dotsSelect(page).selectOption("1");
+    await expect(wrap(page)).toHaveAttribute("data-editor-selected-dots", "1");
+    await selectNote(page, 1);
+    await fretInput(page).fill("0");
+    await fretInput(page).blur();
+    await selectNote(page, 0);
+    await tieButton(page).click();
+    await expect(wrap(page)).toHaveAttribute("data-editor-selected-tie-start", "true");
+
+    // A #10 fret edit on note 2 (G4, string 1 fret 3 -> fret 5 = A4 = MIDI 69),
+    // guard green over the document that now carries a dot and a tie.
+    await selectNote(page, 2);
+    await fretInput(page).fill("5");
+    await fretInput(page).blur();
+    await expect(wrap(page)).toHaveAttribute("data-editor-selected-fret", "5");
+    await expect(wrap(page)).toHaveAttribute("data-editor-selected-midi", "69");
+    await expect(wrap(page)).toHaveAttribute("data-editor-divergence-ok", "true");
+  });
+});

--- a/web/tests/spec-floors/browser-score-editor-rhythm-183.json
+++ b/web/tests/spec-floors/browser-score-editor-rhythm-183.json
@@ -1,0 +1,5 @@
+{
+  "file": "tests/browser/score-editor-rhythm-183.spec.js",
+  "count": 6,
+  "reason": "issue #183 dotted durations and ties (tuplets are a stated follow-on). Dots: the Dots control sets a note's augmentation dots, writing the <dot/>(s) AND a <duration> that stays consistent - a dotted quarter is 720 against divisions 480 and a double-dotted quarter 840 - so a dotted quarter plus the eighth it borrows from still fills the 4/4 bar (720+240+480+480=1920), the re-import shows the dot count, the guard stays green, and setting the dots back to none restores the plain 480. Ties: the Tie control joins the selected note to the next same-pitch note, writing both the <tie> sound element and the <tied> notation with type=start on the first note and type=stop on the second; a tie to a different pitch is refused with the document untouched; the pair reads back as one held note on re-import (start on the first, stop on the second) with the bar arithmetic unchanged and no note destroyed; and the tie can be removed again, dropping both halves on both notes. A #10 fret edit and the divergence guard stay green over a document now carrying a dot and a tie."
+}

--- a/web/tests/spec-floors/unit-editor-10.json
+++ b/web/tests/spec-floors/unit-editor-10.json
@@ -1,5 +1,5 @@
 {
   "file": "tests/unit/editor.spec.js",
-  "count": 12,
-  "reason": "issue #10: the note editor's pure arithmetic - pitch<->MIDI round-trip and sharp spelling, the Rule 5 string/staff-tuning mirror, sounding pitch from string+fret with out-of-range strings and negative frets refused, the Rule 11 writable-pitch range (MIDI 12-131 / octaves 0-9), and duration-from-type including a divisions value that cannot express the type."
+  "count": 16,
+  "reason": "issue #10: the note editor's pure arithmetic - pitch<->MIDI round-trip and sharp spelling, the Rule 5 string/staff-tuning mirror, sounding pitch from string+fret with out-of-range strings and negative frets refused, the Rule 11 writable-pitch range (MIDI 12-131 / octaves 0-9), and duration-from-type including a divisions value that cannot express the type. Plus issue #183's dotted-duration arithmetic (durationForDots): zero dots is the plain value, one dot is 3/2 and two dots 7/4 of it, a dotted value that is not a whole number of divisions is refused, and a dot count outside 0..2 is refused."
 }

--- a/web/tests/unit/editor.spec.js
+++ b/web/tests/unit/editor.spec.js
@@ -10,6 +10,7 @@ import {
   DURATION_TYPES,
   MAX_WRITABLE_MIDI,
   MIN_WRITABLE_MIDI,
+  durationForDots,
   durationForType,
   isWritablePitch,
   midiForStringFret,
@@ -123,4 +124,41 @@ test("a duration that cannot be expressed as a whole number of units is refused"
 test("an unknown type has no duration", () => {
   expect(durationForType("breve", 480)).toBeNull();
   expect(DURATION_TYPES).toContain("quarter");
+});
+
+// ---------------------------------------------------------------- dotted durations (#183)
+
+test("zero dots is the plain duration", () => {
+  // No dots is exactly durationForType, so the same control can ask for either.
+  expect(durationForDots("quarter", 480, 0)).toBe(480);
+  expect(durationForDots("eighth", 480, 0)).toBe(240);
+});
+
+test("a dot adds half the value again, a second dot half of that", () => {
+  // Dotted quarter = 480 * 3/2 = 720; double-dotted = 480 * 7/4 = 840.
+  expect(durationForDots("quarter", 480, 1)).toBe(720);
+  expect(durationForDots("quarter", 480, 2)).toBe(840);
+  // Dotted eighth = 240 * 3/2 = 360; double-dotted = 240 * 7/4 = 420.
+  expect(durationForDots("eighth", 480, 1)).toBe(360);
+  expect(durationForDots("eighth", 480, 2)).toBe(420);
+  // Dotted half = 960 * 3/2 = 1440 (three quarters, the classic 3/4-bar note).
+  expect(durationForDots("half", 480, 1)).toBe(1440);
+});
+
+test("a dotted value that is not a whole number of divisions is refused", () => {
+  // A dotted 16th at divisions 480 is 120 * 3/2 = 180 (fine); a double-dotted
+  // 16th is 120 * 7/4 = 210 (fine). But halve the divisions to where the plain
+  // type is already odd and the dot cannot land on a whole unit:
+  expect(durationForDots("16th", 480, 1)).toBe(180);
+  expect(durationForDots("16th", 480, 2)).toBe(210);
+  // divisions 1: a quarter is 1 unit, and 1 * 3/2 is not a whole number.
+  expect(durationForDots("quarter", 1, 1)).toBeNull();
+  // A plain type that already has no duration stays null with any dots.
+  expect(durationForDots("32nd", 1, 0)).toBeNull();
+});
+
+test("a dot count outside 0..2 is refused", () => {
+  expect(durationForDots("quarter", 480, 3)).toBeNull();
+  expect(durationForDots("quarter", 480, -1)).toBeNull();
+  expect(durationForDots("quarter", 480, 1.5)).toBeNull();
 });


### PR DESCRIPTION
Follow-up to #10, continuing the rhythm-entry work deferred in #183. The first
increment set a note's plain, undotted written type; this lands two of the three
remaining kinds — **dotted durations** and **ties** — each keeping the sounding
`<duration>` exactly consistent with what is written, so the re-import
round-trip and the per-selection divergence guard stay green.

Tuplets, the third kind, are **scoped out to a stated follow-on** (see below).
So this PR **partially addresses #183**; it does not close it.

## Dotted durations

A new **Dots** control (none / dotted / double) sets a note's augmentation dots,
writing the `<dot/>` element(s) and recomputing `<duration>`:

- The multiplier is `(2^(dots+1) - 1) / 2^dots` — one dot is `3/2` the plain
  value, two dots `7/4`. At `divisions=480` a dotted quarter is `720` and a
  double-dotted quarter `840`.
- A value that is not a whole number of divisions is **refused** (the note kept
  as it was) rather than rounded, exactly as `durationForType` already refuses
  an inexpressible plain type.
- Follows `setDurationType`'s shape: it changes the bar's arithmetic, so the
  whole document is re-imported and re-rendered rather than tweaked in place.
- A note carrying a `<time-modification>` (a tuplet member) is refused, since a
  dot-only duration over a scaled one would be inconsistent — deferred with
  tuplets.

## Ties

A new **Tie →** toggle joins the selected note to the next one so the two read
as one held note. It writes **both** halves MusicXML requires — the `<tie>`
sound element (a child of `<note>`) and the `<tied>` notation (in
`<notations>`) — `type="start"` on the first note and `type="stop"` on the
second.

- Ties **this note to the next one**, where "next" is the next sounding note in
  the same voice that is *contiguous* with it — the following beat in the
  measure, or the first beat of the next measure when this note reaches the
  barline (a cross-barline tie). A gap (a rest) between them, or a next note in
  another voice, means there is nothing to tie to, and the request is refused.
- The two notes must be the **same pitch**; a tie to a different pitch is a slur,
  not a tie, and is refused with the document untouched.
- It can be **removed** again, dropping both halves on both notes; the partner is
  found structurally (by the tie, not by re-matching the pitch), so a later fret
  edit cannot orphan the stop.
- Chord beats are not offered in this increment.

## Tuplets — scoped out, with justification

A correct tuplet is a complete **group** (N consecutive notes, `<tuplet
type="start"/>`…`type="stop"`, each with `<time-modification>` and its shortened
sounding `<duration>`); a lone note given a `<time-modification>` leaves the bar
short and is not acceptable. Forming that group needs a **multi-note-selection
model the editor does not have** — today the editor selects and edits exactly
one note — plus group-detection, rest-fill to keep the measure summing, removal,
and id/ordinal remapping. That is materially larger than dots and ties, so no
partial or reachable tuplet code path is shipped here. It is left as the stated
next increment on #183.

## Falsifiable targets (browser specs, against the built `dist`)

New spec `tests/browser/score-editor-rhythm-183.spec.js` (6 tests), plus 4 unit
tests for the dotted arithmetic in `tests/unit/editor.spec.js`:

- **Dotted:** a dotted quarter writes one `<dot/>` and `<duration>720`; paired
  with the eighth it borrows from, voice 1 still fills the 4/4 bar
  (`720+240+480+480=1920`) and a second parse is identical; a double-dotted
  quarter writes two dots and `840`; setting the dots back to none restores
  `480`. Guard green throughout.
- **Tie:** two same-pitch notes tie into one held note — `<tie>`+`<tied>`
  start on the first, stop on the second, bar arithmetic unchanged, no note
  destroyed; a tie to a different pitch is refused with nothing written and
  `dirty` still false; a tie can be removed. Guard green.
- **Regression:** a #10 fret edit and the divergence guard stay green over a
  document now carrying a dot and a tie.

## Verification

- Full browser suite (the project runner, built `dist`): **539 passed, 0 failed,
  0 skipped**; the spec-floor guard and out-of-band-reads guard both pass.
  Existing #10/#182/#186 editor specs and the divergence guard stay green.
- Per-file spec floors added/updated: `browser-score-editor-rhythm-183.json`
  (count 6) and `unit-editor-10.json` (12 → 16).
- Mutation-tested the core of each shipped sub-feature (rebuilt each time):
  - Dotted — omit the `<dot/>` while keeping the longer `<duration>`: **2**
    dotted specs red, naming the re-imported dot count. Restored → green.
  - Tie — drop the `<tied>` notation half: **1** tie spec red, naming the
    missing notation. Restored → green.
