### PR TITLE
Date the practice-history test helper relative to now, not a fixed day

### DIFF
--- a/server/tests/test_scanner.py
+++ b/server/tests/test_scanner.py
@@ -89,7 +89,7 @@ def attach_irreplaceable_work(score_id: int, tag: str = "wedding") -> None:
     conn = db.connect()
     conn.execute(
         """INSERT INTO practice_sessions(score_id, activity, started_at, local_date, seconds, note)
-           VALUES (?, 'piece', '2026-08-01T19:00:00', '2026-08-01', 2400, 'felt rough')""",
+           VALUES (?, 'piece', datetime('now', '-1 day'), date('now', '-1 day'), 2400, 'felt rough')""",
         (score_id,),
     )
     # One goal per period per owner, so each score's goal gets its own week.


### PR DESCRIPTION
`attach_irreplaceable_work` inserted a practice session hardcoded at `2026-08-01`. The neglected-view query flags a score as neglected when its most recent session is older than `date('now','-30 days')`, so once the real calendar passed 30 days beyond that fixed date, the practised score began appearing as neglected and `test_the_library_views_still_answer_with_missing_scores_present` started failing on every run — a time-bomb that fired when the month rolled over, unrelated to any code change (it fails identically on `main`).

Fix: date the session relative to now (yesterday) so a score with attached practice history stays "recently practised" regardless of the calendar. No test asserts on the literal date; full `test_scanner.py` stays green (56 passed).