### PR TITLE
Bind a chord's whole dot column to its members, not one (#160)

### DIFF
--- a/server/fermata/glyph_rhythm.py
+++ b/server/fermata/glyph_rhythm.py
@@ -2641,93 +2641,162 @@ def _displaced_pairs(owners, stems, spacing):
     return pairs
 
 
-def _reach_anchors(owners, pairs):
+def _reach_anchors(owners, pairs, spacing):
     """The x positions a dot's reach may be measured from, per owner.
 
-    Every owner offers its own right edge, as it always did. The lower half of
-    a displaced seconds pair offers its partner's right edge as well - the edge
-    that pair's shared dot column is actually set from (see _displaced_pairs,
-    #112).
+    Every owner offers its own right edge, as it always did. A displaced
+    seconds pair sets its chord's single dot column from the RIGHT (upper)
+    member's right edge, and that column belongs to the whole chord, not to the
+    one member a second away (#160). So every notehead sharing the pair's LEFT
+    (lower) notehead column - the column a full notehead width too far from the
+    dots for its own edge to reach - is lent the upper member's right edge as a
+    second anchor, the edge the shared column is actually set from. The lower
+    member of the pair is one such head (#112); the rest are the chord's other
+    undisplaced members, which the pair fix alone still left short of a column
+    that is theirs as much as anyone's.
+
+    Heads a full notehead width apart on one page x are the same beat - one
+    chord - so the left column is picked out by x alone, within the same abut
+    tolerance _displaced_pairs uses to say two heads' boxes touch.
 
     Returned as a list of (anchor_x, owner_index) sorted by anchor_x, ready to
     bisect. Anchors are ADDED, never substituted, so this cannot take a dot out
     of any owner's reach.
     """
     anchors = [(e.x1, i) for i, e in enumerate(owners)]
+    abut = _DOT_COLUMN_ABUT_TOL * spacing
+    heads = [i for i, e in enumerate(owners) if e.category in NOTEHEAD_CATS]
     for lower, upper in pairs:
-        anchors.append((owners[upper].x1, lower))
+        col_edge = owners[upper].x1
+        far_x1 = owners[lower].x1
+        for i in heads:
+            if owners[i].x1 < col_edge and abs(owners[i].x1 - far_x1) <= abut:
+                anchors.append((col_edge, i))
     anchors.sort()
     return anchors
 
 
 def _pushed_down_pairs(owners, pairs, runs, tol):
-    """Which dot runs a displaced seconds pair resolves JOINTLY, and to whom.
+    """Which dot runs a displaced seconds pair - and the chord members stacked
+    below it - resolve JOINTLY, and to whom.
 
-    Returns (contested_run, upper_i, beneath_run, lower_i) for every pair whose
-    two dots were pushed down a step together, which is the only arrangement
-    that fits two dots into one space's worth of room - see _DOT_PUSHED_STEP.
+    Returns a list of (contested_run, upper_i, chain) for every pair whose dots
+    were pushed down. `chain` is the ordered list of (dot_run, owner_i) whose
+    dots were pushed a FULL space below their owners, top member first;
+    contested_run is the UPPER member's own dot, pushed only into the space
+    below it (the space its partner occupies). Both are out of every tier's
+    reach - see _DOT_PUSHED_STEP.
 
-    The signature has to be the whole thing, not either half of it. A single
-    dot level with the lower head, with nothing a space beneath it, is that
-    head's own ordinary dot and is left to the ordinary rules: there was no
-    collision to avoid, so nothing was pushed anywhere. It is the SECOND dot,
-    a full space below, in the pair's own column, with no notehead of that
-    column down there to own it, that says the pair was pushed - and the first
-    dot is only ever read as the UPPER member's by being read together with it.
+    Two heads a second apart cannot print their dots half a space apart in one
+    column, so the engraver pushes them down a step together: the upper's dot
+    into the lower's space, the lower's a full space below its own centre. When
+    a further chord member sits where the lower's pushed dot lands, ITS slot is
+    taken too, so its dot is pushed a further space in turn, and the walk
+    continues to it - a cascade of evenly spaced dots over members that are NOT
+    evenly spaced (#160). The column is the chord's, and its dots go to the
+    chord's members in printed order.
+
+    The signature has to be the whole thing. What proves a push happened at all
+    is a dot at the BOTTOM of the chain that no notehead of the column owns at a
+    real tier - the orphan a chord that dots every member the ordinary way never
+    leaves. A single dot level with the lower head, nothing beneath it, is that
+    head's own; it takes that orphan a full space down to say the pair was
+    pushed, and the dots above it are only ever read as the upper members' by
+    being read together with it.
+
+    A notehead that already carries its own dot elsewhere in the column, at a
+    tier of its own, is not such an owner and does not refute the orphan: a note
+    takes ONE dot per column (see _DOT_X_DUP_TOL), so a head already spoken for
+    explains nothing. That exemption is what lets the deep pushed-down chord
+    resolve - where the head a third below the lower dot fits it, but owns a dot
+    of its own half a space further down - while still keeping the ordinary
+    all-dotted chords, whose lower member owns the beneath dot outright, out of
+    the joint reading (see the #159 guard fixtures).
     """
     sp = tol.spacing
     slack = _DOT_Y_SLACK * sp
+    step = _DOT_PUSHED_STEP * sp
+    col_reach = (1.0 + _DOT_COLUMN_ABUT_TOL) * sp
+    abut = _DOT_COLUMN_ABUT_TOL * sp
     out = []
     taken = set()
     for lower, upper in pairs:
         lo_e, up_e = owners[lower], owners[upper]
         col = up_e.x1
+        # A chord dots from ONE column but stands on TWO notehead columns a full
+        # notehead width apart (that is what a second forces - see
+        # _displaced_pairs), and both columns' heads share the dot column. So a
+        # chord member is a head on the RIGHT column (near `col`) or on the LEFT
+        # column (near the lower member's own edge, a notehead width left of
+        # `col`); the right-column reach alone would miss the far heads by a
+        # hair and let the cascade fire past a member that owns its own dot (the
+        # #160 defect). far_x1 pins the left column exactly.
+        far_x1 = lo_e.x1
         in_col = [j for j, r in enumerate(runs)
                   if -tol.dot_x_back <= r[1] - col <= tol.dot_x_tol]
-        contested = [j for j in in_col if abs(runs[j][2] - lo_e.yc) <= slack]
-        beneath = [j for j in in_col
-                   if abs(runs[j][2] - (lo_e.yc + _DOT_PUSHED_STEP * sp)) <= slack]
-        if not contested or not beneath:
+        contested = [j for j in in_col
+                     if j not in taken and abs(runs[j][2] - lo_e.yc) <= slack]
+        if not contested:
             continue
-        # ...and only where nothing ELSE in the chord explains that second dot.
-        # A dot a full space below the lower member is also "the space above"
-        # a head a third below it, which is an ordinary tier and an ordinary
-        # reading; a chord that dots every member that way was never pushed
-        # anywhere. So another notehead of this column that the dot fits at a
-        # real tier refutes the joint reading.
-        #
-        # Unless that notehead has a dot of its own already, elsewhere in the
-        # same column and at a tier of its own. Then it is not a rival for
-        # this one: a note carries ONE dot per column (that is what
-        # _DOT_X_DUP_TOL enforces later), so a head that is already spoken for
-        # explains nothing, and letting it refute leaves the pair's second dot
-        # orphaned with the pair unread. Measured across the library, this
-        # exemption recovers two sites - both in "Storm's Past", where the
-        # refuting head's own dot sits half a space above the one it was being
-        # allowed to claim - and touches none of the four chords the guard is
-        # there for (Vamo alla Flamenco twice, A Pendant Darkly, Courage).
-        c0, b0 = contested[0], beneath[0]
+        c0 = contested[0]
+        # Walk the pushed cascade down from the lower member. The dot a full
+        # space below the lower member is the lower member's own; a chord member
+        # sitting where that dot lands has had ITS slot taken, so its own dot is
+        # pushed a further space, and the walk continues to it. Rung k puts a dot
+        # at lower.yc + k*step, owned by the member at lower.yc + (k-1)*step.
+        chain = []
+        chain_owners = {upper}
+        owner_i = lower
+        j = 1
+        while True:
+            target = lo_e.yc + j * step
+            dj = next((k for k in in_col
+                       if k not in taken and k != c0
+                       and all(k != d for d, _o in chain)
+                       and abs(runs[k][2] - target) <= slack), None)
+            if dj is None:
+                break
+            chain.append((dj, owner_i))
+            chain_owners.add(owner_i)
+            nxt = next((i for i, e in enumerate(owners)
+                        if i not in chain_owners and e.category in NOTEHEAD_CATS
+                        and (abs(e.x1 - col) <= col_reach or abs(e.x1 - far_x1) <= abut)
+                        and abs(e.yc - target) <= slack), None)
+            if nxt is None:
+                break
+            owner_i = nxt
+            j += 1
+        if not chain:
+            continue
+        # The joint reading is correct only where the BOTTOM of the chain is an
+        # orphan - a dot no OTHER notehead of this column owns at a real tier,
+        # excepting a head already carrying its own dot elsewhere in the column
+        # (spoken for, so no rival). See the docstring: this one check both
+        # keeps the ordinary all-dotted chords out and lets the deep pushed-down
+        # chord's already-dotted neighbour stand aside.
+        b0 = chain[-1][0]
         b_yc = runs[b0][2]
         rival = False
-        for e in owners:
-            if e is lo_e or e is up_e or e.category not in NOTEHEAD_CATS:
+        for i, e in enumerate(owners):
+            if i in chain_owners or e.category not in NOTEHEAD_CATS:
                 continue
-            if abs(e.x1 - col) > (1.0 + _DOT_COLUMN_ABUT_TOL) * sp:
+            if abs(e.x1 - col) > col_reach and abs(e.x1 - far_x1) > abut:
                 continue
             if _dot_fit(b_yc - e.yc, sp) is None:
                 continue
-            if any(j not in (c0, b0) and _dot_fit(runs[j][2] - e.yc, sp) is not None
-                   for j in in_col):
+            if any(k != b0 and _dot_fit(runs[k][2] - e.yc, sp) is not None
+                   for k in in_col):
                 continue                      # already has its own dot here
             rival = True
             break
         if rival:
             continue
-        if c0 == b0 or c0 in taken or b0 in taken:
+        if c0 in taken or any(d in taken for d, _o in chain):
             continue
         taken.add(c0)
-        taken.add(b0)
-        out.append((c0, upper, b0, lower))
+        for d, _o in chain:
+            taken.add(d)
+        out.append((c0, upper, chain))
     return out
 
 
@@ -2836,7 +2905,7 @@ def _assign_dots(owners, dot_events, tol, stems=()):
     # window beside it was.
     owners = sorted(owners, key=lambda e: e.x1)
     pairs = _displaced_pairs(owners, stems, tol.spacing)
-    anchors = _reach_anchors(owners, pairs)
+    anchors = _reach_anchors(owners, pairs, tol.spacing)
     anchor_xs = [a for a, _i in anchors]
     runs = _dot_runs(dot_events, tol.spacing)
     joint = _pushed_down_pairs(owners, pairs, runs, tol)
@@ -2861,14 +2930,14 @@ def _assign_dots(owners, dot_events, tol, stems=()):
         live.append(sorted(best.values()))
 
     n = len(runs)
-    # The lower member of a pushed-down pair is out of every tier's reach by
-    # construction - its dot is a full space below it, which is exactly what
-    # _DOT_TIERS refuses - so the joint resolution supplies that candidate
-    # here, for the one run it identified and no other. Recorded before
-    # had_candidate is taken, so a jointly-resolved run is never reported as
-    # having reached nothing.
-    for _c_run, _upper, b_run, lower in joint:
-        live[b_run] = [(lower, _TIER_PUSHED_DOWN, 0.0, 0.0)]
+    # Every pushed-down member is out of every tier's reach by construction -
+    # its dot is a full space below it, which is exactly what _DOT_TIERS refuses
+    # - so the joint resolution supplies that candidate here, for the runs it
+    # identified and no others. Recorded before had_candidate is taken, so a
+    # jointly-resolved run is never reported as having reached nothing.
+    for _c_run, _upper, chain in joint:
+        for b_run, owner in chain:
+            live[b_run] = [(owner, _TIER_PUSHED_DOWN, 0.0, 0.0)]
     # Whether dot i EVER had a reachable candidate, fixed here before
     # elimination gets a chance to remove any of them - the only way to tell
     # unassigned_no_candidate apart from unassigned_eliminated below.
@@ -2916,14 +2985,15 @@ def _assign_dots(owners, dot_events, tol, stems=()):
         owner_dot_xs[owner_i].append(runs[dot_idx][1])
         resolved[dot_idx] = True
 
-    # The jointly-resolved pairs go in FIRST, before anything is ranked. Both
-    # their dots are reachable by the lower member and neither is the lower
-    # member's on its own, so any ordering that let ranking see them first
-    # would hand it the upper member's dot and leave the upper member bare -
-    # which is precisely the reading this replaces.
-    for c_run, upper, b_run, lower in joint:
+    # The jointly-resolved cascades go in FIRST, before anything is ranked. Each
+    # pushed dot is reachable by more than its true owner and none is any one
+    # member's on its own, so any ordering that let ranking see them first would
+    # hand a member a neighbour's dot and leave that neighbour bare - which is
+    # precisely the reading this replaces.
+    for c_run, upper, chain in joint:
         _commit(c_run, upper, len(_DOT_TIERS) - 1)   # the space below it
-        _commit(b_run, lower, _TIER_PUSHED_DOWN)     # a full space below it
+        for b_run, owner in chain:
+            _commit(b_run, owner, _TIER_PUSHED_DOWN)  # a full space below it
 
     # Then commit ONE dot at a time, re-running the conflict filter before
     # looking for the next one. Committing every currently-forced dot in a

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -81,6 +81,22 @@ _FIXTURE_RELATIVE_PATHS = {
     # refuting the pushed-down reading has no other real score to be
     # exercised on - see glyph_rhythm._pushed_down_pairs.
     "storms_past": "Patreon/John Oeth/New World/Storm_s Past (New World).pdf",
+    # Issue #160: a chord whose members share ONE dot column, not the pushed-down
+    # arrangement above. Five noteheads, five printed dots in a single column;
+    # the undisplaced members sit a full notehead width too far from the column
+    # for their own reach, so before #160 only the members within reach read - 2
+    # of the 5. Two scores carry the shape; both are pinned. Referenced by
+    # relative path, named here by the mechanism they exercise.
+    "chord_shared_dot_column_a": ("Patreon/John Oeth/The Legend of Zelda/"
+        "TLOZ Link_s Awakening/Inside a House (The Legend of Zelda Link_s Awakening).pdf"),
+    "chord_shared_dot_column_b": ("Patreon/John Oeth/Final Fantasy/FF IX/"
+        "Vamo alla Flamenco (Final Fantasy IX).pdf"),
+    # Issue #160's other class: three members whose dots the engraver pushed into
+    # an evenly spaced cascade - a displaced pair pushed down a step, then a
+    # further member whose own slot the pair took pushed a step again - four dots
+    # over members that are not evenly spaced. The pair model orphaned the last
+    # dot (read 3 of 4). Page 3 (0-based page index 2) isolates it.
+    "pushed_down_cascade": "Patreon/John Oeth/Suikoden/Reminiscence (Suikoden II).pdf",
     # Two of the four scores the #116 research had a guitarist check against
     # the printed page. Born a Stranger's flagged spot is a genuine unison
     # shared by two voices - two notes drawn adjacent on the same row, the
@@ -478,6 +494,33 @@ def storms_past_pdf() -> Path:
     if p is None:
         skip_without_library(
             "FERMATA_TEST_LIBRARY not set (or missing 'Storm's Past' fixture)")
+    return p
+
+
+@pytest.fixture
+def chord_shared_dot_column_a_pdf() -> Path:
+    p = _fixture_path("chord_shared_dot_column_a")
+    if p is None:
+        skip_without_library(
+            "FERMATA_TEST_LIBRARY not set (or missing shared-dot-column fixture A)")
+    return p
+
+
+@pytest.fixture
+def chord_shared_dot_column_b_pdf() -> Path:
+    p = _fixture_path("chord_shared_dot_column_b")
+    if p is None:
+        skip_without_library(
+            "FERMATA_TEST_LIBRARY not set (or missing shared-dot-column fixture B)")
+    return p
+
+
+@pytest.fixture
+def pushed_down_cascade_pdf() -> Path:
+    p = _fixture_path("pushed_down_cascade")
+    if p is None:
+        skip_without_library(
+            "FERMATA_TEST_LIBRARY not set (or missing pushed-down-cascade fixture)")
     return p
 
 

--- a/server/tests/test_glyph_rhythm.py
+++ b/server/tests/test_glyph_rhythm.py
@@ -2016,6 +2016,70 @@ def test_the_column_anchor_never_takes_a_dot_out_of_reach():
     assert no_cand == 0 and eliminated == 0
 
 
+def test_a_five_member_chord_shares_its_dot_column():
+    """Issue #160, class 1: five members, five dots in ONE column, each dot at
+    its own member's tier - the ordinary arrangement, nothing pushed. One pair
+    is a displaced second (the reason the chord needs two notehead columns at
+    all); the other three members sit on the LEFT column, a full notehead width
+    - 1.9 spaces - from the dots, past the 1.17-space reach of their own edge.
+
+    The pair fix alone lends the shared column only to the pair's lower head, so
+    those three read nothing: 2 of the 5. The column is the chord's, so every
+    member on the left column is lent the column-setting edge, and all five
+    reach their own dot. No push fires here - there is no orphan a space below
+    the lowest member - so it is pure reach, resolved by the ordinary tiers."""
+    tol = _tol(_SECONDS_SPACING)
+    upper = _head(_UPPER_HEAD)                    # right column, yc 107.009
+    lower = _head(_LOWER_HEAD)                    # left column, yc 109.489 (a second below)
+    far_a = _head(_LOWER_HEAD, y_shift=-9.95)     # left column, 2 spaces above lower
+    far_b = _head(_LOWER_HEAD, y_shift=-14.925)   # left column, 3 spaces above
+    far_c = _head(_LOWER_HEAD, y_shift=-19.9)     # left column, 4 spaces above
+    heads = [far_c, far_b, far_a, upper, lower]
+    dots = [
+        _column_dot(109.489),                     # level with lower (tier 0)
+        _column_dot(107.009 - 0.5 * _SECONDS_SPACING),  # the space above upper (tier 1)
+        _column_dot(99.539), _column_dot(94.564), _column_dot(89.589),  # the far heads' own
+    ]
+    counts, no_cand, eliminated = G._assign_dots(heads, dots, tol, _SECONDS_STEM)
+    assert all(counts[id(h)] == 1 for h in heads), \
+        "every member reads its own dot - not just the two within their own reach"
+    assert (no_cand, eliminated) == (0, 0)
+
+
+def test_a_pushed_down_cascade_gives_each_member_its_own_dot():
+    """Issue #160, class 2: the pushed-down pair, extended to a cascade. The
+    displaced pair's two dots are pushed down a step (upper's into the lower's
+    space, lower's a full space below). The member a third below the lower sits
+    where the lower's pushed dot lands, so ITS slot is taken and its own dot is
+    pushed a further space in turn. Four dots at evenly spaced positions over
+    members that are NOT evenly spaced (a second, then a third, then a fifth).
+
+    The pair model resolves only its own two dots and orphans the third pushed
+    dot - 3 of 4. The cascade walks the push down the chord in printed order.
+    The fourth member, a fifth below, is far enough that its own slot is free -
+    its dot sits at its own tier, not pushed - so the cascade stops and it reads
+    the ordinary way. What proves the push happened is the orphan at the bottom
+    of the pushed run that no member owns at any tier; reading either pushed dot
+    alone gets its owner wrong."""
+    tol = _tol(_SECONDS_SPACING)
+    sp = _SECONDS_SPACING
+    upper = _head(_UPPER_HEAD)                    # right, yc 107.009
+    lower = _head(_LOWER_HEAD)                    # left, yc 109.489 (a second below upper)
+    mid = _head(_UPPER_HEAD, y_shift=(109.489 + sp) - 107.009)   # a third below lower
+    low = _head(_UPPER_HEAD, y_shift=(109.489 + 3 * sp) - 107.009)  # a fifth below lower
+    contested = _column_dot(109.489)              # level with lower -> upper's, pushed
+    beneath = _column_dot(109.489 + sp)           # a space below lower -> lower's own, pushed
+    third = _column_dot(109.489 + 2 * sp)         # a further space -> mid's own, pushed
+    ordinary = _column_dot(109.489 + 3 * sp)      # level with low -> low's own, NOT pushed
+    counts, no_cand, eliminated = G._assign_dots(
+        [upper, lower, mid, low], [contested, beneath, third, ordinary], tol, _SECONDS_STEM)
+    assert counts[id(upper)] == 1, "the contested dot is the UPPER member's"
+    assert counts[id(lower)] == 1, "the first pushed dot is the lower member's"
+    assert counts[id(mid)] == 1, "the cascade carries the push to the third member"
+    assert counts[id(low)] == 1, "and the fifth-below member keeps its own untouched dot"
+    assert (no_cand, eliminated) == (0, 0), "nothing is left over - 4 of 4"
+
+
 # ---------------------------------------------------------------------------
 # A glyph's position is its ink, not its metrics box (finding 88)
 # ---------------------------------------------------------------------------

--- a/server/tests/test_tabextract.py
+++ b/server/tests/test_tabextract.py
@@ -608,6 +608,89 @@ def test_a_deep_chords_pushed_down_dots_all_find_their_own_note(storms_past_pdf)
         "and this staff's only remaining orphan is the three-in-a-row cascade"
 
 
+def _chord_in_box(page, x_lo, x_hi, y_lo, y_hi):
+    """Decode every standard staff on `page` and return, from the staff that
+    covers the most of them, the noteheads whose centre falls in the box,
+    sorted top to bottom, together with that staff's decode stats.
+
+    A single frame's chord can be caught by more than one detected staff record
+    when two are ruled a fraction of a space apart, so the staff is chosen by
+    which decode actually reads the frame rather than by a fragile top-y match.
+    """
+    best = None
+    for staff in tabextract._detect_staves(page)[0]:
+        if staff.kind != "standard":
+            continue
+        notes, stats = glyph_rhythm.decode_note_events(
+            page, staff.top, staff.bottom, staff.x0, staff.x1,
+            staff.line_ys, staff.spacing)
+        heads = sorted(
+            (n for n in notes if not n.is_rest
+             and x_lo <= n.x <= x_hi and y_lo <= n.y <= y_hi),
+            key=lambda n: n.y)
+        if best is None or len(heads) > len(best[0]):
+            best = (heads, stats)
+    return best
+
+
+def test_a_five_member_chord_shares_its_dot_column_a(chord_shared_dot_column_a_pdf):
+    """Issue #160, class 1: a five-note chord with five printed dots in ONE
+    column. The dots stand a fixed distance right of the chord's rightmost
+    (displaced) head, so the undisplaced members - a full notehead width to the
+    left - sit 1.9 spaces from the column, past the 1.17-space reach of their
+    own edge. Before #160 only the members within reach of their own dot read:
+    2 of the 5.
+
+    The column belongs to the whole chord, not to the one member a second away,
+    so every member on the chord's left notehead column is lent the column-
+    setting (right) edge as a second anchor (see glyph_rhythm._reach_anchors).
+    All five then reach their own dot at their own tier - no push, no cascade,
+    the ordinary tier ranking does the rest. Read off decode_note_events, since
+    the beat model collapses a chord's members to one duration and would hide
+    which notehead each dot landed on."""
+    page = fitz.open(chord_shared_dot_column_a_pdf)[0]
+    heads, _stats = _chord_in_box(page, 524, 542, 652, 680)
+    assert len(heads) == 5, "the five noteheads of the chord, one frame"
+    assert [n.dotted for n in heads] == [1, 1, 1, 1, 1], \
+        "five printed dots, one to each member - not the 2 the pair fix read"
+
+
+def test_a_five_member_chord_shares_its_dot_column_b(chord_shared_dot_column_b_pdf):
+    """Issue #160, class 1, on the library's second instance of the shape - a
+    row of repeated five-note chords, each with five dots in one column, each
+    read 2 of 5 before #160. The first chord of the first standard staff is
+    pinned; the rest move with it (the whole score's dots_unassigned falls from
+    40 to 16). Same mechanism as _a: the chord's dot column is lent to every
+    member, not only the displaced pair's lower head."""
+    page = fitz.open(chord_shared_dot_column_b_pdf)[0]
+    heads, _stats = _chord_in_box(page, 149, 166, 118, 154)
+    assert len(heads) == 5, "the five noteheads of the first chord, one frame"
+    assert [n.dotted for n in heads] == [1, 1, 1, 1, 1], \
+        "five printed dots, one to each member - not the 2 the pair fix read"
+
+
+def test_a_pushed_down_cascade_gives_each_member_its_own_dot(pushed_down_cascade_pdf):
+    """Issue #160, class 2: three members whose dots the engraver pushed into an
+    evenly spaced cascade. A displaced seconds pair is pushed down a step (the
+    upper's dot into the lower's space, the lower's a full space below); the
+    member below the pair, whose own slot the lower's pushed dot now takes, is
+    pushed a further space in turn. Four dots at evenly spaced positions over
+    members that are NOT evenly spaced.
+
+    The pair model resolved only its own two dots and orphaned the third pushed
+    dot - read 3 of 4. The cascade walk carries the push down the chord in
+    printed order, proven by the orphan at the bottom of the column that no
+    member owns at a tier (see glyph_rhythm._pushed_down_pairs). All four dots,
+    one to each of the four dotted members; the fifth (undotted) head of the
+    frame stays bare. Page index 2 is page 3."""
+    page = fitz.open(pushed_down_cascade_pdf)[2]
+    heads, stats = _chord_in_box(page, 470, 485, 662, 692)
+    dotted = [n for n in heads if n.dotted]
+    assert len(dotted) == 4, "the four dotted members of the chord"
+    assert stats["dots_unassigned"] == 0, \
+        "no dot of this staff is left orphaned - the cascade's last is bound"
+
+
 def test_a_top_member_copy_that_borrows_a_stem_is_left_exactly_as_it_was(spanish_romance_pdf):
     """The refusal that keeps #210 off correct output, pinned on the library's
     largest population of the shape (34 of the 48 in-chord onsets whose
@@ -4844,10 +4927,21 @@ def test_library_wide_repeat_structure_leaves_conformance_untouched(library_root
     # (see _share_top_member_unison) land in a DOTTED chord, so each emits its
     # own <dot /> alongside the chord's other members. They are bound to their
     # note, so dots_unassigned below does not move.
+    # #160 moves dots_unassigned WITHOUT moving `dots`: it binds augmentation
+    # dots that were left over on chords whose members share ONE dot column - the
+    # undisplaced members a full notehead width too far from the column for their
+    # own reach, and the members below a displaced pair whose dots were pushed
+    # into an evenly spaced cascade (see glyph_rhythm._reach_anchors and
+    # ._pushed_down_pairs). Each such chord was ALREADY dotted by the members
+    # that did bind, and the beat model carries one duration per chord, so
+    # accounting for the extra glyph emits no new <dot /> - only the disclosure
+    # counter falls. -76 across 16 scores, every move a chord gaining a dot it
+    # already reads no differently for; notes, beats and the emitted MusicXML
+    # and alphaTex are byte-for-byte identical library-wide.
     assert totals["dots"] == 9185                          # 8884 -> 9182 (#111/#112) -> 9183 (#180) -> 9185 (#210)
-    assert totals["dots_unassigned"] == 1154                # 1280
-    assert totals["dots_unassigned_no_candidate"] == 1144   # 1226
-    assert totals["dots_unassigned_eliminated"] == 10       # 54
+    assert totals["dots_unassigned"] == 1078                # 1280 -> 1154 (#111/#112) -> 1078 (#160)
+    assert totals["dots_unassigned_no_candidate"] == 1073   # 1226 -> 1144 (#111/#112) -> 1073 (#160)
+    assert totals["dots_unassigned_eliminated"] == 5        # 54 -> 10 (#111/#112) -> 5 (#160)
     # ...and the repeat furniture the same glyph stream carries, unmoved by
     # any of it. Maestro and Opus draw a repeat's dots with the augmentation
     # dot's own glyph, and issue #138 reads them off this stream, so a change


### PR DESCRIPTION
Closes #160.

Within one chord, dots in a shared column belong to the chord's members in printed order — the column is the chord's, not any single member's. Two independently-gated extensions in `glyph_rhythm.py` (`dot_x_tol`/`dot_x_back` untouched):

- **Reach (class 1):** a chord a second wide stands on two notehead columns; dots set off the right member's edge leave the left-column members ~1.9 spaces away, past their own 1.17-space reach. Each left-column member is now lent the column-setting edge (added, never substituted); ordinary tier ranking then reads each member's own dot.
- **Cascade (class 2):** the pushed-down pair generalised to a chain — where a member sits at the previous pushed dot's height, its dot is pushed a further space, carried down the chord in printed order.

**Guards preserved (#159):** the joint reading fires only when the chain's bottom dot is an orphan no member owns at any tier (ordinary all-dotted chords leave no orphan and stay out); a head already carrying its own dot in the column is no rival; the cascade is only ever anchored by a real shared-stem displaced pair.

**Measured (full 297-score sweep, independently re-derived):**
- The two five-dot chords read 5/5; the cascade reads 4/4 (page-rendered and read by eye).
- `dots_unassigned` 1154 → 1078 (−76); 16 scores' counters fall, **none worse**.
- **Emitted MusicXML + alphaTex byte-identical on all 297** — `notes`/`beats`/`dots` unchanged. Each recovered dot is on an already-dotted chord, so no duration or note changes; only the disclosure counter falls. This cannot regress any transcription.

**Mutation:** reverting the reach rule reds the five-member pins (3); severing the cascade reds the cascade pins (2); every #159 pin stays green. Op-count unmoved (no routes); no new disclosure counter.

Scores referred to by mechanism/neutral labels; the public tracker does not enumerate specific works.