### PR TITLE
Render every track of a multi-part score, not just the first (#93)

### DIFF
--- a/docs/rendering.md
+++ b/docs/rendering.md
@@ -623,8 +623,9 @@ according to nothing but enum order. It is **not** the transcription's
 bars whose instruction went out *without* a `<sound>`, this one about marks
 that arrived *with* one and were declined. A words-only instruction — the shape
 the extractor writes when it could not read the target off the page — is never
-seen here at all and is counted by neither cause. Measured on conftest score_af:
-`nav_marks_unresolved` 1, `skipped` 0.
+seen here at all and is counted by neither cause. Measured on one library
+score, score_af in the server test pins: `nav_marks_unresolved` 1,
+`skipped` 0.
 
 `data-score-jumps-unread` exists because an empty `data-score-jumps` would
 otherwise mean two different things. `.mxl` — a MusicXML score inside a ZIP —

--- a/web/src/lib/score-render.js
+++ b/web/src/lib/score-render.js
@@ -14,6 +14,20 @@ import { barAtTick } from "./metronome.js";
 /** Which staves a score is drawn with. */
 export const SCORE_PROFILES = ["score", "tab", "scoretab"];
 
+// alphaTab's own "render every track" sentinel (issue #93). AlphaTabApiBase's
+// renderScore() special-cases a track-index array of exactly one element
+// equal to -1 as "all tracks in the score" (see its bundled source); any
+// falsy or empty list instead falls back to `[score.tracks[0]]`. `api.load()`
+// forwards its own track-index argument straight into that same renderScore()
+// call, with no translation - so a load call that wants every track drawn has
+// to pass this literal array, not `undefined` and not a real index list built
+// from a track count nothing has parsed yet. `api.tex()` on the concrete
+// browser AlphaTabApi additionally accepts the string `"all"` and turns it
+// into this same array itself; the two spellings are used at their matching
+// call sites below only for that reason, not because they mean anything
+// different.
+const ALL_TRACKS = [-1];
+
 const STAVE_PROFILE = {
   score: alphaTab.StaveProfile.Score,
   tab: alphaTab.StaveProfile.Tab,
@@ -1497,11 +1511,16 @@ function jumpDirectionFor(kind, words, bar, targets, codaRouteIsSafe) {
  */
 function beatsInBarCreationOrder(score, barIndex) {
   const out = [];
-  // The first track only. A `<part>` becomes a track, and the importer parses
-  // each part's measures to the end before starting the next - so the words
-  // held from a direction in the first part's measure are always consumed by a
-  // beat in the first part. Marks are indexed against the first part's
-  // measures (see musicXmlMeasures), so that is the track to look in.
+  // The first track only, DELIBERATELY - not "whichever tracks are rendered"
+  // (issue #93 made that every track, not just this one). A `<part>` becomes
+  // a track, and the importer parses each part's measures to the end before
+  // starting the next - so the words held from a direction in the first
+  // part's measure are always consumed by a beat in the first part.
+  // musicXmlMeasures() and navigationMarks() index marks against the
+  // document's first `<part>` element specifically, by reading the raw XML
+  // directly rather than anything alphaTab decided to draw - so this is the
+  // one track whose identity that indexing already assumes, regardless of how
+  // many tracks the renderer is now asked to show.
   for (const staff of score.tracks?.[0]?.staves ?? []) {
     for (const voice of staff.bars?.[barIndex]?.voices ?? []) {
       for (const beat of voice.beats ?? []) out.push(beat);
@@ -2002,6 +2021,18 @@ export function createScoreView(host, opts = {}) {
   // for beat. One part, one staff is this profile's scope (Rule 17); a second
   // staff or track would need an axis this walk does not name, exactly as
   // Rule 17's own uniqueness note says of its id formula.
+  //
+  // Still `tracks[0]` on purpose after issue #93, which made every OTHER
+  // load()/tex() call in this file render every track: this editor seam is
+  // reachable only from ScoreCompare.svelte's `editable` prop, fed
+  // `transcription.content` - Fermata's own tabextract output - and
+  // server/fermata/musicxml.py's emitter hard-codes that output to a single
+  // `<part>` (issue #93's own Occurrence note). So `tracks[0]` is not just
+  // "the first of several" here, it is currently the only track that exists
+  // for anything this function is ever called on. A multi-track document
+  // reaching the editor would need the axis Rule 17 already says this id
+  // formula does not name - that is the track-selector work the issue calls
+  // out of scope, not a gap this comment is papering over.
   function buildNoteOrdinals() {
     noteOrdinals = new Map();
     notesInOrder = [];
@@ -2781,6 +2812,18 @@ export function createScoreView(host, opts = {}) {
         delete host.dataset.scoreTabWithheld;
       }
     }
+    // Already track-aware, and needs no change for issue #93: `api.tracks`
+    // (plural) is alphaTab's own account of every track the CURRENT render
+    // request resolved to, not `tracks[0]` - and load()/tex() now always ask
+    // for ALL_TRACKS, so once a score has actually loaded this is every track
+    // the document has, not just the first. The `loadedScore.tracks` fallback
+    // is for the one moment `api.tracks` cannot be trusted instead: alphaTab
+    // sets its internal `_tracks` field to the resolved list BEFORE firing
+    // scoreLoaded (see AlphaTabApiBase._internalRenderTracks in the bundled
+    // source), so in practice `api.tracks` is already correct by the time
+    // this handler runs - this is a belt-and-braces read of the score's own
+    // tracks for a future alphaTab release that reordered that sequence, not
+    // evidence of a real gap today.
     scoreProfiles = supportedProfiles(api.tracks?.length ? api.tracks : loadedScore.tracks);
     unrenderable = scoreProfiles.length === 0;
     if (!unrenderable && !scoreProfiles.includes(profile)) {
@@ -2969,12 +3012,18 @@ export function createScoreView(host, opts = {}) {
     pendingSourceText = null;
     pendingUnreadReason = null;
     if (next.kind === "alphatex") {
-      api.tex(next.text);
+      // "all", not the default first-track-only render (issue #93) - an
+      // alphaTeX document can declare more than one `\track`, and every one
+      // of them should draw, the same as a multi-part MusicXML file.
+      api.tex(next.text, "all");
     } else if (next.kind === "musicxml") {
       // Goes through the same byte loader a library file uses: the format is
       // detected from the content, so there is no separate entry point.
       pendingSourceText = next.text;
-      api.load(new TextEncoder().encode(next.text));
+      // ALL_TRACKS (issue #93): a MusicXML file with more than one <part>
+      // becomes more than one track here, and every one of them should draw -
+      // api.load()'s own default, with no track list, renders only the first.
+      api.load(new TextEncoder().encode(next.text), ALL_TRACKS);
     } else if (next.kind === "file") {
       fetch(next.url)
         .then((r) => r.arrayBuffer())
@@ -2989,7 +3038,10 @@ export function createScoreView(host, opts = {}) {
           const document = await readMusicXml(bytes);
           pendingSourceText = document.text;
           pendingUnreadReason = document.unread;
-          api.load(bytes);
+          // ALL_TRACKS (issue #93): same reasoning as the musicxml branch
+          // above - this is the path a library file (of any track count) and
+          // a directly uploaded MusicXML/.mxl/Guitar Pro file both take.
+          api.load(bytes, ALL_TRACKS);
         })
         .catch((e) => onError(String(e)));
     }
@@ -3208,7 +3260,17 @@ export function createScoreView(host, opts = {}) {
       pendingSourceText = text;
       pendingUnreadReason = null;
       try {
-        api.load(new TextEncoder().encode(text));
+        // ALL_TRACKS (issue #93), for consistency with every other load()
+        // call in this file. The editor only ever reaches this path for
+        // Fermata's own transcription output (ScoreCompare.svelte's
+        // `editable` prop is fed `transcription.content`), which
+        // server/fermata/musicxml.py's emitter hard-codes to a single part
+        // today - so this is currently a no-op change, not a fix - but a
+        // reload that silently dropped back to track 0 the moment that
+        // emitter grew a second part would be a second, easy-to-miss version
+        // of the same bug, and there is no reason for this call to be the one
+        // load() site in the file that still defaults.
+        api.load(new TextEncoder().encode(text), ALL_TRACKS);
       } catch (e) {
         pendingEditResolve = null;
         reject(e instanceof Error ? e : new Error(String(e)));

--- a/web/src/lib/score-render.js
+++ b/web/src/lib/score-render.js
@@ -1573,8 +1573,8 @@ function clearLateBeatText(score, mark) {
  * A words-only instruction - the shape the extractor writes when it could not
  * read the target off the page - carries no `<sound>` at all, is therefore
  * never seen by this function, and is counted by neither branch above.
- * Measured on Phantom Train: `nav_marks_unresolved` 1 (its words-only To
- * Coda), `skipped` 0.
+ * Measured on one library score, score_af in the server test pins:
+ * `nav_marks_unresolved` 1 (its words-only To Coda), `skipped` 0.
  *
  * Targets go on first, all of them, before any jump is decided: a Fine only
  * exists on the model because this function puts it there, and a "D.C. al

--- a/web/src/lib/score-render.js
+++ b/web/src/lib/score-render.js
@@ -183,15 +183,20 @@ function canDraw(track, staff, profileKey) {
  *
  * EVERY track renders now, not just the first (issue #93: load()/tex() ask
  * for ALL_TRACKS, and this function is handed `api.tracks` - see its call
- * site - which is that same resolved, now-plural list). So the OR above is
- * exercised across tracks as well as across one track's staves: a two-part
- * document where each part supports a different single profile (see
- * web/test-fixtures/multi-part.musicxml and score-multi-part.spec.js) has to
- * offer both, the same way multi-staff.musicxml's two staves do within one
- * track. Before that fix, a second track was never part of the pairs this
- * function saw at all - only the first track rendered by default - so that
- * cross-track case could not have exercised this OR no matter how the
- * fixture was built.
+ * site - which is that same resolved, now-plural list). So a second track's
+ * staves are among the pairs this function ORs across, where before that fix
+ * they never were - only the first track rendered by default, so a second
+ * track could not have reached this OR no matter how a fixture was built.
+ * web/test-fixtures/multi-part.musicxml (two parts, both plain notation
+ * staves) and score-multi-part.spec.js prove exactly that much: every track
+ * is now among the pairs, and both are rendered. They do NOT exercise the
+ * cross-track OR itself - both parts support the same profiles, so
+ * `data-score-profiles` reads identically whether the second part is present
+ * or dropped ("score,scoretab" either way) - that is a claim this comment is
+ * not making. No fixture in this repo yet has two tracks that each support a
+ * different single profile; multi-staff.musicxml remains the only fixture
+ * that exercises the OR itself, and it does so within one track's staves,
+ * not across tracks.
  */
 export function supportedProfiles(tracks) {
   // The whole body is inside the try, not just the canDraw loop: a malformed
@@ -2044,7 +2049,7 @@ export function createScoreView(host, opts = {}) {
   // walks track 0 only, so only notes in the first part are selectable or
   // editable at all; clicking a note drawn in a second part has nothing here
   // to find it. That is a pre-existing gap this fix does not close - tracked
-  // as its own issue rather than folded into #93's track-aware-editor-is-out-
+  // as issue #226, rather than folded into #93's track-aware-editor-is-out-
   // of-scope decision.
   function buildNoteOrdinals() {
     noteOrdinals = new Map();
@@ -3285,8 +3290,8 @@ export function createScoreView(host, opts = {}) {
         // drawing only the first part after an edit, on a document that drew
         // every part before it. buildNoteOrdinals() above still only builds
         // ordinals for track 0, so a second part's notes render but are not
-        // selectable - a pre-existing gap, tracked as its own issue, that
-        // this call is not attempting to close.
+        // selectable - a pre-existing gap, tracked as issue #226, that this
+        // call is not attempting to close.
         api.load(new TextEncoder().encode(text), ALL_TRACKS);
       } catch (e) {
         pendingEditResolve = null;

--- a/web/src/lib/score-render.js
+++ b/web/src/lib/score-render.js
@@ -175,13 +175,23 @@ function canDraw(track, staff, profileKey) {
  * pair in the rendered set fails a profile's check - the renderer loops over
  * all of them building one staff system - so a profile is supported the
  * moment any single pair can draw it: this ORs canDraw across every pair, it
- * does not decide from one staff. A score with two staves in the one track
- * that gets rendered - one notation-only, one tab-only - still has to offer
- * both "score" and "tab", each justified by only one of the two staves; see
+ * does not decide from one staff. A score with two staves in one track -
+ * one notation-only, one tab-only - still has to offer both "score" and
+ * "tab", each justified by only one of the two staves; see
  * multi-staff.musicxml in web/test-fixtures for a fixture built to reach
- * exactly this (deliberately one track, not two - only the first track
- * renders by default, so a second track would never be part of the pairs
- * this function is given at all, and would not exercise the OR here).
+ * exactly this within a single track's staves.
+ *
+ * EVERY track renders now, not just the first (issue #93: load()/tex() ask
+ * for ALL_TRACKS, and this function is handed `api.tracks` - see its call
+ * site - which is that same resolved, now-plural list). So the OR above is
+ * exercised across tracks as well as across one track's staves: a two-part
+ * document where each part supports a different single profile (see
+ * web/test-fixtures/multi-part.musicxml and score-multi-part.spec.js) has to
+ * offer both, the same way multi-staff.musicxml's two staves do within one
+ * track. Before that fix, a second track was never part of the pairs this
+ * function saw at all - only the first track rendered by default - so that
+ * cross-track case could not have exercised this OR no matter how the
+ * fixture was built.
  */
 export function supportedProfiles(tracks) {
   // The whole body is inside the try, not just the canDraw loop: a malformed
@@ -2015,24 +2025,27 @@ export function createScoreView(host, opts = {}) {
   // redraw the way an editor step needs to before re-reading bounds.
   let pendingEditResolve = null;
 
-  // Walk the one rendered track's model in document order - bar, then each
-  // voice in turn, then each beat, then each chord member - skipping rests, so
-  // the ordinal assigned here matches document.js's sounding-note order beat
-  // for beat. One part, one staff is this profile's scope (Rule 17); a second
-  // staff or track would need an axis this walk does not name, exactly as
-  // Rule 17's own uniqueness note says of its id formula.
+  // Walk track 0's model in document order - bar, then each voice in turn,
+  // then each beat, then each chord member - skipping rests, so the ordinal
+  // assigned here matches document.js's sounding-note order beat for beat.
+  // One part, one staff is this profile's scope (Rule 17); a second staff or
+  // track would need an axis this walk does not name, exactly as Rule 17's
+  // own uniqueness note says of its id formula.
   //
-  // Still `tracks[0]` on purpose after issue #93, which made every OTHER
-  // load()/tex() call in this file render every track: this editor seam is
-  // reachable only from ScoreCompare.svelte's `editable` prop, fed
-  // `transcription.content` - Fermata's own tabextract output - and
-  // server/fermata/musicxml.py's emitter hard-codes that output to a single
-  // `<part>` (issue #93's own Occurrence note). So `tracks[0]` is not just
-  // "the first of several" here, it is currently the only track that exists
-  // for anything this function is ever called on. A multi-track document
-  // reaching the editor would need the axis Rule 17 already says this id
-  // formula does not name - that is the track-selector work the issue calls
-  // out of scope, not a gap this comment is papering over.
+  // NOT limited to single-part documents by anything upstream - issue #93's
+  // fix made load()/reloadScore() render every track, and the editor has no
+  // gate of its own that keeps a multi-part document out: ScoreCompare.svelte
+  // passes `editable` on a free-text textarea whose save PUTs arbitrary
+  // content, TabViewer.svelte's canEditNotes() checks only `format ===
+  // "musicxml"`, and the server's XSD validation is a no-op unless
+  // FERMATA_MUSICXML_XSD is configured. So a hand-pasted two-part document
+  // reaching this editor is a real, reachable case, not a hypothetical one -
+  // it renders every part (the view is fixed), but this ordinal map still
+  // walks track 0 only, so only notes in the first part are selectable or
+  // editable at all; clicking a note drawn in a second part has nothing here
+  // to find it. That is a pre-existing gap this fix does not close - tracked
+  // as its own issue rather than folded into #93's track-aware-editor-is-out-
+  // of-scope decision.
   function buildNoteOrdinals() {
     noteOrdinals = new Map();
     notesInOrder = [];
@@ -3261,15 +3274,19 @@ export function createScoreView(host, opts = {}) {
       pendingUnreadReason = null;
       try {
         // ALL_TRACKS (issue #93), for consistency with every other load()
-        // call in this file. The editor only ever reaches this path for
-        // Fermata's own transcription output (ScoreCompare.svelte's
-        // `editable` prop is fed `transcription.content`), which
-        // server/fermata/musicxml.py's emitter hard-codes to a single part
-        // today - so this is currently a no-op change, not a fix - but a
-        // reload that silently dropped back to track 0 the moment that
-        // emitter grew a second part would be a second, easy-to-miss version
-        // of the same bug, and there is no reason for this call to be the one
-        // load() site in the file that still defaults.
+        // call in this file - and not a no-op here either. Nothing gates a
+        // multi-part document out of this editor: ScoreCompare.svelte's
+        // `editable` prop sits on a free-text textarea whose save PUTs
+        // arbitrary content, and TabViewer.svelte's canEditNotes() checks
+        // only `format === "musicxml"`, with the server's XSD validation a
+        // no-op unless FERMATA_MUSICXML_XSD is configured - so a hand-pasted
+        // two-part document reaching this reload is real, not hypothetical.
+        // Without ALL_TRACKS here, that reload would silently drop back to
+        // drawing only the first part after an edit, on a document that drew
+        // every part before it. buildNoteOrdinals() above still only builds
+        // ordinals for track 0, so a second part's notes render but are not
+        // selectable - a pre-existing gap, tracked as its own issue, that
+        // this call is not attempting to close.
         api.load(new TextEncoder().encode(text), ALL_TRACKS);
       } catch (e) {
         pendingEditResolve = null;

--- a/web/test-fixtures/multi-part.musicxml
+++ b/web/test-fixtures/multi-part.musicxml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.musicxml.org/xsd/musicxml.xsd">
+  <work>
+    <work-title>Two-part render fixture</work-title>
+  </work>
+  <identification>
+    <encoding>
+      <software>Fermata test fixture</software>
+      <encoding-date>2026-09-03</encoding-date>
+    </encoding>
+  </identification>
+  <!-- Two separate <part>s (not two staves of one part, as
+       multi-staff.musicxml uses) - this is the shape that becomes two
+       alphaTab tracks, one per <score-part>, which is what issue #93 is
+       about: renderScore()'s default of tracks[0] only draws the first. -->
+  <part-list>
+    <score-part id="P1">
+      <part-name>Upper Part</part-name>
+    </score-part>
+    <score-part id="P2">
+      <part-name>Lower Part</part-name>
+    </score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>1</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <note><pitch><step>C</step><octave>5</octave></pitch><duration>1</duration><voice>1</voice><type>quarter</type></note>
+      <note><pitch><step>D</step><octave>5</octave></pitch><duration>1</duration><voice>1</voice><type>quarter</type></note>
+      <note><pitch><step>E</step><octave>5</octave></pitch><duration>1</duration><voice>1</voice><type>quarter</type></note>
+      <note><pitch><step>F</step><octave>5</octave></pitch><duration>1</duration><voice>1</voice><type>quarter</type></note>
+    </measure>
+    <measure number="2">
+      <note><pitch><step>G</step><octave>5</octave></pitch><duration>1</duration><voice>1</voice><type>quarter</type></note>
+      <note><pitch><step>A</step><octave>5</octave></pitch><duration>1</duration><voice>1</voice><type>quarter</type></note>
+      <note><pitch><step>B</step><octave>5</octave></pitch><duration>1</duration><voice>1</voice><type>quarter</type></note>
+      <note><pitch><step>C</step><octave>6</octave></pitch><duration>1</duration><voice>1</voice><type>quarter</type></note>
+    </measure>
+    <measure number="3">
+      <note><pitch><step>C</step><octave>5</octave></pitch><duration>4</duration><voice>1</voice><type>whole</type></note>
+    </measure>
+  </part>
+  <part id="P2">
+    <measure number="1">
+      <attributes>
+        <divisions>1</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>F</sign><line>4</line></clef>
+      </attributes>
+      <note><pitch><step>C</step><octave>3</octave></pitch><duration>1</duration><voice>1</voice><type>quarter</type></note>
+      <note><pitch><step>B</step><octave>2</octave></pitch><duration>1</duration><voice>1</voice><type>quarter</type></note>
+      <note><pitch><step>A</step><octave>2</octave></pitch><duration>1</duration><voice>1</voice><type>quarter</type></note>
+      <note><pitch><step>G</step><octave>2</octave></pitch><duration>1</duration><voice>1</voice><type>quarter</type></note>
+    </measure>
+    <measure number="2">
+      <note><pitch><step>F</step><octave>2</octave></pitch><duration>1</duration><voice>1</voice><type>quarter</type></note>
+      <note><pitch><step>E</step><octave>2</octave></pitch><duration>1</duration><voice>1</voice><type>quarter</type></note>
+      <note><pitch><step>D</step><octave>2</octave></pitch><duration>1</duration><voice>1</voice><type>quarter</type></note>
+      <note><pitch><step>C</step><octave>2</octave></pitch><duration>1</duration><voice>1</voice><type>quarter</type></note>
+    </measure>
+    <measure number="3">
+      <note><pitch><step>C</step><octave>3</octave></pitch><duration>4</duration><voice>1</voice><type>whole</type></note>
+    </measure>
+  </part>
+</score-partwise>

--- a/web/tests/browser/fixtures/multi-part-score.js
+++ b/web/tests/browser/fixtures/multi-part-score.js
@@ -1,0 +1,57 @@
+// Fixture data + route stub for tests/browser/score-multi-part.spec.js
+// (issue #93).
+//
+// The fixture itself lives at web/test-fixtures/multi-part.musicxml and is
+// read here, byte for byte, rather than inlined - the same reasoning
+// fixtures/navigation-score.js gives for reading its own committed
+// transcription off disk: a hand-written copy in two places would only prove
+// this file and the fixture agree with themselves, not that the real
+// document renders correctly. It is a real MusicXML document through the
+// real importer, for the same reason every other fixture in this directory
+// is: what issue #93 is about (whether a second <part> reaches the renderer
+// at all) is not something a stub of TabViewer's internals could ever answer.
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const WEB_ROOT = path.join(here, "..", "..", "..");
+
+/**
+ * Two <part>s - P1 "Upper Part" (treble, three bars), P2 "Lower Part" (bass,
+ * three bars) - which is what becomes two alphaTab tracks, not two staves of
+ * one track (contrast web/test-fixtures/multi-staff.musicxml, which is one
+ * <part> with <staves>2</staves> and is not this bug: that file's second
+ * staff already drew before this issue, because supportedProfiles() and the
+ * renderer both walk every STAFF of the one track that was ever rendered.
+ * Issue #93 is specifically that only the first TRACK renders, and a
+ * multi-staff single-part file never exercises that).
+ */
+export const MULTI_PART_MUSICXML = fs.readFileSync(path.join(WEB_ROOT, "test-fixtures", "multi-part.musicxml"), "utf-8");
+
+function scoreMeta(id, title) {
+  // file_type not "pdf" routes Viewer.svelte to TabViewer directly, the same
+  // choice fixtures/navigation-score.js's own scoreMeta() makes.
+  return {
+    id,
+    title,
+    composer: "",
+    source: "",
+    file_type: "musicxml",
+    has_transcription: false,
+    favorite: false,
+    content_kind: "notation",
+    tags: [],
+  };
+}
+
+/** Score id 30: the two-part fixture above. */
+export async function stubMultiPartScore(page) {
+  await page.route(`**/api/scores/30`, (route) => route.fulfill({ json: scoreMeta(30, "Two-part fixture") }));
+  await page.route(`**/api/scores/30/file`, (route) =>
+    route.fulfill({ body: MULTI_PART_MUSICXML, contentType: "application/vnd.recordare.musicxml+xml" }),
+  );
+  await page.route(`**/api/scores/30/practice`, (route) =>
+    route.fulfill({ json: { total_seconds: 0, sessions: [] } }),
+  );
+}

--- a/web/tests/browser/score-multi-part.spec.js
+++ b/web/tests/browser/score-multi-part.spec.js
@@ -79,19 +79,27 @@ test.describe("a multi-part score draws every part, not just the first", () => {
     // a dozen digit/accidental-adjacent glyphs from four notes per bar) and
     // 30 with both, so ">10" already passes against the unfixed page -
     // measured directly, not assumed. What a second STAFF adds that a longer
-    // label never could is a second row of five staff lines, drawn as a
-    // distinct group of `<rect>`s at a `y` no first staff system ever uses -
-    // rendering one track always draws exactly one such group (5 distinct y
-    // values, one per staff line), so a second group is unambiguous proof a
-    // second staff was laid out, not merely that more text happened to print.
+    // label never could is a second row of five staff lines: this fixture
+    // (web/test-fixtures/multi-part.musicxml, two parts) draws 5 distinct
+    // staff-line rows with only track 0 rendered and 10 with both - a second
+    // group is unambiguous proof a second staff was laid out, not merely
+    // that more text happened to print. (Not a claim about every fixture:
+    // multi-staff.musicxml - one part, two STAVES - draws 11 rows by itself,
+    // for reasons that have nothing to do with this bug.)
     await stubMultiPartScore(page);
     await openScore(page, 30);
     const staffLineRowCount = await page.evaluate(() => {
-      // Staff lines are the thin horizontal rects alphaTab draws in its own
-      // muted staff-line colour; anything taller (a beam, an eighth-note
-      // flag stroke) shares that same fill but is thicker, so height alone
-      // separates a staff line from everything else painted with it.
-      const lines = [...document.querySelectorAll('.at-host svg rect[fill="#B3A284"]')].filter(
+      // Staff lines are the thin horizontal rects alphaTab draws - not by
+      // colour, which is a per-theme setting (score-render.js's
+      // THEME_TOKENS) and must not be hardcoded here: staff_theme is a
+      // server-side setting shared by the whole suite, so a spec that ran
+      // earlier and left it on something other than the default would make a
+      // colour-specific selector match zero elements for the wrong reason
+      // entirely. Height is what actually separates a staff line from
+      // everything else alphaTab paints at a comparable size (a beam or an
+      // eighth-note flag stroke is taller), and height does not change with
+      // theme.
+      const lines = [...document.querySelectorAll(".at-host svg rect")].filter(
         (r) => Number(r.getAttribute("height")) < 1.3,
       );
       return new Set(lines.map((r) => Number(r.getAttribute("y")).toFixed(1))).size;

--- a/web/tests/browser/score-multi-part.spec.js
+++ b/web/tests/browser/score-multi-part.spec.js
@@ -18,14 +18,33 @@ import { expect, test } from "@playwright/test";
 import { stubMultiPartScore } from "./fixtures/multi-part-score.js";
 
 const host = (page) => page.locator(".at-host");
+const playButton = (page) => page.locator(".player button.primary");
 
+// Mirrors navigation.spec.js's openScore(): data-score-render-ok reads "true"
+// in two states that drew nothing at all - before the very first render ever
+// runs, and when a render request was silently dropped at width 0 or deferred
+// by font loading (see web/test-fixtures/tab-profile-selection.md, "A score
+// that draws nothing") - so it is not on its own proof that anything is on
+// screen yet. Waiting for the play button to become enabled as well is what
+// the rest of this suite uses to mean "a real render actually finished."
 async function openScore(page, id) {
   await page.goto(`/#/score/${id}`);
+  await expect(playButton(page)).toBeEnabled({ timeout: 30_000 });
   await expect(host(page)).toHaveAttribute("data-score-render-ok", "true", { timeout: 30_000 });
 }
 
+// Trimmed and NBSP-normalized: alphaTab pads some drawn text (bar numbers
+// render as "1  ", for instance) with trailing whitespace, and writes a
+// multi-word track name with a U+00A0 NON-BREAKING space between the words
+// (measured directly - a plain ASCII space would not survive this) rather
+// than an ordinary one, almost certainly to stop its own line-wrapping
+// splitting a track name across two lines. Neither has anything to do with a
+// string's identity for this spec's purposes, so both are normalized away
+// here rather than baked into the two literals this file compares against.
 async function drawnText(page) {
-  return await page.evaluate(() => [...document.querySelectorAll(".at-host svg text")].map((t) => t.textContent));
+  return await page.evaluate(() =>
+    [...document.querySelectorAll(".at-host svg text")].map((t) => t.textContent.replace(/ /g, " ").trim()),
+  );
 }
 
 test.describe("a multi-part score draws every part, not just the first", () => {

--- a/web/tests/browser/score-multi-part.spec.js
+++ b/web/tests/browser/score-multi-part.spec.js
@@ -1,0 +1,67 @@
+// Issue #93: only the first part of a multi-part score is drawn.
+//
+// WHAT IS ASSERTED, AND WHY. score-render.js's load() calls hand alphaTab a
+// byte buffer with no track list, and AlphaTabApiBase.renderScore() falls
+// back to `[score.tracks[0]]` whenever the track-index argument is falsy or
+// empty (confirmed by reading the bundled renderScore() source in
+// node_modules/@coderline/alphatab/dist/alphaTab.js - see score-render.js's
+// own ALL_TRACKS comment). A two-part MusicXML document becomes two alphaTab
+// tracks, one per <part>; on unfixed main only the first part's name reaches
+// the drawn SVG's text nodes at all - the second part is imported into the
+// score model (the importer never drops it) but never handed to the
+// renderer, so there is nothing on screen naming it, positioning it, or
+// letting a person play it. Asserting the drawn SVG's own text content -
+// rather than something read off the score model - is deliberate: a fix that
+// parsed both parts correctly but still only rendered one would pass any
+// assertion made against the model and fail only this one.
+import { expect, test } from "@playwright/test";
+import { stubMultiPartScore } from "./fixtures/multi-part-score.js";
+
+const host = (page) => page.locator(".at-host");
+
+async function openScore(page, id) {
+  await page.goto(`/#/score/${id}`);
+  await expect(host(page)).toHaveAttribute("data-score-render-ok", "true", { timeout: 30_000 });
+}
+
+async function drawnText(page) {
+  return await page.evaluate(() => [...document.querySelectorAll(".at-host svg text")].map((t) => t.textContent));
+}
+
+test.describe("a multi-part score draws every part, not just the first", () => {
+  test("both part names reach the rendered SVG", async ({ page }) => {
+    const consoleErrors = [];
+    page.on("console", (m) => {
+      if (m.type() === "error") consoleErrors.push(m.text());
+    });
+    page.on("pageerror", (e) => consoleErrors.push(String(e)));
+
+    await stubMultiPartScore(page);
+    await openScore(page, 30);
+
+    const drawn = await drawnText(page);
+    // Pre-fix (renderScore()'s default, tracks[0] only): drawn contains
+    // "Upper Part" and NOT "Lower Part" - this is the exact issue #93
+    // repro, reproduced against this fixture below before the fix (see the
+    // PR description's mutation record). Post-fix: both are present, because
+    // load() now asks alphaTab for ALL_TRACKS rather than accepting its
+    // first-track-only default.
+    expect(drawn).toContain("Upper Part");
+    expect(drawn).toContain("Lower Part");
+    expect(consoleErrors).toEqual([]);
+  });
+
+  test("the second part's own notation actually draws, not just its label", async ({ page }) => {
+    // The label alone does not prove the STAFF drew - alphaTab prints a
+    // track's name once per staff system regardless of whether the staff
+    // beneath it holds any glyphs. Both parts here are pitched, non-percussion
+    // treble/bass staves with four notes per bar for three bars, so a
+    // genuinely rendered second track draws real glyph volume, not just a
+    // name. Measured on a fixed page: comfortably more than a bare label and
+    // an empty staff would ever produce.
+    await stubMultiPartScore(page);
+    await openScore(page, 30);
+    const glyphCount = await page.evaluate(() => document.querySelectorAll(".at-host svg text").length);
+    expect(glyphCount).toBeGreaterThan(10);
+  });
+});

--- a/web/tests/browser/score-multi-part.spec.js
+++ b/web/tests/browser/score-multi-part.spec.js
@@ -70,17 +70,34 @@ test.describe("a multi-part score draws every part, not just the first", () => {
     expect(consoleErrors).toEqual([]);
   });
 
-  test("the second part's own notation actually draws, not just its label", async ({ page }) => {
+  test("the second part's own staff actually draws, not just its label", async ({ page }) => {
     // The label alone does not prove the STAFF drew - alphaTab prints a
     // track's name once per staff system regardless of whether the staff
-    // beneath it holds any glyphs. Both parts here are pitched, non-percussion
-    // treble/bass staves with four notes per bar for three bars, so a
-    // genuinely rendered second track draws real glyph volume, not just a
-    // name. Measured on a fixed page: comfortably more than a bare label and
-    // an empty staff would ever produce.
+    // beneath it holds any glyphs. A bare glyph-count threshold does not
+    // discriminate here either: this fixture draws 17 SVG text nodes with
+    // only the first part rendered (title, three bar numbers, one track name,
+    // a dozen digit/accidental-adjacent glyphs from four notes per bar) and
+    // 30 with both, so ">10" already passes against the unfixed page -
+    // measured directly, not assumed. What a second STAFF adds that a longer
+    // label never could is a second row of five staff lines, drawn as a
+    // distinct group of `<rect>`s at a `y` no first staff system ever uses -
+    // rendering one track always draws exactly one such group (5 distinct y
+    // values, one per staff line), so a second group is unambiguous proof a
+    // second staff was laid out, not merely that more text happened to print.
     await stubMultiPartScore(page);
     await openScore(page, 30);
-    const glyphCount = await page.evaluate(() => document.querySelectorAll(".at-host svg text").length);
-    expect(glyphCount).toBeGreaterThan(10);
+    const staffLineRowCount = await page.evaluate(() => {
+      // Staff lines are the thin horizontal rects alphaTab draws in its own
+      // muted staff-line colour; anything taller (a beam, an eighth-note
+      // flag stroke) shares that same fill but is thicker, so height alone
+      // separates a staff line from everything else painted with it.
+      const lines = [...document.querySelectorAll('.at-host svg rect[fill="#B3A284"]')].filter(
+        (r) => Number(r.getAttribute("height")) < 1.3,
+      );
+      return new Set(lines.map((r) => Number(r.getAttribute("y")).toFixed(1))).size;
+    });
+    // Pre-fix (tracks[0] only): exactly 5 - one staff, one system. Post-fix:
+    // 10 - two staves, one per part, five lines each.
+    expect(staffLineRowCount).toBe(10);
   });
 });

--- a/web/tests/browser/toolbar-responsive.spec.js
+++ b/web/tests/browser/toolbar-responsive.spec.js
@@ -254,6 +254,16 @@ test.describe("every toolbar control is reachable by an actual click, not merely
       await tap(page, ladderStart, "ladder start");
       await ladderStart.fill("70");
       await expect(ladderStart).toHaveValue("70");
+
+      // Restore the theme picker's own selection before finishing: staff_theme
+      // is a server-side setting (server/fermata/api.py), shared by the whole
+      // suite rather than scoped to this test or even this file - leaving it
+      // on "noir" here leaked into whatever spec happened to run next and read
+      // the rendered staff colour (measured: score-multi-part.spec.js's
+      // staff-line count reading 0 instead of 10 when it ran after this one).
+      await tap(page, themePicker, "theme picker");
+      await themePicker.selectOption("parchment");
+      await expect(themePicker).toHaveValue("parchment");
     });
   }
 });

--- a/web/tests/spec-floors/browser-score-multi-part-93.json
+++ b/web/tests/spec-floors/browser-score-multi-part-93.json
@@ -1,0 +1,5 @@
+{
+  "file": "tests/browser/score-multi-part.spec.js",
+  "count": 2,
+  "reason": "issue #93: a two-part MusicXML document draws only its first part's name/notation on unfixed main - alphaTab's renderScore() falls back to tracks[0] when load() is given no track list - and both parts must reach the drawn SVG once load()/tex() ask for ALL_TRACKS instead."
+}


### PR DESCRIPTION
## Summary

- `score-render.js`'s three `api.load(bytes)` sites and one `api.tex(...)` site left alphaTab's track list unset, so `AlphaTabApiBase.renderScore()` fell back to `tracks[0]` whenever a MusicXML file (or alphaTeX document) carried more than one part/track. The second part was already in the imported score model; it just never reached the renderer.
- Pass alphaTab's own "render every track" sentinel (`[-1]`, or `"all"` on the browser `tex()` override - confirmed by reading the bundled `renderScore()` source) at all four `load()`/`tex()` call sites, including the note editor's `reloadScore()` path, for consistency.
- Revisited the two remaining `tracks[0]` reads and the `supportedProfiles()` track derivation per the issue's own scope:
  - `beatsInBarCreationOrder()` (navigation-mark indexing): still `tracks[0]` on purpose - marks are indexed against the document's first `<part>` element by reading the raw XML directly, independent of which tracks the renderer draws.
  - `buildNoteOrdinals()` (note editor hit-test) and `reloadScore()`: still `tracks[0]` for the ordinal map. Nothing gates a multi-part document out of the editor - `ScoreCompare.svelte`'s `editable` prop sits on a free-text textarea whose save PUTs arbitrary content, `TabViewer.svelte`'s `canEditNotes()` checks only `format === "musicxml"`, and the server's XSD validation is a no-op unless `FERMATA_MUSICXML_XSD` is configured - so a hand-pasted two-part document reaching the editor is real, not hypothetical. It now renders every part (this fix reaches `reloadScore()` too), but only track 0's notes are selectable/editable; a second part's notes render with nothing to find them on click. That gap is pre-existing and out of scope for this PR - tracked as issue #226; the comments at both sites now say this plainly instead of the incorrect "editor only ever sees Fermata's own single-part transcriptions" claim an earlier revision of this branch made.
  - `supportedProfiles()`: its own docstring previously said a second track "would never be part of the pairs this function is given" - that predates this fix and is now false, since `api.tracks` (its actual input at the call site) is every rendered track. Rewritten to state that every track is now among the pairs this function ORs across - and to stop overclaiming what the new fixture proves: `multi-part.musicxml`'s two parts are both plain notation staves, so `data-score-profiles` reads the same ("score,scoretab") whether the second part is present or dropped. It proves every track renders, not that the cross-track OR itself is exercised - no fixture in the repo yet has two tracks that each support a different single profile; `multi-staff.musicxml` remains the only fixture that exercises the OR itself, and it does so within one track's staves, not across tracks.
- Removed one copyrighted work title from a `score-render.js` doc comment (a "Measured on <title>: ..." note citing where a count came from) and its twin in `docs/rendering.md`, replacing both with a neutral reference to the anonymized server test fixture the measurement came from, keeping the measured counts unchanged.

## New test

- `web/test-fixtures/multi-part.musicxml`: a synthetic two-part fixture ("Upper Part" / "Lower Part", three bars each, neutral title).
- `web/tests/browser/score-multi-part.spec.js`: asserts both part names reach the rendered SVG, and that the second part's own STAFF actually draws - a distinct second row of five staff-line rects, counted by height (theme-independent) rather than fill colour, since `staff_theme` is a server-side setting shared by the whole suite and an earlier revision of this test hardcoded the parchment theme's staff-line colour, which broke when a prior spec left the suite on `noir`. Not just a longer glyph count, which does not discriminate here (see the test's own comment: 17 SVG text nodes with only the first part rendered, 30 with both, so a bare `>10` threshold passes against the unfixed page too).
- `web/tests/browser/toolbar-responsive.spec.js`: its reachability test sets the theme picker to `noir` and, until this revision, never restored it - a suite-wide leak (`staff_theme` is persisted server-side) that made `score-multi-part.spec.js`'s staff-line count depend on run order. Now restores the picker to `parchment` at the end of that test.
- `web/tests/spec-floors/browser-score-multi-part-93.json`: raises the spec-floor guard by the 2 tests added (this repo replaced the `MINIMUM_TESTS` constant with a per-file spec-floor directory before this change; there is no `MINIMUM_TESTS` left to raise).

## Test plan

- [x] Re-derived the premise on current main (`d43c3f1`) against the new fixture: only "Upper Part" reached the rendered SVG text, "Lower Part" was absent - matches the issue.
- [x] `web/tests/browser/score-multi-part.spec.js` red on main (mutation check: reverted just the `score-render.js` fix, rebuilt, reran) - both new tests failed, one naming the missing part (`Lower Part`) exactly and the other reporting 5 staff-line rows instead of 10; both green again after restoring the fix.
- [x] Re-ran with the suite's theme forced to `noir` before `score-multi-part.spec.js`: both tests still pass (the staff-line count no longer depends on the theme's colour). Ran `toolbar-responsive.spec.js` immediately before `score-multi-part.spec.js` in one invocation: green - the theme-leak that made this order-dependent is fixed on both sides.
- [x] Full browser+unit suite, rebuilt each time: 561 tests before this PR's changes; 563 after (561 + 2 new), all 563 passing.
- [x] `score-editor*.spec.js` (all seven, including `score-editor-fuzz-189.spec.js`) and `navigation.spec.js`: green in every full-suite run - single-part behaviour unchanged.
