### PR TITLE
Correct the user-facing docs against what main actually does

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,6 +52,15 @@ npm ci
 npm run build
 ```
 
+Frontend tests — unit specs and the browser suite, which drives a real backend
+serving the build, so `npm run build` has to have run first:
+
+```bash
+cd web
+npx playwright install --with-deps chromium
+npm run test:browser
+```
+
 Whole thing, as it actually ships:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -23,10 +23,13 @@ them.
 - **PDF practice reader** — continuous or paged reading, keyboard/pedal page
   turns (any Bluetooth pedal that sends arrow keys works), remembers your last
   page per piece, and a dark "practice room" inversion mode.
-- **Notation / tab / both** — MusicXML and Guitar Pro files render
-  interactively and can be switched between standard notation, tablature, or
-  both staves at once, with audio playback, adjustable speed, and a moving
-  cursor. The built-in synthesizer also drives practice tools: drag-select a
+- **Notation / tab / both** — MusicXML files render interactively and can be
+  switched between standard notation, tablature, or both staves at once, with
+  audio playback, adjustable speed, and a moving cursor. Guitar Pro files are
+  accepted by the scanner and handed to the same renderer's importer, which
+  reads that format natively; nothing in this repository covers that path
+  end to end, so it is untested here rather than proven. The built-in
+  synthesizer also drives practice tools: drag-select a
   passage on the score to loop it, plus a count-in. The
   staff is themed to match the interface, lays itself out differently on a
   phone, a tablet on a stand and a desktop, and can be drawn dark for
@@ -54,7 +57,9 @@ them.
   read and are not transcribed. A tie is written where the curve joining its
   two notes was matched, and a note the engraving marks as a harmonic is
   written as one; a tie drawn across a system break is not matched, and the
-  ends of it that were found are counted rather than half-written.
+  ends of it that were found are counted rather than half-written. A whole
+  library, or one collection, transcribes in a single background pass rather
+  than one score at a time.
 - **Instruments** — define what you actually play: any number of strings, any
   tuning including reentrant ones, a capo, and a reference pitch other than
   A440. Each string shows the note and frequency it sounds and can be played,
@@ -96,6 +101,14 @@ them.
   accuracy percentage and no streak, and a note you could not name is what the
   practice consists of. The time lands in your practice history as ear training
   and counts towards a weekly goal like anything else.
+- **Fretboard drills** — *Fret to note* asks in both directions: a position is
+  shown and you name what it sounds, or a note is named and you tap where it
+  lies. *Chord flash cards* does the same for major, minor and seventh shapes.
+  Either can be narrowed to the strings, the fret range and the key you are
+  actually working on, and every answered question is stored as a structured
+  row — which positions and which chords were missed, counted, never divided
+  into an accuracy percentage ([the data model](docs/practice-data.md)). The
+  time lands in your practice history like anything else.
 - **Weekly goals, and an honest review** — how many days you mean to practise
   and for how long, on what. While the week runs it says where you stand so the
   goal can still change it; afterwards it states plainly what happened and asks
@@ -214,7 +227,7 @@ it — see [the tab profile](docs/musicxml-tab-profile.md#checking-a-file).
 | PDF, engraved without tab | Practice reader; nothing to transcribe from |
 | PDF, scanned | Practice reader only — a scan holds no text or glyphs to read |
 | MusicXML (`.musicxml`, `.mxl`) | Interactive: notation / tab / both, audio, full fidelity |
-| Guitar Pro (`.gp3`–`.gp5`, `.gpx`, `.gp`) | Interactive: notation / tab / both, audio |
+| Guitar Pro (`.gp3`–`.gp5`, `.gpx`, `.gp`) | Scanned and indexed, then handed to the renderer's own importer, which reads the format natively — **untested here**: no fixture, no end-to-end test |
 
 A PDF is a fixed rendering, so the notation/tab toggle belongs to the
 structured formats — and to a transcription made from a PDF, which is what the
@@ -234,12 +247,15 @@ demo*) if your library is PDF-only so far.
 - **Instrument-aware transcription** — reading a score against the instrument it
   is written for, instead of assuming standard six-string tuning whatever the
   score says
-- **Score creation and editing** — build a staff from scratch in the browser,
-  instrument-agnostic with first-class guitar tablature support
+- **Score creation from scratch** — a blank staff built in the browser,
+  instrument-agnostic with first-class guitar tablature support. Editing the
+  notes, rhythms and spellings of a staff that already exists works today;
+  starting from nothing does not
 - **More import formats** — MIDI and plain-text tab in particular, since those
   accompany most freely-licensed sheet music you can download
-- **A fretboard trainer** — note finding, chord flash cards and reach drills,
-  scoped to the strings and frets you are working on
+- **Interval and reach drills** — finding the third, the fifth or the octave
+  from a given position, and widening a fret span on purpose. The fretboard
+  drills that exist today test recall, not reach
 - Recognition for what you have accomplished over time
 - Annotations on PDFs (fingerings, markings)
 - Multi-user accounts (reverse proxy authentication - trusting a login a

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ them.
   accepted by the scanner and handed to the same renderer's importer, which
   reads that format natively; nothing in this repository covers that path
   end to end, so it is untested here rather than proven. The built-in
-  synthesizer also drives practice tools: drag-select a
-  passage on the score to loop it, plus a count-in. The
+  synthesizer also drives practice tools: drag-select a passage on the score
+  to loop it, plus a count-in. The
   staff is themed to match the interface, lays itself out differently on a
   phone, a tablet on a stand and a desktop, and can be drawn dark for
   practising in the dark — see [how scores are rendered](docs/rendering.md) for

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -26,12 +26,19 @@ your own browser. The interesting attack surface is roughly:
   escapes the configured library directory.
 - Anything that lets a request read or write outside the library and config
   volumes.
+- Reverse proxy authentication, when it has been turned on. Anything that lets
+  a request Fermata should have refused be accepted as vouched for — spoofing
+  the configured user header, or getting an untrusted peer address to test as a
+  trusted proxy — is worth reporting. See
+  [docs/deployment.md](docs/deployment.md#reverse-proxy-authentication).
 
 ## What isn't
 
-- Fermata ships with no authentication and assumes it sits on a network you
-  control, or behind a reverse proxy that handles access. "Anyone who can reach
-  the port can use it" is the documented design, not a vulnerability.
+- Fermata ships with no authentication of its own and assumes it sits on a
+  network you control, or behind a reverse proxy that handles access. "Anyone
+  who can reach the port can use it" is the documented design in that default
+  state, not a vulnerability. (Once reverse proxy authentication is configured,
+  getting past it is in scope — see above.)
 - Denial of service through deliberately enormous or pathological files. Worth
   an ordinary issue, not a security report.
 - Vulnerabilities in a dependency with no demonstrated path through Fermata.

--- a/docs/api.md
+++ b/docs/api.md
@@ -68,7 +68,8 @@ expectations are:
   credential of its own. The one identity this API knows about comes from
   outside it: with reverse-proxy authentication configured, a request that
   did not arrive from a trusted proxy carrying the configured header is
-  refused with `401`, and `GET /api/me` reads back the username the proxy
+  refused with `401` (`GET /api/health` alone stays open, so a load balancer
+  can probe it), and `GET /api/me` reads back the username the proxy
   vouched for. That is off by default — unset, every request behaves exactly
   as it did before it existed, `GET /api/me` answers `{"enabled": false,
   "username": null}`, and nothing else in the API acts on an identity either

--- a/docs/api.md
+++ b/docs/api.md
@@ -64,8 +64,16 @@ expectations are:
   should not infer "this will become non-null once the feature is finished".
 - **This is a single-owner, self-hosted server**, not a multi-tenant service.
   `owner` fields exist in several tables for a future multi-account version
-  and are always `'local'` today; nothing in the API takes or checks
-  credentials yet (see [SECURITY.md](../SECURITY.md)).
+  and are always `'local'` today, and no endpoint has a login, a token or a
+  credential of its own. The one identity this API knows about comes from
+  outside it: with reverse-proxy authentication configured, a request that
+  did not arrive from a trusted proxy carrying the configured header is
+  refused with `401`, and `GET /api/me` reads back the username the proxy
+  vouched for. That is off by default — unset, every request behaves exactly
+  as it did before it existed, `GET /api/me` answers `{"enabled": false,
+  "username": null}`, and nothing else in the API acts on an identity either
+  way. See [SECURITY.md](../SECURITY.md) and
+  [docs/deployment.md](deployment.md#reverse-proxy-authentication).
 
 The data model behind the practice endpoints specifically - what a session
 and a goal mean, what is derived versus stored, and what deliberately has no

--- a/docs/practice-data.md
+++ b/docs/practice-data.md
@@ -374,7 +374,7 @@ One table, `trainer_attempts`, independent of `practice_sessions`:
 | `id` | Stable for the life of the row. |
 | `owner` | `'local'`, same as everywhere else. |
 | `session_id` | The `practice_sessions` row logging the surrounding drill's TIME, when there is one yet - `NULL` otherwise. See below for why that is the ordinary case, not an edge one. |
-| `drill` | Which exercise asked it. `'fret_to_note'` today; a second fretboard drill (#26, #29) widens this, not a migration. |
+| `drill` | Which exercise asked it. `'fret_to_note'` today; a second fretboard drill would widen this tuple, not require a migration. |
 | `direction` | `position_to_note` (shown a position, asked for its note) or `note_to_position` (shown a note, asked to find a position). |
 | `target_string`, `target_fret` | The position a question NAMED - set only on `position_to_note`, where there is one. A note prompt has no single expected position (most notes sound in several places), so these stay `NULL` on `note_to_position`. |
 | `target_note` | The note being tested, always set. |

--- a/server/fermata/db.py
+++ b/server/fermata/db.py
@@ -209,7 +209,7 @@ _PRACTICE_SCHEMA = (
 #
 # `drill` is a free second axis on purpose, alongside `direction`: fret to
 # note is the first trainer to write here, and is not assumed to be the last
-# fretboard exercise this table will ever hold (#26, #29). Widening the
+# fretboard exercise this table will ever hold. Widening the
 # CHECK in trainer.py's DRILLS is how a second one arrives; the table itself
 # needs no migration for that.
 #

--- a/server/fermata/trainer.py
+++ b/server/fermata/trainer.py
@@ -21,7 +21,7 @@ import json
 from typing import Any
 
 # The one drill that writes here today. A widened tuple, not a migration, is
-# how a second one (#26, #29) arrives - the table itself is drill-agnostic
+# how a second one arrives - the table itself is drill-agnostic
 # already (db.py's _TRAINER_ATTEMPTS_COLUMNS).
 DRILLS = ("fret_to_note",)
 


### PR DESCRIPTION
An accuracy pass over the user-facing docs — `README.md`, `docs/*.md`,
`SECURITY.md`, `CONTRIBUTING.md` — against `main` at d43c3f1. Every claim
below was checked against a code path and, where it asserts a capability, a
test or a fixture. Nothing here changes voice or structure; only claims that
were wrong or stale moved.

## Corrections

**1. Guitar Pro was presented as a covered interactive format** (`README.md`,
the *Notation / tab / both* bullet and the Formats table)

- was: "MusicXML and Guitar Pro files render interactively … with audio
  playback, adjustable speed, and a moving cursor", and a Formats row reading
  "Interactive: notation / tab / both, audio".
- now: MusicXML carries the interactive claim on its own. Guitar Pro is
  described as scanned, indexed and handed to the renderer's own importer,
  which reads the format natively — and marked **untested here: no fixture,
  no end-to-end test**.
- evidence: `git ls-files | grep -iE '\.(gp[0-9x]?)$'` returns nothing — there
  is no Guitar Pro file under version control. No test loads one through a
  real importer; `server/tests/test_scanner.py`'s module docstring says its
  own `.gp` files are arbitrary bytes chosen precisely because the scanner
  parses nothing for that type. What *is* real is the acceptance path:
  `server/fermata/config.py`'s `FILE_TYPES` maps `.gp`, `.gp3`, `.gp4`,
  `.gp5`, `.gpx`, and `web/src/lib/Library.svelte:577` accepts them on upload.
  The extension list in the table was already correct and is unchanged. No
  fixture is added in this PR.

**2. Two shipped features were still listed as future work** (`README.md`
Roadmap)

- was: "**A fretboard trainer** — note finding, chord flash cards and reach
  drills, scoped to the strings and frets you are working on".
- now: a new **Fretboard drills** bullet in Features describes what exists,
  and the roadmap entry narrows to **Interval and reach drills**, which do
  not.
- evidence: both drills are routes in `web/src/App.svelte` (`#/fretboard`,
  `#/chords`), both are links in the library sidebar
  (`web/src/lib/Library.svelte:589-590`), and both have components
  (`web/src/lib/trainer/FretToNote.svelte`, `ChordFlashCards.svelte`),
  endpoints (`/api/trainer/attempts`, `/api/trainer/chord-attempts`), tables
  (`trainer_attempts`, `trainer_chord_attempts`), server tests
  (`server/tests/test_trainer_api.py`, `test_chord_trainer_api.py`) and
  browser specs (`web/tests/browser/fretboard-trainer.spec.js`,
  `chord-flashcards.spec.js`). Scoping by string, fret range and key is
  `web/src/lib/trainer/constraints.js`. Nothing in `web/src/lib/trainer/`
  implements an interval or stretch drill, so that half stays on the roadmap.

**3. Score editing was listed as future work** (`README.md` Roadmap)

- was: "**Score creation and editing** — build a staff from scratch in the
  browser…".
- now: "**Score creation from scratch**", with an explicit note that editing
  an existing staff's notes, rhythms and spellings works today.
- evidence: `web/src/lib/editor/document.js` and `notes.js` are the editor's
  model, driven from `ScoreCompare.svelte` and saved through
  `PUT /api/scores/{id}/transcription`; seven browser specs exercise it
  (`web/tests/browser/score-editor*.spec.js`) plus
  `web/tests/unit/editor.spec.js`. The editor's own header says the document
  it edits is one an import produced — there is no path that starts from a
  blank staff, so creation stays on the roadmap.

**4. Bulk transcription was documented nowhere in the README**

- was: absent from both Features and Roadmap (so not a false statement, but
  the README described transcription as a per-score action only).
- now: one sentence on the transcription bullet — a whole library, or one
  collection, transcribes in a single background pass.
- evidence: `POST /api/transcribe/batch` and `GET /api/transcribe/batch/status`
  are served (both appear in `app.openapi()`), `server/fermata/api.py`'s
  handler selects by explicit ids, by collection, or the whole library;
  `server/fermata/transcribe_batch.py` runs the pass;
  `server/tests/test_transcribe_batch_api.py` and
  `web/tests/browser/zzzz-library-transcribe-batch.spec.js` cover it; the
  library page calls it (`web/src/lib/Library.svelte:407`).

**5. `docs/api.md` said the API checks no credentials**

- was: "`owner` fields … are always `'local'` today; nothing in the API takes
  or checks credentials yet".
- now: no endpoint has a login or token of its own, but with reverse-proxy
  authentication configured a request that did not arrive from a trusted
  proxy carrying the configured header is refused with `401`, and
  `GET /api/me` reads back the vouched-for username. Off by default is stated
  as such.
- evidence: `server/fermata/authproxy.py`'s `RemoteUserAuthMiddleware.dispatch`
  returns `_unauthorized(...)`, which is `JSONResponse(..., status_code=401)`,
  for any request from a peer outside `config.AUTH_TRUSTED_NETWORKS` or with
  the header sent more than once; `/api/health` is the only exempt path.
  `server/fermata/api.py:275` is `GET /api/me`. With `FERMATA_AUTH_HEADER`
  empty the middleware is a documented no-op. Covered by
  `server/tests/test_authproxy.py` and
  `server/tests/test_live_server_proxy_headers.py`.

**6. `SECURITY.md`'s scope excluded a bypass of that same check**

- was: "Fermata ships with no authentication … 'Anyone who can reach the port
  can use it' is the documented design, not a vulnerability" — with nothing in
  the in-scope list about the proxy trust boundary.
- now: the exclusion is qualified to the default state, and getting past a
  configured reverse-proxy authentication — spoofing the user header, or
  getting an untrusted peer to test as trusted — is named as in scope.
- evidence: same as (5). The module's own docstring records that a
  full-authentication-bypass shape was found in review and reproduced against
  a real `uvicorn` process, which is precisely the class of report the old
  wording read as excluding.

**7. `docs/practice-data.md` referenced two tracker entries for a drill that
does not exist**

- was: "`'fret_to_note'` today; a second fretboard drill (#26, #29) widens
  this, not a migration."
- now: "…a second fretboard drill would widen this tuple, not require a
  migration." The design statement is unchanged; only the dependence on
  tracker state is gone.
- evidence: `server/fermata/trainer.py`'s `DRILLS` is still
  `("fret_to_note",)`, and no interval or stretch drill exists in
  `web/src/lib/trainer/`.

**8. `CONTRIBUTING.md` said the listed checks are the ones CI runs**

- was: a backend block and a frontend `npm run build` block, under "Run the
  checks locally (below). CI runs the same ones."
- now: the browser suite is listed too, with the note that `npm run build` has
  to have run first.
- evidence: `.github/workflows/ci.yml` has a third job that runs
  `npx playwright install --with-deps chromium` then `npm run test:browser`;
  `web/playwright.config.js` throws outright if `web/dist/index.html` is
  missing, and its `testDir: "tests"` covers both `tests/unit` and
  `tests/browser`. A contributor following the old list would have had CI fail
  on a suite the page never mentioned.

## Verified and left alone

- **`docs/api.md` against the served routes.** Imported the app with
  `PYTHONPATH` set and diffed every `METHOD /api/...` mention in the docs
  against `app.openapi()`: **68 operations over 49 paths**, and **zero**
  documented-but-not-served. `GET /docs` and `GET /openapi.json` are both
  served and both pinned by `server/tests/test_api_docs.py`. Nineteen served
  routes are not named in the prose (instruments, settings, tags,
  collections, duplicates, per-score reads), which is by design — that file
  says the per-endpoint reference is `/docs`.
- **Milestone names.** No occurrence of "Rev 1", "Patch 1", "Patch 2" or the
  word "milestone" anywhere in the docs. Nothing to reword.
- **Every other issue reference in the docs is retrospective** ("issue #56 did
  this"), not a claim about anything being open. `#8` and `#93`, the two the
  docs treat as unfinished, are both genuinely still open.
- **The roadmap items that are genuinely absent stay:** tuplets and grace
  notes when transcribing (`server/fermata/tabextract.py:99` names both as
  deliberate non-modelling), a harmonic's duration, instrument-aware
  transcription, MIDI and plain-text import, achievements
  (`docs/practice-data.md`'s own "what is not here yet"), PDF annotations,
  compilation splitting, PWA mode (no `manifest.json`, no service worker
  anywhere in `web/`), and recognition for scanned pages.
- **Reorganise / move / rename / delete / trash were already documented as
  shipped**, in Features, not the roadmap — the README needed no change there.
- **Spot-checked and true:** Python 3.12 (`requires-python = ">=3.12"`, CI
  matches), alphaTab 1.8.4 (`package-lock.json` resolves exactly that, and
  `docs/rendering.md` says "in 1.8.4"), the metronome's 15%–175% range
  (`PROPORTION_PRESETS` in `metronome-engine.js`), four ear-training choices
  and the four-octave fallback (`CHOICE_COUNT = 4`, `ear-training.js`), the
  instrument preset list (guitars, basses, ukulele, violin, viola, cello in
  `instruments.py`), the three calibrated font vocabularies
  (`glyph_rhythm.py`), gig-mode wake lock and half-page turns
  (`Viewer.svelte`, `PdfViewer.svelte`), the environment variables named in
  the docs against `config.py`, and the compose/Dockerfile facts in
  `docs/deployment.md` (port, two mounts, healthcheck, `--no-proxy-headers`).

## Not changed, reported instead

- **The corpus figures in `docs/musicxml-tab-profile.md`** (297 scores, 188 of
  297, 166 of 297, 86 of 297, and the rest) are measurements over a private
  library that is not in this repository, and each is already labelled as
  such. I could not re-measure them. Worth noting that d43c3f1 changed staff
  clustering, which is upstream of several of those counts; a re-run against
  that library is the only way to know whether they still hold.
- **`docs/deployment.md`'s Backups section** describes copying `config/` and
  does not mention `GET /api/export`, which now produces a portable archive
  that `docs/api.md` calls "a real backup". The folder copy is still correct,
  so this is an omission rather than an error, and out of scope for a pass
  that only corrects false statements.

## Test run

`PYTHONPATH=<worktree>/server py -3.13 -m pytest -q -rs` in `server/`, after
verifying the import resolves to this worktree's own `fermata/__init__.py`:

**1207 passed, 81 skipped, 0 failed** (103s). Skip reasons, all environmental:

| Count | Reason |
| --- | --- |
| 76 | `FERMATA_TEST_LIBRARY` not set — tests that need real sheet music |
| 5 | `FERMATA_MUSICXML_XSD` not set to a local `musicxml.xsd` |

`server/tests/test_api_docs.py` on its own: **19 passed, 0 skipped**.

One caveat worth recording. On a first run this suite reported **1 failed,
1195 passed, 92 skipped** —
`test_engraved_fixtures.py::test_the_summary_says_how_many_tests_skipped_for_want_of_a_library`.
That test asserts the terminal summary is empty in a case where a *second*,
unrelated counter had written a line: "6 test(s) skipped for want of
web/node_modules". It reproduces identically on the base commit's own file
contents, so it is not caused by anything here; it is a test-isolation gap
that only appears when `web/node_modules` is absent. Running `npm ci --omit=dev`
in `web/` — which is exactly what CI's server-test job does before pytest —
turned it green and released the 11 alphaTab-dependent skips, giving the
numbers above. So CI never sees it, and a contributor running only
`pip install -e ".[dev]" && pytest` does.

Review follow-up: the API guide now names the one endpoint exempt from proxy authentication (the health probe), and two code comments that pointed at closed tracker items now describe the design without them.