### PR TITLE
Note editor: an N-random-edits divergence fuzz guard and polyphonic selection (#189)

### DIFF
--- a/web/src/lib/TabViewer.svelte
+++ b/web/src/lib/TabViewer.svelte
@@ -270,7 +270,10 @@
     doc = null;
     editError = "";
     view?.editor?.setNotationShown(false);
-    if (typeof window !== "undefined") window.__scoreEditor = null;
+    if (typeof window !== "undefined") {
+      window.__scoreEditor = null;
+      window.__scoreEditorHarness = null;
+    }
   }
 
   function toggleEdit() {
@@ -349,6 +352,76 @@
       width: r.width,
       height: r.height,
     };
+  }
+
+  // The N-random-edits fuzz guard's assertion (#189), stronger than the
+  // per-selection divergence cross-check above because it spans EVERY note, not
+  // just the selected one. The per-selection guard catches a MISREAD of the note
+  // under the cursor; it cannot catch a positional-map SHIFT - a voice move or a
+  // delete that leaves the renderer's ordinal N naming a different note than the
+  // document's ordinal N - unless that exact note happens to be selected. This
+  // re-imports the WRITTEN MusicXML (a fresh parse of doc.text()) and asserts the
+  // on-screen model equals it across all ordinals, so a shift anywhere shows.
+  //
+  // The equality asserted, enumerated:
+  //   - count: the renderer's sounding-note count equals the re-import's.
+  //   - per ordinal, the note the renderer drew and the note the re-import reads
+  //     at that SAME ordinal are the same note: pitch (midi), string (MusicXML
+  //     numbering), fret and voice all agree. This is what a positional shift
+  //     breaks.
+  //   - a full written-document round-trip: the live model's own reads against a
+  //     fresh re-parse of the written text, field by field - id, pitch/spelling,
+  //     string, fret, voice, ONSET, duration (via type + dots) and TIES - so the
+  //     serializer/parser round-trip is proven lossless over onsets, durations
+  //     and ties too, not only the four the renderer exposes.
+  //
+  // Returns { ok, docCount, renderCount, divergences } where each divergence
+  // NAMES what disagreed ({ ordinal, field, id, doc, render } or a round-trip
+  // entry), so a failing fuzz run points at the note rather than only going red.
+  function auditAllNotes() {
+    if (!doc || !view) return { ok: false, docCount: 0, renderCount: 0, divergences: [{ field: "no-document" }] };
+    let redoc;
+    try {
+      redoc = createDocument(doc.text());
+    } catch (e) {
+      return { ok: false, docCount: 0, renderCount: 0, divergences: [{ field: "reimport-failed", detail: String(e?.message ?? e) }] };
+    }
+    const docCount = redoc.count();
+    const renderCount = view.editor.noteCount();
+    const divergences = [];
+    if (docCount !== renderCount) divergences.push({ field: "count", doc: docCount, render: renderCount });
+    const n = Math.min(docCount, renderCount);
+    for (let i = 0; i < n; i++) {
+      const d = redoc.noteAt(i);
+      const v = view.editor.viewInfo(i);
+      if (!v) {
+        divergences.push({ ordinal: i, field: "no-render-view", id: d?.id ?? null });
+        continue;
+      }
+      if (v.midi !== d.midi) divergences.push({ ordinal: i, field: "midi", id: d.id, doc: d.midi, render: v.midi });
+      if (v.mxString !== d.string)
+        divergences.push({ ordinal: i, field: "string", id: d.id, doc: d.string, render: v.mxString });
+      if (v.fret !== d.fret) divergences.push({ ordinal: i, field: "fret", id: d.id, doc: d.fret, render: v.fret });
+      if (v.voice != null && v.voice !== d.voice)
+        divergences.push({ ordinal: i, field: "voice", id: d.id, doc: d.voice, render: v.voice });
+    }
+    // The written-document round-trip: the live (edited-in-place) model vs a
+    // fresh re-parse of its own serialization, so onset/duration/tie identity is
+    // asserted on both sides even though the renderer seam does not expose them.
+    const live = doc.soundingNotes();
+    const round = redoc.soundingNotes();
+    if (live.length !== round.length) {
+      divergences.push({ field: "roundtrip-count", live: live.length, round: round.length });
+    } else {
+      const fields = ["id", "midi", "step", "alter", "string", "fret", "voice", "onset", "type", "dots", "tieStart", "tieStop"];
+      for (let i = 0; i < live.length; i++) {
+        for (const f of fields) {
+          if (live[i][f] !== round[i][f])
+            divergences.push({ ordinal: i, field: `roundtrip-${f}`, id: live[i].id, live: live[i][f], round: round[i][f] });
+        }
+      }
+    }
+    return { ok: divergences.length === 0, docCount, renderCount, divergences };
   }
 
   async function applyEdit(mutate, refusal) {
@@ -626,7 +699,93 @@
           viewInfo: (ordinal) => v.editor.viewInfo(ordinal),
           noteCount: () => v.editor.noteCount(),
           boundsCount: () => v.editor.boundsCount(),
+          // The whole-model re-import cross-check (#189). Read-only like the rest
+          // of this hook - it re-parses the written document and compares, it
+          // does not write. Exposed here so the fuzz spec can assert on the same
+          // audit the guard runs, and NAME a divergence when one is found.
+          audit: () => auditAllNotes(),
         };
+        // The N-random-edits fuzz DRIVER (#189) - test instrumentation, gated
+        // behind an opt-in flag a test sets before load (addInitScript), so it
+        // never exists in an ordinary session. Unlike __scoreEditor above it
+        // MUTATES, but only by calling the very functions the panel's own
+        // controls call, so it can drive nothing a user with the editor open
+        // could not. It lets a seeded sequence apply real edits through the real
+        // reload/re-render/divergence path (`apply`), and deliberately induce a
+        // stale-render divergence for the guard to catch (`corrupt`).
+        if (window.__fermataEditorHarness) {
+          window.__scoreEditorHarness = {
+            count: () => (doc ? doc.count() : 0),
+            stringCount: () => (doc ? doc.stringCount : 0),
+            noteAt: (ordinal) => (doc ? doc.noteAt(ordinal) : null),
+            text: () => (doc ? doc.text() : null),
+            select: (ordinal) => {
+              if (doc == null || ordinal == null || ordinal < 0 || ordinal >= doc.count()) return null;
+              selectedOrdinal = ordinal;
+              refreshSelection();
+              return selectedOrdinal;
+            },
+            audit: () => auditAllNotes(),
+            // Apply one shipped edit op to `ordinal` through the real handler,
+            // awaiting its reload/re-render, and report whether it applied, was
+            // refused, and the per-edit divergence flag afterwards.
+            async apply(ordinal, op, arg) {
+              if (doc == null || ordinal == null || ordinal < 0 || ordinal >= doc.count())
+                return { applied: false, refused: false, reason: "ordinal-out-of-range", divergenceOk };
+              selectedOrdinal = ordinal;
+              refreshSelection();
+              editWarn = "";
+              const before = doc.text();
+              switch (op) {
+                case "fret": await changeFret(arg); break;
+                case "string": await changeString(arg); break;
+                case "duration": await changeDuration(arg); break;
+                case "dots": await changeDots(arg); break;
+                case "tie": await toggleTie(); break;
+                case "accidental": await changeAccidental(arg); break;
+                case "enharmonic": await cycleEnharmonic(arg); break;
+                case "voice": await changeVoice(arg); break;
+                case "delete": await deleteSelected(); break;
+                default: return { applied: false, refused: false, reason: "unknown-op", divergenceOk };
+              }
+              const after = doc ? doc.text() : before;
+              return {
+                op,
+                arg: arg ?? null,
+                ordinal,
+                applied: after !== before,
+                refused: !!editWarn,
+                warn: editWarn || null,
+                selected: selectedOrdinal,
+                divergenceOk,
+              };
+            },
+            // Mutate the DOCUMENT but skip the re-render, leaving the on-screen
+            // model stale against the written MusicXML - the exact positional-map
+            // /stale-render divergence the audit exists to catch. Used by the
+            // "the guard actually catches a divergence" spec (#189, target 2).
+            corrupt(ordinal, op, arg) {
+              if (doc == null || ordinal == null || ordinal < 0 || ordinal >= doc.count()) return { changed: false };
+              const before = doc.text();
+              let changed = false;
+              switch (op) {
+                case "fret": changed = doc.setFret(ordinal, arg); break;
+                case "string": changed = doc.setString(ordinal, arg); break;
+                case "duration": changed = doc.setDurationType(ordinal, arg); break;
+                case "delete": changed = doc.deleteNote(ordinal); break;
+                case "voice": changed = doc.moveToVoice(ordinal, arg) != null; break;
+                default: return { changed: false, reason: "unknown-op" };
+              }
+              // Keep the in-place model consistent with its own text for the
+              // round-trip half of the audit, but do NOT reload the view - that
+              // is the whole point: the render now lags the written document.
+              if (changed) doc = createDocument(doc.text());
+              return { changed, before, after: doc.text() };
+            },
+          };
+        } else {
+          window.__scoreEditorHarness = null;
+        }
       }
     });
   });

--- a/web/src/lib/editor/document.js
+++ b/web/src/lib/editor/document.js
@@ -468,6 +468,7 @@ export function createDocument(xml) {
     if (midi == null || !isWritablePitch(midi)) return false;
     if (!setTechText(el, "fret", fret)) return false;
     writePitch(el, midi);
+    dropBrokenTies(ordinal);
     return true;
   }
 
@@ -486,6 +487,7 @@ export function createDocument(xml) {
     if (midi == null || !isWritablePitch(midi)) return false;
     if (!setTechText(el, "string", string)) return false;
     writePitch(el, midi);
+    dropBrokenTies(ordinal);
     return true;
   }
 
@@ -698,6 +700,53 @@ export function createDocument(xml) {
     }
   }
 
+  // Break any tie on the note at `ordinal` whose two ends are no longer the SAME
+  // FRETBOARD POSITION (#189). setTie ties one fretted position (same string AND
+  // fret - see its contract); a fret or string edit MOVES the note to another
+  // position, so a tie it was part of would now span two positions - invalid, and
+  // the measured renderer trap alphaTab draws wrong (a tie-STOP note gets a fret
+  // derived from its start, so the written stop and the drawn one disagree).
+  // Rather than leave that broken tie, the edit drops it on BOTH ends,
+  // structurally (by contiguity, like setTie's removal), so the note simply stops
+  // being tied once it moves. Called from setFret/setString - the two ops that
+  // change position; the respell paths keep string+fret fixed and cannot break a
+  // tie.
+  function samePosition(a, b) {
+    return a.string != null && a.string === b.string && a.fret === b.fret;
+  }
+  function dropBrokenTies(ordinal) {
+    const el = noteEls[ordinal];
+    if (!el) return;
+    const mine = describe(el, ordinal);
+    // Forward: this note starts a tie into its contiguous same-voice successor.
+    if (hasTie(el, "start")) {
+      const partner = tieNext(ordinal);
+      if (!partner || !samePosition(mine, describe(partner.el, partner.ordinal))) {
+        removeTie(el, "start");
+        if (partner) removeTie(partner.el, "stop");
+      }
+    }
+    // Backward: this note stops a tie from its contiguous same-voice predecessor.
+    // The partner is the immediately-preceding non-chord note in the same voice;
+    // confirm it actually ties here (its tieNext is this note) before breaking.
+    if (hasTie(el, "stop")) {
+      const voice = voiceNumber(el);
+      for (let i = ordinal - 1; i >= 0; i--) {
+        const cand = noteEls[i];
+        if (hasChord(cand)) continue;
+        if (voiceNumber(cand) !== voice) continue;
+        if (hasTie(cand, "start")) {
+          const pn = tieNext(i);
+          if (pn && pn.ordinal === ordinal && !samePosition(mine, describe(cand, i))) {
+            removeTie(cand, "start");
+            removeTie(el, "stop");
+          }
+        }
+        break; // the contiguous predecessor is the only candidate
+      }
+    }
+  }
+
   // Remove the <tie> sound element and <tied> notation of `type` from a note.
   function removeTie(el, type) {
     const tie = firstTie(el, type);
@@ -720,9 +769,16 @@ export function createDocument(xml) {
    *   measure, or the first beat of the next measure when this note reaches the
    *   barline. A gap (a rest) between them, or the next note being in another
    *   voice, means there is nothing to tie to and the request is refused.
-   * - The two notes must be the SAME pitch. A tie sustains one pitch; joining two
-   *   different pitches is a slur, not a tie, and is refused with the document
-   *   untouched (so the field can be corrected).
+   * - The two notes must be the SAME FRETBOARD POSITION - the same <string> AND
+   *   <fret>, not merely the same sounding pitch. A tie sustains one fretted
+   *   note; on a fretboard that is one string held at one fret, so two positions
+   *   that only happen to SOUND alike (E4 as string 1 fret 0 and as string 2 fret
+   *   5) would still have to be re-fretted, which a tie cannot express. It is
+   *   also a measured renderer trap: alphaTab draws a tie-STOP note at a fret
+   *   derived from its tie-START partner, so a tie across two positions renders
+   *   one pitch while the document holds the other (the whole-model fuzz guard's
+   *   find, #189). Same string+fret implies same pitch, so this is the stricter,
+   *   correct reading of "the same note". A mismatch is refused, untouched.
    * - Chord beats are not offered. A tie on a chord member (or from a chord) would
    *   have to pair every voice of the chord; this increment refuses it.
    * - It can be removed. Toggling a started tie off drops both the start on this
@@ -737,9 +793,10 @@ export function createDocument(xml) {
       if (startsHere) return false; // already tied to the next note - a no-op
       const next = tieNext(ordinal);
       if (!next) return false;
-      const here = describe(el, ordinal).midi;
-      const there = describe(next.el, next.ordinal).midi;
-      if (here == null || there == null || here !== there) return false;
+      const here = describe(el, ordinal);
+      const there = describe(next.el, next.ordinal);
+      if (here.string == null || here.fret == null) return false;
+      if (here.string !== there.string || here.fret !== there.fret) return false;
       writeTie(el, "start");
       writeTie(next.el, "stop");
       return true;

--- a/web/src/lib/score-render.js
+++ b/web/src/lib/score-render.js
@@ -1987,6 +1987,11 @@ export function createScoreView(host, opts = {}) {
   // position, not the id - the id (Rule 17) is what makes it auditable.
   let noteOrdinals = new Map();
   let notesInOrder = [];
+  // The last note-head hit and how far into its overlap stack the click landed,
+  // so a repeat click at the SAME spot cycles to the next overlapping note (see
+  // hitTestNote). Reset whenever the model is rebuilt - the ordinal it remembers
+  // names a note in the old model.
+  let lastHit = null;
   // Resolved by the next postRenderFinished, so reloadScore() can await the
   // redraw the way an editor step needs to before re-reading bounds.
   let pendingEditResolve = null;
@@ -2000,6 +2005,9 @@ export function createScoreView(host, opts = {}) {
   function buildNoteOrdinals() {
     noteOrdinals = new Map();
     notesInOrder = [];
+    // The click-cycle stack (hitTestNote) remembers ordinals of the OLD model;
+    // a rebuild retires them, so a click after a re-render starts a fresh stack.
+    lastHit = null;
     const track = api.score?.tracks?.[0];
     if (!track) return;
     for (const staff of track.staves ?? []) {
@@ -3010,6 +3018,11 @@ export function createScoreView(host, opts = {}) {
   // still lands on it - the fret digits especially are small targets.
   const NOTE_HIT_PADDING = 3;
 
+  // How close (in surface pixels) two clicks must be to count as "the same spot"
+  // for cycling. Small: a genuine overlap draws its heads within a pixel or two
+  // of each other, and a click that moves further than this is aiming elsewhere.
+  const SAME_SPOT_PX = 3;
+
   function boundsOf() {
     return api.renderer?.boundsLookup ?? api.boundsLookup ?? null;
   }
@@ -3019,16 +3032,28 @@ export function createScoreView(host, opts = {}) {
   // measured this resolving 100% where alphaTab's own getBeatAtPos returned a
   // different voice's beat on polyphony. With the notation staff shown a note
   // carries two head rectangles (one per staff); both belong to the same Note,
-  // so clicking either selects the same ordinal. On a genuine overlap the
-  // nearest head centre wins.
+  // so clicking either selects the same ordinal.
+  //
+  // On a genuine overlap - the ~1.5% of note heads the #10 evaluation flagged,
+  // where two voices sound the same pitch at the same onset and draw one head on
+  // top of another - the nearest head centre alone can never reach the note
+  // behind, so this DISAMBIGUATES BY CLICK-CYCLING: a first click at a spot
+  // selects the nearest of the notes stacked there (document order breaks a tie),
+  // and each further click at the SAME spot advances to the next note in that
+  // stack, wrapping around. A click that moves elsewhere starts a fresh stack.
+  // This is the stated rule (a voice filter was the alternative); it needs no
+  // extra chrome and keeps a single click's behaviour - the nearest note -
+  // exactly as it was for the monophonic 98.5%.
   function hitTestNote(clientX, clientY) {
     const lookup = boundsOf();
     const rect = surfaceRect();
     if (!lookup || !rect) return null;
     const x = clientX - rect.left;
     const y = clientY - rect.top;
-    let best = null;
-    let bestDist = Infinity;
+    // Every note whose head rectangle (either staff) covers the point, paired
+    // with its ordinal and squared distance to that head's centre. A note with
+    // two heads keeps only its nearer one, so it appears once.
+    const byOrdinal = new Map();
     for (const sys of lookup.staffSystems ?? []) {
       for (const mb of sys.bars ?? []) {
         for (const bar of mb.bars ?? []) {
@@ -3043,21 +3068,44 @@ export function createScoreView(host, opts = {}) {
                 y > b.y + b.h + NOTE_HIT_PADDING
               )
                 continue;
+              const ordinal = noteOrdinals.get(nb.note);
+              if (ordinal == null) continue;
               const dx = x - (b.x + b.w / 2);
               const dy = y - (b.y + b.h / 2);
               const dist = dx * dx + dy * dy;
-              if (dist < bestDist) {
-                bestDist = dist;
-                best = nb.note;
-              }
+              const prev = byOrdinal.get(ordinal);
+              if (prev == null || dist < prev) byOrdinal.set(ordinal, dist);
             }
           }
         }
       }
     }
-    if (!best) return null;
-    const ordinal = noteOrdinals.get(best);
-    return ordinal == null ? null : ordinal;
+    if (byOrdinal.size === 0) {
+      lastHit = null;
+      return null;
+    }
+    // The stack under the click, ordered nearest-first with document order
+    // breaking a tie - a stable order so a repeat click cycles predictably.
+    const stack = [...byOrdinal.entries()]
+      .sort((a, b) => a[1] - b[1] || a[0] - b[0])
+      .map(([ordinal]) => ordinal);
+
+    const sameSpot =
+      lastHit &&
+      Math.abs(lastHit.x - x) <= SAME_SPOT_PX &&
+      Math.abs(lastHit.y - y) <= SAME_SPOT_PX;
+    let chosen;
+    if (sameSpot && stack.length > 1) {
+      // Advance from wherever the last click on this spot landed to the next note
+      // in the stack, wrapping. If the last chosen note is gone from the stack
+      // (a re-render moved things), fall back to the nearest.
+      const at = stack.indexOf(lastHit.ordinal);
+      chosen = at < 0 ? stack[0] : stack[(at + 1) % stack.length];
+    } else {
+      chosen = stack[0];
+    }
+    lastHit = { x, y, ordinal: chosen };
+    return chosen;
   }
 
   // What alphaTab itself makes of the sounding note at `ordinal` - read back

--- a/web/tests/browser/fixtures/editor-poly.js
+++ b/web/tests/browser/fixtures/editor-poly.js
@@ -1,0 +1,316 @@
+// Polyphonic fixtures for the note editor's N-random-edits fuzz guard and its
+// overlapping-voice selection (#189), a follow-on to the monophonic
+// fixtures/editor-score.js the first increment (#10) shipped.
+//
+// Why a built fixture and not a library file: the editor only opens a one-part
+// TAB score with a <staff-tuning> (see editor/document.js's createDocument
+// throws), and the two committed .musicxml files under FERMATA_TEST_LIBRARY are
+// single-voice lead sheets with no tuning at all - the real polyphonic tab
+// transcriptions live only in the server's database, which this suite cannot
+// reach (the browser suite stubs the HTTP transport; the live instance on 8080
+// is off limits). So a genuinely polyphonic document is BUILT here in the
+// emitter's exact shape - one part, one six-string TAB staff, <divisions>480,
+// a Rule 17 id on every note (n{measure}-{voice}-{onset}-{chord}), two voices
+// separated by a <backup> (Rule 6), chords (Rule 7), ties (#183) and mixed
+// durations - and served through the same stub the monophonic suite uses. It is
+// a real document the real alphaTab importer renders and the real
+// editor/document.js parses; nothing is stubbed but the transport.
+//
+// The point of the polyphony is the reorder/add/remove surface the fuzz needs:
+// two voices with backups is where a voice move (#182) or a delete (#186) can
+// shift an ordinal rather than merely misread one, which is the divergence the
+// N-edits guard exists to catch and the per-selection guard cannot.
+import { spellPitch } from "../../../src/lib/editor/notes.js";
+
+const DIVISIONS = 480;
+
+// Standard six-string tuning, high string (1) to low (6). The <staff-tuning>
+// line a MusicXML <string> maps to is stringCount + 1 - string (Rule 5), so
+// string 1 (E4) reads line 6. Open-string MIDI, indexed by <string>.
+const OPEN_MIDI = { 1: 64, 2: 59, 3: 55, 4: 50, 5: 45, 6: 40 };
+
+const STAFF_DETAILS = `
+        <staff-details>
+          <staff-lines>6</staff-lines>
+          <staff-tuning line="1"><tuning-step>E</tuning-step><tuning-octave>2</tuning-octave></staff-tuning>
+          <staff-tuning line="2"><tuning-step>A</tuning-step><tuning-octave>2</tuning-octave></staff-tuning>
+          <staff-tuning line="3"><tuning-step>D</tuning-step><tuning-octave>3</tuning-octave></staff-tuning>
+          <staff-tuning line="4"><tuning-step>G</tuning-step><tuning-octave>3</tuning-octave></staff-tuning>
+          <staff-tuning line="5"><tuning-step>B</tuning-step><tuning-octave>3</tuning-octave></staff-tuning>
+          <staff-tuning line="6"><tuning-step>E</tuning-step><tuning-octave>4</tuning-octave></staff-tuning>
+        </staff-details>`;
+
+const TYPE_DUR = { whole: 1920, half: 960, quarter: 480, eighth: 240, "16th": 120 };
+
+function midiOf(string, fret) {
+  return OPEN_MIDI[string] + fret;
+}
+
+// One <note> element, sounding or (when notes is null) a rest. `spelled` follows
+// the C-major spelling the emitter writes (spellPitch(midi, 0)), so the pitch is
+// consistent with the string+fret the divergence guard cross-checks it against.
+function noteXml(id, { string, fret, type, chord, tie }) {
+  const midi = midiOf(string, fret);
+  const p = spellPitch(midi, 0);
+  const alterEl = p.alter ? `<alter>${p.alter}</alter>` : "";
+  const chordEl = chord ? "<chord/>" : "";
+  const tieSound = tie ? tie.map((t) => `<tie type="${t}"/>`).join("") : "";
+  const tiedNotation = tie ? tie.map((t) => `<tied type="${t}"/>`).join("") : "";
+  const dur = TYPE_DUR[type];
+  return `      <note id="${id}">
+        ${chordEl}<pitch><step>${p.step}</step>${alterEl}<octave>${p.octave}</octave></pitch>
+        <duration>${dur}</duration>${tieSound}
+        <voice>{{VOICE}}</voice>
+        <type>${type}</type>
+        <notations>${tiedNotation}<technical><string>${string}</string><fret>${fret}</fret></technical></notations>
+      </note>`;
+}
+
+function restXml(dur, type) {
+  const typeEl = type ? `<type>${type}</type>` : "";
+  return `      <note>
+        <rest/>
+        <duration>${dur}</duration>
+        <voice>{{VOICE}}</voice>
+        ${typeEl}
+      </note>`;
+}
+
+// Build one voice's stream for a measure from a list of beats laid contiguously
+// from onset 0. Each beat is either { rest: true, type } or { type, chord?,
+// notes: [{string, fret}], tie? }. Rule 17 ids are derived from position:
+// n{measure}-{voice}-{beatIndex}-{chordIndex}. Returns { xml, total } so the
+// caller can assert Rule 8 (every voice sums to the measure).
+function voiceStream(measureNumber, voice, beats) {
+  const parts = [];
+  let total = 0;
+  let beatIndex = 0;
+  for (const beat of beats) {
+    const dur = TYPE_DUR[beat.type];
+    if (beat.rest) {
+      parts.push(restXml(dur, beat.type).replaceAll("{{VOICE}}", String(voice)));
+      total += dur;
+      beatIndex += 1;
+      continue;
+    }
+    beat.notes.forEach((n, chordIndex) => {
+      const id = `n${measureNumber}-${voice}-${beatIndex}-${chordIndex}`;
+      const tie = chordIndex === 0 ? beat.tie : undefined;
+      parts.push(
+        noteXml(id, { ...n, type: beat.type, chord: chordIndex > 0, tie }).replaceAll("{{VOICE}}", String(voice)),
+      );
+    });
+    total += dur;
+    beatIndex += 1;
+  }
+  return { xml: parts.join("\n"), total };
+}
+
+// Assemble a whole measure from its voices. A <backup> rewinding the full
+// measure precedes every voice after the first (Rule 6). Throws if any voice
+// does not sum to measureDur - a fixture that broke Rule 8 would fail the
+// importer quietly, so it fails loudly here instead.
+function measureXml(measureNumber, voices, attributes, measureDur) {
+  const chunks = [];
+  const voiceNums = Object.keys(voices).map(Number).sort((a, b) => a - b);
+  voiceNums.forEach((v, i) => {
+    if (i > 0) {
+      chunks.push(`      <backup><duration>${measureDur}</duration></backup>`);
+    }
+    const { xml, total } = voiceStream(measureNumber, v, voices[v]);
+    if (total !== measureDur) {
+      throw new Error(`fixture measure ${measureNumber} voice ${v} sums to ${total}, not ${measureDur}`);
+    }
+    chunks.push(xml);
+  });
+  return `    <measure number="${measureNumber}">${attributes}
+${chunks.join("\n")}
+    </measure>`;
+}
+
+// The polyphonic score, eight measures, two voices throughout: an upper melodic
+// voice (voice 1, on the higher strings) and a lower voice (voice 2, on the
+// bass strings), with chords, a within-bar tie and a cross-barline tie. Every
+// voice fills its 4/4 bar (1920 divisions). Enough sounding notes (~50) that N
+// random voice moves, deletes and duration changes genuinely reorder and
+// add/remove within the model.
+function buildPolyScore() {
+  const attrs = `
+      <attributes>
+        <divisions>${DIVISIONS}</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>TAB</sign><line>5</line></clef>${STAFF_DETAILS}
+      </attributes>`;
+
+  // Compact per-measure spec. Voice 1: melody on strings 1-3. Voice 2: bass on
+  // strings 4-6. `q`/`e`/`h` shorthand kept explicit for readability.
+  const measures = [
+    // m1: melody four quarters over two half-note bass notes.
+    {
+      1: [
+        { type: "quarter", notes: [{ string: 1, fret: 0 }] },
+        { type: "quarter", notes: [{ string: 1, fret: 2 }] },
+        { type: "quarter", notes: [{ string: 1, fret: 3 }] },
+        { type: "quarter", notes: [{ string: 2, fret: 1 }] },
+      ],
+      2: [
+        { type: "half", notes: [{ string: 5, fret: 0 }] },
+        { type: "half", notes: [{ string: 4, fret: 0 }] },
+      ],
+    },
+    // m2: melody with an opening two-note chord (Rule 7), then eighths; bass a
+    // whole note.
+    {
+      1: [
+        { type: "quarter", notes: [{ string: 1, fret: 0 }, { string: 2, fret: 1 }] },
+        { type: "quarter", notes: [{ string: 2, fret: 3 }] },
+        { type: "eighth", notes: [{ string: 1, fret: 0 }] },
+        { type: "eighth", notes: [{ string: 1, fret: 2 }] },
+        { type: "quarter", notes: [{ string: 1, fret: 3 }] },
+      ],
+      2: [{ type: "whole", notes: [{ string: 6, fret: 3 }] }],
+    },
+    // m3: a within-bar tie in voice 1 (two tied quarters, same string+fret), a
+    // rest, then a quarter; bass two half notes.
+    {
+      1: [
+        { type: "quarter", notes: [{ string: 1, fret: 5 }], tie: ["start"] },
+        { type: "quarter", notes: [{ string: 1, fret: 5 }], tie: ["stop"] },
+        { type: "quarter", rest: true },
+        { type: "quarter", notes: [{ string: 2, fret: 0 }] },
+      ],
+      2: [
+        { type: "half", notes: [{ string: 5, fret: 2 }] },
+        { type: "half", notes: [{ string: 4, fret: 2 }] },
+      ],
+    },
+    // m4: a cross-barline tie starts here (voice 1's last note ties into m5's
+    // first). Melody eighths; bass a whole note.
+    {
+      1: [
+        { type: "eighth", notes: [{ string: 1, fret: 0 }] },
+        { type: "eighth", notes: [{ string: 1, fret: 2 }] },
+        { type: "eighth", notes: [{ string: 1, fret: 3 }] },
+        { type: "eighth", notes: [{ string: 1, fret: 5 }] },
+        { type: "eighth", notes: [{ string: 2, fret: 1 }] },
+        { type: "eighth", notes: [{ string: 2, fret: 3 }] },
+        { type: "quarter", notes: [{ string: 3, fret: 2 }], tie: ["start"] },
+      ],
+      2: [{ type: "whole", notes: [{ string: 6, fret: 0 }] }],
+    },
+    // m5: the cross-barline tie stops on the first note; then quarters. Bass two
+    // half notes.
+    {
+      1: [
+        { type: "quarter", notes: [{ string: 3, fret: 2 }], tie: ["stop"] },
+        { type: "quarter", notes: [{ string: 2, fret: 3 }] },
+        { type: "quarter", notes: [{ string: 1, fret: 0 }] },
+        { type: "quarter", notes: [{ string: 1, fret: 2 }] },
+      ],
+      2: [
+        { type: "half", notes: [{ string: 5, fret: 3 }] },
+        { type: "half", notes: [{ string: 5, fret: 0 }] },
+      ],
+    },
+    // m6: a three-note chord opens the bar (Rule 7), then rests filled around a
+    // melody note; bass a whole note.
+    {
+      1: [
+        {
+          type: "half",
+          notes: [{ string: 1, fret: 0 }, { string: 2, fret: 1 }, { string: 3, fret: 0 }],
+        },
+        { type: "quarter", notes: [{ string: 1, fret: 3 }] },
+        { type: "quarter", notes: [{ string: 1, fret: 5 }] },
+      ],
+      2: [{ type: "whole", notes: [{ string: 4, fret: 0 }] }],
+    },
+    // m7: melody eighths; bass quarters walking down.
+    {
+      1: [
+        { type: "eighth", notes: [{ string: 2, fret: 0 }] },
+        { type: "eighth", notes: [{ string: 2, fret: 1 }] },
+        { type: "eighth", notes: [{ string: 2, fret: 3 }] },
+        { type: "eighth", notes: [{ string: 1, fret: 0 }] },
+        { type: "quarter", notes: [{ string: 1, fret: 2 }] },
+        { type: "quarter", notes: [{ string: 1, fret: 3 }] },
+      ],
+      2: [
+        { type: "quarter", notes: [{ string: 4, fret: 2 }] },
+        { type: "quarter", notes: [{ string: 5, fret: 0 }] },
+        { type: "quarter", notes: [{ string: 5, fret: 2 }] },
+        { type: "quarter", notes: [{ string: 6, fret: 3 }] },
+      ],
+    },
+    // m8: a closing two-note melody chord over a bass half note and a rest.
+    {
+      1: [
+        { type: "half", notes: [{ string: 1, fret: 0 }, { string: 2, fret: 1 }] },
+        { type: "half", notes: [{ string: 1, fret: 3 }] },
+      ],
+      2: [
+        { type: "half", notes: [{ string: 5, fret: 0 }] },
+        { type: "half", rest: true },
+      ],
+    },
+  ];
+
+  const body = measures
+    .map((voices, i) => measureXml(i + 1, voices, i === 0 ? attrs : "", 1920))
+    .join("\n");
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list>
+    <score-part id="P1"><part-name>Guitar</part-name></score-part>
+  </part-list>
+  <part id="P1">
+${body}
+  </part>
+</score-partwise>`;
+}
+
+export const POLY_MUSICXML = buildPolyScore();
+
+// A one-measure score whose voice 1 and voice 2 each sound the SAME pitch at the
+// SAME onset - a unison across two voices (string 1 fret 0 = E4 in both). On the
+// tab staff both draw the digit "0" at the same x on the same line, and on the
+// notation staff both draw an E4 head at the same y: the ~1.5% genuinely
+// OVERLAPPING note-head case the #10 evaluation flagged. Selecting between them
+// is what the click-cycle disambiguation (score-render.js hitTestNote) exists
+// for - a second click at the same spot cycles to the other voice's note.
+//
+//   ord  id          voice  onset  string  fret  pitch  midi
+//   0    n1-1-0-0    1      0      1       0     E4     64   (voice 1, overlaps)
+//   1    n1-1-1-0    1      960    1       3     G4     67
+//   2    n1-2-0-0    2      0      1       0     E4     64   (voice 2, overlaps 0)
+//   3    n1-2-1-0    2      960    4       0     D3     50
+export const OVERLAP_MUSICXML = (() => {
+  const attrs = `
+      <attributes>
+        <divisions>${DIVISIONS}</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>TAB</sign><line>5</line></clef>${STAFF_DETAILS}
+      </attributes>`;
+  const voices = {
+    1: [
+      { type: "half", notes: [{ string: 1, fret: 0 }] },
+      { type: "half", notes: [{ string: 1, fret: 3 }] },
+    ],
+    2: [
+      { type: "half", notes: [{ string: 1, fret: 0 }] },
+      { type: "half", notes: [{ string: 4, fret: 0 }] },
+    ],
+  };
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list>
+    <score-part id="P1"><part-name>Guitar</part-name></score-part>
+  </part-list>
+  <part id="P1">
+${measureXml(1, voices, attrs, 1920)}
+  </part>
+</score-partwise>`;
+})();

--- a/web/tests/browser/score-editor-fuzz-189.spec.js
+++ b/web/tests/browser/score-editor-fuzz-189.spec.js
@@ -1,0 +1,306 @@
+// The N-random-edits divergence fuzz guard (#189), the stronger check the #10
+// evaluation asked for once the editor grew operations that REORDER or
+// ADD/REMOVE notes (voice moves #182, deletes #186): after N seeded random
+// edits, RE-IMPORT the written MusicXML and assert the on-screen model equals
+// it across EVERY note - not just the selected one the per-selection guard
+// cross-checks. A positional-map SHIFT (the renderer's ordinal N naming a
+// different note than the document's ordinal N) is invisible to the
+// per-selection guard unless that exact note is selected; this catches it.
+//
+// Design, stated so it can be audited rather than inferred:
+//   - Seeded, reproducible: the whole edit sequence is driven from a SEEDED
+//     mulberry32 RNG (SEED below), so a failing run reproduces exactly. The seed
+//     and the failing step are emitted in the assertion message. Never
+//     Math.random().
+//   - Fixed for CI, sweepable locally: SEED and N are constants in this spec so
+//     CI is deterministic and cheap; FERMATA_FUZZ_SEED / FERMATA_FUZZ_N override
+//     them for a larger local sweep.
+//   - The score: the real polyphonic fixture (fixtures/editor-poly.js,
+//     POLY_MUSICXML) - two voices with backups, chords and ties across eight
+//     4/4 bars (~50 sounding notes). Polyphony is the point: it is where a voice
+//     move or a delete can shift an ordinal.
+//   - The edit menu, uniform over the shipped ops that touch note IDENTITY or
+//     ORDERING: fret, string, accidental, enharmonic, tie, voice move, delete.
+//     Duration and dots are deliberately NOT in the menu: setDurationType/setDots
+//     change one note's written value WITHOUT refilling the bar (see their
+//     docstrings), so stacking them drives a polyphonic bar out of this profile's
+//     Rule 8 - a validity question distinct from the positional-map integrity
+//     this guard proves, and one #183 already covers per-op.
+//   - Refusals are not failures: an op that legitimately refuses (a tie to a
+//     different pitch, a voice already occupied at the onset) leaves the document
+//     untouched and the sequence continues.
+//   - The equality asserted: see auditAllNotes in TabViewer.svelte - count,
+//     per-ordinal pitch/string/fret/voice between the render and the re-import,
+//     plus a full written-document round-trip (id, spelling, string, fret, voice,
+//     onset, duration via type+dots, ties).
+//
+// The crucial second test proves the guard is not green-by-construction: a
+// deliberate stale-render divergence is induced and the audit is shown to go red
+// and NAME the note - a fuzz guard that cannot fail is worthless.
+import { test, expect } from "@playwright/test";
+
+import { POLY_MUSICXML } from "./fixtures/editor-poly.js";
+import { stubEditorApi } from "./fixtures/editor-score.js";
+
+const wrap = (page) => page.locator(".staff-render .wrap");
+const host = (page) => page.locator(".staff-render .at-host");
+
+const SEED = Number(process.env.FERMATA_FUZZ_SEED ?? 0x1a2b3c);
+const N = Number(process.env.FERMATA_FUZZ_N ?? 40);
+
+async function renderedOk(page) {
+  await expect(host(page)).toHaveAttribute("data-score-render-ok", "true");
+}
+
+// Opens the editor over `content` with the fuzz harness enabled, waiting until
+// the whole score's `expected` sounding notes are laid out.
+async function openEditor(page, content, expected) {
+  await page.addInitScript(() => {
+    window.__fermataEditorHarness = true;
+  });
+  const handle = await stubEditorApi(page, content);
+  await page.goto("/#/score/1");
+  await page.waitForSelector(".staff-render");
+  await page.getByRole("button", { name: "Staff", exact: true }).click();
+  await renderedOk(page);
+  await page.getByRole("button", { name: "Edit notes" }).click();
+  await expect(wrap(page)).toHaveAttribute("data-editor-active", "true");
+  await expect.poll(() => page.evaluate(() => window.__scoreEditor?.noteCount() ?? 0)).toBe(expected);
+  await expect.poll(() => page.evaluate(() => window.__scoreEditorHarness?.count() ?? 0)).toBe(expected);
+  return handle;
+}
+
+test.describe("note editor - N-random-edits divergence fuzz guard", () => {
+  // Target 1: N seeded random edits on a real polyphonic score, the per-edit
+  // divergence flag green throughout, and after the run the written MusicXML
+  // re-imports to a model identical to the one on screen (auditAllNotes ok).
+  test(`${N} seeded random edits keep the model and the render identical (seed ${SEED})`, async ({ page }) => {
+    await openEditor(page, POLY_MUSICXML, 52);
+
+    // The whole sequence runs in one page evaluate for speed and determinism -
+    // the seeded RNG is pure, so this reproduces byte-for-byte. It awaits each
+    // real edit's reload/re-render before the next, and records the first step
+    // (if any) where the per-edit divergence flag went false.
+    const result = await page.evaluate(
+      async ({ seed, n }) => {
+        // mulberry32: a small, fast, well-distributed seeded PRNG. Deterministic
+        // from `seed`, so the same seed replays the same sequence.
+        function mulberry32(a) {
+          return function () {
+            a |= 0;
+            a = (a + 0x6d2b79f5) | 0;
+            let t = Math.imul(a ^ (a >>> 15), 1 | a);
+            t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+            return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+          };
+        }
+        const rng = mulberry32(seed);
+        const pick = (arr) => arr[Math.floor(rng() * arr.length)];
+        const h = window.__scoreEditorHarness;
+        const stringCount = h.stringCount();
+        const OPS = ["fret", "string", "accidental", "enharmonic", "tie", "voice", "delete"];
+        const opCounts = {};
+        let applied = 0;
+        let refused = 0;
+        let firstBadStep = -1;
+        let firstBad = null;
+        const steps = [];
+        for (let i = 0; i < n; i++) {
+          const count = h.count();
+          if (count === 0) break;
+          const ordinal = Math.floor(rng() * count);
+          const op = pick(OPS);
+          let arg = null;
+          if (op === "fret") arg = Math.floor(rng() * 13);
+          else if (op === "string") arg = 1 + Math.floor(rng() * stringCount);
+          else if (op === "accidental") arg = pick([-2, -1, 0, 1, 2]);
+          else if (op === "enharmonic") arg = pick([-1, 1]);
+          else if (op === "voice") arg = 1 + Math.floor(rng() * 3);
+          const r = await h.apply(ordinal, op, arg);
+          opCounts[op] = (opCounts[op] ?? 0) + 1;
+          if (r.applied) applied += 1;
+          if (r.refused) refused += 1;
+          steps.push({ i, op, ordinal, arg, applied: r.applied, refused: r.refused, divergenceOk: r.divergenceOk });
+          if (r.divergenceOk === false && firstBadStep < 0) {
+            firstBadStep = i;
+            firstBad = { step: steps[steps.length - 1], audit: h.audit() };
+            break;
+          }
+        }
+        return {
+          seed,
+          n,
+          applied,
+          refused,
+          opCounts,
+          firstBadStep,
+          firstBad,
+          finalCount: h.count(),
+          renderCount: window.__scoreEditor.noteCount(),
+          audit: h.audit(),
+        };
+      },
+      { seed: SEED, n: N },
+    );
+
+    // The per-edit guard never went red across the whole sequence.
+    expect(
+      result.firstBadStep,
+      `per-edit divergence flag went red. seed=${SEED} step=${result.firstBadStep} ` +
+        `detail=${JSON.stringify(result.firstBad)}`,
+    ).toBe(-1);
+
+    // At least some edits actually applied AND at least one of the reorder/
+    // add/remove ops landed - a run that refused everything would prove nothing.
+    expect(result.applied, "no edit applied - the sequence exercised nothing").toBeGreaterThan(5);
+    const structural = (result.opCounts.voice ?? 0) + (result.opCounts.delete ?? 0);
+    expect(structural, "no voice-move or delete was attempted").toBeGreaterThan(0);
+
+    // The written MusicXML re-imports to a model identical to the one on screen,
+    // across every note - the fuzz guard's assertion.
+    expect(
+      result.audit.divergences,
+      `after ${N} edits the re-import diverged from the render. seed=${SEED} ` +
+        `divergences=${JSON.stringify(result.audit.divergences)}`,
+    ).toEqual([]);
+    expect(result.audit.ok).toBe(true);
+    expect(result.audit.docCount).toBe(result.audit.renderCount);
+    expect(result.renderCount).toBe(result.finalCount);
+
+    // The live DOM flag the per-selection guard drives is green too.
+    await expect(wrap(page)).toHaveAttribute("data-editor-divergence-ok", "true");
+  });
+
+  // Target 2 (the crucial one): the guard actually CATCHES a divergence. A
+  // stale-render divergence is induced deterministically - the document is edited
+  // but the view is NOT reloaded, exactly the positional-map/stale-render shift
+  // the audit exists to catch - and the audit is shown to go red and NAME the
+  // note that diverged. Then a real reload heals it, proving the red was the
+  // divergence and not a broken audit.
+  test("the audit reds and names a note when the render is left stale against the document", async ({ page }) => {
+    await openEditor(page, POLY_MUSICXML, 52);
+
+    // Baseline: the freshly-loaded model and render agree.
+    const clean = await page.evaluate(() => window.__scoreEditorHarness.audit());
+    expect(clean.ok, `baseline audit should be clean: ${JSON.stringify(clean.divergences)}`).toBe(true);
+
+    // Plant a divergence: change ordinal 0's fret in the DOCUMENT only, skipping
+    // the re-render. The written MusicXML now says one thing; the screen still
+    // shows the old note.
+    const planted = await page.evaluate(() => {
+      const h = window.__scoreEditorHarness;
+      const before = h.noteAt(0);
+      const changed = h.corrupt(0, "fret", (before.fret + 5) % 13 === before.fret ? before.fret + 1 : (before.fret + 5) % 13);
+      const audit = h.audit();
+      return { before, changed: changed.changed, audit };
+    });
+
+    expect(planted.changed, "the planted document edit should have applied").toBe(true);
+    // The audit goes red...
+    expect(planted.audit.ok).toBe(false);
+    // ...and NAMES the divergence: ordinal 0, a pitch/fret mismatch, with the
+    // document value and the (stale) render value both reported.
+    const named = planted.audit.divergences.filter((d) => d.ordinal === 0 && (d.field === "fret" || d.field === "midi"));
+    expect(
+      named.length,
+      `the audit should name ordinal 0's fret/midi divergence, got ${JSON.stringify(planted.audit.divergences)}`,
+    ).toBeGreaterThan(0);
+    const fretDiv = named.find((d) => d.field === "fret");
+    expect(fretDiv.render).toBe(planted.before.fret); // the screen still shows the old fret
+    expect(fretDiv.doc).not.toBe(planted.before.fret); // the document holds the new one
+
+    // Heal it: a real edit through the normal path RELOADS the view, so the
+    // render matches the document again and the audit goes green - proving the
+    // red above was the divergence, not a guard that is always red. (Re-applying
+    // the note's CURRENT fret would be a no-op that skips the reload, so a
+    // genuinely different fret is used to force the re-render.)
+    const healed = await page.evaluate(async () => {
+      const h = window.__scoreEditorHarness;
+      const now = h.noteAt(0);
+      const other = (now.fret + 1) % 13;
+      await h.apply(0, "fret", other);
+      return { audit: h.audit(), applied: h.noteAt(0).fret === other };
+    });
+    expect(healed.applied).toBe(true);
+    expect(healed.audit.ok, `after a real reload the audit should be clean: ${JSON.stringify(healed.audit.divergences)}`).toBe(true);
+  });
+
+  // Target 4-adjacent: the fuzz's own harness aside, a plain fret edit on the
+  // polyphonic fixture keeps the per-selection guard green - the earlier #10
+  // guard still holds over a two-voice document driven note-by-note.
+  test("a single fret edit on the polyphonic score keeps the per-selection guard green", async ({ page }) => {
+    await openEditor(page, POLY_MUSICXML, 52);
+    const r = await page.evaluate(async () => {
+      const h = window.__scoreEditorHarness;
+      const res = await h.apply(0, "fret", 7);
+      return { res, audit: h.audit() };
+    });
+    expect(r.res.applied).toBe(true);
+    expect(r.res.divergenceOk).toBe(true);
+    expect(r.audit.ok, JSON.stringify(r.audit.divergences)).toBe(true);
+    await expect(wrap(page)).toHaveAttribute("data-editor-divergence-ok", "true");
+    await expect(wrap(page)).toHaveAttribute("data-editor-selected-fret", "7");
+  });
+
+  // The specific editor gap this fuzz FOUND (then fixed), pinned as its own
+  // falsifiable test: a tie must join the same FRETBOARD POSITION, not merely the
+  // same sounding pitch. alphaTab draws a tie-stop note at a fret derived from its
+  // start, so a tie across two positions that only sound alike renders one pitch
+  // while the document holds the other - a whole-model divergence the per-
+  // selection guard never sees (the diverging note is the unselected partner).
+  test("a tie between two same-pitch but different-position notes is refused", async ({ page }) => {
+    await openEditor(page, POLY_MUSICXML, 52);
+    const out = await page.evaluate(async () => {
+      const h = window.__scoreEditorHarness;
+      // Notes 0 (E4, string 1 fret 0) and 1 (F#4, string 1 fret 2) are contiguous
+      // in voice 1. Re-fret note 1 to E4 on ANOTHER string+fret: string 2 fret 5
+      // = E4 (64), the SAME sounding pitch as note 0 but a different position.
+      await h.apply(1, "string", 2);
+      await h.apply(1, "fret", 5);
+      const n0 = h.noteAt(0);
+      const n1 = h.noteAt(1);
+      // Now try to tie 0 -> 1. Same MIDI, different position: it must refuse.
+      const tie = await h.apply(0, "tie", null);
+      return { n0, n1, tie, after0: h.noteAt(0), audit: h.audit() };
+    });
+    expect(out.n0.midi).toBe(64);
+    expect(out.n1.midi).toBe(64); // same sounding pitch
+    expect(out.n0.string).not.toBe(out.n1.string); // different position
+    expect(out.tie.refused).toBe(true); // the tie is refused
+    expect(out.tie.applied).toBe(false);
+    expect(out.after0.tieStart).toBe(false); // nothing was written
+    expect(out.audit.ok, JSON.stringify(out.audit.divergences)).toBe(true);
+  });
+
+  // The other half of the same fix: a fret edit that MOVES a tied note off its
+  // partner's position breaks the now-invalid tie on BOTH ends, rather than
+  // leaving a tie the renderer would draw wrong.
+  test("moving a tied note to another position breaks the tie", async ({ page }) => {
+    await openEditor(page, POLY_MUSICXML, 52);
+    const out = await page.evaluate(async () => {
+      const h = window.__scoreEditorHarness;
+      // Make note 1 the SAME position as note 0 (string 1 fret 0), then tie 0->1.
+      await h.apply(1, "fret", 0);
+      const tie = await h.apply(0, "tie", null);
+      const tiedStart = h.noteAt(0).tieStart;
+      const tiedStop = h.noteAt(1).tieStop;
+      // Move note 1 to a different fret: the tie must break on both ends.
+      await h.apply(1, "fret", 5);
+      return {
+        tie,
+        tiedStart,
+        tiedStop,
+        after0Start: h.noteAt(0).tieStart,
+        after1Stop: h.noteAt(1).tieStop,
+        audit: h.audit(),
+      };
+    });
+    expect(out.tie.applied).toBe(true); // the tie was created (same position)
+    expect(out.tiedStart).toBe(true);
+    expect(out.tiedStop).toBe(true);
+    // After moving note 1's fret, both halves are gone.
+    expect(out.after0Start).toBe(false);
+    expect(out.after1Stop).toBe(false);
+    expect(out.audit.ok, JSON.stringify(out.audit.divergences)).toBe(true);
+  });
+});

--- a/web/tests/browser/score-editor-poly-189.spec.js
+++ b/web/tests/browser/score-editor-poly-189.spec.js
@@ -1,0 +1,156 @@
+// Polyphonic selection, including the genuinely-overlapping note heads (#189).
+//
+// The first editor increment's fixture is monophonic, so overlapping-voice
+// selection was untested. This covers it end to end against the real alphaTab
+// render: a two-voice score (fixtures/editor-poly.js) where a note in each voice
+// sounds the SAME pitch at the SAME onset (a cross-voice unison), so their heads
+// draw one on top of the other - the ~1.5% genuinely-overlapping case the #10
+// evaluation flagged as an open question.
+//
+// The disambiguation, stated and tested here: CLICK-CYCLING. A first click at a
+// spot selects the nearest note stacked there; each further click at the SAME
+// spot advances to the next note in that stack, wrapping around (see
+// score-render.js hitTestNote). A single click still selects the nearest note
+// exactly as before for the non-overlapping 98.5%. This test proves BOTH
+// overlapping notes can be reached - two distinct ordinals, two different voices,
+// the divergence guard green for each.
+import { test, expect } from "@playwright/test";
+
+import { OVERLAP_MUSICXML, POLY_MUSICXML } from "./fixtures/editor-poly.js";
+import { stubEditorApi } from "./fixtures/editor-score.js";
+
+const wrap = (page) => page.locator(".staff-render .wrap");
+const host = (page) => page.locator(".staff-render .at-host");
+
+async function renderedOk(page) {
+  await expect(host(page)).toHaveAttribute("data-score-render-ok", "true");
+}
+
+async function openEditor(page, content, expected) {
+  await stubEditorApi(page, content);
+  await page.goto("/#/score/1");
+  await page.waitForSelector(".staff-render");
+  await page.getByRole("button", { name: "Staff", exact: true }).click();
+  await renderedOk(page);
+  await page.getByRole("button", { name: "Edit notes" }).click();
+  await expect(wrap(page)).toHaveAttribute("data-editor-active", "true");
+  await expect.poll(() => page.evaluate(() => window.__scoreEditor?.noteCount() ?? 0)).toBe(expected);
+}
+
+// The currently-selected ordinal, as an integer, read off the DOM.
+async function selectedOrdinal(page) {
+  const v = await wrap(page).getAttribute("data-editor-selected");
+  return v == null ? null : Number(v);
+}
+
+test.describe("note editor - polyphonic selection", () => {
+  // A plain (non-overlapping) note in each voice selects with a single click and
+  // the guard is green - the polyphonic baseline the overlap case builds on.
+  test("a note in each voice selects with the divergence guard green", async ({ page }) => {
+    await openEditor(page, POLY_MUSICXML, 52);
+
+    // Ordinal 0 is voice 1's first note (E4). Select it by its own head point.
+    const p0 = await page.evaluate(() => window.__scoreEditor.headPoint(0));
+    expect(p0).toBeTruthy();
+    await page.mouse.click(p0.x, p0.y);
+    await expect(wrap(page)).toHaveAttribute("data-editor-selected", "0");
+    await expect(wrap(page)).toHaveAttribute("data-editor-selected-voice", "1");
+    await expect(wrap(page)).toHaveAttribute("data-editor-divergence-ok", "true");
+
+    // A note the fixture places in voice 2 (a bass note) selects too, its voice
+    // read back as 2 from BOTH the document and the renderer, guard green.
+    const v2 = await page.evaluate(() => {
+      const h = window.__scoreEditor;
+      for (let i = 0; i < h.noteCount(); i++) {
+        if (h.viewInfo(i)?.voice === 2) return i;
+      }
+      return -1;
+    });
+    expect(v2).toBeGreaterThan(-1);
+    const pv2 = await page.evaluate((i) => window.__scoreEditor.headPoint(i), v2);
+    await page.mouse.click(pv2.x, pv2.y);
+    await expect(wrap(page)).toHaveAttribute("data-editor-selected", String(v2));
+    await expect(wrap(page)).toHaveAttribute("data-editor-selected-voice", "2");
+    await expect(wrap(page)).toHaveAttribute("data-editor-divergence-ok", "true");
+  });
+
+  // Target 3: two genuinely-overlapping notes (a cross-voice unison, ordinals 0
+  // and 2, both E4 at onset 0) can EACH be selected by click-cycling at the one
+  // spot, and the guard is green for each. Asserts BOTH distinct notes reached.
+  test("overlapping-voice note heads are each reachable by click-cycling", async ({ page }) => {
+    await openEditor(page, OVERLAP_MUSICXML, 4);
+
+    // Ordinals 0 (voice 1) and 2 (voice 2) are the unison. Confirm the fixture
+    // really overlaps: same pitch, and their head points essentially coincide.
+    const geom = await page.evaluate(() => {
+      const h = window.__scoreEditor;
+      return {
+        p0: h.headPoint(0),
+        p2: h.headPoint(2),
+        v0: h.viewInfo(0),
+        v2: h.viewInfo(2),
+        hit: h.hitTest(h.headPoint(0).x, h.headPoint(0).y),
+      };
+    });
+    expect(geom.v0.midi).toBe(64); // E4
+    expect(geom.v2.midi).toBe(64); // E4 - the unison
+    expect(geom.v0.voice).toBe(1);
+    expect(geom.v2.voice).toBe(2);
+    // The two heads draw within a couple of pixels of each other - a real
+    // overlap, not two separated heads.
+    expect(Math.abs(geom.p0.x - geom.p2.x)).toBeLessThanOrEqual(3);
+    expect(Math.abs(geom.p0.y - geom.p2.y)).toBeLessThanOrEqual(3);
+
+    // Click the one spot. The first click selects the nearest of the stacked
+    // notes; capture which.
+    const spot = geom.p0;
+    await page.mouse.click(spot.x, spot.y);
+    await expect(wrap(page)).toHaveAttribute("data-editor-selected", /^(0|2)$/);
+    const first = await selectedOrdinal(page);
+    expect([0, 2]).toContain(first);
+    await expect(wrap(page)).toHaveAttribute("data-editor-divergence-ok", "true");
+    const firstVoice = await wrap(page).getAttribute("data-editor-selected-voice");
+
+    // A second click at the SAME spot cycles to the OTHER note in the stack.
+    await page.mouse.click(spot.x, spot.y);
+    await expect
+      .poll(() => selectedOrdinal(page), "a second click at the same spot should cycle to the other overlapping note")
+      .not.toBe(first);
+    const second = await selectedOrdinal(page);
+    expect([0, 2]).toContain(second);
+    expect(second).not.toBe(first);
+    await expect(wrap(page)).toHaveAttribute("data-editor-divergence-ok", "true");
+    const secondVoice = await wrap(page).getAttribute("data-editor-selected-voice");
+
+    // BOTH distinct notes were selected, and they are the two different voices of
+    // the unison - the overlap was fully disambiguated.
+    expect(new Set([first, second])).toEqual(new Set([0, 2]));
+    expect(new Set([firstVoice, secondVoice])).toEqual(new Set(["1", "2"]));
+
+    // A third click at the same spot wraps back to the first note.
+    await page.mouse.click(spot.x, spot.y);
+    await expect.poll(() => selectedOrdinal(page)).toBe(first);
+    await expect(wrap(page)).toHaveAttribute("data-editor-divergence-ok", "true");
+  });
+
+  // Cycling is anchored to the SPOT: moving to a different note and back resets
+  // the stack, so a single click there again selects the nearest (not the next
+  // in a stale cycle).
+  test("moving the click elsewhere resets the overlap cycle", async ({ page }) => {
+    await openEditor(page, OVERLAP_MUSICXML, 4);
+    const spot = await page.evaluate(() => window.__scoreEditor.headPoint(0));
+    // A clearly non-overlapping note: ordinal 1 (G4, voice 1, second half of the
+    // bar) sits elsewhere on the staff.
+    const other = await page.evaluate(() => window.__scoreEditor.headPoint(1));
+
+    await page.mouse.click(spot.x, spot.y);
+    const first = await selectedOrdinal(page);
+    await page.mouse.click(other.x, other.y);
+    await expect(wrap(page)).toHaveAttribute("data-editor-selected", "1");
+    // Back to the overlap spot: a fresh stack, so the nearest (the same `first`)
+    // is selected again rather than the cycle continuing from where it left off.
+    await page.mouse.click(spot.x, spot.y);
+    await expect.poll(() => selectedOrdinal(page)).toBe(first);
+    await expect(wrap(page)).toHaveAttribute("data-editor-divergence-ok", "true");
+  });
+});

--- a/web/tests/spec-floors/browser-score-editor-fuzz-189.json
+++ b/web/tests/spec-floors/browser-score-editor-fuzz-189.json
@@ -1,0 +1,5 @@
+{
+  "file": "tests/browser/score-editor-fuzz-189.spec.js",
+  "count": 5,
+  "reason": "issue #189 N-random-edits divergence fuzz guard: after N seeded (mulberry32) random edits on a real polyphonic score (fixtures/editor-poly.js), the written MusicXML re-imports to a model identical to the one on screen across every note (auditAllNotes), with the per-edit divergence flag green throughout - the stronger whole-model check #10 asked for once voice moves (#182) and deletes (#186) could shift an ordinal rather than merely misread one. The five tests: the seeded run stays identical (fixed seed + N, FERMATA_FUZZ_SEED/N override for a local sweep); the guard actually CATCHES a planted stale-render divergence and NAMES the note, then heals; a single fret edit keeps the per-selection guard green over the two-voice document; and the two tie-invariant tests the fuzz surfaced - a tie must join the same fretboard position (same string+fret), not merely the same sounding pitch (alphaTab draws a tie-stop at a fret derived from its start), so a same-pitch different-position tie is refused and moving a tied note off its partner's position breaks the tie on both ends."
+}

--- a/web/tests/spec-floors/browser-score-editor-poly-189.json
+++ b/web/tests/spec-floors/browser-score-editor-poly-189.json
@@ -1,0 +1,5 @@
+{
+  "file": "tests/browser/score-editor-poly-189.spec.js",
+  "count": 3,
+  "reason": "issue #189 polyphonic selection, including the genuinely-overlapping note heads the #10 evaluation flagged (~1.5%). Against the real two-voice fixture (fixtures/editor-poly.js): a note in each voice selects with the divergence guard green (the polyphonic baseline); two overlapping-voice note heads (a cross-voice unison, same pitch and onset drawing one head over the other) are EACH reachable by the stated disambiguation - click-cycling, where a repeat click at the same spot advances to the next note in the stack (score-render.js hitTestNote) - selecting BOTH distinct notes (two ordinals, two voices) with the guard green for each and wrapping back on a third click; and moving the click elsewhere resets the overlap cycle so a single click there again selects the nearest."
+}


### PR DESCRIPTION
Closes #189.

Follow-on to #10. The per-selection divergence guard cross-checks only the **selected** note's renderer read against the document read, so it misses a positional-map **shift** — a voice move (#182) or delete (#186) leaving the renderer's ordinal N naming a different note than the document's ordinal N — unless that exact note is selected. This adds the stronger whole-model check the #10 evaluation asked for, plus polyphonic (overlapping-voice) selection.

## Part 1 — the N-random-edits fuzz guard

- **`auditAllNotes` (TabViewer):** re-imports the **written** MusicXML (a fresh parse of `doc.text()`) and asserts the on-screen model equals it across **every** note: count; per-ordinal pitch (midi), string (MusicXML numbering), fret and voice between the render and the re-import; plus a full written-document round-trip (id, spelling, string, fret, voice, **onset**, **duration** via type+dots, **ties**). Each divergence **names** the note (`{ordinal, field, id, doc, render}`).
- **Seeded, reproducible:** the sequence is driven by a **mulberry32** seeded RNG — never `Math.random()`. The seed and failing step are emitted on failure. Fixed seed + N in the committed spec keep CI deterministic and bounded; `FERMATA_FUZZ_SEED` / `FERMATA_FUZZ_N` override for a larger local sweep (verified green to N=250 across many seeds).
- **Score:** a real polyphonic fixture — two voices with backups, chords and ties across eight 4/4 bars (~52 sounding notes). The library has **no** polyphonic tab MusicXML to reuse (its two `.musicxml` files are single-voice lead sheets with no tuning, which the editor cannot open), so it is built in the emitter's exact shape and served through the same stub the monophonic suite uses.
- **Edit menu:** uniform over the shipped ops that touch note identity/ordering — fret, string, accidental, enharmonic, tie, voice move, delete. Duration/dots are excluded (they intentionally don't refill the bar, a Rule 8 validity concern distinct from positional-map integrity, already covered by #183). Refusals are not failures.
- **Proven to catch a divergence:** a committed test induces a stale-render divergence (edit the document, skip the re-render) and shows the audit go red and name ordinal 0's fret/midi, then heals. Separately validated with a **real** planted bug — reversing voice order in `buildNoteOrdinals` — which reddened the guard at step 0, naming per-note divergences across the whole score; reverted.

## Part 2 — polyphonic selection

- **Click-cycling** disambiguates genuinely overlapping note heads (`hitTestNote`): a first click selects the nearest note stacked at a spot; each further click at the **same** spot advances to the next note in the stack, wrapping. A single click is unchanged for the non-overlapping majority. Tested on a cross-voice **unison** (same pitch and onset, one head over the other) — both distinct notes reached, two voices, guard green for each.

## Editor fix the fuzz surfaced

The fuzz found a real gap: a tie was allowed between notes of the **same sounding pitch but different fretboard position**, which alphaTab draws wrong (a tie-stop note takes a fret derived from its start), so the written and drawn pitches disagreed — invisible to the per-selection guard because the diverging note is the unselected partner. `setTie` now requires the **same string AND fret**, and a fret/string edit that moves a tied note off its partner's position **breaks** the tie on both ends. Pinned with two focused tests.

## Tests

New browser specs: `score-editor-fuzz-189.spec.js` (5) and `score-editor-poly-189.spec.js` (3), with per-file spec floors. Full suite: **561 passed, 0 failed, 0 skipped**; existing #10/#182/#183/#185/#186 editor specs and the live divergence guard stay green.

Do not merge — for adversarial review.