### PR TITLE
Read-only Model Context Protocol server over the documented REST API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,9 +22,12 @@ jobs:
           node-version: "22"
           cache: npm
           cache-dependency-path: web/package-lock.json
+      # [mcp] as well as [dev]: server/tests/test_mcp_server.py connects a
+      # real protocol client to a real listener, and without the extra those
+      # tests would skip - green, and proving nothing about the feature.
       - name: Install
         working-directory: server
-        run: pip install -e ".[dev]"
+        run: pip install -e ".[dev,mcp]"
       # An extracted transcription is stored to be rendered, so the tests
       # check it parses with the real alphaTab importer the player uses -
       # which is a runtime dependency of the web project. Installing it here

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,12 @@ RUN npm run build
 FROM python:3.12-slim
 WORKDIR /app
 COPY server/ ./server/
-RUN pip install --no-cache-dir ./server
+# The [mcp] extra is installed even though the Model Context Protocol server
+# (issue #31) is off by default, and that is the point: an operator turns it
+# on with FERMATA_MCP in their compose file, not by rebuilding an image.
+# Nothing it brings in is imported unless that flag is set - see
+# server/fermata/main.py's _start_mcp_server.
+RUN pip install --no-cache-dir "./server[mcp]"
 COPY --from=web /web/dist ./static
 
 # The commit and date GET /api/version reports (see server/fermata/version.py).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -31,6 +31,15 @@ your own browser. The interesting attack surface is roughly:
   the configured user header, or getting an untrusted peer address to test as a
   trusted proxy — is worth reporting. See
   [docs/deployment.md](docs/deployment.md#reverse-proxy-authentication).
+- The Model Context Protocol server, when it has been turned on. It is off by
+  default and, once on, it is a **second listening port with no
+  authentication of its own** — the same "anyone who can reach it can read
+  the library" model as the web interface, on a port of its own, which is
+  why it binds loopback unless deliberately moved and why Fermata refuses to
+  start with it and reverse proxy authentication both on. Its tools are
+  read-only; anything that gets a write through them, or that reads outside
+  the documented routes they wrap, is worth reporting. See
+  [docs/deployment.md](docs/deployment.md#the-model-context-protocol-server).
 
 ## What isn't
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -174,7 +174,8 @@ the library flagged `missing_since`, which is the state it was in before.
 `GET /api/transcribe/batch/status` polls it - the same start/poll shape
 `POST /api/scan` and `GET /api/scan/status` use, rather than a client looping
 single `POST /api/scores/{id}/transcribe` calls itself. The MCP layer (see
-below) wraps this endpoint's status route for exactly that reason.
+below) does not cover batch transcription in this release: its tools are
+read-only, and batch status is deliberately not among them.
 
 **Selection.** Give `score_ids` (an explicit list, honoured exactly - even an
 id that turns out not to be a pdf or to be in the trash gets its own outcome

--- a/docs/api.md
+++ b/docs/api.md
@@ -173,8 +173,8 @@ the library flagged `missing_since`, which is the state it was in before.
 `POST /api/transcribe/batch` starts a background pass over many scores and
 `GET /api/transcribe/batch/status` polls it - the same start/poll shape
 `POST /api/scan` and `GET /api/scan/status` use, rather than a client looping
-single `POST /api/scores/{id}/transcribe` calls itself. The planned MCP
-layer (see below) wraps this endpoint for exactly that reason.
+single `POST /api/scores/{id}/transcribe` calls itself. The MCP layer (see
+below) wraps this endpoint's status route for exactly that reason.
 
 **Selection.** Give `score_ids` (an explicit list, honoured exactly - even an
 id that turns out not to be a pdf or to be in the trash gets its own outcome

--- a/docs/api.md
+++ b/docs/api.md
@@ -307,8 +307,21 @@ dangling reference — the setlist itself still travels, just without that membe
 
 ## Who else reads this contract
 
-A planned companion server speaks the Model Context Protocol, an open
-standard, and is meant to wrap this REST API rather than reimplement its
-logic - which is the reason "generated but wrong or incomplete" is not good
-enough here: that layer's own correctness depends on this one meaning what it
-says.
+A companion server speaks the Model Context Protocol, an open standard, and
+wraps this REST API rather than reimplementing its logic - which is the
+reason "generated but wrong or incomplete" is not good enough here: that
+layer's own correctness depends on this one meaning what it says.
+
+That server (issue #31, `server/fermata/mcp_server.py`) is off unless
+`FERMATA_MCP` is set, and when it runs it is a CLIENT of this API like any
+other: each of its thirteen read-only tools is one documented `GET` from the
+list above, called over HTTP, answering with that route's own JSON
+unchanged. It never adds an operation to this document - it reads it. The
+tool list and every tool's input schema are generated from `app.openapi()`
+at startup, so a tool cannot describe a route that no longer looks like
+that, and `server/tests/test_mcp_server.py` requires every readable route
+here to be either exposed as a tool or recorded with a reason why not -
+which means adding or renaming a route in `api.py` fails that test by name
+rather than quietly leaving the tool layer behind. Operators turn it on and
+publish it as described in
+[docs/deployment.md](deployment.md#the-model-context-protocol-server).

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -9,6 +9,7 @@ that's enough. Every command below is meant to be copied and pasted as-is.
 - [Getting it running](#getting-it-running)
 - [Reaching it from another device](#reaching-it-from-another-device)
 - [Reverse proxy authentication](#reverse-proxy-authentication)
+- [The Model Context Protocol server](#the-model-context-protocol-server)
 - [Backups](#backups)
 - [Upgrading](#upgrading)
 - [Current limitations](#current-limitations)
@@ -452,6 +453,110 @@ services:
       default:
         ipv4_address: 172.28.1.11
 ```
+
+## The Model Context Protocol server
+
+Fermata can offer its library and practice history as a set of **read-only
+tools** over the Model Context Protocol — an open standard for describing
+tools to a program that reads them. It is a way to let an external tool ask
+"what's in the library" or "how much did I practise last week" without
+anyone writing HTTP requests by hand.
+
+**This is off by default, and stays off after an upgrade unless you turn it
+on.** Nothing below runs, and nothing listens, until you set `FERMATA_MCP`.
+
+### What it does and does not do
+
+- **Read only.** The tools list and search scores, read a score's metadata
+  and its transcription status, read practice history and summaries, read
+  goals, and read trainer attempts. There is no tool that changes anything —
+  not "log a session", not "rename a score", not "delete". That is not a
+  setting; there is no code path in it that can send anything but a `GET`.
+- **It wraps the REST API, it does not replace it.** Every tool is one
+  documented route from [the REST API](api.md), called over ordinary HTTP,
+  and every answer is that route's own JSON handed back unchanged. The tool
+  descriptions and their input schemas are generated from the same
+  `/openapi.json` the API serves, at startup, so a tool cannot describe a
+  route that no longer looks like that.
+- **It has no login of its own.** Anything that can reach the port can read
+  your whole library and practice history. That is the same trust model as
+  Fermata's own web interface (see [Current
+  limitations](#current-limitations)), and it is why the listener stays on
+  `127.0.0.1` — inside the container only — unless you deliberately move it.
+
+### Turning it on
+
+Add the environment variable to the `fermata` service in
+`docker-compose.yml` and publish a second port:
+
+```yaml
+services:
+  fermata:
+    # ... build, volumes, restart as in "Getting it running"
+    ports:
+      - "8080:8080"
+      - "8765:8765"
+    environment:
+      FERMATA_MCP: "1"
+      FERMATA_MCP_HOST: 0.0.0.0
+```
+
+Then rebuild and restart:
+
+```bash
+docker compose up -d
+```
+
+The tools are then reachable at **http://localhost:8765/mcp**, over the
+protocol's Streamable HTTP transport. Point a client that speaks the Model
+Context Protocol at that URL; it will list thirteen tools, each named after
+what it reads (`list_scores`, `get_practice_summary`, and so on).
+
+The four settings, only the first of which turns anything on:
+
+| Variable | Default | What it does |
+| --- | --- | --- |
+| `FERMATA_MCP` | unset (off) | Set to `1` to run the server at all. Every other setting here is inert while this is unset. |
+| `FERMATA_MCP_HOST` | `127.0.0.1` | What the listener binds. Inside a container the default means "this container only" — set it to `0.0.0.0` if you are publishing the port, as above. |
+| `FERMATA_MCP_PORT` | `8765` | The port it listens on. |
+| `FERMATA_MCP_API_URL` | `http://127.0.0.1:8080` | Where it finds Fermata's own REST API. The default is right for the container; change it only if you are running from source and told `uvicorn` to use a different port. |
+
+`FERMATA_MCP_HOST` defaulting to loopback is deliberate: publishing this is
+two decisions (set the host, map the port), not one, so it is hard to expose
+by accident. Do not publish that port to the open internet — put it behind
+the same reverse proxy and login as everything else, or leave it on your own
+network.
+
+### Checking it, and what failure looks like
+
+You can see exactly which tools it would offer without connecting anything:
+
+```bash
+docker compose exec fermata python -m fermata.mcp_server
+```
+
+That prints each tool with the route it reads and the arguments it takes.
+
+If the port you chose is already taken, **the container will not start**,
+and `docker compose logs fermata` will say so in a sentence naming the port.
+That is on purpose: a container that came up healthy while the feature you
+just turned on silently did nothing is the worse outcome. Change
+`FERMATA_MCP_PORT`, or unset `FERMATA_MCP`, and it starts again — nothing in
+your library or your practice history is touched either way.
+
+### Running it from source
+
+The protocol library is an optional extra, so a source install needs it
+asked for by name:
+
+```bash
+pip install -e "server[mcp]"
+FERMATA_MCP=1 FERMATA_MCP_API_URL=http://127.0.0.1:8000 \
+  uvicorn fermata.main:app --port 8000 --no-proxy-headers
+```
+
+The container image already includes the extra, which is why turning the
+feature on there is an environment variable rather than a rebuild.
 
 ## Backups
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -484,6 +484,36 @@ on.** Nothing below runs, and nothing listens, until you set `FERMATA_MCP`.
   limitations](#current-limitations)), and it is why the listener stays on
   `127.0.0.1` — inside the container only — unless you deliberately move it.
 
+### It does not work with reverse-proxy authentication
+
+**Fermata refuses to start if you set both `FERMATA_MCP` and
+`FERMATA_AUTH_HEADER`**, and will tell you so by name in the log. The two
+are not supported together in this release.
+
+The reason is the first bullet above, from the other side. The tools read
+the REST API as an ordinary anonymous client over loopback — that is what
+"wraps the documented routes" means, and it is what keeps this layer from
+being a second copy of the API. With
+[reverse-proxy authentication](#reverse-proxy-authentication) turned on,
+every request that did not come from your trusted proxy carrying the
+identity header is refused, and the tools' requests are exactly that. So
+every tool would answer `401` while the tool list went on advertising
+thirteen working tools — a failure with no symptom except an emptiness that
+looks like an empty library.
+
+The two obvious workarounds are both worse than the fault, which is why
+neither is offered. Adding `127.0.0.1` to `FERMATA_TRUSTED_PROXIES` does not
+fix it (the internal client still sends no identity header, so the request
+is refused a second time) and it does mean anything else running on that
+machine can now set the identity header itself and be believed. Having
+Fermata's own internal client send an identity header is worse still: it
+would turn the trusted header into something a process on the box can mint,
+which is the exact forgery reverse-proxy authentication exists to prevent.
+
+So: pick one. Keep your login and leave `FERMATA_MCP` unset, or use the
+tools and leave `FERMATA_AUTH_HEADER` unset with the port reachable only
+from somewhere you trust.
+
 ### Turning it on
 
 Add the environment variable to the `fermata` service in
@@ -495,11 +525,17 @@ services:
     # ... build, volumes, restart as in "Getting it running"
     ports:
       - "8080:8080"
-      - "8765:8765"
+      - "127.0.0.1:8765:8765"
     environment:
       FERMATA_MCP: "1"
       FERMATA_MCP_HOST: 0.0.0.0
 ```
+
+Note the `127.0.0.1:` on the second port — without it Docker publishes that
+port to your whole local network, the way port 8080 above is published, and
+this one has no login in front of it at all. Start with it reachable only
+from the machine running the container, and widen it deliberately (drop the
+prefix) once you have decided who should be able to read your library.
 
 Then rebuild and restart:
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -299,8 +299,10 @@ but reaching this endpoint through a different path than your proxy, that is
 Fermata acts on this identity today** — there are no per-user permissions,
 no filtering of what a given username can see, and this does not turn
 Fermata into a multi-user application. It is read, logged, and left there
-for a future consumer — the practice-data MCP server this project is heading
-toward, or a possible sharing layer — to build on. (A few database tables
+for a consumer that might one day act on it — a sharing layer, say. The
+[Model Context Protocol server](#the-model-context-protocol-server) is not
+one: it leaves this identity inert, and Fermata refuses to run the two
+features together in any case. (A few database tables
 already carry an `owner` column reserved for that future, every row
 currently written as the single placeholder owner `local` — wiring a real
 username into it today would only orphan your own data from the very
@@ -543,7 +545,7 @@ Then rebuild and restart:
 docker compose up -d
 ```
 
-The tools are then reachable at **http://localhost:8765/mcp**, over the
+The tools are then reachable at **http://127.0.0.1:8765/mcp**, over the
 protocol's Streamable HTTP transport. Point a client that speaks the Model
 Context Protocol at that URL; it will list thirteen tools, each named after
 what it reads (`list_scores`, `get_practice_summary`, and so on).

--- a/server/fermata/api.py
+++ b/server/fermata/api.py
@@ -280,8 +280,8 @@ def get_me(request: Request):
     verified before this handler ran (a header naming the user, sent by a
     proxy address on the configured trust list) and stashed on
     `request.state`. Nothing in Fermata acts on this today - no per-user
-    filtering, no permissions - it exists for a future consumer (the
-    planned MCP server, a possible sharing layer) to read. Always 200: when
+    filtering, no permissions - it exists for a consumer (a possible sharing
+    layer; the MCP server leaves it inert, #31) to read. Always 200: when
     reverse-proxy auth is off (the default) or this particular request
     carried no identity, that is `{"enabled": false, "username": null}`
     rather than an error, since asking "who am I" is safe regardless of
@@ -3688,7 +3688,7 @@ def purge_score(score_id: RowId):
 # ONE ENDPOINT AND NOT SIX, and every figure on it computed here. A client that
 # had to fetch the sessions for one score and total them itself would be
 # writing the arithmetic this module already owns - and the second reader of
-# this surface (the planned MCP server, #31) would then write it a third time,
+# this surface (the MCP server, #31) would then write it a third time,
 # slightly differently, with nothing to say which of the three was right. See
 # issue #32's design rules: every field readable through the documented API, so
 # any future integration wraps one source of truth.
@@ -3772,7 +3772,7 @@ def score_practice_progress(
 #
 # Issue #32's design rule - structured, queryable, every field readable
 # through the documented API - is what makes the OTHER half of #32 possible:
-# a planned MCP server (#31) wraps this REST surface rather than reading
+# the MCP server (#31) wraps this REST surface rather than reading
 # SQLite directly. That rule is also what makes THIS feature nearly free.
 # Nothing here invents a second notion of what a session or a goal is; export
 # reads the same tables every other endpoint reads, and import writes rows

--- a/server/fermata/api_models.py
+++ b/server/fermata/api_models.py
@@ -64,8 +64,8 @@ class MeOut(BaseModel):
     """The identity, if any, that fermata.authproxy's reverse-proxy auth
     middleware attached to this request (issue #16). Fermata has no accounts
     of its own and builds none here - `username` is only ever a name a
-    trusted reverse proxy vouched for, exposed for a future consumer (the
-    planned MCP server, a possible sharing layer) to read. `enabled` is
+    trusted reverse proxy vouched for, exposed for a consumer (a possible
+    sharing layer; the MCP server leaves it inert, #31) to read. `enabled` is
     whether reverse-proxy auth is turned on at all, independent of whether
     THIS request carried an identity, so a client can tell "no auth
     configured" apart from "auth configured but nothing to show" without

--- a/server/fermata/authproxy.py
+++ b/server/fermata/authproxy.py
@@ -180,6 +180,57 @@ def check_trusted_proxies_are_not_everyone() -> None:
         )
 
 
+def check_mcp_is_not_configured_behind_proxy_auth() -> None:
+    """Refuses to start (raises RuntimeError, caught by main.py's lifespan
+    the same way ensure_dirs's library-folder check is) when the Model
+    Context Protocol server and reverse-proxy authentication are both turned
+    on. They do not work together in this release, and the way they fail is
+    the reason this is fatal rather than logged.
+
+    WHAT ACTUALLY HAPPENS WITHOUT THIS CHECK. The protocol server reads the
+    REST API as an ordinary anonymous client over loopback (issue #31's rule
+    that it wraps the API rather than reimplementing it). With
+    FERMATA_AUTH_HEADER set, this middleware refuses every request that did
+    not arrive from a trusted proxy carrying that header - so every single
+    tool call comes back 401, while `tools/list` goes on advertising a full
+    set of working tools. Nothing anywhere says why. That is the worst shape
+    a failure can have: silent, total, and indistinguishable from an empty
+    library.
+
+    AND THE OBVIOUS WORKAROUND IS WORSE. An operator who diagnoses the 401
+    reaches for adding 127.0.0.1 to FERMATA_TRUSTED_PROXIES. That does not
+    even fix it - the internal client sends no identity header, so the
+    request is refused a second time for the header being missing - but it
+    DOES mean that anything else on loopback may now set the identity header
+    itself and be believed. The fix that suggests itself next, having the
+    internal client send an identity header of its own, is precisely the
+    forgery this module exists to prevent: it would make the trusted header
+    something a process on the box can mint. So neither half is offered, and
+    the combination is refused instead.
+
+    A no-op unless BOTH are on. Either alone is a supported deployment."""
+    if not (config.MCP_ENABLED and config.AUTH_HEADER):
+        return
+    raise RuntimeError(
+        "Fermata cannot start: FERMATA_MCP is on and FERMATA_AUTH_HEADER is set "
+        f"({config.AUTH_HEADER!r}), and those two are not supported together in this "
+        "release.\n"
+        "\n"
+        "The Model Context Protocol server reads this API as an anonymous client over "
+        "loopback, so with reverse-proxy authentication on, every one of its tools would "
+        "answer 401 while still advertising itself as working. Refusing to start says that "
+        "now, out loud, instead of leaving you to discover it one empty tool call at a "
+        "time.\n"
+        "\n"
+        "Turn one of them off: unset FERMATA_MCP to keep your login, or unset "
+        "FERMATA_AUTH_HEADER to use the tools. See docs/deployment.md's 'The Model Context "
+        "Protocol server' section.\n"
+        "\n"
+        "Nothing has been changed. Your sheet music and your practice history are both as "
+        "they were."
+    )
+
+
 def check_auth_configuration_sanity() -> None:
     """The one remaining way to configure this feature into silently doing
     nothing - see check_trusted_proxies_are_not_everyone for the other

--- a/server/fermata/config.py
+++ b/server/fermata/config.py
@@ -133,20 +133,34 @@ MCP_PORT = 0
 def load_mcp_settings() -> None:
     """Parse FERMATA_MCP_PORT into MCP_PORT. Called once from main.py's
     lifespan, inside the same try/except every other startup
-    misconfiguration is reported through. A no-op when the feature is off,
-    so an operator who never turned it on cannot be stopped by a stale value
-    left in their environment."""
+    misconfiguration is reported through.
+
+    The PARSE happens whether or not the feature is on; only the COMPLAINT
+    is conditional. Two reasons, and the second is the load-bearing one. An
+    operator who never turned this on should not be stopped by a stale value
+    left in their environment - so a bad value with the flag off is ignored
+    rather than fatal. But MCP_PORT still ends up holding the port that
+    WOULD be used, which is what makes the flag the only thing standing
+    between "off" and "listening": if the gate in main._start_mcp_server
+    were ever removed, the server would bind the real configured port and
+    test_nothing_listens_with_the_flag_off would notice. Short-circuiting
+    this function on the flag as well would leave MCP_PORT at 0, uvicorn
+    would bind an arbitrary free port, and that test could pass with the
+    gate gone - a guard that cannot fail.
+    """
     global MCP_PORT
-    if not MCP_ENABLED:
-        return
     try:
         port = int(MCP_PORT_RAW)
     except ValueError as exc:
+        if not MCP_ENABLED:
+            return
         raise RuntimeError(
             f"FERMATA_MCP_PORT is {MCP_PORT_RAW!r}, which is not a port number. See "
             "docs/deployment.md's 'The Model Context Protocol server' section."
         ) from exc
     if not 1 <= port <= 65535:
+        if not MCP_ENABLED:
+            return
         raise RuntimeError(
             f"FERMATA_MCP_PORT is {port}, which is not a port number between 1 and 65535. "
             "See docs/deployment.md's 'The Model Context Protocol server' section."

--- a/server/fermata/config.py
+++ b/server/fermata/config.py
@@ -89,6 +89,71 @@ def load_auth_trusted_networks() -> None:
     AUTH_TRUSTED_NETWORKS = parse_trusted_proxies(AUTH_TRUSTED_PROXIES_RAW)
 
 
+# The Model Context Protocol server (issue #31) - an open standard for
+# describing a set of tools to a program that reads them. OFF unless
+# FERMATA_MCP is set to something true; that one variable is the whole gate,
+# and the three below it are inert while it is unset.
+#
+# Off by default is not caution for its own sake. Turning this on opens a
+# SECOND listener with no authentication of its own, offering the library
+# and the practice history to anything that can reach it - so it has to be
+# something an operator chose, on a port they chose, rather than something
+# an upgrade quietly started. See docs/deployment.md's "The Model Context
+# Protocol server" section.
+#
+# Nothing in fermata/mcp_server.py is imported unless this is on: main.py's
+# lifespan does that import inside the `if`, so a deployment with the flag
+# unset never loads the protocol library and does not need it installed at
+# all. server/tests/test_mcp_server.py pins both halves of that.
+MCP_ENABLED = os.environ.get("FERMATA_MCP", "").strip().lower() in {"1", "true", "yes", "on"}
+
+# Where the protocol server listens. Loopback by default, which inside a
+# container means "reachable from this container only" - publishing it is a
+# second deliberate act (set this to 0.0.0.0 and map the port), for the same
+# reason the flag itself is off by default.
+MCP_HOST = os.environ.get("FERMATA_MCP_HOST", "127.0.0.1").strip() or "127.0.0.1"
+MCP_PORT_RAW = os.environ.get("FERMATA_MCP_PORT", "8765")
+
+# Where the protocol server finds the REST API - it is a CLIENT of the API,
+# over ordinary HTTP, exactly as any other client is (docs/api.md's rule
+# that this layer wraps the REST API rather than reimplementing it). The
+# default matches the port the Dockerfile's CMD serves on; running from
+# source on another port means setting this to match, because the
+# application genuinely does not know what port uvicorn was told to use.
+MCP_API_URL = os.environ.get("FERMATA_MCP_API_URL", "http://127.0.0.1:8080").rstrip("/")
+
+# Parsed by load_mcp_settings(), not here - same reason as
+# AUTH_TRUSTED_NETWORKS above: a RuntimeError raised during THIS module's
+# import happens before main.py's lifespan exists to turn it into a readable
+# sentence, so a typo in FERMATA_MCP_PORT would arrive as a bare "Error
+# loading ASGI app" traceback instead of a message naming the setting.
+MCP_PORT = 0
+
+
+def load_mcp_settings() -> None:
+    """Parse FERMATA_MCP_PORT into MCP_PORT. Called once from main.py's
+    lifespan, inside the same try/except every other startup
+    misconfiguration is reported through. A no-op when the feature is off,
+    so an operator who never turned it on cannot be stopped by a stale value
+    left in their environment."""
+    global MCP_PORT
+    if not MCP_ENABLED:
+        return
+    try:
+        port = int(MCP_PORT_RAW)
+    except ValueError as exc:
+        raise RuntimeError(
+            f"FERMATA_MCP_PORT is {MCP_PORT_RAW!r}, which is not a port number. See "
+            "docs/deployment.md's 'The Model Context Protocol server' section."
+        ) from exc
+    if not 1 <= port <= 65535:
+        raise RuntimeError(
+            f"FERMATA_MCP_PORT is {port}, which is not a port number between 1 and 65535. "
+            "See docs/deployment.md's 'The Model Context Protocol server' section."
+        )
+    MCP_PORT = port
+
+
 # File extensions the scanner picks up, mapped to a broad type used by the UI
 # to pick a viewer.
 FILE_TYPES = {

--- a/server/fermata/db.py
+++ b/server/fermata/db.py
@@ -554,7 +554,7 @@ CREATE INDEX IF NOT EXISTS idx_instruments_owner ON instruments(owner);
 -- AUTOINCREMENT, for the same reason instruments and goals have it: a setlist
 -- is routinely deleted, and a plain INTEGER PRIMARY KEY hands a deleted row's
 -- id to the next one - so a rename typed into an open tab, or an id held by a
--- second reader (the planned MCP server #31, a bookmarked gig-mode URL), could
+-- second reader (the MCP server #31, a bookmarked gig-mode URL), could
 -- silently act on a different setlist than the one it meant.
 --
 -- `owner` mirrors settings, instruments and the practice tables: unused today,

--- a/server/fermata/main.py
+++ b/server/fermata/main.py
@@ -35,7 +35,26 @@ def _start_mcp_server(app: FastAPI):
     """
     if not config.MCP_ENABLED:
         return None
-    from . import mcp_server
+    try:
+        from . import mcp_server
+    except ModuleNotFoundError as exc:
+        # Turning the flag on in a source install that never asked for the
+        # optional extra is an ordinary mistake, and without this it arrives
+        # as a bare ModuleNotFoundError traceback - the one shape of startup
+        # failure this application does not use, and the one that sends a
+        # worried operator reaching for the previous image tag (see the
+        # lifespan's own comment on why that is the dangerous move). Same
+        # treatment as a bad port: a sentence naming what to do.
+        raise RuntimeError(
+            f"Fermata cannot start: FERMATA_MCP is on, but {exc.name!r} is not installed. "
+            "The Model Context Protocol server is an optional extra - install it with "
+            "`pip install -e \"server[mcp]\"` (the container image already includes it), or "
+            "unset FERMATA_MCP to turn the feature off. See docs/deployment.md's 'The Model "
+            "Context Protocol server' section.\n"
+            "\n"
+            "Nothing has been changed. Your sheet music and your practice history are both "
+            "as they were."
+        ) from exc
 
     return mcp_server.start(
         app.openapi(),
@@ -78,6 +97,14 @@ async def lifespan(app: FastAPI):
         # FERMATA_MCP is on; see that function's own docstring for why it
         # parses either way.
         config.load_mcp_settings()
+        # Also fatal, same bucket as the two checks above: with reverse-proxy
+        # auth on, every tool the protocol server offers would answer 401
+        # while advertising itself as working, and the workarounds an
+        # operator would reach for are each worse than the fault. See
+        # authproxy.check_mcp_is_not_configured_behind_proxy_auth's own
+        # docstring. Runs BEFORE _start_mcp_server so a refused combination
+        # never opens a listener at all.
+        authproxy.check_mcp_is_not_configured_behind_proxy_auth()
         init_db()
         mcp_listener = _start_mcp_server(app)
     except RuntimeError as exc:

--- a/server/fermata/main.py
+++ b/server/fermata/main.py
@@ -72,10 +72,11 @@ async def lifespan(app: FastAPI):
         # docstring for why this is fatal and a genuinely broad-but-real
         # subnet is not.
         authproxy.check_trusted_proxies_are_not_everyone()
-        # Parses FERMATA_MCP_PORT when, and only when, FERMATA_MCP is on -
-        # in here, not at import time, for exactly the same reason
-        # load_auth_trusted_networks is (see config.py's comment on
-        # MCP_PORT).
+        # Parses FERMATA_MCP_PORT - in here, not at import time, for exactly
+        # the same reason load_auth_trusted_networks is (see config.py's
+        # comment on MCP_PORT). It complains about a bad value only when
+        # FERMATA_MCP is on; see that function's own docstring for why it
+        # parses either way.
         config.load_mcp_settings()
         init_db()
         mcp_listener = _start_mcp_server(app)

--- a/server/fermata/main.py
+++ b/server/fermata/main.py
@@ -16,8 +16,38 @@ from .db import init_db
 log = logging.getLogger("fermata.startup")
 
 
+def _start_mcp_server(app: FastAPI):
+    """Start the Model Context Protocol server (issue #31), or don't.
+
+    THE IMPORT IS INSIDE THE `if` ON PURPOSE, and it is the whole reason this
+    is a function rather than three lines in the lifespan. With FERMATA_MCP
+    unset, `fermata.mcp_server` - and through it the protocol library - is
+    never imported, so a deployment that turned this feature off does not
+    need the optional dependency installed at all, and `import fermata.main`
+    keeps working without it. server/tests/test_mcp_server.py pins that in
+    both directions.
+
+    The tools are generated from `app.openapi()`: the same document the
+    application serves at `/openapi.json`, read here at startup, so a tool
+    schema cannot drift from the route it wraps. Note the direction - this
+    reads the document, it does not add to it. Turning the flag on does not
+    change a single line of the API's own contract.
+    """
+    if not config.MCP_ENABLED:
+        return None
+    from . import mcp_server
+
+    return mcp_server.start(
+        app.openapi(),
+        host=config.MCP_HOST,
+        port=config.MCP_PORT,
+        api_base_url=config.MCP_API_URL,
+    )
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
+    mcp_listener = None
     try:
         ensure_dirs()
         # Parses FERMATA_TRUSTED_PROXIES - not done at import time (see
@@ -42,7 +72,13 @@ async def lifespan(app: FastAPI):
         # docstring for why this is fatal and a genuinely broad-but-real
         # subnet is not.
         authproxy.check_trusted_proxies_are_not_everyone()
+        # Parses FERMATA_MCP_PORT when, and only when, FERMATA_MCP is on -
+        # in here, not at import time, for exactly the same reason
+        # load_auth_trusted_networks is (see config.py's comment on
+        # MCP_PORT).
+        config.load_mcp_settings()
         init_db()
+        mcp_listener = _start_mcp_server(app)
     except RuntimeError as exc:
         # Said plainly BEFORE the exception propagates, because of what happens
         # next in the real world. Uvicorn prints a traceback for anything raised
@@ -70,7 +106,11 @@ async def lifespan(app: FastAPI):
     # that, not buried under a warning about a different one.
     authproxy.check_auth_configuration_sanity()
     scanner.start_scan()
-    yield
+    try:
+        yield
+    finally:
+        if mcp_listener is not None:
+            mcp_listener.stop()
 
 
 app = FastAPI(title="Fermata", lifespan=lifespan)

--- a/server/fermata/mcp_server.py
+++ b/server/fermata/mcp_server.py
@@ -209,10 +209,11 @@ def start(document: dict, *, host: str, port: int, api_base_url: str) -> Listene
     runner.should_exit = True
     raise RuntimeError(
         f"Fermata cannot start: FERMATA_MCP is on, but the Model Context Protocol server "
-        f"could not listen on {host}:{port}. The usual cause is that something else already "
-        f"has that port - set FERMATA_MCP_PORT to a free one, or unset FERMATA_MCP to turn "
-        "the feature off. See docs/deployment.md's 'The Model Context Protocol server' "
-        "section.\n"
+        f"could not listen on {host}:{port}. Either something else already has that port - "
+        "set FERMATA_MCP_PORT to a free one - or FERMATA_MCP_HOST names an address this "
+        f"machine does not have ({host!r}); inside a container that is usually 0.0.0.0 or "
+        "127.0.0.1 and nothing else. Unsetting FERMATA_MCP turns the feature off. See "
+        "docs/deployment.md's 'The Model Context Protocol server' section.\n"
         "\n"
         "Nothing has been changed. Your sheet music and your practice history are both as "
         "they were."

--- a/server/fermata/mcp_server.py
+++ b/server/fermata/mcp_server.py
@@ -1,0 +1,244 @@
+"""The Model Context Protocol server (issue #31) - an open standard for
+offering a named set of tools to a program that reads them.
+
+WHAT THIS IS. A second listener, off unless `FERMATA_MCP` is set, that
+answers the protocol's `tools/list` with the read tools
+`fermata/mcp_tools.py` generated from the served OpenAPI document, and
+answers `tools/call` by making the corresponding HTTP request to the REST
+API and handing back the response body unchanged.
+
+WHAT THIS IS NOT. It is not a second copy of the API. Every tool call leaves
+this process as an ordinary HTTP GET to `FERMATA_MCP_API_URL` and comes back
+as bytes; nothing here opens the database, imports `fermata.api`, or knows
+what a score is. That is the rule `docs/api.md`'s "Who else reads this
+contract" section states, and it is the reason the API's own tests are
+enough to know a tool is correct - there is no second implementation for
+them to be correct about.
+
+It is also read-only, and structurally so rather than by intention:
+`mcp_tools.check_tool_mapping` refuses to build a tool for anything but a
+GET, and `mcp_tools.plan_request` refuses an argument the route did not
+declare. There is no code path here that can send a POST.
+
+WHY THIS MODULE IS IMPORTED LATE. `fermata/main.py` imports it inside its
+lifespan, under the flag, so that with the flag unset the protocol library
+is never imported and does not have to be installed. Everything above that
+line - `import fermata.main` itself - must keep working in a deployment that
+never installed the extra, which `server/tests/test_mcp_server.py` pins.
+
+WHY A THREAD AND NOT A SECOND PROCESS. Fermata ships as one container with
+one command. A second process there means a supervisor, a second thing that
+can die unnoticed, and a second set of logs; a thread running its own
+`uvicorn` on its own port is the smallest arrangement that actually
+satisfies "off by default, nothing listens" and "an external client connects
+to the running container". It starts and stops with the application, and
+when the flag is off it does not exist at all. See docs/deployment.md's "The
+Model Context Protocol server" section.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+import time
+
+import httpx
+import uvicorn
+from mcp import types
+from mcp.server.lowlevel import Server
+
+from . import mcp_tools
+from .mcp_tools import ToolSpec
+from .version import version as fermata_version
+
+
+log = logging.getLogger("fermata.mcp")
+
+# How long a tool's HTTP call to the REST API may take. Generous, because
+# `GET /api/scores` on a large library and `GET /api/practice/history` over
+# a long history are both genuinely slow the first time, and a truncated
+# read reported as a tool error would send a caller looking for a bug that
+# is not there.
+API_TIMEOUT_SECONDS = 30.0
+
+# How long to wait for the listener to actually bind before giving up. A
+# port already in use is the realistic failure, and it is one uvicorn
+# reports by exiting its thread - so this is what turns "the flag is on and
+# nothing happened" into a startup error naming the port.
+BIND_TIMEOUT_SECONDS = 10.0
+
+
+def _text_result(text: str, *, is_error: bool = False) -> types.CallToolResult:
+    return types.CallToolResult(content=[types.TextContent(type="text", text=text)], isError=is_error)
+
+
+def build_server(document: dict, api_base_url: str) -> Server:
+    """A protocol server whose tools are generated from `document`.
+
+    Kept separate from `start` so a test can build one, list its tools and
+    call them in-process - the tool list and the flag gate are different
+    claims and are checked separately.
+    """
+    specs: list[ToolSpec] = mcp_tools.build_tools(document)
+    by_name = {spec.name: spec for spec in specs}
+    base = api_base_url.rstrip("/")
+
+    tools = [
+        types.Tool(
+            name=spec.name,
+            description=mcp_tools.tool_description(spec),
+            inputSchema=spec.input_schema,
+            # Both of these are the same claim said twice, to two different
+            # readers. The annotation tells a client this tool does not
+            # change anything; the `_meta` entry names the OpenAPI operation
+            # it came from, so a client (or a test, which is what actually
+            # reads it) can check the tool against `/openapi.json` without
+            # having this repository in front of it.
+            annotations=types.ToolAnnotations(readOnlyHint=True, destructiveHint=False),
+            _meta={"fermata": spec.trace},
+        )
+        for spec in specs
+    ]
+
+    async def on_list_tools(ctx, params) -> types.ListToolsResult:
+        return types.ListToolsResult(tools=tools)
+
+    async def on_call_tool(ctx, params: types.CallToolRequestParams) -> types.CallToolResult:
+        spec = by_name.get(params.name)
+        if spec is None:
+            # Named, not merely refused: a caller working from a stale tool
+            # list needs to know WHICH name went away, and the list it
+            # should have is right there.
+            return _text_result(
+                f"no tool named {params.name!r} - this server offers {sorted(by_name)}",
+                is_error=True,
+            )
+        try:
+            path, query = mcp_tools.plan_request(spec, params.arguments or {})
+        except ValueError as exc:
+            return _text_result(str(exc), is_error=True)
+
+        url = f"{base}{path}"
+        try:
+            async with httpx.AsyncClient(timeout=API_TIMEOUT_SECONDS) as client:
+                response = await client.get(url, params=query)
+        except httpx.HTTPError as exc:
+            # The REST API not being reachable is a deployment fact, not a
+            # bad tool call, and saying which URL was tried is the whole
+            # diagnosis: it is almost always FERMATA_MCP_API_URL naming a
+            # port uvicorn was not told to serve on.
+            return _text_result(
+                f"could not reach the REST API at {url}: {exc} - check FERMATA_MCP_API_URL "
+                "names the host and port this instance actually serves on.",
+                is_error=True,
+            )
+
+        if response.status_code >= 400:
+            return _text_result(
+                f"{spec.method.upper()} {path} returned {response.status_code}: {response.text}",
+                is_error=True,
+            )
+        # The body VERBATIM. Not re-serialised, not reshaped, not summarised:
+        # the point of this server is that a tool answers with exactly what
+        # the documented route answers, and a test asserts that equality
+        # against a plain HTTP request for the same parameters.
+        return _text_result(response.text)
+
+    return Server(
+        "fermata",
+        version=fermata_version(),
+        title="Fermata",
+        instructions=(
+            "Read-only tools over Fermata's documented REST API. Every tool wraps one "
+            "documented route and returns its JSON response unchanged; the route each tool "
+            "reads is named in the tool's description and in its _meta.fermata entry."
+        ),
+        on_list_tools=on_list_tools,
+        on_call_tool=on_call_tool,
+    )
+
+
+class Listener:
+    """A running protocol server, and the handle used to stop it."""
+
+    def __init__(self, server: uvicorn.Server, thread: threading.Thread, host: str, port: int):
+        self._server = server
+        self._thread = thread
+        self.host = host
+        self.port = port
+
+    def stop(self, timeout: float = 10.0) -> None:
+        self._server.should_exit = True
+        self._thread.join(timeout=timeout)
+        if self._thread.is_alive():
+            # Not fatal, and deliberately not escalated: the thread is a
+            # daemon, so a listener that will not let go cannot keep the
+            # process alive past the application's own exit. Worth a line
+            # in the log so a slow shutdown is explicable.
+            log.warning("the Model Context Protocol listener did not stop within %ss", timeout)
+
+
+def start(document: dict, *, host: str, port: int, api_base_url: str) -> Listener:
+    """Build the server from `document` and start listening on host:port.
+
+    Raises RuntimeError, naming the port, if the listener does not bind -
+    which is what an operator who turned this on deserves instead of a
+    healthy-looking container with nothing on the port they published.
+    """
+    server = build_server(document, api_base_url)
+    app = server.streamable_http_app(streamable_http_path="/mcp", host=host)
+    runner = uvicorn.Server(
+        uvicorn.Config(app, host=host, port=port, log_level="info", access_log=False)
+    )
+    thread = threading.Thread(target=runner.run, name="fermata-mcp", daemon=True)
+    thread.start()
+
+    deadline = time.monotonic() + BIND_TIMEOUT_SECONDS
+    while time.monotonic() < deadline:
+        if runner.started:
+            log.info(
+                "Model Context Protocol server listening on http://%s:%s/mcp, reading the REST "
+                "API at %s", host, port, api_base_url,
+            )
+            return Listener(runner, thread, host, port)
+        if not thread.is_alive():
+            break
+        time.sleep(0.05)
+
+    runner.should_exit = True
+    raise RuntimeError(
+        f"Fermata cannot start: FERMATA_MCP is on, but the Model Context Protocol server "
+        f"could not listen on {host}:{port}. The usual cause is that something else already "
+        f"has that port - set FERMATA_MCP_PORT to a free one, or unset FERMATA_MCP to turn "
+        "the feature off. See docs/deployment.md's 'The Model Context Protocol server' "
+        "section.\n"
+        "\n"
+        "Nothing has been changed. Your sheet music and your practice history are both as "
+        "they were."
+    )
+
+
+def describe_tools(document: dict) -> str:
+    """The tool list as JSON, for `python -m fermata.mcp_server` - a way to
+    see exactly what this server would offer without starting it or
+    connecting a client. Handy when an operator wants to know what a tool
+    caller can see before they publish a port."""
+    return json.dumps(
+        [
+            {
+                "name": spec.name,
+                "operationId": spec.operation_id,
+                "route": f"{spec.method.upper()} {spec.path}",
+                "inputSchema": spec.input_schema,
+            }
+            for spec in mcp_tools.build_tools(document)
+        ],
+        indent=2,
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover - an operator's convenience
+    from .main import app
+
+    print(describe_tools(app.openapi()))

--- a/server/fermata/mcp_tools.py
+++ b/server/fermata/mcp_tools.py
@@ -1,0 +1,342 @@
+"""The tool list, derived from the served OpenAPI document (issue #31).
+
+THIS MODULE DELIBERATELY IMPORTS NOTHING FROM THE PROTOCOL LIBRARY, and
+nothing from `fermata.api` either. It is the half of the Model Context
+Protocol server that is pure data: which documented routes are exposed as
+tools, what each tool's input schema is, and what HTTP request a tool call
+turns into. `fermata/mcp_server.py` is the half that speaks the protocol and
+makes the request.
+
+The split is what lets `server/tests/test_mcp_server.py` check the tool list
+against the OpenAPI document in an ordinary test run, with no protocol
+library installed and no server listening - and it is what keeps the promise
+in `docs/api.md` that this layer wraps the REST API rather than
+reimplementing it. Nothing here knows how a score is stored or how practice
+totals are computed; it knows a route's name, its parameters, and how to
+spell a URL.
+
+WHY THE SCHEMAS ARE GENERATED. A tool schema written by hand is a second
+copy of the contract, and a second copy drifts: a route grows a query
+parameter, the tool does not, and a client is told something false about a
+surface that still validates. So `build_tools` reads the document the server
+already serves at `/openapi.json` - the same one Swagger UI and any codegen
+read, the one `server/tests/test_api_docs.py` pins as valid and complete -
+and turns each named operation's own `parameters` into the tool's
+`inputSchema`. The only thing written by hand is WHICH operations are
+exposed, and that hand-written part is itself checked against the document
+by `check_tool_mapping` and `unclassified_read_operations`, so an added or
+renamed route fails by name rather than passing silently.
+
+WHY THE READ SET IS AN ALLOWLIST AND NOT "EVERY GET". Two reasons. A GET is
+not automatically something worth handing a tool caller - `GET /api/export`
+is the entire library as one download, `GET /api/scores/{id}/file` is a PDF -
+and, more importantly, an allowlist with a matching NOT_EXPOSED census turns
+"somebody added a route" into a test failure that names the route and forces
+a decision, which is exactly what issue #31's "Done when" asks for. A
+denylist would silently expose whatever arrives next.
+"""
+
+from __future__ import annotations
+
+import copy
+from dataclasses import dataclass
+from urllib.parse import quote
+
+# Only routes under this prefix are considered at all. The application also
+# serves the built frontend from a catch-all route when FERMATA_WEB_DIST is
+# set, which shows up in the document as `/{full_path}`; that is the SPA
+# shell, not part of the REST contract, and scoping to the API prefix keeps
+# the census below from having to know that.
+API_PREFIX = "/api/"
+
+# The first tool set, exactly as issue #31 names it: list and search scores,
+# read a score's metadata and transcription status, read practice history
+# and summaries, read goals, read trainer attempts.
+#
+# Keys are tool names - short, stable, and chosen for a caller reading a
+# tool list. Values are OPERATION IDS from the OpenAPI document, which is
+# what makes the mapping checkable: FastAPI derives an operation id from the
+# handler's function name and route, so renaming either changes the id and
+# `check_tool_mapping` fails naming the tool that lost its route.
+READ_TOOLS: dict[str, str] = {
+    "list_scores": "list_scores_api_scores_get",
+    "get_score": "get_score_api_scores__score_id__get",
+    "get_score_transcription": "get_transcription_api_scores__score_id__transcription_get",
+    "get_score_transcription_analysis": (
+        "get_transcription_analysis_api_scores__score_id__transcription_analysis_get"
+    ),
+    "get_score_practice": "get_practice_api_scores__score_id__practice_get",
+    "get_score_practice_progress": (
+        "score_practice_progress_api_scores__score_id__practice_progress_get"
+    ),
+    "list_practice_sessions": "list_sessions_api_practice_sessions_get",
+    "get_practice_summary": "practice_summary_api_practice_summary_get",
+    "get_practice_history": "practice_history_api_practice_history_get",
+    "list_goals": "list_goals_api_practice_goals_get",
+    "get_current_goal": "current_goal_api_practice_goals_current_get",
+    "list_trainer_attempts": "list_trainer_attempts_api_trainer_attempts_get",
+    "list_trainer_chord_attempts": "list_trainer_chord_attempts_api_trainer_chord_attempts_get",
+}
+
+# Every OTHER readable route under /api, each with the reason it is not a
+# tool in this first set. This is not documentation for its own sake:
+# `unclassified_read_operations` requires every GET in the document to
+# appear either here or in READ_TOOLS, so a route added to api.py without a
+# decision recorded here fails the test by name. Deleting an entry from
+# here without deleting the route fails the same way.
+NOT_EXPOSED: dict[str, str] = {
+    "health_api_health_get": "liveness, not library or practice data",
+    "get_version_api_version_get": "build identity, not library or practice data",
+    "get_me_api_me_get": (
+        "identity is inert (issue #31 leaves it that way) - a tool here would report "
+        "nothing a caller could act on"
+    ),
+    "get_settings_api_settings_get": "deployment configuration, not library or practice data",
+    "list_instruments_api_instruments_get": "instrument setup is not in the first tool set",
+    "list_instrument_presets_api_instruments_presets_get": (
+        "instrument setup is not in the first tool set"
+    ),
+    "get_instrument_api_instruments__instrument_id__get": (
+        "instrument setup is not in the first tool set"
+    ),
+    "list_collections_api_collections_get": "library organisation view, not in the first tool set",
+    "list_tags_api_tags_get": "library organisation view, not in the first tool set",
+    "list_duplicates_api_duplicates_get": "library maintenance view, not in the first tool set",
+    "list_trash_api_trash_get": "library maintenance view, not in the first tool set",
+    "list_folders_api_library_folders_get": (
+        "library organisation view, not in the first tool set"
+    ),
+    "list_setlists_api_setlists_get": "setlists are not in the first tool set",
+    "get_setlist_api_setlists__setlist_id__get": "setlists are not in the first tool set",
+    "get_scan_status_api_scan_status_get": "background job state, not in the first tool set",
+    "get_transcribe_batch_status_api_transcribe_batch_status_get": (
+        "background job state, not in the first tool set"
+    ),
+    "export_library_api_export_get": (
+        "the whole library as one archive download - a bulk file transfer, not a read tool"
+    ),
+    "get_file_api_scores__score_id__file_get": "serves the score file itself, not JSON",
+    "get_thumb_api_scores__score_id__thumb_get": "serves a thumbnail image, not JSON",
+    "practice_review_api_practice_review_get": (
+        "answers 'what should I practise next', which is a step past the history and "
+        "summaries this first tool set covers"
+    ),
+}
+
+
+class ToolMappingError(Exception):
+    """Raised when READ_TOOLS and the OpenAPI document disagree.
+
+    Its message always names the tool and the operation id involved, because
+    the only way anyone reads this exception is as a test failure telling
+    them which route they just added, renamed or removed.
+    """
+
+
+@dataclass(frozen=True)
+class ToolSpec:
+    """One tool, fully derived from one OpenAPI operation."""
+
+    name: str
+    operation_id: str
+    method: str
+    path: str
+    """The OpenAPI path template, e.g. `/api/scores/{score_id}`."""
+    summary: str
+    description: str
+    input_schema: dict
+    path_params: tuple[str, ...]
+    query_params: tuple[str, ...]
+
+    @property
+    def trace(self) -> dict[str, str]:
+        """What the tool carries in `_meta` so a client can check for itself
+        that the tool came from a documented route: the operation id, the
+        method and the path template. Issue #31 asks that every tool's
+        schema be traceable to an OpenAPI operation; this is that trace,
+        travelling with the tool rather than living only in this file."""
+        return {"operationId": self.operation_id, "method": self.method.upper(), "path": self.path}
+
+
+def _operations(document: dict) -> dict[str, tuple[str, str, dict]]:
+    """Index the document's `/api` operations by operation id, as
+    `{operation_id: (method, path, operation)}`."""
+    found: dict[str, tuple[str, str, dict]] = {}
+    for path, item in (document.get("paths") or {}).items():
+        if not path.startswith(API_PREFIX):
+            continue
+        for method, operation in item.items():
+            if not isinstance(operation, dict):
+                continue
+            operation_id = operation.get("operationId")
+            if operation_id:
+                found[operation_id] = (method.lower(), path, operation)
+    return found
+
+
+def check_tool_mapping(document: dict) -> None:
+    """Every tool names an operation that is really in the document, and
+    really is a read. Raises ToolMappingError naming the first tool that
+    does not.
+
+    Renaming a route is what this catches in practice: FastAPI's operation
+    id contains both the handler's name and the route's path, so either kind
+    of rename lands here rather than in a client's lap.
+    """
+    operations = _operations(document)
+    for name, operation_id in READ_TOOLS.items():
+        if operation_id not in operations:
+            raise ToolMappingError(
+                f"tool {name!r} maps to operation id {operation_id!r}, which is not in the "
+                "OpenAPI document - the route was renamed, moved or removed. Update "
+                "READ_TOOLS in fermata/mcp_tools.py to match, or drop the tool."
+            )
+        method, path, _ = operations[operation_id]
+        if method != "get":
+            raise ToolMappingError(
+                f"tool {name!r} maps to {method.upper()} {path} - this server exposes read "
+                "tools only (issue #31's no-gos), so a tool may only wrap a GET."
+            )
+
+
+def unclassified_read_operations(document: dict) -> list[str]:
+    """Readable `/api` operations that are neither exposed as a tool nor
+    recorded in NOT_EXPOSED, as `"GET /api/..."` strings.
+
+    A non-empty result means somebody added a route and nobody decided
+    whether a tool caller should see it. The strings name the route so the
+    failure reads as an instruction rather than a count.
+    """
+    stray = []
+    for operation_id, (method, path, _) in sorted(_operations(document).items(), key=lambda e: e[1][1]):
+        if method != "get":
+            continue
+        if operation_id in READ_TOOLS.values() or operation_id in NOT_EXPOSED:
+            continue
+        stray.append(f"{method.upper()} {path} ({operation_id})")
+    return stray
+
+
+def _input_schema(operation: dict) -> tuple[dict, tuple[str, ...], tuple[str, ...]]:
+    """Turn an operation's declared parameters into a JSON Schema object,
+    plus the path and query parameter names in declaration order.
+
+    The parameter's own `schema` is copied through verbatim - type, default,
+    enum, title, whatever FastAPI derived from the handler's signature - so
+    the tool tells a caller exactly what the route tells a codegen. Copied,
+    not referenced, because the document is a live object here and a tool
+    schema handed to a client must not be a window onto it.
+    """
+    properties: dict[str, dict] = {}
+    required: list[str] = []
+    path_params: list[str] = []
+    query_params: list[str] = []
+    for parameter in operation.get("parameters") or []:
+        name = parameter.get("name")
+        location = parameter.get("in")
+        if not name or location not in ("path", "query"):
+            # Header and cookie parameters are not something a tool caller
+            # supplies - this server talks to the API on loopback and sends
+            # nothing on a caller's behalf.
+            continue
+        schema = copy.deepcopy(parameter.get("schema") or {})
+        if parameter.get("description") and "description" not in schema:
+            schema["description"] = parameter["description"]
+        properties[name] = schema
+        if parameter.get("required"):
+            required.append(name)
+        (path_params if location == "path" else query_params).append(name)
+    input_schema = {
+        "type": "object",
+        "properties": properties,
+        "required": required,
+        # A tool call carrying an argument the route never declared is a
+        # mistake worth reporting, not something to quietly drop - and
+        # refusing it here is also what stops an unexpected key from being
+        # smuggled into the outgoing URL.
+        "additionalProperties": False,
+    }
+    return input_schema, tuple(path_params), tuple(query_params)
+
+
+def build_tools(document: dict) -> list[ToolSpec]:
+    """The whole tool list, generated from the document.
+
+    Called once at startup with `app.openapi()`. Raises ToolMappingError
+    (via check_tool_mapping) rather than silently shipping a shorter list if
+    the document and READ_TOOLS have parted company - a server that quietly
+    served twelve tools where thirteen were meant is the failure this whole
+    design exists to make impossible.
+    """
+    check_tool_mapping(document)
+    operations = _operations(document)
+    tools = []
+    for name, operation_id in READ_TOOLS.items():
+        method, path, operation = operations[operation_id]
+        input_schema, path_params, query_params = _input_schema(operation)
+        summary = (operation.get("summary") or "").strip()
+        description = (operation.get("description") or "").strip()
+        tools.append(
+            ToolSpec(
+                name=name,
+                operation_id=operation_id,
+                method=method,
+                path=path,
+                summary=summary,
+                description=description,
+                input_schema=input_schema,
+                path_params=path_params,
+                query_params=query_params,
+            )
+        )
+    return tools
+
+
+def tool_description(spec: ToolSpec) -> str:
+    """What a caller sees when it lists the tools: the route, then the
+    route's own documentation. The route line is first on purpose - it is
+    the sentence that makes the tool traceable to the contract, and it is
+    the one thing a caller can check against `/openapi.json` by hand."""
+    head = f"Reads {spec.method.upper()} {spec.path}."
+    body = spec.description or spec.summary
+    return f"{head}\n\n{body}".strip()
+
+
+def plan_request(spec: ToolSpec, arguments: dict) -> tuple[str, dict[str, str]]:
+    """Turn a tool call's arguments into a path and a query string mapping.
+
+    Raises ValueError, naming the argument, on anything the route did not
+    declare or anything required that is missing. Path values are
+    percent-encoded with no safe characters at all, so a value carrying a
+    slash or a `..` cannot walk out of the route it was given to - the
+    request this server makes is always the route the tool names.
+    """
+    declared = set(spec.path_params) | set(spec.query_params)
+    for key in arguments:
+        if key not in declared:
+            raise ValueError(
+                f"tool {spec.name!r} has no argument {key!r} - "
+                f"{spec.method.upper()} {spec.path} declares {sorted(declared)}"
+            )
+    for key in spec.input_schema["required"]:
+        if key not in arguments:
+            raise ValueError(f"tool {spec.name!r} requires argument {key!r}")
+
+    path = spec.path
+    for key in spec.path_params:
+        path = path.replace("{" + key + "}", quote(_as_text(arguments[key]), safe=""))
+
+    query = {
+        key: _as_text(arguments[key]) for key in spec.query_params if arguments.get(key) is not None
+    }
+    return path, query
+
+
+def _as_text(value) -> str:
+    """A JSON argument as a query/path string. `True` has to become `true`,
+    not `True`: FastAPI parses the lowercase spelling and 422s on the other
+    one, and `favorite=True` silently failing would be a confusing way to
+    learn that."""
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    return str(value)

--- a/server/fermata/practice.py
+++ b/server/fermata/practice.py
@@ -813,7 +813,7 @@ def time_spent(
 # deciding what to practise next needs the per-piece picture as much as the
 # overall one, and reassembling it from the general endpoints meant a client
 # filtering the whole history by score_id and doing the arithmetic itself -
-# which is the arithmetic a second reader (the planned MCP server, #31) would
+# which is the arithmetic a second reader (the MCP server, #31) would
 # then have to write again and get subtly differently.
 #
 # WHAT THIS DELIBERATELY DOES NOT COMPUTE, and will not:

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -28,6 +28,28 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+# The Model Context Protocol server (issue #31). An EXTRA, not a core
+# dependency, because the feature is off unless FERMATA_MCP is set and
+# nothing imports any of this until it is - a source install that never
+# turns it on should not have to carry the protocol library or its
+# transitive dependencies. The container image installs the extra anyway
+# (see the Dockerfile), so that flipping the flag there is an environment
+# variable rather than a rebuild.
+#
+# Pinned exactly, unlike everything above. This is the one dependency whose
+# wire behaviour IS the feature - a protocol revision arriving in a patch
+# release would change what a connected client sees without a line of this
+# repository changing - so the version that was actually tested is the
+# version that ships, and moving it is a deliberate commit.
+#
+# httpx is named explicitly rather than relied on from the protocol
+# library's own dependency tree: fermata/mcp_server.py imports it directly
+# to make each tool's HTTP request against the REST API, and a dependency
+# you import is one you declare.
+mcp = [
+    "mcp==2.1.1",
+    "httpx>=0.27",
+]
 dev = [
     "pytest>=8.0",
     "httpx>=0.27",

--- a/server/tests/test_api_docs.py
+++ b/server/tests/test_api_docs.py
@@ -6,8 +6,8 @@ Five separate claims, each with its own test group below:
 
 1. GET /openapi.json is a document that validates against the OpenAPI spec -
    FastAPI producing SOME JSON is not the same claim as producing one a
-   client's codegen (or a planned MCP server - issue #31 - built on this
-   surface as its contract) could actually trust.
+   client's codegen (or the MCP server - issue #31 - which generates its
+   whole tool list from this document) could actually trust.
 2. Every route carries a summary, a description and at least one tag, and
    its success response declares a schema (or, for the two file-serving
    routes, a real content type, with no stray application/json alongside
@@ -198,7 +198,7 @@ def test_openapi_document_validates_against_the_spec(openapi_schema):
     malformed against the spec - a response with no "content" at all under a
     status code, a $ref FastAPI failed to resolve, and so on. This is the
     check that a tool consuming the document (Swagger UI, a codegen, the
-    planned MCP server this documents the contract for) would not choke on
+    MCP server this documents the contract for) would not choke on
     it. openapi_spec_validator.validate raises on the first thing wrong,
     which pytest reports directly - there is no assertion to write."""
     validate_openapi(openapi_schema)

--- a/server/tests/test_mcp_server.py
+++ b/server/tests/test_mcp_server.py
@@ -61,7 +61,18 @@ FLAG = "FERMATA_MCP"
 # value left in the ambient environment (a developer who exported the flag
 # in their shell) cannot make the flag-off tests pass or fail for the wrong
 # reason.
-FEATURE_ENV = (FLAG, "FERMATA_MCP_HOST", "FERMATA_MCP_PORT", "FERMATA_MCP_API_URL")
+FEATURE_ENV = (
+    FLAG,
+    "FERMATA_MCP_HOST",
+    "FERMATA_MCP_PORT",
+    "FERMATA_MCP_API_URL",
+    # Not this feature's own, but the one setting that changes what it does:
+    # with reverse-proxy auth on, the two together are refused at startup
+    # (see the group below), so an ambient value would turn every spawn in
+    # this file into a test of that refusal instead.
+    "FERMATA_AUTH_HEADER",
+    "FERMATA_TRUSTED_PROXIES",
+)
 
 
 # ---------------------------------------------------------------------------
@@ -224,7 +235,7 @@ def test_the_application_imports_with_the_protocol_library_absent():
         "class Absent:\n"
         "    def find_spec(self, name, path=None, target=None):\n"
         "        if name == 'mcp' or name.startswith('mcp.'):\n"
-        "            raise ImportError('not installed in this deployment')\n"
+        "            raise ModuleNotFoundError(f'No module named {name!r}', name=name)\n"
         "        return None\n"
         "sys.meta_path.insert(0, Absent())\n"
         "try:\n"
@@ -245,6 +256,107 @@ def test_the_application_imports_with_the_protocol_library_absent():
     # The tool table is derivable without the protocol library too - that is
     # what keeps group 2 below runnable on a machine without the extra.
     assert lines[-2] == str(len(mcp_tools.READ_TOOLS)), result.stdout
+
+
+def test_the_flag_on_without_the_extra_says_so_instead_of_a_traceback():
+    """Turning the flag on in a source install that never asked for the
+    optional extra is an ordinary mistake. It has to arrive as this
+    application's own kind of startup failure - a RuntimeError carrying a
+    sentence, routed through the lifespan's handler - and not as the bare
+    ModuleNotFoundError traceback that sends a worried operator reaching for
+    the previous image tag.
+
+    The module is blocked rather than uninstalled, and the blocker raises
+    ModuleNotFoundError specifically (what a genuinely absent package
+    raises, carrying `.name`) rather than a plain ImportError, so what is
+    caught here is what would really happen.
+    """
+    snippet = (
+        "import sys\n"
+        "class Absent:\n"
+        "    def find_spec(self, name, path=None, target=None):\n"
+        "        if name == 'mcp' or name.startswith('mcp.'):\n"
+        "            raise ModuleNotFoundError(f'No module named {name!r}', name=name)\n"
+        "        return None\n"
+        "sys.meta_path.insert(0, Absent())\n"
+        "from fermata import config, main\n"
+        "config.MCP_ENABLED = True\n"
+        "config.MCP_PORT = 1\n"
+        "try:\n"
+        "    main._start_mcp_server(main.app)\n"
+        "except RuntimeError as exc:\n"
+        "    print('RUNTIMEERROR')\n"
+        "    print(exc)\n"
+        "except ModuleNotFoundError:\n"
+        "    print('RAW-TRACEBACK-ESCAPED')\n"
+        "    raise SystemExit(3)\n"
+        "else:\n"
+        "    print('NOTHING-RAISED')\n"
+        "    raise SystemExit(4)\n"
+    )
+    result = _python(snippet)
+    assert result.returncode == 0, result.stdout + result.stderr
+    # `in`, not startswith: importing fermata prints a third-party
+    # deprecation warning to stdout first, and that is not this test's
+    # business.
+    assert "RUNTIMEERROR" in result.stdout, result.stdout
+    assert "'mcp' is not installed" in result.stdout, result.stdout
+    assert 'server[mcp]' in result.stdout, result.stdout
+
+
+def test_the_feature_and_reverse_proxy_auth_are_refused_together(tmp_path):
+    """Both on is not a working deployment: the tools read the API as an
+    anonymous loopback client, so reverse-proxy auth would 401 every one of
+    them while the tool list still advertised thirteen. Refusing to start
+    says that out loud - see
+    authproxy.check_mcp_is_not_configured_behind_proxy_auth for why neither
+    workaround is offered instead.
+    """
+    api_port = _free_port()
+    mcp_port = _free_port()
+    proc = _spawn(
+        tmp_path, api_port,
+        {
+            FLAG: "1",
+            "FERMATA_MCP_PORT": str(mcp_port),
+            "FERMATA_MCP_API_URL": f"http://127.0.0.1:{api_port}",
+            "FERMATA_AUTH_HEADER": "X-Remote-User",
+            "FERMATA_TRUSTED_PROXIES": "203.0.113.9/32",
+        },
+    )
+    try:
+        proc.wait(timeout=30)
+    except subprocess.TimeoutExpired:
+        pytest.fail(
+            "the server started with both the protocol server and reverse-proxy auth on - "
+            "every tool would answer 401 while advertising itself as working:\n"
+            + _terminate(proc)
+        )
+    finally:
+        output = _terminate(proc)
+    # Both variables named, so the log says which two settings to choose
+    # between rather than merely that something is wrong.
+    assert FLAG in output, output
+    assert "FERMATA_AUTH_HEADER" in output, output
+    assert not _accepts_a_connection(mcp_port), "a listener was opened before the refusal"
+    assert not _accepts_a_connection(api_port), "the API is still serving after that refusal"
+
+
+def test_reverse_proxy_auth_alone_still_starts(tmp_path):
+    """The refusal above must be about the COMBINATION. Reverse-proxy auth
+    on its own is a supported deployment and this is what stops the new
+    check quietly breaking it."""
+    api_port = _free_port()
+    proc = _spawn(
+        tmp_path, api_port,
+        {"FERMATA_AUTH_HEADER": "X-Remote-User", "FERMATA_TRUSTED_PROXIES": "203.0.113.9/32"},
+    )
+    try:
+        assert _wait_until_serving(api_port), (
+            "reverse-proxy auth alone stopped the server:\n" + _terminate(proc)
+        )
+    finally:
+        _terminate(proc)
 
 
 def test_nothing_listens_with_the_flag_off(tmp_path):

--- a/server/tests/test_mcp_server.py
+++ b/server/tests/test_mcp_server.py
@@ -292,6 +292,68 @@ def test_the_listener_is_there_with_the_flag_on(tmp_path):
         _terminate(proc)
 
 
+def test_a_port_already_taken_stops_the_server_loudly(tmp_path):
+    """An operator who turned this on and published a port deserves a
+    failure, not a healthy-looking container with nothing on that port. The
+    port is genuinely occupied here - by a socket this test holds open - so
+    the bind really does fail.
+    """
+    api_port = _free_port()
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as squatter:
+        squatter.bind(("127.0.0.1", 0))
+        squatter.listen(1)
+        taken = squatter.getsockname()[1]
+        proc = _spawn(
+            tmp_path, api_port,
+            {
+                FLAG: "1",
+                "FERMATA_MCP_PORT": str(taken),
+                "FERMATA_MCP_API_URL": f"http://127.0.0.1:{api_port}",
+            },
+        )
+        try:
+            # It must EXIT, not merely fail to serve: a half-started
+            # deployment - API up, published protocol port dead - is exactly
+            # what the loud failure exists to prevent.
+            proc.wait(timeout=30)
+        except subprocess.TimeoutExpired:
+            pytest.fail(
+                "the server kept running even though the protocol server could not bind:\n"
+                + _terminate(proc)
+            )
+        finally:
+            output = _terminate(proc)
+    assert not _accepts_a_connection(api_port), "the API is still serving after that failure"
+    assert str(taken) in output, output
+    assert "Model Context Protocol server" in output, output
+
+
+def test_an_unusable_port_setting_is_harmless_while_the_flag_is_off(tmp_path):
+    """The other side of that loudness: a stale, nonsensical value in the
+    environment of a deployment that never turned the feature on must not
+    stop it starting."""
+    api_port = _free_port()
+    proc = _spawn(tmp_path, api_port, {"FERMATA_MCP_PORT": "not-a-port"})
+    try:
+        assert _wait_until_serving(api_port), (
+            "a bad FERMATA_MCP_PORT stopped a server that never turned the feature on:\n"
+            + _terminate(proc)
+        )
+    finally:
+        _terminate(proc)
+
+
+def test_the_documented_defaults_are_the_real_ones():
+    """docs/deployment.md's settings table names a default port and a
+    default host; this is what stops that table becoming fiction."""
+    result = _python(
+        "from fermata import config; "
+        "print(config.MCP_HOST, config.MCP_PORT_RAW, config.MCP_API_URL)"
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "127.0.0.1 8765 http://127.0.0.1:8080"
+
+
 def test_turning_the_flag_on_changes_the_rest_contract_not_at_all(tmp_path):
     """Two real servers, one with the flag off and one with it on, and their
     served OpenAPI documents compared byte for byte.

--- a/server/tests/test_mcp_server.py
+++ b/server/tests/test_mcp_server.py
@@ -1,0 +1,684 @@
+"""The Model Context Protocol server (issue #31) - the flag that gates it,
+the tool list generated from the OpenAPI document, and a real client talking
+to a real listener.
+
+Four claims, each with its own group below.
+
+1. THE FLAG IS THE WHOLE GATE. With FERMATA_MCP unset: nothing listens,
+   `import fermata.main` does not import the protocol library, and the
+   application starts in a deployment where that library is not installed at
+   all. Turning the flag on also does not change the REST contract by one
+   byte - the two documents are compared literally.
+2. THE TOOL LIST CANNOT DRIFT FROM THE ROUTES. Every tool names an operation
+   that is really in the document and really is a GET; every readable route
+   in the document is either a tool or recorded, with a reason, as not
+   exposed. Renaming a route, adding one, or dropping a tool's mapping each
+   fail here, naming the route - which is what issue #31's "Done when" asks
+   for. Those three failures are not hypothetical: three tests below perform
+   the mutation and assert the red.
+3. THE TOOLS ARE READ-ONLY AND CANNOT BE TALKED PAST. A write route cannot
+   be made into a tool, an argument the route did not declare is refused,
+   and a path argument carrying a slash is encoded rather than obeyed.
+4. A GENERIC CLIENT SEES WHAT THIS FILE SAYS IT WILL. The last group starts
+   a real server on a free port, connects the protocol's own client library
+   over the real transport, lists the tools, and asserts that a tool call
+   returns the SAME JSON as an ordinary HTTP request to the route it wraps -
+   which is the only assertion that can tell "wraps the route" from
+   "reimplements the route badly".
+
+Group 4 needs the optional [mcp] extra and skips without it, saying so. CI
+installs it (see .github/workflows/ci.yml) precisely so that group runs
+there rather than passing by absence.
+"""
+
+import asyncio
+import copy
+import http.client
+import json
+import os
+import shutil
+import socket
+import subprocess
+import sys
+from pathlib import Path
+import time
+
+import pytest
+
+from fermata import mcp_tools
+from fermata.main import app as full_app
+
+
+SERVER_ROOT = Path(__file__).resolve().parent.parent
+FIXTURES = Path(__file__).resolve().parent / "fixtures" / "engraved"
+STARTUP_TIMEOUT = 40.0
+
+# The whole point of the feature is that this is the only switch.
+FLAG = "FERMATA_MCP"
+
+# Every environment variable this feature reads, cleared from a spawned
+# server's environment before the test sets what it means to set - so a
+# value left in the ambient environment (a developer who exported the flag
+# in their shell) cannot make the flag-off tests pass or fail for the wrong
+# reason.
+FEATURE_ENV = (FLAG, "FERMATA_MCP_HOST", "FERMATA_MCP_PORT", "FERMATA_MCP_API_URL")
+
+
+# ---------------------------------------------------------------------------
+# Harness - the same shape as test_live_server_proxy_headers.py's, which is
+# this repository's existing precedent for driving a real uvicorn process
+# from the test runner.
+# ---------------------------------------------------------------------------
+
+
+def _free_port() -> int:
+    """A port nothing is on, obtained by binding zero and letting the OS
+    choose. Inherently a small race - something could take it between the
+    close here and the bind in the server - and accepted for the same reason
+    test_live_server_proxy_headers.py accepts it: retrying on a bind failure
+    costs more than it saves. Never a fixed number, and never 8080."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _get(port: int, path: str):
+    conn = http.client.HTTPConnection("127.0.0.1", port, timeout=10)
+    try:
+        conn.request("GET", path)
+        resp = conn.getresponse()
+        return resp.status, resp.read()
+    finally:
+        conn.close()
+
+
+def _wait_until_serving(port: int, timeout: float = STARTUP_TIMEOUT) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            status, _ = _get(port, "/api/health")
+            if status == 200:
+                return True
+        except (ConnectionRefusedError, OSError, TimeoutError):
+            pass
+        time.sleep(0.2)
+    return False
+
+
+def _accepts_a_connection(port: int, timeout: float = 1.0) -> bool:
+    """Whether anything at all is listening on the port - a TCP connect, not
+    an HTTP request, because "nothing listens" is a claim about the socket
+    and not about what any protocol would answer."""
+    try:
+        with socket.create_connection(("127.0.0.1", port), timeout=timeout):
+            return True
+    except OSError:
+        return False
+
+
+def _spawn(tmp_path: Path, port: int, env_overrides: dict, seed_score: bool = False):
+    library = tmp_path / "library"
+    library.mkdir(parents=True, exist_ok=True)
+    if seed_score:
+        # A real PDF from the committed engraved fixtures, so the library the
+        # tools read is not empty - comparing two empty lists would be an
+        # equality assertion that could never notice a difference.
+        shutil.copy(FIXTURES / "dadgad.pdf", library / "mcp_fixture_score.pdf")
+    env = dict(os.environ)
+    for name in FEATURE_ENV:
+        env.pop(name, None)
+    env.pop("FORWARDED_ALLOW_IPS", None)
+    env.update({
+        "FERMATA_LIBRARY": str(library),
+        "FERMATA_CONFIG": str(tmp_path / "config"),
+        "PYTHONPATH": str(SERVER_ROOT),
+    })
+    env.update(env_overrides)
+    return subprocess.Popen(
+        [
+            sys.executable, "-m", "uvicorn", "fermata.main:app",
+            "--host", "127.0.0.1", "--port", str(port), "--no-proxy-headers",
+        ],
+        cwd=str(SERVER_ROOT), env=env,
+        stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True,
+    )
+
+
+def _terminate(proc: subprocess.Popen) -> str:
+    if proc.poll() is None:
+        proc.terminate()
+        try:
+            proc.wait(timeout=15)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait(timeout=5)
+    try:
+        return proc.stdout.read() or ""
+    except Exception:
+        return ""
+
+
+def _python(snippet: str, env_overrides: dict | None = None) -> subprocess.CompletedProcess:
+    """Run a snippet in a FRESH interpreter. Import-time claims cannot be
+    checked in this process: pytest has already imported fermata, and this
+    very module imports the protocol library in group 4."""
+    env = dict(os.environ)
+    for name in FEATURE_ENV:
+        env.pop(name, None)
+    env["PYTHONPATH"] = str(SERVER_ROOT)
+    env.update(env_overrides or {})
+    return subprocess.run(
+        [sys.executable, "-c", snippet],
+        cwd=str(SERVER_ROOT), env=env, capture_output=True, text=True, timeout=180,
+    )
+
+
+@pytest.fixture(scope="module")
+def openapi_document():
+    return full_app.openapi()
+
+
+# ---------------------------------------------------------------------------
+# 1. The flag is the whole gate.
+# ---------------------------------------------------------------------------
+
+
+def test_the_feature_is_off_unless_the_flag_says_otherwise():
+    """Off by default, in a fresh interpreter with the variable genuinely
+    absent - not merely off in this test session's imported config."""
+    off = _python("from fermata import config; print(config.MCP_ENABLED)")
+    assert off.returncode == 0, off.stderr
+    assert off.stdout.strip() == "False", off.stdout
+
+    on = _python("from fermata import config; print(config.MCP_ENABLED)", {FLAG: "1"})
+    assert on.returncode == 0, on.stderr
+    assert on.stdout.strip() == "True", (
+        f"{FLAG}=1 did not turn the feature on - the flag is the only switch this feature "
+        "has, so this failing means it has no switch at all"
+    )
+
+
+def test_importing_the_application_does_not_import_the_protocol_library():
+    """`import fermata.main` must not drag the protocol library in. If it
+    did, the optional dependency would be a required one in everything but
+    name, and the next test could not pass."""
+    result = _python(
+        "import sys; import fermata.main; "
+        "print('LOADED' if any(m == 'mcp' or m.startswith('mcp.') for m in sys.modules) else 'ABSENT')"
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip().splitlines()[-1] == "ABSENT", (
+        "importing fermata.main imported the protocol library - the import in "
+        "main._start_mcp_server has escaped the `if config.MCP_ENABLED` it belongs inside:\n"
+        + result.stdout
+    )
+
+
+def test_the_application_imports_with_the_protocol_library_absent():
+    """The deployment that never installed the [mcp] extra. Simulated by
+    making the import genuinely fail, and the blocker is proven to work
+    first - a blocker that silently did nothing would turn this into a test
+    that passes on any machine for no reason."""
+    snippet = (
+        "import sys\n"
+        "class Absent:\n"
+        "    def find_spec(self, name, path=None, target=None):\n"
+        "        if name == 'mcp' or name.startswith('mcp.'):\n"
+        "            raise ImportError('not installed in this deployment')\n"
+        "        return None\n"
+        "sys.meta_path.insert(0, Absent())\n"
+        "try:\n"
+        "    import mcp\n"
+        "except ImportError:\n"
+        "    pass\n"
+        "else:\n"
+        "    print('BLOCKER-INERT'); raise SystemExit(2)\n"
+        "import fermata.main\n"
+        "from fermata import mcp_tools\n"
+        "print(len(mcp_tools.build_tools(fermata.main.app.openapi())))\n"
+        "print('IMPORTED')\n"
+    )
+    result = _python(snippet)
+    assert result.returncode == 0, result.stdout + result.stderr
+    lines = result.stdout.strip().splitlines()
+    assert lines[-1] == "IMPORTED", result.stdout
+    # The tool table is derivable without the protocol library too - that is
+    # what keeps group 2 below runnable on a machine without the extra.
+    assert lines[-2] == str(len(mcp_tools.READ_TOOLS)), result.stdout
+
+
+def test_nothing_listens_with_the_flag_off(tmp_path):
+    """A real server, really running, with the flag unset: the API answers
+    and the port the protocol server WOULD have used is refused.
+
+    The port is reserved by asking the OS for a free one and then telling the
+    server that number, so a pass cannot come from having pointed the check
+    at an arbitrary closed port - it is the exact port a flag-on run would
+    bind.
+    """
+    api_port = _free_port()
+    mcp_port = _free_port()
+    proc = _spawn(tmp_path, api_port, {"FERMATA_MCP_PORT": str(mcp_port)})
+    try:
+        assert _wait_until_serving(api_port), "server never became healthy:\n" + _terminate(proc)
+        assert not _accepts_a_connection(mcp_port), (
+            f"something is listening on {mcp_port} with {FLAG} unset - the feature is not "
+            "off by default"
+        )
+    finally:
+        _terminate(proc)
+
+
+def test_the_listener_is_there_with_the_flag_on(tmp_path):
+    """The other half of the previous test: the same arrangement with the
+    flag set does bind that port. Without this, "nothing listens" could be
+    passing because nothing ever listens."""
+    api_port = _free_port()
+    mcp_port = _free_port()
+    proc = _spawn(
+        tmp_path, api_port,
+        {
+            FLAG: "1",
+            "FERMATA_MCP_PORT": str(mcp_port),
+            "FERMATA_MCP_API_URL": f"http://127.0.0.1:{api_port}",
+        },
+    )
+    try:
+        assert _wait_until_serving(api_port), "server never became healthy:\n" + _terminate(proc)
+        assert _accepts_a_connection(mcp_port), (
+            f"{FLAG}=1 but nothing is listening on {mcp_port}:\n" + _terminate(proc)
+        )
+    finally:
+        _terminate(proc)
+
+
+def test_turning_the_flag_on_changes_the_rest_contract_not_at_all(tmp_path):
+    """Two real servers, one with the flag off and one with it on, and their
+    served OpenAPI documents compared byte for byte.
+
+    This is the promise that makes the feature safe to turn on: it READS the
+    document to build its tools and adds nothing to it, so every existing
+    client sees the identical contract either way.
+    """
+    off_port, on_port, mcp_port = _free_port(), _free_port(), _free_port()
+    off = _spawn(tmp_path / "off", off_port, {})
+    on = _spawn(
+        tmp_path / "on", on_port,
+        {
+            FLAG: "1",
+            "FERMATA_MCP_PORT": str(mcp_port),
+            "FERMATA_MCP_API_URL": f"http://127.0.0.1:{on_port}",
+        },
+    )
+    try:
+        assert _wait_until_serving(off_port), _terminate(off)
+        assert _wait_until_serving(on_port), _terminate(on)
+        _, off_doc = _get(off_port, "/openapi.json")
+        _, on_doc = _get(on_port, "/openapi.json")
+        assert off_doc == on_doc, (
+            "the served OpenAPI document differs with the feature on - this feature is "
+            "supposed to read the contract, not add to it"
+        )
+        # Said as a number too, so a future failure reports what moved.
+        operations = [
+            (method, path)
+            for path, item in json.loads(off_doc)["paths"].items()
+            for method in item
+        ]
+        assert len(operations) == len(
+            [
+                (method, path)
+                for path, item in json.loads(on_doc)["paths"].items()
+                for method in item
+            ]
+        )
+    finally:
+        _terminate(off)
+        _terminate(on)
+
+
+# ---------------------------------------------------------------------------
+# 2. The tool list cannot drift from the routes.
+# ---------------------------------------------------------------------------
+
+
+def test_every_tool_maps_to_a_read_operation_in_the_document(openapi_document):
+    mcp_tools.check_tool_mapping(openapi_document)
+    tools = mcp_tools.build_tools(openapi_document)
+    assert len(tools) == len(mcp_tools.READ_TOOLS)
+    assert all(tool.method == "get" for tool in tools)
+
+
+def test_every_readable_route_is_either_a_tool_or_recorded_as_not_exposed(openapi_document):
+    """The census. A GET added to api.py and left unclassified fails here,
+    naming the route, which is what forces the decision rather than letting
+    a new endpoint quietly become invisible to tool callers."""
+    stray = mcp_tools.unclassified_read_operations(openapi_document)
+    assert stray == [], (
+        "these readable routes are neither exposed as tools nor recorded in NOT_EXPOSED "
+        "with a reason - add each to READ_TOOLS or to NOT_EXPOSED in "
+        "fermata/mcp_tools.py:\n  " + "\n  ".join(stray)
+    )
+
+
+def test_renaming_a_route_fails_the_tool_check_naming_it(openapi_document):
+    """THE MUTATION, performed. A copy of the document with one operation id
+    changed - exactly what renaming a handler or moving a route does - must
+    make the check fail, and the message must name the tool that lost its
+    route. A guard nobody has watched go red is not a guard."""
+    document = copy.deepcopy(openapi_document)
+    scores = document["paths"]["/api/scores"]["get"]
+    assert scores["operationId"] == mcp_tools.READ_TOOLS["list_scores"]
+    scores["operationId"] = "list_scores_api_library_get"
+
+    with pytest.raises(mcp_tools.ToolMappingError) as raised:
+        mcp_tools.check_tool_mapping(document)
+    message = str(raised.value)
+    assert "list_scores" in message and mcp_tools.READ_TOOLS["list_scores"] in message, message
+
+
+def test_adding_a_route_fails_the_census_naming_it(openapi_document):
+    """The other half of "an added or renamed route fails by name": a new
+    readable route nobody classified."""
+    document = copy.deepcopy(openapi_document)
+    document["paths"]["/api/practice/streaks"] = {
+        "get": {"operationId": "list_streaks_api_practice_streaks_get", "responses": {}}
+    }
+    stray = mcp_tools.unclassified_read_operations(document)
+    assert stray == ["GET /api/practice/streaks (list_streaks_api_practice_streaks_get)"], stray
+
+
+def test_dropping_a_tools_mapping_fails_the_census_naming_it(openapi_document, monkeypatch):
+    """The third mutation: a tool quietly removed from READ_TOOLS. The
+    census notices, because the route it used to cover is now unclassified,
+    and it names that route."""
+    shortened = dict(mcp_tools.READ_TOOLS)
+    dropped = shortened.pop("get_practice_summary")
+    monkeypatch.setattr(mcp_tools, "READ_TOOLS", shortened)
+
+    stray = mcp_tools.unclassified_read_operations(openapi_document)
+    assert stray == [f"GET /api/practice/summary ({dropped})"], stray
+
+
+def test_tool_names_and_operation_ids_are_one_to_one(openapi_document):
+    """No two tools wrap the same route, and nothing is both exposed and
+    recorded as not exposed - either would make the census pass while the
+    tool list said something else."""
+    ids = list(mcp_tools.READ_TOOLS.values())
+    assert len(set(ids)) == len(ids), "two tools name the same operation id"
+    overlap = set(ids) & set(mcp_tools.NOT_EXPOSED)
+    assert overlap == set(), f"operation ids both exposed and excluded: {sorted(overlap)}"
+
+    from_document = {tool.operation_id: tool.name for tool in mcp_tools.build_tools(openapi_document)}
+    assert len(from_document) == len(mcp_tools.READ_TOOLS)
+
+
+def test_input_schemas_are_generated_from_the_document(openapi_document):
+    """Each tool's schema property set is exactly its operation's declared
+    path and query parameters - no more (which would be invented) and no
+    less (which would hide one)."""
+    operations = {
+        operation["operationId"]: operation
+        for path, item in openapi_document["paths"].items()
+        if path.startswith("/api/")
+        for operation in item.values()
+        if isinstance(operation, dict) and operation.get("operationId")
+    }
+    for tool in mcp_tools.build_tools(openapi_document):
+        declared = {
+            parameter["name"]
+            for parameter in operations[tool.operation_id].get("parameters") or []
+            if parameter.get("in") in ("path", "query")
+        }
+        assert set(tool.input_schema["properties"]) == declared, tool.name
+        assert tool.input_schema["additionalProperties"] is False
+
+
+def test_the_scores_tool_schema_carries_the_routes_own_filters(openapi_document):
+    """A named spot-check under the generated one: the library tool really
+    does offer search and the filters `GET /api/scores` documents, so
+    "generated" cannot mean "generated empty"."""
+    tools = {tool.name: tool for tool in mcp_tools.build_tools(openapi_document)}
+    scores = tools["list_scores"]
+    assert set(scores.input_schema["properties"]) >= {
+        "search", "collection", "kind", "tag", "favorite", "practiced",
+    }
+    assert scores.input_schema["required"] == []
+    assert tools["get_score"].input_schema["required"] == ["score_id"]
+    assert scores.trace == {
+        "operationId": mcp_tools.READ_TOOLS["list_scores"],
+        "method": "GET",
+        "path": "/api/scores",
+    }
+
+
+# ---------------------------------------------------------------------------
+# 3. Read-only, and it cannot be talked past.
+# ---------------------------------------------------------------------------
+
+
+def test_a_write_route_cannot_be_made_into_a_tool(openapi_document, monkeypatch):
+    """Read-only is structural here, not a convention: point a tool at a
+    POST and the server refuses to build at all, rather than building a tool
+    that writes."""
+    monkeypatch.setattr(
+        mcp_tools, "READ_TOOLS", {"log_practice": "log_practice_api_scores__score_id__practice_post"}
+    )
+    with pytest.raises(mcp_tools.ToolMappingError) as raised:
+        mcp_tools.build_tools(openapi_document)
+    assert "read tools only" in str(raised.value)
+    assert "POST" in str(raised.value)
+
+
+def test_an_undeclared_argument_is_refused_by_name(openapi_document):
+    tools = {tool.name: tool for tool in mcp_tools.build_tools(openapi_document)}
+    with pytest.raises(ValueError) as raised:
+        mcp_tools.plan_request(tools["list_scores"], {"limit": 5})
+    assert "'limit'" in str(raised.value)
+
+
+def test_a_missing_required_argument_is_refused_by_name(openapi_document):
+    tools = {tool.name: tool for tool in mcp_tools.build_tools(openapi_document)}
+    with pytest.raises(ValueError) as raised:
+        mcp_tools.plan_request(tools["get_score"], {})
+    assert "'score_id'" in str(raised.value)
+
+
+def test_a_path_argument_cannot_walk_out_of_its_route(openapi_document):
+    """A tool call is always a request to the route the tool names. A path
+    value carrying slashes and dot segments is percent-encoded, so it stays
+    one path segment instead of steering the request somewhere else."""
+    tools = {tool.name: tool for tool in mcp_tools.build_tools(openapi_document)}
+    path, query = mcp_tools.plan_request(tools["get_score"], {"score_id": "1/../../api/export"})
+    assert path == "/api/scores/1%2F..%2F..%2Fapi%2Fexport"
+    assert query == {}
+
+
+def test_a_boolean_argument_is_spelled_the_way_the_route_reads_it(openapi_document):
+    tools = {tool.name: tool for tool in mcp_tools.build_tools(openapi_document)}
+    _, query = mcp_tools.plan_request(tools["list_scores"], {"favorite": True, "search": "etude"})
+    assert query == {"favorite": "true", "search": "etude"}
+
+
+# ---------------------------------------------------------------------------
+# 4. A generic client, over the real transport, against a real server.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def live_server(tmp_path_factory):
+    """One real Fermata with the feature on, shared by the tests below -
+    starting a process per test would triple the runtime of this file for no
+    extra claim."""
+    pytest.importorskip(
+        "mcp",
+        reason="the optional [mcp] extra is not installed (pip install -e '.[dev,mcp]')",
+    )
+    tmp_path = tmp_path_factory.mktemp("mcp_live")
+    api_port = _free_port()
+    mcp_port = _free_port()
+    proc = _spawn(
+        tmp_path, api_port,
+        {
+            FLAG: "1",
+            "FERMATA_MCP_PORT": str(mcp_port),
+            "FERMATA_MCP_API_URL": f"http://127.0.0.1:{api_port}",
+        },
+        seed_score=True,
+    )
+    if not _wait_until_serving(api_port):
+        pytest.fail("server never became healthy:\n" + _terminate(proc))
+    # The startup scan runs in the background; the equality assertions below
+    # are worth much more against a library with something in it.
+    deadline = time.monotonic() + 30
+    while time.monotonic() < deadline:
+        status, body = _get(api_port, "/api/scores")
+        if status == 200 and json.loads(body):
+            break
+        time.sleep(0.2)
+    try:
+        yield api_port, mcp_port
+    finally:
+        _terminate(proc)
+
+
+def _through_the_client(mcp_port: int, action):
+    """Connect a generic protocol client to the listener and run `action`
+    against it. `mcp.client.Client` is the protocol's own client library -
+    deliberately not a hand-rolled request, so what this proves is that the
+    server speaks the protocol rather than that it agrees with itself."""
+    from mcp.client import Client
+
+    async def run():
+        async with Client(f"http://127.0.0.1:{mcp_port}/mcp") as client:
+            return await action(client)
+
+    return asyncio.run(run())
+
+
+def _tool_json(result):
+    assert not result.is_error, result.content[0].text
+    return json.loads(result.content[0].text)
+
+
+def test_a_client_lists_exactly_the_generated_tools(live_server):
+    api_port, mcp_port = live_server
+
+    async def action(client):
+        return (await client.list_tools()).tools
+
+    tools = _through_the_client(mcp_port, action)
+    assert len(tools) == len(mcp_tools.READ_TOOLS), [tool.name for tool in tools]
+    assert {tool.name for tool in tools} == set(mcp_tools.READ_TOOLS)
+
+    # Every listed tool traces to an operation in the document the SAME
+    # server is serving - fetched over HTTP here rather than built in
+    # process, so the two halves really are the same document.
+    _, raw = _get(api_port, "/openapi.json")
+    served = {
+        operation["operationId"]
+        for item in json.loads(raw)["paths"].values()
+        for operation in item.values()
+        if isinstance(operation, dict) and operation.get("operationId")
+    }
+    for tool in tools:
+        trace = (tool.meta or {})["fermata"]
+        assert trace["operationId"] in served, tool.name
+        assert trace["operationId"] == mcp_tools.READ_TOOLS[tool.name]
+        assert trace["method"] == "GET"
+        assert tool.annotations.read_only_hint is True
+
+
+def test_the_library_tool_returns_the_same_json_as_the_route(live_server):
+    """The claim that this wraps the API rather than reimplementing it,
+    stated as an equality anyone can check: the tool's answer and the
+    route's answer, for the same parameters, are the same JSON."""
+    api_port, mcp_port = live_server
+
+    async def action(client):
+        return (
+            await client.call_tool("list_scores", {}),
+            await client.call_tool("list_scores", {"search": "dadgad"}),
+            await client.call_tool("list_scores", {"search": "nothing-matches-this"}),
+        )
+
+    everything, matching, empty = _through_the_client(mcp_port, action)
+
+    _, raw_all = _get(api_port, "/api/scores")
+    assert _tool_json(everything) == json.loads(raw_all)
+    assert json.loads(raw_all), "the seeded library was never scanned - the equality above is vacuous"
+
+    _, raw_search = _get(api_port, "/api/scores?search=dadgad")
+    assert _tool_json(matching) == json.loads(raw_search)
+    assert len(json.loads(raw_search)) == 1, "the search filter reached the route"
+
+    assert _tool_json(empty) == []
+
+
+def test_a_score_tool_reaches_its_path_parameter(live_server):
+    api_port, mcp_port = live_server
+    _, raw_all = _get(api_port, "/api/scores")
+    score_id = json.loads(raw_all)[0]["id"]
+
+    async def action(client):
+        return (
+            await client.call_tool("get_score", {"score_id": score_id}),
+            await client.call_tool("get_score_practice_progress", {"score_id": score_id}),
+        )
+
+    score, progress = _through_the_client(mcp_port, action)
+    _, raw_score = _get(api_port, f"/api/scores/{score_id}")
+    _, raw_progress = _get(api_port, f"/api/scores/{score_id}/practice/progress")
+    assert _tool_json(score) == json.loads(raw_score)
+    assert _tool_json(progress) == json.loads(raw_progress)
+
+
+def test_the_practice_tools_match_their_routes(live_server):
+    api_port, mcp_port = live_server
+
+    async def action(client):
+        return (
+            await client.call_tool("get_practice_summary", {}),
+            await client.call_tool("get_practice_history", {}),
+            await client.call_tool("list_goals", {}),
+            await client.call_tool("list_trainer_attempts", {}),
+        )
+
+    summary, history, goals, attempts = _through_the_client(mcp_port, action)
+    for result, path in (
+        (summary, "/api/practice/summary"),
+        (history, "/api/practice/history"),
+        (goals, "/api/practice/goals"),
+        (attempts, "/api/trainer/attempts"),
+    ):
+        _, raw = _get(api_port, path)
+        assert _tool_json(result) == json.loads(raw), path
+
+
+def test_a_write_route_is_neither_offered_nor_callable(live_server):
+    """No tool wraps a write route, and asking for one by the name it would
+    have had is refused rather than guessed at."""
+    _, mcp_port = live_server
+
+    async def action(client):
+        listed = (await client.list_tools()).tools
+        return listed, await client.call_tool("log_practice", {"score_id": 1, "seconds": 60})
+
+    tools, refused = _through_the_client(mcp_port, action)
+    assert "log_practice" not in {tool.name for tool in tools}
+    assert refused.is_error
+    assert "log_practice" in refused.content[0].text
+
+
+def test_an_argument_the_route_never_declared_is_refused_over_the_wire(live_server):
+    """The same refusal as the in-process test above, but reached through
+    the real transport - the guard is in the request path, not only in a
+    helper a test happens to call."""
+    _, mcp_port = live_server
+
+    async def action(client):
+        return await client.call_tool("list_scores", {"order_by": "title; drop table scores"})
+
+    result = _through_the_client(mcp_port, action)
+    assert result.is_error
+    assert "order_by" in result.content[0].text


### PR DESCRIPTION
Closes #31.

A companion server that speaks the Model Context Protocol - an open standard - offering **read-only** tools over Fermata's documented REST API. Off unless `FERMATA_MCP` is set; with the flag unset nothing listens, and nothing imports the protocol library at all.

## What it is

`server/fermata/mcp_tools.py` is the half with no protocol dependency: which routes are exposed, generated input schemas, and the URL a tool call turns into. `server/fermata/mcp_server.py` is the half that speaks the protocol and makes the request. Every tool is one documented `GET`, called over ordinary HTTP against `FERMATA_MCP_API_URL`, answering with that route's own JSON **unchanged** - nothing here opens the database or imports `fermata.api`.

Thirteen tools, exactly the first set the issue names: `list_scores`, `get_score`, `get_score_transcription`, `get_score_transcription_analysis`, `get_score_practice`, `get_score_practice_progress`, `list_practice_sessions`, `get_practice_summary`, `get_practice_history`, `list_goals`, `get_current_goal`, `list_trainer_attempts`, `list_trainer_chord_attempts`.

Every tool's description and `inputSchema` are generated from `app.openapi()` at startup, and each tool carries its OpenAPI operation id, method and path in `_meta.fermata`, so a client can trace a tool to the contract without this repository in front of it.

## Read-only, structurally

`check_tool_mapping` refuses to build a tool for anything but a `GET`, and `plan_request` refuses an argument the route did not declare and percent-encodes every path value. There is no code path that can send a `POST`.

## The guard the issue asks for

`READ_TOOLS` names the exposed operations; `NOT_EXPOSED` records every other readable `/api` route with the reason it is not a tool. A census test requires every `GET` in the document to be in one or the other, so **an added or renamed route fails by name** rather than silently leaving the tool layer behind.

## Three ways it refuses to start rather than half-work

Each is a `RuntimeError` carrying a sentence, routed through the lifespan's existing handler so the explanation prints above the traceback - the same convention as `ensure_dirs` and the reverse-proxy-auth checks:

- **`FERMATA_MCP` and `FERMATA_AUTH_HEADER` both set.** The tools read the API as an anonymous loopback client, so with reverse-proxy authentication on every tool would answer `401` while `tools/list` went on advertising thirteen working tools. Both workarounds are worse than the fault - trusting `127.0.0.1` does not even fix it (no identity header is sent) and lets anything on loopback forge the header, and having the internal client mint an identity header is the exact forgery `authproxy.py` exists to prevent - so the combination is refused and documented as unsupported this release.
- **The chosen port cannot be bound** (taken, or `FERMATA_MCP_HOST` naming an address the machine does not have).
- **The flag on without the `[mcp]` extra installed** - names the missing module and the install command instead of a bare `ModuleNotFoundError` traceback.

## Transport

Streamable HTTP on its own port (`8765` by default), served by its own `uvicorn` in a thread that starts and stops with the application - the smallest arrangement that satisfies both "nothing listens when off" and "an external client connects to the running container" without adding a process supervisor to a one-command image. Bound to `127.0.0.1` unless an operator deliberately moves it, and the documented compose example publishes it as `127.0.0.1:8765:8765`.

## Dependency, and what it costs

`mcp==2.1.1` plus `httpx`, as the optional `[mcp]` extra. Pinned exactly because this is the one dependency whose wire behaviour *is* the feature. The image installs the extra so turning the flag on there is an environment variable, not a rebuild.

Measured, building the same tree twice with and without the extra: the image goes **423 MB → 463 MB (+40 MB)**, of which the `pip install` layer alone is **166 MB → 196 MB (+30 MB)**. The tree pulls in `cryptography` (via `pyjwt[crypto]`), OpenTelemetry's API package, and a second HTTP client stack (`httpx2`) alongside the `httpx` already present. That is real weight for a feature that is off by default. `mcp` 1.x would avoid `cryptography` and OpenTelemetry; 2.x stays because it is the maintained line, and pinning it exactly means the version that ships is the version that was tested.

## Measured

Baseline on `origin/main` (`web/node_modules` absent, `FERMATA_TEST_LIBRARY` unset): **1 failed, 1195 passed, 92 skipped** - the failure is the pre-existing skip-counter defect (#217). With this branch: **1 failed, 1226 passed, 92 skipped** - the same failure, 31 new tests, no new skips. The 92 skips partition as 76 wanting `FERMATA_TEST_LIBRARY`, 11 wanting `web/node_modules` (alphaTab, for the importer check), and 5 wanting `FERMATA_MUSICXML_XSD` - counted by parsing the `SKIPPED [n]` multiplicities rather than the line count.

`app.openapi()` is untouched: **68 operations / 49 paths** without `web/dist`, **70 / 50** with it, identical with the flag on and off. Two live servers' served `/openapi.json` are compared byte for byte in a test; the same comparison across two container runs gave identical 153,549-byte documents.

Mutation checks, each performed and reverted:

| Mutation | Red |
| --- | --- |
| Flag gate removed from `main._start_mcp_server` | 1 - `test_nothing_listens_with_the_flag_off`, naming the port |
| One tool's mapping deleted from `READ_TOOLS` | 4 - the census names `GET /api/practice/summary` |
| The renamed-route check made not to raise | 1 - `test_renaming_a_route_fails_the_tool_check_naming_it` |
| The auth-plus-flag refusal deleted from the lifespan | 1 - `test_the_feature_and_reverse_proxy_auth_are_refused_together` |

`docker build` succeeds with the dependency on `python:3.12-slim`. A container run with the flag off is healthy with nothing on 8765, inside or outside; with the flag on, a generic client from the protocol's own client library listed 13 tools, every one traceable to an operation in the document that container serves, `list_scores` and `get_practice_summary` returned byte-equal JSON to the routes, and a write tool call was refused.

## Docs

A new "The Model Context Protocol server" section in `docs/deployment.md` (including why the two features are refused together, and why the compose example binds the port to loopback), a sentence in `SECURITY.md`'s scope section noting the listener is a second, separately unauthenticated surface that is off by default, and the existing paragraph in `docs/api.md` updated from planned to shipped. Nine other places across the codebase still described this server as "planned"; each is corrected. `README.md` untouched.
