### PR TITLE
Settle the editor layout before the poly-selection click, hardening #189's spec

### DIFF
--- a/web/tests/browser/score-editor-poly-189.spec.js
+++ b/web/tests/browser/score-editor-poly-189.spec.js
@@ -35,6 +35,36 @@ async function openEditor(page, content, expected) {
   await page.getByRole("button", { name: "Edit notes" }).click();
   await expect(wrap(page)).toHaveAttribute("data-editor-active", "true");
   await expect.poll(() => page.evaluate(() => window.__scoreEditor?.noteCount() ?? 0)).toBe(expected);
+  await settleEditorLayout(page);
+}
+
+// Entering edit mode turns the notation staff on (an alphaTab re-render) AND
+// mounts the edit panel (a DOM reflow); the coordinates headPoint()/hitTest()
+// work in are live screen geometry (an alphaTab bound plus the surface's
+// getBoundingClientRect), so a click fired before that geometry settles
+// hit-tests against a layout still in motion and lands on empty space - the
+// select registers nothing and data-editor-selected reads null. This is #189's
+// intermittent flake: noteCount() does NOT gate on the settle (it is already
+// 52/4 from the tab-only render before edit mode, so its poll passes at once),
+// and neither does a render-completion signal - the note's screen y was
+// measured still shifting (363 -> 295 px) after alphaTab's postRenderFinished
+// had fired and the note bounds had doubled, because the panel-mount reflow and
+// growPaperToDrawing move the surface, not the alphaTab bounds. So gate on the
+// hit-test geometry itself holding still: the same head point across two
+// consecutive reads. Once the layout has settled it stays put (measured stable
+// across 29 further reads), so this waits out the transient without a fixed
+// sleep, exactly where the click's coordinates come from.
+async function settleEditorLayout(page) {
+  let prev = null;
+  await expect
+    .poll(async () => {
+      const p = await page.evaluate(() => window.__scoreEditor?.headPoint(0) ?? null);
+      const key = p ? `${Math.round(p.x)},${Math.round(p.y)}` : null;
+      const stable = key != null && key === prev;
+      prev = key;
+      return stable;
+    })
+    .toBe(true);
 }
 
 // The currently-selected ordinal, as an integer, read off the DOM.


### PR DESCRIPTION
## What

Partially addresses the reliability of #189's poly-selection spec
(`tests/browser/score-editor-poly-189.spec.js`). It does not close #189.

The test `a note in each voice selects with the divergence guard green`
intermittently timed out on CI at
`toHaveAttribute("data-editor-selected", "0")` with the attribute reading
null - the click to select the note registered no selection.

## Root cause - a test race (not a UI race)

Entering edit mode turns the notation staff on (an alphaTab re-render) **and**
mounts the edit panel (a DOM reflow). The coordinates `headPoint()`/`hitTest()`
work in are live screen geometry: an alphaTab bound plus the drawing surface's
`getBoundingClientRect()`. The spec read `headPoint(0)` and clicked before that
geometry had settled, so the hit-test ran against a layout still in motion and
landed on empty space -> no selection -> `data-editor-selected` stays null.

`openEditor`'s only readiness barrier, `noteCount()` reaching the expected
count, does **not** gate on the settle: `noteCount()` is already the same value
(52 / 4) from the tab-only render that precedes edit mode, so its poll passes
immediately. A render-completion signal does not gate on it either - the note's
screen y was measured still shifting (363 -> 295 px) **after** alphaTab's
`postRenderFinished` had fired and the note bounds had doubled, because the
panel-mount reflow and `growPaperToDrawing` move the surface, not the alphaTab
bounds.

Evidence it is the test, not the component: on an unmodified build the spec is
50/50 green locally; the component selects correctly once the layout settles.
Simulating a slow CI edit-mode render (a temporary, reverted delay on the
notation re-render) reproduced the exact failure - `data-editor-selected`
`Received: ""` - at **8/16 runs**. A render-completion-counter barrier still
left **2/20** failing; the geometry-stability barrier below made it **0/25**
(and 0/20 at a larger delay).

## Fix

Test-only. Gate on the hit-test geometry itself holding still - the same
head point across two consecutive reads - before reading coordinates and
clicking. Once the layout settles it stays put (measured stable across 29
further reads), so this waits out the transient without a fixed sleep, exactly
where the click's coordinates come from. No component change.

## Verification

- Reproduced pre-fix: 8/16 with a simulated slow edit-mode render.
- After fix, clean unmodified build: **120/120** (all 3 poly tests x40 repeats).
- Full browser + unit suite via `node scripts/run-browser-tests.mjs`
  (spec-floor + out-of-band-read guards): reported separately once the local
  run lands; the divergence guard stays green (asserted within the poly tests).