### PR TITLE
Transcribe a freshly scanned library automatically

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -206,6 +206,16 @@ complete, already-committed rows behind - nothing half-written - so
 scores already done come back `already_transcribed` and the rest are
 attempted for the first time.
 
+**A freshly scanned library transcribes itself (issue #190).** The last scan
+of a chain - including the one `POST /api/upload` triggers - starts this
+same background pass on its own, over exactly the scores that chain added.
+A bulk pass already running by hand is never interrupted for this: the
+scan's own attempt is simply skipped, recorded in `GET /api/scan/status`'s
+`transcribe_batch_started` and `transcribe_batch_note`, never queued or
+retried. `GET /api/scores` accepts `transcribed=yes` or `transcribed=no` to
+narrow the library to scores with a transcription (extracted or hand-edited
+- undistinguished here) or its exact complement.
+
 ## Getting everything in and out (issue #58)
 
 Two endpoints, one archive format, and one rule that holds for both directions:

--- a/server/fermata/api.py
+++ b/server/fermata/api.py
@@ -128,6 +128,13 @@ Count = Annotated[StrictInt, Field()]
 
 VALID_KINDS = {"notation", "tab", "both", "unknown"}
 VALID_PRACTICED = {"recent", "neglected"}
+# GET /api/scores' `transcribed` filter (#190): "yes" narrows to scores with
+# a transcription (extracted or hand-edited, and the filter draws no
+# distinction between those two - see the No-gos on #190), "no" to its exact
+# complement. Anything a scan judged non-extractable has no transcription
+# and so falls under "no", which is what makes the filter double as "show me
+# what a scan could not read".
+VALID_TRANSCRIBED = {"yes", "no"}
 
 # A user setting, not a per-score one - kept server-side (not browser storage)
 # so it follows a person between devices. Defaults are what a fresh install
@@ -531,12 +538,16 @@ def list_scores(
     tag: str = "",
     favorite: bool = False,
     practiced: str = "",
+    transcribed: str = "",
 ):
     """The library, filtered and searched. `search` matches title, composer,
     source or series; `practiced` is 'recent' (practised in the last 14 days)
     or 'neglected' (present on disk, and either never practised or not
     practised in 30 days) - see the query's own comments for why those two
-    views disagree about a score whose file has gone missing.
+    views disagree about a score whose file has gone missing. `transcribed`
+    is 'yes' (has a transcription, extracted or hand-edited - this filter
+    draws no distinction between the two) or 'no' (its exact complement,
+    which is also every score a scan judged non-extractable) (#190).
 
     A DELETED SCORE IS NEVER HERE, under any filter - it is in GET /api/trash
     until it is restored or destroyed. A score whose FILE has gone missing is a
@@ -545,6 +556,8 @@ def list_scores(
     thrown it away."""
     if practiced and practiced not in VALID_PRACTICED:
         raise HTTPException(422, f"practiced must be one of {sorted(VALID_PRACTICED)}")
+    if transcribed and transcribed not in VALID_TRANSCRIBED:
+        raise HTTPException(422, f"transcribed must be one of {sorted(VALID_TRANSCRIBED)}")
     conn = connect()
     sql = "SELECT DISTINCT s.* FROM scores s"
     # A deleted score is not in the library, and no filter brings it back here -
@@ -567,6 +580,10 @@ def list_scores(
     if kind:
         where.append("s.content_kind = ?")
         params.append(kind)
+    if transcribed == "yes":
+        where.append("EXISTS (SELECT 1 FROM transcriptions t WHERE t.score_id = s.id)")
+    elif transcribed == "no":
+        where.append("NOT EXISTS (SELECT 1 FROM transcriptions t WHERE t.score_id = s.id)")
     if favorite:
         where.append("s.favorite = 1")
     # Windowed on the practice DAY, not on the UTC timestamp. These two views
@@ -2323,6 +2340,19 @@ def _batch_process_one(score_id: int, reconvert: bool) -> dict:
         "score_id": score_id, "title": title, "outcome": "transcribed", "reason": None,
         "bars_defective": stored.get("bars_defective"), "bars_measured": stored.get("bars_measured"),
     }
+
+
+# A freshly scanned library should not sit with zero transcriptions until
+# somebody clicks a bulk pass by hand (#190) - so the scan itself starts one,
+# over exactly the scores it added, once its own chain of passes finishes
+# (scanner._finish_scan_chain). scanner.py cannot call `_batch_process_one`
+# directly - it would have to import this module to reach it, and this
+# module already imports scanner.py, which is the circular import
+# transcribe_batch.py's own module comment already argues against one layer
+# up. Registering it here, right after its definition, is the seam instead:
+# scanner.py depends on nothing above it, and this is the one place that
+# hands it something to call.
+scanner.register_transcribe_hook(_batch_process_one)
 
 
 class TranscribeBatchIn(BaseModel):

--- a/server/fermata/api_models.py
+++ b/server/fermata/api_models.py
@@ -813,6 +813,13 @@ class ScanStatusOut(BaseModel):
     last_error: str | None
     started_at: float | None
     finished_at: float | None
+    # Whether the bulk transcription pass this scan's own chain tried to
+    # start (over the ids it added) actually started - None until a chain
+    # that added at least one score finishes (#190). False means a bulk pass
+    # was already running by somebody's own hand; `transcribe_batch_note`
+    # says which, in words a person can read.
+    transcribe_batch_started: bool | None
+    transcribe_batch_note: str | None
 
 
 class ScanTriggerOut(ScanStatusOut):

--- a/server/fermata/scanner.py
+++ b/server/fermata/scanner.py
@@ -57,8 +57,9 @@ _state = {
     # tried to start over the ids it added - see _finish_scan_chain. None at
     # the start of every pass (_scan() resets both keys unconditionally,
     # chained or not - see its own reset block) and set only once, by
-    # _decide_and_settle_chain, when the chain's LAST pass finishes - so a
-    # pass still mid-chain, or one that added nothing at all, reads as None
+    # _finish_scan_chain itself, when the chain's LAST pass finishes and
+    # _decide_and_settle_chain has handed it that pass's ids - so a pass
+    # still mid-chain, or one that added nothing at all, reads as None
     # rather than carrying over whatever an earlier, unrelated chain left
     # here (#190).
     "transcribe_batch_started": None,
@@ -862,6 +863,14 @@ def start_scan(acknowledge: str | None = None, _continuing_chain: bool = False) 
     own tests use for determinism - never goes through this reset either,
     which is correct: those ids were never claimed by a chain this function
     tracks, so a later, real start_scan() must not inherit them.
+
+    NOTE for the continuing case: this function is NOT how a scan's own
+    chain actually continues any more (#190 review, second pass - see
+    _decide_and_settle_chain's own comment for why a separate call here,
+    even with `_continuing_chain=True`, was itself still a gap). It is kept
+    reachable with that flag only because tests exercise it directly; real
+    continuations go through `_begin_scan_locked` instead, inside the same
+    lock that decided to continue.
     """
     global _rescan_pending
     with _state_lock:
@@ -876,12 +885,33 @@ def start_scan(acknowledge: str | None = None, _continuing_chain: bool = False) 
             # having looked for it.
             _rescan_pending = True
             return False
-        _state["scanning"] = True
-        _state["started_at"] = time.time()
-        _state["finished_at"] = None
-        if not _continuing_chain:
-            global _chain_added_ids
-            _chain_added_ids = []
+        _begin_scan_locked(_continuing_chain)
+    _spawn_scan_thread(acknowledge)
+    return True
+
+
+def _begin_scan_locked(_continuing_chain: bool) -> None:
+    """The part of starting a scan that must happen while `_state_lock` is
+    already held (#190 review, F2 second pass): flip `scanning` on and,
+    unless this is a chain's own continuation, reset `_chain_added_ids` for
+    the fresh chain that's beginning. Called from start_scan() (which holds
+    the lock itself) and from _decide_and_settle_chain's continuing branch
+    (which holds it for exactly this reason - see that function's comment).
+    """
+    global _chain_added_ids
+    _state["scanning"] = True
+    _state["started_at"] = time.time()
+    _state["finished_at"] = None
+    if not _continuing_chain:
+        _chain_added_ids = []
+
+
+def _spawn_scan_thread(acknowledge: str | None) -> None:
+    """The background thread every scan pass runs in, whether started by
+    start_scan() or by a chain continuing itself directly. Factored out so
+    _decide_and_settle_chain can spawn a continuation's thread without
+    going back through start_scan()'s own lock acquisition (#190 review,
+    F2 second pass)."""
 
     def run():
         try:
@@ -893,36 +923,45 @@ def start_scan(acknowledge: str | None = None, _continuing_chain: bool = False) 
         _decide_and_settle_chain()
 
     threading.Thread(target=run, name="fermata-scan", daemon=True).start()
-    return True
 
 
 def _decide_and_settle_chain() -> None:
-    """Clear `scanning` and decide the chain's fate in the SAME lock
-    acquisition (#190 review, F2) - not, as an earlier version of this had
-    it, one after the other with the lock released in between.
+    """Decide the chain's fate - continue with another pass, or end and hand
+    off to _finish_scan_chain - and, if it continues, hand `scanning` and
+    `_chain_added_ids` straight to that continuation, all in ONE lock
+    acquisition (#190 review, two rounds).
 
-    THE GAP THAT USED TO BE HERE. `scanning` used to clear (and the lock
-    release) BEFORE anything asked whether the chain continues or ends.
-    start_scan()'s own guard only checks `scanning` (and `_mutating`), so an
-    ordinary POST /api/scan or /api/upload landing in exactly that gap saw
-    nothing running, was entitled to proceed, and reset `_chain_added_ids` to
-    start ITS OWN fresh chain (see start_scan's own docstring on
-    `_continuing_chain`) - taking the ids this finishing chain was about to
-    hand to transcribe_batch with it. Nothing about the arriving scan was
-    wrong. What was wrong is that this function, running microseconds later,
-    found an empty list where the chain's real ids had been - indistinguishable
-    from a chain that genuinely added nothing - so
-    transcribe_batch_started/note stayed None and the scores that chain added
-    were silently never transcribed, with no record that anything had gone
-    missing.
+    THE GAP THIS CLOSES, FIRST ROUND. `scanning` used to clear (and the lock
+    release) BEFORE anything asked whether the chain continues or ends. An
+    ordinary POST /api/scan or /api/upload landing in that gap reset
+    `_chain_added_ids` to start ITS OWN fresh chain, taking the ids THIS
+    chain was about to hand to transcribe_batch with it (see the ENDING
+    branch below, which closes this by deciding under the lock).
 
-    Closed by deciding under the SAME lock that clears `scanning`: whether
-    this chain continues (another pass was declined against it,
-    `_rescan_pending`) or ends (nothing was declined; `_chain_added_ids` is
-    pulled out here, atomically, for `_finish_scan_chain` to hand off once
-    the lock is released) is settled before `scanning` becomes visible to
-    anybody as False. A start_scan() arriving after this returns is starting
-    a genuinely new chain, not stealing the tail of this one.
+    THE GAP THIS CLOSES, SECOND ROUND - and this is the one the first fix
+    left open. The ENDING branch decided everything it needed under the
+    lock, but the CONTINUING branch did not: it left `ids = None`,
+    `_chain_added_ids` untouched, and called `start_scan(_continuing_chain=
+    True)` - a SEPARATE function, with its OWN SEPARATE lock acquisition -
+    only AFTER this function's own lock had already released `scanning`
+    back to False. Anything landing in THAT gap (an ordinary start_scan(),
+    or a move/delete taking `_mutating` via hold_library_still and later
+    running _run_pending_rescan's plain start_scan() from its finally) saw
+    a genuinely idle scanner, was entitled to proceed, and reset
+    `_chain_added_ids` before the real continuation ever got there -
+    measured: a chain that added {1, 2} handed transcribe_batch only [2].
+    Worse than the first gap's silence: a pass still started, over a
+    subset, and transcribe_batch_started/note reported that smaller count
+    as though it were the whole chain's.
+
+    Closed the same way as the first gap, extended to cover the
+    continuation too: when this chain continues, `_begin_scan_locked` runs
+    right here, inside this SAME lock - `scanning` never becomes visible as
+    False, and `_chain_added_ids` is never reset, between one pass ending
+    and the next one of the SAME chain beginning. A start_scan() or a
+    mutation arriving after this function returns is starting or applying
+    against a genuinely settled scanner, never stealing the tail of a
+    chain still mid-flight.
     """
     global _rescan_pending, _chain_added_ids
     with _state_lock:
@@ -931,31 +970,54 @@ def _decide_and_settle_chain() -> None:
             _rescan_pending = False
             continuing = True
             ids = None
+            # The continuation itself, right here, under the same lock that
+            # just decided to continue - see the docstring above for why a
+            # separate start_scan() call, even after this lock released,
+            # was still the gap.
+            _begin_scan_locked(_continuing_chain=True)
         else:
             continuing = False
             ids = _chain_added_ids
             _chain_added_ids = []
-        _state["scanning"] = False
+            _state["scanning"] = False
+    # A no-op in production - see its own docstring. The one moment a test
+    # can inject something deterministically to prove nothing can land in
+    # a gap that, by design, no longer exists for anything else to use.
+    _after_chain_decided(continuing)
     if continuing:
-        # Plain start_scan(), never the acknowledge token a refused scan
-        # might have been holding: that token is consent to one specific,
-        # named set of missing files, and replaying it against whatever the
-        # library looks like now would apply a person's "yes" to evidence
-        # they never saw. _continuing_chain=True: this pass belongs to the
-        # SAME chain as the one that just declined to start it.
-        start_scan(_continuing_chain=True)
+        # No acknowledge token carried forward - see start_scan's own
+        # docstring for why a continuation never replays one.
+        _spawn_scan_thread(acknowledge=None)
     else:
         _finish_scan_chain(ids)
+
+
+def _after_chain_decided(continuing: bool) -> None:
+    """A no-op in production, always. The fix above (#190 review, F2
+    second pass) closes the continuing branch's gap by making `scanning`
+    and `_chain_added_ids` never externally observable in an inconsistent
+    state between one pass ending and the next one of the same chain
+    beginning - which is exactly why there is no other seam left for a
+    test to inject at and prove that. This one exists purely so a test can
+    try landing something HERE, right after `_decide_and_settle_chain`'s
+    own lock has genuinely released, and show it lands on a scanner that
+    is already fully settled (an ended chain) or already fully reclaimed
+    (a continuing one) either way - never on one still mid-transition."""
 
 
 def _run_pending_rescan() -> bool:
     """Start exactly one follow-up scan if something was declined while a
     MUTATION held the library - see `_rescan_pending` and
-    hold_library_still's own finally, the one remaining caller. A scan's own
-    chain no longer uses this (see _decide_and_settle_chain): mutations never
-    touch `_chain_added_ids`, so there is no ids-race here to close the way
-    there was one for a scan's own chain - `_mutating` and `_state["scanning"]`
-    are never both true, so no chain can be mid-flight when this fires.
+    hold_library_still's own finally, the one remaining caller. A scan's
+    own chain no longer uses this (see _decide_and_settle_chain) - and,
+    since that function now hands a continuing chain its `scanning` state
+    and `_chain_added_ids` directly, under one lock, `_mutating` and
+    `_state["scanning"]` genuinely are never both true here: a mutation
+    cannot begin while a chain is mid-flight (hold_library_still's own
+    guard refuses it, and `scanning` stays visibly True for the chain's
+    entire lifetime now, continuations included), so there is no
+    accumulated-ids state for this call to disturb - mutations never touch
+    `_chain_added_ids` in the first place.
 
     Plain start_scan(), never the acknowledge token a refused scan might have
     been holding: that token is consent to one specific, named set of missing

--- a/server/fermata/scanner.py
+++ b/server/fermata/scanner.py
@@ -82,6 +82,24 @@ _state_lock = threading.Lock()
 # acquisition used to leave open (#190 review, F2).
 _chain_added_ids: list[int] = []
 
+# Bumped exactly once per genuinely NEW chain - inside _begin_scan_locked,
+# whenever it is NOT a continuation - never for a chain continuing itself.
+# What this is for: _finish_scan_chain calls transcribe_batch.start_batch
+# OUTSIDE any lock (deliberately - see its own docstring, and the existing
+# test built to land a scan in exactly this window), so a plain start_scan()
+# can be accepted, run its own _scan() pass, and reset
+# transcribe_batch_started/note to None for ITSELF before this chain gets
+# back around to writing ITS OWN result. Without a way to notice that,
+# _finish_scan_chain's write would land last and clobber the newer chain's
+# fresh None with THIS chain's now-stale numbers - measured (#190 review,
+# F2-1): a chain B that added nothing had its own status read "started
+# transcribing 1", chain A's own count. _decide_and_settle_chain captures
+# this alongside `ids`, under the same lock; _finish_scan_chain checks it
+# again immediately before writing and simply does not write if a newer
+# chain has since been accepted - that newer chain will report its own
+# result, accurately, when it finishes.
+_scan_generation = 0
+
 # Where a deleted score's file goes, as a folder name directly under the library
 # root (#56). Inside the library rather than beside it, deliberately: the library
 # folder is very often a mount or an external drive, and a trash kept anywhere
@@ -844,7 +862,7 @@ def _scan_file(conn, path, rel: str, seen_paths: set, disk_paths: set) -> None:
     conn.commit()
 
 
-def start_scan(acknowledge: str | None = None, _continuing_chain: bool = False) -> bool:
+def start_scan(acknowledge: str | None = None) -> bool:
     """Begin a scan in the background. `acknowledge` is a token from a refusal.
 
     An acknowledgement stands down the guard for exactly the evidence the token
@@ -853,24 +871,22 @@ def start_scan(acknowledge: str | None = None, _continuing_chain: bool = False) 
     simply does not apply, and the scan refuses again with the new figures,
     which is the safe way for stale consent to fail.
 
-    `_continuing_chain` is for `_decide_and_settle_chain` alone, when a
-    scan's own chain has another pass coming - every OTHER caller (POST
-    /scan, POST /upload, POST /scan/acknowledge, the startup scan, and
-    `_run_pending_rescan` on hold_library_still's behalf) is starting a
-    fresh chain and must not carry forward whatever a previous, unrelated
-    chain left in `_chain_added_ids` (#190). A test that calls `_scan()`
-    directly, bypassing this function entirely - the pattern this module's
-    own tests use for determinism - never goes through this reset either,
-    which is correct: those ids were never claimed by a chain this function
-    tracks, so a later, real start_scan() must not inherit them.
-
-    NOTE for the continuing case: this function is NOT how a scan's own
-    chain actually continues any more (#190 review, second pass - see
-    _decide_and_settle_chain's own comment for why a separate call here,
-    even with `_continuing_chain=True`, was itself still a gap). It is kept
-    reachable with that flag only because tests exercise it directly; real
-    continuations go through `_begin_scan_locked` instead, inside the same
-    lock that decided to continue.
+    Always a genuinely NEW chain - this function is never how a scan's own
+    chain continues itself (#190 review, second pass): a continuation goes
+    through `_begin_scan_locked` directly, from inside
+    `_decide_and_settle_chain`'s own lock, which is the only place with a
+    `_continuing_chain=True` case to hand it. Every caller here (POST /scan,
+    POST /upload, POST /scan/acknowledge, the startup scan, and
+    `_run_pending_rescan` on hold_library_still's behalf) must not carry
+    forward whatever a previous, unrelated chain left in `_chain_added_ids`
+    (#190) - a test that calls `_scan()` directly, bypassing this function
+    entirely (the pattern this module's own tests use for determinism),
+    never goes through this reset either, which is correct: those ids were
+    never claimed by a chain this function tracks, so a later, real
+    start_scan() must not inherit them. (An earlier version of this took a
+    `_continuing_chain` parameter kept reachable "for tests"; nothing ever
+    called it that way, so it was dead weight - removed rather than kept as
+    an unused door back into a state this function no longer produces.)
     """
     global _rescan_pending
     with _state_lock:
@@ -885,7 +901,7 @@ def start_scan(acknowledge: str | None = None, _continuing_chain: bool = False) 
             # having looked for it.
             _rescan_pending = True
             return False
-        _begin_scan_locked(_continuing_chain)
+        _begin_scan_locked(_continuing_chain=False)
     _spawn_scan_thread(acknowledge)
     return True
 
@@ -894,16 +910,20 @@ def _begin_scan_locked(_continuing_chain: bool) -> None:
     """The part of starting a scan that must happen while `_state_lock` is
     already held (#190 review, F2 second pass): flip `scanning` on and,
     unless this is a chain's own continuation, reset `_chain_added_ids` for
-    the fresh chain that's beginning. Called from start_scan() (which holds
-    the lock itself) and from _decide_and_settle_chain's continuing branch
+    the fresh chain that's beginning and bump `_scan_generation` (#190
+    review, F2-1) - the moment a genuinely NEW chain is accepted, which
+    `_finish_scan_chain` uses afterwards to notice a still-in-flight OLDER
+    chain's write has gone stale. Called from start_scan() (which holds the
+    lock itself) and from _decide_and_settle_chain's continuing branch
     (which holds it for exactly this reason - see that function's comment).
     """
-    global _chain_added_ids
+    global _chain_added_ids, _scan_generation
     _state["scanning"] = True
     _state["started_at"] = time.time()
     _state["finished_at"] = None
     if not _continuing_chain:
         _chain_added_ids = []
+        _scan_generation += 1
 
 
 def _spawn_scan_thread(acknowledge: str | None) -> None:
@@ -970,6 +990,7 @@ def _decide_and_settle_chain() -> None:
             _rescan_pending = False
             continuing = True
             ids = None
+            generation = None
             # The continuation itself, right here, under the same lock that
             # just decided to continue - see the docstring above for why a
             # separate start_scan() call, even after this lock released,
@@ -978,6 +999,18 @@ def _decide_and_settle_chain() -> None:
         else:
             continuing = False
             ids = _chain_added_ids
+            # Captured under this SAME lock, alongside `ids` - the
+            # generation THIS chain belongs to, for _finish_scan_chain to
+            # check again once it is about to write (#190 review, F2-1).
+            # See `_scan_generation`'s own comment for the write race this
+            # closes: transcribe_batch.start_batch runs outside any lock,
+            # deliberately, so a newer chain can be accepted and reset
+            # transcribe_batch_started/note for itself before this chain's
+            # own write lands - checking the generation again right before
+            # that write is what lets it notice and skip, rather than
+            # clobbering the newer chain's fresh None with its own now-
+            # stale numbers.
+            generation = _scan_generation
             _chain_added_ids = []
             _state["scanning"] = False
     # A no-op in production - see its own docstring. The one moment a test
@@ -989,7 +1022,7 @@ def _decide_and_settle_chain() -> None:
         # docstring for why a continuation never replays one.
         _spawn_scan_thread(acknowledge=None)
     else:
-        _finish_scan_chain(ids)
+        _finish_scan_chain(ids, generation)
 
 
 def _after_chain_decided(continuing: bool) -> None:
@@ -1058,7 +1091,7 @@ def register_transcribe_hook(process_one) -> None:
     _transcribe_process_one = process_one
 
 
-def _finish_scan_chain(ids: list[int]) -> None:
+def _finish_scan_chain(ids: list[int], generation: int) -> None:
     """Start ONE bulk transcription pass over every id any pass of this
     scan's chain added, now that the chain's last pass has finished - never
     once per pass (#190). A freshly scanned library should not sit with zero
@@ -1072,6 +1105,8 @@ def _finish_scan_chain(ids: list[int]) -> None:
     atomically with clearing `scanning`, or a scan landing in the gap
     between the two can reset the list before this function ever sees it -
     see _decide_and_settle_chain, the only caller, for the full argument.
+    `generation` is the same idea applied to transcribe_batch_started/note
+    (#190 review, F2-1) - see `_scan_generation`'s own comment.
 
     Does nothing if the chain added nothing - nothing new to transcribe - or
     if nobody has registered a hook (see register_transcribe_hook: a test
@@ -1083,11 +1118,35 @@ def _finish_scan_chain(ids: list[int]) -> None:
     #190: no queue), so it is not retried or queued, only recorded into this
     scan's own status in words. A scan runs unattended on every boot, which
     is the one place nobody is watching transcribe_batch's own status for it.
+
+    DELIBERATELY NOT HELD UNDER `_state_lock` for the `start_batch` call
+    itself - the same "one thing settles the chain, everything else may
+    proceed" reasoning `_decide_and_settle_chain` already applies to
+    `scanning`. That is exactly what leaves a window between capturing
+    `ids`/`generation` and this function's own write: a plain start_scan()
+    can be accepted, and its own `_scan()` pass can reset
+    transcribe_batch_started/note to None for ITSELF, before this call gets
+    back around to writing. The write below checks `_scan_generation` again,
+    immediately before writing, specifically to notice that and skip rather
+    than clobber - see `_before_finish_writes_status`, the seam a test uses
+    to land exactly there.
     """
     if not ids or _transcribe_process_one is None:
         return
     started = transcribe_batch.start_batch(_transcribe_process_one, ids)
+    # A no-op in production - see the docstring above. The one moment a test
+    # can inject a newer chain being accepted, to prove this chain's own
+    # write below does not clobber it.
+    _before_finish_writes_status(ids)
     with _state_lock:
+        if _scan_generation != generation:
+            # A newer chain has already been accepted since this chain's
+            # ids were captured - it has its own fresh None waiting for its
+            # own result, and writing this chain's numbers over it would
+            # misattribute them to a scan that has not decided anything yet
+            # (#190 review, F2-1). That newer chain reports its own result,
+            # accurately, when it finishes.
+            return
         _state["transcribe_batch_started"] = started
         _state["transcribe_batch_note"] = (
             f"started transcribing {len(ids)} newly scanned score(s) in the background"
@@ -1096,3 +1155,11 @@ def _finish_scan_chain(ids: list[int]) -> None:
             "transcription pass was already running - start one by hand from the "
             "library view to pick them up"
         )
+
+
+def _before_finish_writes_status(ids: list[int]) -> None:
+    """A no-op in production, always. The one seam between
+    transcribe_batch.start_batch returning and _finish_scan_chain writing
+    transcribe_batch_started/note that a test can inject a newer chain being
+    accepted at, deterministically, to prove the generation check just below
+    it actually stops the stale write (#190 review, F2-1)."""

--- a/server/fermata/scanner.py
+++ b/server/fermata/scanner.py
@@ -5,6 +5,7 @@ import time
 from contextlib import contextmanager
 from pathlib import Path
 
+from . import transcribe_batch
 from .config import FILE_TYPES, LIBRARY_DIR
 from .db import DEFAULT_OWNER, connect
 from .metadata import musicxml_info, parse_path
@@ -52,8 +53,25 @@ _state = {
     "last_error": None,
     "started_at": None,
     "finished_at": None,
+    # What happened to the bulk transcription pass this scan's OWN chain
+    # tried to start over the ids it added - see _finish_scan_chain. None
+    # until a chain that added at least one score finishes; a scan that adds
+    # nothing has nothing to say here, so it stays whatever the previous
+    # chain left (#190).
+    "transcribe_batch_started": None,
+    "transcribe_batch_note": None,
 }
 _state_lock = threading.Lock()
+
+# Ids `scores` rows this SCAN gained, across every pass of the chain a
+# refused-then-acknowledged or upload-stacked rescan builds (see
+# _run_pending_rescan) - handed to transcribe_batch.start_batch exactly once,
+# by _finish_scan_chain, when the chain's last pass finishes rather than
+# once per pass (#190: a chained rescan must start ONE bulk pass over the
+# union of ids the whole chain added, not one per scan). Lives outside
+# `_state` because `_state` is reset at the top of every _scan() call
+# (including a chained one) and this has to survive exactly that reset.
+_chain_added_ids: list[int] = []
 
 # Where a deleted score's file goes, as a folder name directly under the library
 # root (#56). Inside the library rather than beside it, deliberately: the library
@@ -464,6 +482,8 @@ def _scan(acknowledge: str | None = None) -> None:
             acknowledge_token=None,
             errors=0,
             last_error=None,
+            transcribe_batch_started=None,
+            transcribe_batch_note=None,
         )
 
     # Checked here as well as at startup, and not only for tidiness: the library
@@ -784,7 +804,7 @@ def _scan_file(conn, path, rel: str, seen_paths: set, disk_paths: set) -> None:
             with _state_lock:
                 _state["updated"] += 1
         else:
-            conn.execute(
+            cur = conn.execute(
                 """INSERT INTO scores
                    (title, composer, collection, series, source, path,
                     file_type, content_kind, pages, hash, size, mtime)
@@ -806,10 +826,16 @@ def _scan_file(conn, path, rel: str, seen_paths: set, disk_paths: set) -> None:
             )
             with _state_lock:
                 _state["added"] += 1
+                # Only a genuinely NEW row - never the relink branch above,
+                # which is counted as an update because it is one (see its
+                # own comment) - is a score a bulk transcription pass has
+                # never seen before (#190). `cur.lastrowid` is sqlite's id
+                # for the row this exact INSERT just created.
+                _chain_added_ids.append(cur.lastrowid)
     conn.commit()
 
 
-def start_scan(acknowledge: str | None = None) -> bool:
+def start_scan(acknowledge: str | None = None, _continuing_chain: bool = False) -> bool:
     """Begin a scan in the background. `acknowledge` is a token from a refusal.
 
     An acknowledgement stands down the guard for exactly the evidence the token
@@ -817,6 +843,15 @@ def start_scan(acknowledge: str | None = None) -> bool:
     matches (the library changed again while somebody was reading the message)
     simply does not apply, and the scan refuses again with the new figures,
     which is the safe way for stale consent to fail.
+
+    `_continuing_chain` is for `_run_pending_rescan` alone - every OTHER
+    caller (POST /scan, POST /upload, POST /scan/acknowledge, the startup
+    scan) is starting a fresh chain and must not carry forward whatever a
+    previous, unrelated chain left in `_chain_added_ids` (#190). A test that
+    calls `_scan()` directly, bypassing this function entirely - the pattern
+    this module's own tests use for determinism - never goes through this
+    reset either, which is correct: those ids were never claimed by a chain
+    this function tracks, so a later, real start_scan() must not inherit them.
     """
     global _rescan_pending
     with _state_lock:
@@ -834,6 +869,9 @@ def start_scan(acknowledge: str | None = None) -> bool:
         _state["scanning"] = True
         _state["started_at"] = time.time()
         _state["finished_at"] = None
+        if not _continuing_chain:
+            global _chain_added_ids
+            _chain_added_ids = []
 
     def run():
         try:
@@ -846,15 +884,25 @@ def start_scan(acknowledge: str | None = None) -> bool:
             with _state_lock:
                 _state["scanning"] = False
                 _state["finished_at"] = time.time()
-        _run_pending_rescan()
+        # The chain continues (another pass was just started, or a mutation
+        # is holding the library and will resume it) or it does not - and
+        # only when it does not is this scan actually the LAST one, which is
+        # the one moment _finish_scan_chain is allowed to act (#190). Calling
+        # it after every pass would start a bulk transcription pass per scan
+        # in a chain instead of one for the whole chain.
+        if not _run_pending_rescan():
+            _finish_scan_chain()
 
     threading.Thread(target=run, name="fermata-scan", daemon=True).start()
     return True
 
 
-def _run_pending_rescan() -> None:
+def _run_pending_rescan() -> bool:
     """Start exactly one follow-up scan if something was declined while this
-    scan (or mutation) held the library - see `_rescan_pending`.
+    scan (or mutation) held the library - see `_rescan_pending`. Returns
+    whether it did, so a scan's own chain (see start_scan's `run`) can tell
+    whether it just finished as the LAST pass of that chain or whether
+    another pass is coming.
 
     Plain start_scan(), never the acknowledge token a refused scan might have
     been holding: that token is consent to one specific, named set of missing
@@ -864,6 +912,77 @@ def _run_pending_rescan() -> None:
     global _rescan_pending
     with _state_lock:
         if not _rescan_pending:
-            return
+            return False
         _rescan_pending = False
-    start_scan()
+    # _continuing_chain=True: this scan belongs to the SAME chain as the one
+    # that just declined to start it (#190) - see start_scan's own docstring
+    # for why that matters to _chain_added_ids. Correct for both callers of
+    # this function: from a scan's own `run()`, this genuinely is a
+    # continuation; from hold_library_still's finally, `_mutating` and
+    # `_state["scanning"]` are never both true, so no chain can be mid-flight
+    # when this fires there and `_chain_added_ids` is already empty either way.
+    start_scan(_continuing_chain=True)
+    return True
+
+
+# Set by api.py at import time, right after it defines _batch_process_one -
+# see register_transcribe_hook just below. scanner.py cannot import api.py
+# directly to reach it: api.py already imports scanner.py (for start_scan,
+# scan_status and LIBRARY_DIR), so the other direction would be a circular
+# import - the same reasoning transcribe_batch.py's own module comment gives
+# for why ITS dependency on api.py runs one direction only, carried one layer
+# further down. Stays None in a test that imports scanner.py (and
+# transcribe_batch.py) without ever importing api.py - a scan then has
+# nothing registered to call, so it simply starts no bulk pass, which is a
+# fine thing for such a test to mean.
+_transcribe_process_one = None
+
+
+def register_transcribe_hook(process_one) -> None:
+    """Say how to transcribe one score, so a scan's own chain can start a
+    bulk pass over what it added without scanner.py importing api.py to find
+    out how (#190). `process_one` has the same shape transcribe_batch.
+    start_batch already requires: `process_one(score_id, reconvert) -> dict`
+    naming the outcome. Called exactly once, by api.py, right after
+    `_batch_process_one` is defined.
+    """
+    global _transcribe_process_one
+    _transcribe_process_one = process_one
+
+
+def _finish_scan_chain() -> None:
+    """Start ONE bulk transcription pass over every id any pass of this
+    scan's chain added, now that the chain's last pass has finished - never
+    once per pass (#190). A freshly scanned library should not sit with zero
+    transcriptions until somebody clicks a bulk pass by hand, and a chain
+    that stitched several rescans together (an upload landing mid-scan, a
+    refusal that got acknowledged) must still only ever start one pass over
+    the union of everything it added, not one pass per link in the chain.
+
+    Does nothing if the chain added nothing - nothing new to transcribe - or
+    if nobody has registered a hook (see register_transcribe_hook: a test
+    that imports scanner.py without api.py has nothing to call this with).
+
+    transcribe_batch.start_batch already refuses re-entrantly, returning
+    False and changing nothing, if a pass is already running by somebody's
+    own hand - that refusal is exactly right here too (see the No-gos on
+    #190: no queue), so it is not retried or queued, only recorded into this
+    scan's own status in words. A scan runs unattended on every boot, which
+    is the one place nobody is watching transcribe_batch's own status for it.
+    """
+    global _chain_added_ids
+    with _state_lock:
+        ids = _chain_added_ids
+        _chain_added_ids = []
+    if not ids or _transcribe_process_one is None:
+        return
+    started = transcribe_batch.start_batch(_transcribe_process_one, ids)
+    with _state_lock:
+        _state["transcribe_batch_started"] = started
+        _state["transcribe_batch_note"] = (
+            f"started transcribing {len(ids)} newly scanned score(s) in the background"
+            if started
+            else "did not start transcribing the newly scanned scores because a bulk "
+            "transcription pass was already running - start one by hand from the "
+            "library view to pick them up"
+        )

--- a/server/fermata/scanner.py
+++ b/server/fermata/scanner.py
@@ -54,10 +54,13 @@ _state = {
     "started_at": None,
     "finished_at": None,
     # What happened to the bulk transcription pass this scan's OWN chain
-    # tried to start over the ids it added - see _finish_scan_chain. None
-    # until a chain that added at least one score finishes; a scan that adds
-    # nothing has nothing to say here, so it stays whatever the previous
-    # chain left (#190).
+    # tried to start over the ids it added - see _finish_scan_chain. None at
+    # the start of every pass (_scan() resets both keys unconditionally,
+    # chained or not - see its own reset block) and set only once, by
+    # _decide_and_settle_chain, when the chain's LAST pass finishes - so a
+    # pass still mid-chain, or one that added nothing at all, reads as None
+    # rather than carrying over whatever an earlier, unrelated chain left
+    # here (#190).
     "transcribe_batch_started": None,
     "transcribe_batch_note": None,
 }
@@ -65,12 +68,17 @@ _state_lock = threading.Lock()
 
 # Ids `scores` rows this SCAN gained, across every pass of the chain a
 # refused-then-acknowledged or upload-stacked rescan builds (see
-# _run_pending_rescan) - handed to transcribe_batch.start_batch exactly once,
-# by _finish_scan_chain, when the chain's last pass finishes rather than
-# once per pass (#190: a chained rescan must start ONE bulk pass over the
-# union of ids the whole chain added, not one per scan). Lives outside
+# _decide_and_settle_chain) - handed to transcribe_batch.start_batch exactly
+# once, by _finish_scan_chain, when the chain's last pass finishes rather
+# than once per pass (#190: a chained rescan must start ONE bulk pass over
+# the union of ids the whole chain added, not one per scan). Lives outside
 # `_state` because `_state` is reset at the top of every _scan() call
 # (including a chained one) and this has to survive exactly that reset.
+#
+# Pulled out of this variable ATOMICALLY with `scanning` clearing, inside
+# _decide_and_settle_chain's single lock acquisition, never in a separate
+# one - see that function's own comment for the race a second lock
+# acquisition used to leave open (#190 review, F2).
 _chain_added_ids: list[int] = []
 
 # Where a deleted score's file goes, as a folder name directly under the library
@@ -844,14 +852,16 @@ def start_scan(acknowledge: str | None = None, _continuing_chain: bool = False) 
     simply does not apply, and the scan refuses again with the new figures,
     which is the safe way for stale consent to fail.
 
-    `_continuing_chain` is for `_run_pending_rescan` alone - every OTHER
-    caller (POST /scan, POST /upload, POST /scan/acknowledge, the startup
-    scan) is starting a fresh chain and must not carry forward whatever a
-    previous, unrelated chain left in `_chain_added_ids` (#190). A test that
-    calls `_scan()` directly, bypassing this function entirely - the pattern
-    this module's own tests use for determinism - never goes through this
-    reset either, which is correct: those ids were never claimed by a chain
-    this function tracks, so a later, real start_scan() must not inherit them.
+    `_continuing_chain` is for `_decide_and_settle_chain` alone, when a
+    scan's own chain has another pass coming - every OTHER caller (POST
+    /scan, POST /upload, POST /scan/acknowledge, the startup scan, and
+    `_run_pending_rescan` on hold_library_still's behalf) is starting a
+    fresh chain and must not carry forward whatever a previous, unrelated
+    chain left in `_chain_added_ids` (#190). A test that calls `_scan()`
+    directly, bypassing this function entirely - the pattern this module's
+    own tests use for determinism - never goes through this reset either,
+    which is correct: those ids were never claimed by a chain this function
+    tracks, so a later, real start_scan() must not inherit them.
     """
     global _rescan_pending
     with _state_lock:
@@ -880,29 +890,72 @@ def start_scan(acknowledge: str | None = None, _continuing_chain: bool = False) 
             with _state_lock:
                 _state["errors"] += 1
                 _state["last_error"] = str(exc)
-        finally:
-            with _state_lock:
-                _state["scanning"] = False
-                _state["finished_at"] = time.time()
-        # The chain continues (another pass was just started, or a mutation
-        # is holding the library and will resume it) or it does not - and
-        # only when it does not is this scan actually the LAST one, which is
-        # the one moment _finish_scan_chain is allowed to act (#190). Calling
-        # it after every pass would start a bulk transcription pass per scan
-        # in a chain instead of one for the whole chain.
-        if not _run_pending_rescan():
-            _finish_scan_chain()
+        _decide_and_settle_chain()
 
     threading.Thread(target=run, name="fermata-scan", daemon=True).start()
     return True
 
 
+def _decide_and_settle_chain() -> None:
+    """Clear `scanning` and decide the chain's fate in the SAME lock
+    acquisition (#190 review, F2) - not, as an earlier version of this had
+    it, one after the other with the lock released in between.
+
+    THE GAP THAT USED TO BE HERE. `scanning` used to clear (and the lock
+    release) BEFORE anything asked whether the chain continues or ends.
+    start_scan()'s own guard only checks `scanning` (and `_mutating`), so an
+    ordinary POST /api/scan or /api/upload landing in exactly that gap saw
+    nothing running, was entitled to proceed, and reset `_chain_added_ids` to
+    start ITS OWN fresh chain (see start_scan's own docstring on
+    `_continuing_chain`) - taking the ids this finishing chain was about to
+    hand to transcribe_batch with it. Nothing about the arriving scan was
+    wrong. What was wrong is that this function, running microseconds later,
+    found an empty list where the chain's real ids had been - indistinguishable
+    from a chain that genuinely added nothing - so
+    transcribe_batch_started/note stayed None and the scores that chain added
+    were silently never transcribed, with no record that anything had gone
+    missing.
+
+    Closed by deciding under the SAME lock that clears `scanning`: whether
+    this chain continues (another pass was declined against it,
+    `_rescan_pending`) or ends (nothing was declined; `_chain_added_ids` is
+    pulled out here, atomically, for `_finish_scan_chain` to hand off once
+    the lock is released) is settled before `scanning` becomes visible to
+    anybody as False. A start_scan() arriving after this returns is starting
+    a genuinely new chain, not stealing the tail of this one.
+    """
+    global _rescan_pending, _chain_added_ids
+    with _state_lock:
+        _state["finished_at"] = time.time()
+        if _rescan_pending:
+            _rescan_pending = False
+            continuing = True
+            ids = None
+        else:
+            continuing = False
+            ids = _chain_added_ids
+            _chain_added_ids = []
+        _state["scanning"] = False
+    if continuing:
+        # Plain start_scan(), never the acknowledge token a refused scan
+        # might have been holding: that token is consent to one specific,
+        # named set of missing files, and replaying it against whatever the
+        # library looks like now would apply a person's "yes" to evidence
+        # they never saw. _continuing_chain=True: this pass belongs to the
+        # SAME chain as the one that just declined to start it.
+        start_scan(_continuing_chain=True)
+    else:
+        _finish_scan_chain(ids)
+
+
 def _run_pending_rescan() -> bool:
-    """Start exactly one follow-up scan if something was declined while this
-    scan (or mutation) held the library - see `_rescan_pending`. Returns
-    whether it did, so a scan's own chain (see start_scan's `run`) can tell
-    whether it just finished as the LAST pass of that chain or whether
-    another pass is coming.
+    """Start exactly one follow-up scan if something was declined while a
+    MUTATION held the library - see `_rescan_pending` and
+    hold_library_still's own finally, the one remaining caller. A scan's own
+    chain no longer uses this (see _decide_and_settle_chain): mutations never
+    touch `_chain_added_ids`, so there is no ids-race here to close the way
+    there was one for a scan's own chain - `_mutating` and `_state["scanning"]`
+    are never both true, so no chain can be mid-flight when this fires.
 
     Plain start_scan(), never the acknowledge token a refused scan might have
     been holding: that token is consent to one specific, named set of missing
@@ -914,14 +967,7 @@ def _run_pending_rescan() -> bool:
         if not _rescan_pending:
             return False
         _rescan_pending = False
-    # _continuing_chain=True: this scan belongs to the SAME chain as the one
-    # that just declined to start it (#190) - see start_scan's own docstring
-    # for why that matters to _chain_added_ids. Correct for both callers of
-    # this function: from a scan's own `run()`, this genuinely is a
-    # continuation; from hold_library_still's finally, `_mutating` and
-    # `_state["scanning"]` are never both true, so no chain can be mid-flight
-    # when this fires there and `_chain_added_ids` is already empty either way.
-    start_scan(_continuing_chain=True)
+    start_scan()
     return True
 
 
@@ -950,7 +996,7 @@ def register_transcribe_hook(process_one) -> None:
     _transcribe_process_one = process_one
 
 
-def _finish_scan_chain() -> None:
+def _finish_scan_chain(ids: list[int]) -> None:
     """Start ONE bulk transcription pass over every id any pass of this
     scan's chain added, now that the chain's last pass has finished - never
     once per pass (#190). A freshly scanned library should not sit with zero
@@ -958,6 +1004,12 @@ def _finish_scan_chain() -> None:
     that stitched several rescans together (an upload landing mid-scan, a
     refusal that got acknowledged) must still only ever start one pass over
     the union of everything it added, not one pass per link in the chain.
+
+    `ids` is handed in rather than read from `_chain_added_ids` here, and
+    that is deliberate (#190 review, F2): pulling it out has to happen
+    atomically with clearing `scanning`, or a scan landing in the gap
+    between the two can reset the list before this function ever sees it -
+    see _decide_and_settle_chain, the only caller, for the full argument.
 
     Does nothing if the chain added nothing - nothing new to transcribe - or
     if nobody has registered a hook (see register_transcribe_hook: a test
@@ -970,10 +1022,6 @@ def _finish_scan_chain() -> None:
     scan's own status in words. A scan runs unattended on every boot, which
     is the one place nobody is watching transcribe_batch's own status for it.
     """
-    global _chain_added_ids
-    with _state_lock:
-        ids = _chain_added_ids
-        _chain_added_ids = []
     if not ids or _transcribe_process_one is None:
         return
     started = transcribe_batch.start_batch(_transcribe_process_one, ids)

--- a/server/fermata/scanner.py
+++ b/server/fermata/scanner.py
@@ -96,8 +96,16 @@ _chain_added_ids: list[int] = []
 # transcribing 1", chain A's own count. _decide_and_settle_chain captures
 # this alongside `ids`, under the same lock; _finish_scan_chain checks it
 # again immediately before writing and simply does not write if a newer
-# chain has since been accepted - that newer chain will report its own
-# result, accurately, when it finishes.
+# chain has since been accepted.
+#
+# STATED PLAINLY, because it is a real trade rather than a clean win: if the
+# newer chain adds nothing of its own, ITS _finish_scan_chain also returns
+# early (see `if not ids`) and never writes anything either - so the OLDER
+# chain's genuinely real, genuinely running pass simply goes unreported.
+# `transcribe_batch_started`/`note` stay None, which understates what is
+# actually happening (a pass IS running), rather than misattributing it to
+# a scan that never asked for it. Losing that one note is the accepted cost
+# of never showing a person a number that belongs to the wrong scan.
 _scan_generation = 0
 
 # Where a deleted score's file goes, as a folder name directly under the library
@@ -1144,8 +1152,15 @@ def _finish_scan_chain(ids: list[int], generation: int) -> None:
             # ids were captured - it has its own fresh None waiting for its
             # own result, and writing this chain's numbers over it would
             # misattribute them to a scan that has not decided anything yet
-            # (#190 review, F2-1). That newer chain reports its own result,
-            # accurately, when it finishes.
+            # (#190 review, F2-1). If that newer chain goes on to add
+            # something of its own, IT reports its own result accurately
+            # when it finishes - but if it adds nothing, its own
+            # _finish_scan_chain also returns early (see `if not ids`
+            # above) and writes nothing either, so THIS chain's genuinely
+            # running pass simply goes unreported: transcribe_batch_started/
+            # note stay None rather than say anything at all. See
+            # `_scan_generation`'s own comment for why that understatement
+            # is the accepted trade against the misattribution.
             return
         _state["transcribe_batch_started"] = started
         _state["transcribe_batch_note"] = (

--- a/server/tests/test_transcribe_batch_api.py
+++ b/server/tests/test_transcribe_batch_api.py
@@ -971,3 +971,192 @@ def test_a_chain_with_no_hook_registered_still_clears_its_own_ids(
     status = scanner.scan_status()
     assert status["transcribe_batch_started"] is None
     assert status["transcribe_batch_note"] is None
+
+
+def test_a_plain_start_scan_landing_right_after_a_chain_continues_does_not_lose_the_chains_ids(
+    library, extractable_pdf, monkeypatch
+):
+    """#190 review, F2 second pass. The first fix closed the gap for a
+    chain's LAST pass (the ENDING branch); the CONTINUING branch still had
+    one: `_decide_and_settle_chain` left `_chain_added_ids` untouched,
+    cleared `scanning`, released its lock, and only THEN called
+    `start_scan(_continuing_chain=True)` - a separate function with its
+    own separate lock acquisition. An ordinary start_scan() landing in
+    that gap saw a genuinely idle scanner, was entitled to proceed, and
+    reset `_chain_added_ids` before the real continuation ever got there -
+    measured (this exact construction): a chain that added {1, 2} handed
+    transcribe_batch only [2].
+
+    Pinned via `scanner._after_chain_decided` - a hook that is a no-op in
+    production, called the moment `_decide_and_settle_chain`'s own lock
+    genuinely releases, whether the chain just continued or just ended
+    (see its own docstring for why this is the only seam left to inject
+    at: the fix's whole point is that no OTHER gap remains for a test, or
+    anything else, to land in). Synchronous and deterministic on purpose -
+    an earlier version of the FIRST round's equivalent test tried a
+    genuinely concurrent thread instead and it essentially never won the
+    race against the very same thread's own uninterrupted continuation
+    under CPython's GIL.
+    """
+    import shutil
+
+    shutil.copy(extractable_pdf, library / "one.pdf")
+
+    calls = []
+    real_start_batch = transcribe_batch.start_batch
+
+    def recording_start_batch(process_one, score_ids, reconvert=False):
+        calls.append(list(score_ids))
+        return real_start_batch(process_one, score_ids, reconvert)
+
+    monkeypatch.setattr(transcribe_batch, "start_batch", recording_start_batch)
+
+    real_hash_file = scanner.hash_file
+
+    def slow_hash_file(path):
+        time.sleep(0.3)
+        return real_hash_file(path)
+
+    monkeypatch.setattr(scanner, "hash_file", slow_hash_file)
+
+    intruder_started = []
+    fired = False
+
+    def intruding_hook(continuing):
+        nonlocal fired
+        if continuing and not fired:
+            fired = True
+            # The ordinary start_scan() from the reviewer's own
+            # reproduction - fired at the exact moment the lock that
+            # decided this chain continues has released.
+            intruder_started.append(scanner.start_scan())
+
+    monkeypatch.setattr(scanner, "_after_chain_decided", intruding_hook)
+
+    scan_started = scanner.start_scan()
+    assert scan_started is True
+    time.sleep(0.1)  # let it start hashing one.pdf
+    assert scanner.scan_status()["scanning"] is True
+
+    shutil.copy(extractable_pdf, library / "two.pdf")
+    second_call_started = scanner.start_scan()
+    assert second_call_started is False  # declined - the chain will continue
+
+    _wait_for_scan()
+    _wait_for_batch()
+
+    assert fired, "the hook never fired for the continuing branch"
+    # On the fix, `scanning` is already True (set inside the SAME lock that
+    # decided to continue) by the time the hook runs, so the intruder is
+    # refused - exactly what proves there is no gap for it to exploit.
+    assert intruder_started == [False], (
+        f"the intruding start_scan() was not refused: {intruder_started}"
+    )
+
+    assert len(calls) == 1, f"expected exactly one bulk pass, got {len(calls)}: {calls}"
+    conn = db.connect()
+    one_id = conn.execute("SELECT id FROM scores WHERE path='one.pdf'").fetchone()["id"]
+    two_id = conn.execute("SELECT id FROM scores WHERE path='two.pdf'").fetchone()["id"]
+    assert set(calls[0]) == {one_id, two_id}, (
+        f"expected the union {{one_id, two_id}}, got {calls[0]}"
+    )
+
+
+def test_a_mutation_landing_right_after_a_chain_continues_does_not_lose_the_chains_ids(
+    library, extractable_pdf, monkeypatch
+):
+    """#190 review, F2 second pass, the OTHER reproduction the reviewer
+    named: a move/delete (hold_library_still) taking `_mutating` in the
+    same gap, refusing the chain's own continuation, and then - on the
+    mutation's own finally, via _run_pending_rescan - starting a plain,
+    non-continuing start_scan() that resets `_chain_added_ids`. Same loss
+    as the plain-start_scan case, reached a different way, and worse than
+    silence: a pass still starts, over a subset, and transcribe_batch_note
+    reports that smaller count as though it were the whole chain's.
+
+    Same hook, same reasoning as the sibling test above. On the fix,
+    `hold_library_still` itself refuses outright (`scanning` is already
+    True by the time the hook runs), which is the strongest form this
+    assertion can take: not merely "the ids survive" but "the mutation
+    could not even begin".
+    """
+    import shutil
+
+    shutil.copy(extractable_pdf, library / "one.pdf")
+
+    calls = []
+    real_start_batch = transcribe_batch.start_batch
+
+    def recording_start_batch(process_one, score_ids, reconvert=False):
+        calls.append(list(score_ids))
+        return real_start_batch(process_one, score_ids, reconvert)
+
+    monkeypatch.setattr(transcribe_batch, "start_batch", recording_start_batch)
+
+    real_hash_file = scanner.hash_file
+
+    def slow_hash_file(path):
+        time.sleep(0.3)
+        return real_hash_file(path)
+
+    monkeypatch.setattr(scanner, "hash_file", slow_hash_file)
+
+    mutation_started = []
+    mutation_cm = {}
+    fired = False
+
+    def intruding_hook(continuing):
+        nonlocal fired
+        if continuing and not fired:
+            fired = True
+            try:
+                cm = scanner.hold_library_still()
+                cm.__enter__()
+            except scanner.LibraryBusy:
+                mutation_started.append(False)
+            else:
+                mutation_started.append(True)
+                mutation_cm["cm"] = cm
+
+    monkeypatch.setattr(scanner, "_after_chain_decided", intruding_hook)
+
+    scan_started = scanner.start_scan()
+    assert scan_started is True
+    time.sleep(0.1)
+    assert scanner.scan_status()["scanning"] is True
+
+    shutil.copy(extractable_pdf, library / "two.pdf")
+    second_call_started = scanner.start_scan()
+    assert second_call_started is False
+
+    try:
+        _wait_for_scan()
+        _wait_for_batch()
+    finally:
+        # If the hook's mutation genuinely got in (the bug), it is still
+        # HELD at this point - nothing else releases it. Exiting it here,
+        # unconditionally, both completes the reviewer's exact scenario
+        # (hold_library_still's own finally calls _run_pending_rescan,
+        # which is the second half of the loss) and guarantees this test
+        # never leaves `_mutating` stuck for whatever runs after it.
+        cm = mutation_cm.get("cm")
+        if cm is not None:
+            cm.__exit__(None, None, None)
+            _wait_for_scan()
+            _wait_for_batch()
+
+    assert fired, "the hook never fired for the continuing branch"
+    # On the fix, hold_library_still's own guard refuses outright - it
+    # never even gets as far as setting `_mutating`, because `scanning`
+    # reads True (set inside the same lock that decided to continue).
+    assert mutation_started == [False], (
+        f"the intruding mutation was not refused: {mutation_started}"
+    )
+
+    assert len(calls) == 1, f"expected exactly one bulk pass, got {len(calls)}: {calls}"
+    conn = db.connect()
+    one_id = conn.execute("SELECT id FROM scores WHERE path='one.pdf'").fetchone()["id"]
+    two_id = conn.execute("SELECT id FROM scores WHERE path='two.pdf'").fetchone()["id"]
+    assert set(calls[0]) == {one_id, two_id}, (
+        f"expected the union {{one_id, two_id}}, got {calls[0]}"
+    )

--- a/server/tests/test_transcribe_batch_api.py
+++ b/server/tests/test_transcribe_batch_api.py
@@ -21,7 +21,13 @@ about a single POST /transcribe:
      held against one another, mirroring scanner.hold_library_still's
      reasoning for why upload() is not held against a scan either;
   6. a second batch refuses while one is already running, the same rule
-     scanner.start_scan applies to a second scan.
+     scanner.start_scan applies to a second scan;
+  7. issue #190's own scan-triggered hook: the LAST scan of a chain starts
+     one bulk pass over exactly the ids that chain added (never one per
+     pass), that hook is refused rather than interrupting a pass already
+     running by hand - recorded into the scan's own status in words - and an
+     upload (which triggers a scan) is covered by the same hook, proven
+     directly rather than only inferred.
 """
 import threading
 import time
@@ -81,6 +87,27 @@ def _wait_for_scan(timeout: float = 10.0) -> None:
     while scanner.scan_status()["scanning"]:
         if time.monotonic() > deadline:
             raise AssertionError("the scan did not finish")
+        time.sleep(0.02)
+
+
+def _wait_for_scan_chain_decision(timeout: float = 10.0) -> dict:
+    """Wait past the exact race zz-library-missing.spec.js's own scanAndWait
+    warns about, one layer further down (#190): `scanning` going false only
+    means the SCAN is done, not that its own chain-completion hook
+    (scanner._finish_scan_chain) has decided anything about a bulk pass yet.
+    `transcribe_batch_started` moving away from `None` IS that hook having
+    decided - only once it has is a read of transcribe_batch.batch_status()
+    actually about the pass THIS chain may have started, rather than one
+    left over from before."""
+    deadline = time.monotonic() + timeout
+    while True:
+        status = scanner.scan_status()
+        if not status["scanning"] and status["transcribe_batch_started"] is not None:
+            return status
+        if time.monotonic() > deadline:
+            raise AssertionError(
+                f"the scan's chain never finished deciding about a bulk pass: {status}"
+            )
         time.sleep(0.02)
 
 
@@ -499,3 +526,216 @@ def test_a_second_batch_refuses_while_one_is_running(app_env, extractable_pdf, m
     _wait_for_batch()
     # The first (only) pass completed normally once released.
     assert transcribe_batch.batch_status()["processed"] == 1
+
+
+# ---------------------------------------------------------------------------
+# 7. The scan's own scan-triggered hook (#190): a freshly scanned library
+#    transcribes itself, and says so.
+# ---------------------------------------------------------------------------
+
+
+def test_a_scan_that_adds_scores_starts_one_pass_over_exactly_those_ids(
+    library, extractable_pdf, non_extractable_pdf, monkeypatch
+):
+    """#190's core mechanism: at the end of a scan's own chain, exactly one
+    bulk transcription pass starts over exactly the ids that chain added -
+    not the whole library, and not one pass per file the scan touched."""
+    import shutil
+
+    shutil.copy(extractable_pdf, library / "good.pdf")
+    shutil.copy(non_extractable_pdf, library / "bad.pdf")
+
+    calls = []
+    real_start_batch = transcribe_batch.start_batch
+
+    def recording_start_batch(process_one, score_ids, reconvert=False):
+        calls.append(list(score_ids))
+        return real_start_batch(process_one, score_ids, reconvert)
+
+    monkeypatch.setattr(transcribe_batch, "start_batch", recording_start_batch)
+
+    scan_started = scanner.start_scan()
+    assert scan_started is True
+    status = _wait_for_scan_chain_decision()
+    _wait_for_batch()
+
+    assert len(calls) == 1, f"expected exactly one bulk pass, got {len(calls)}: {calls}"
+    conn = db.connect()
+    ids = {r["id"] for r in conn.execute("SELECT id FROM scores")}
+    assert len(ids) == 2
+    assert set(calls[0]) == ids
+
+    batch = transcribe_batch.batch_status()
+    assert batch["total"] == 2
+    assert batch["transcribed"] == 1
+    assert batch["non_extractable"] == 1
+
+    good_id = conn.execute("SELECT id FROM scores WHERE path='good.pdf'").fetchone()["id"]
+    bad_id = conn.execute("SELECT id FROM scores WHERE path='bad.pdf'").fetchone()["id"]
+    assert conn.execute(
+        "SELECT COUNT(*) FROM transcriptions WHERE score_id=?", (good_id,)
+    ).fetchone()[0] == 1
+    assert conn.execute(
+        "SELECT COUNT(*) FROM transcriptions WHERE score_id=?", (bad_id,)
+    ).fetchone()[0] == 0
+
+    # Said in the scan's own status, in words - the one place anybody could
+    # read it, since the startup scan runs unattended.
+    assert status["transcribe_batch_started"] is True
+    assert "2" in status["transcribe_batch_note"]
+
+
+def test_a_scan_that_adds_a_score_does_not_interrupt_a_bulk_pass_already_running_by_hand(
+    library, extractable_pdf, monkeypatch
+):
+    """#190's own rabbit hole: a hand-started bulk pass takes priority over
+    the scan's own hook, not the other way round. The hook is refused the
+    same way transcribe_batch.start_batch already refuses a second manual
+    call - never a queue, never a retry - and the scan says so in its own
+    status, in words a person can read."""
+    import shutil
+
+    shutil.copy(extractable_pdf, library / "existing.pdf")
+    scanner._scan()
+    conn = db.connect()
+    existing_id = conn.execute(
+        "SELECT id FROM scores WHERE path='existing.pdf'"
+    ).fetchone()["id"]
+
+    release = threading.Event()
+
+    def blocking_process_one(score_id, reconvert):
+        release.wait(timeout=10)
+        return api._batch_process_one(score_id, reconvert)
+
+    hand_started = transcribe_batch.start_batch(blocking_process_one, [existing_id], False)
+    assert hand_started is True
+
+    try:
+        shutil.copy(extractable_pdf, library / "fresh.pdf")
+        scan_started = scanner.start_scan()
+        assert scan_started is True
+        status = _wait_for_scan_chain_decision()
+
+        assert status["transcribe_batch_started"] is False, status
+        assert status["transcribe_batch_note"]
+        assert "already running" in status["transcribe_batch_note"]
+
+        # The hand-started pass itself is untouched - still just the one
+        # score it was given, not the one the scan just added.
+        running = transcribe_batch.batch_status()
+        assert running["running"] is True
+        assert running["total"] == 1
+    finally:
+        release.set()
+        _wait_for_batch()
+
+    # No queue (#190's No-gos): the freshly scanned score really was not
+    # transcribed, not merely "not transcribed yet".
+    fresh_id = conn.execute("SELECT id FROM scores WHERE path='fresh.pdf'").fetchone()["id"]
+    assert conn.execute(
+        "SELECT COUNT(*) FROM transcriptions WHERE score_id=?", (fresh_id,)
+    ).fetchone()[0] == 0
+
+
+def test_a_chained_rescan_starts_one_bulk_pass_over_the_union_of_every_id_the_chain_added(
+    library, extractable_pdf, monkeypatch
+):
+    """#190: a scan whose chain has more than one pass - a second request
+    landing while the first is still walking the library, so
+    scanner._run_pending_rescan starts a follow-up pass over the library's
+    new state - must still start only ONE bulk pass, over every id ANY pass
+    in the chain added, never one pass per link.
+
+    Built the same way test_a_bulk_transcription_pass_runs_while_a_scan_is_
+    in_progress builds a scan slow enough to prove genuine overlap:
+    hash_file slowed down enough that a second start_scan() call, made
+    while the first pass is still hashing its only file, is genuinely
+    declined for re-entrancy (see scanner._rescan_pending) rather than
+    racing to go first.
+    """
+    import shutil
+
+    shutil.copy(extractable_pdf, library / "one.pdf")
+
+    calls = []
+    real_start_batch = transcribe_batch.start_batch
+
+    def recording_start_batch(process_one, score_ids, reconvert=False):
+        calls.append(list(score_ids))
+        return real_start_batch(process_one, score_ids, reconvert)
+
+    monkeypatch.setattr(transcribe_batch, "start_batch", recording_start_batch)
+
+    real_hash_file = scanner.hash_file
+
+    def slow_hash_file(path):
+        time.sleep(0.3)
+        return real_hash_file(path)
+
+    monkeypatch.setattr(scanner, "hash_file", slow_hash_file)
+
+    scan_started = scanner.start_scan()
+    assert scan_started is True
+    time.sleep(0.1)  # let it start hashing one.pdf
+    assert scanner.scan_status()["scanning"] is True
+
+    # A second file lands mid-pass, and the request made for it is declined
+    # rather than starting a scan of its own - the running pass already took
+    # its directory listing, before this file existed.
+    shutil.copy(extractable_pdf, library / "two.pdf")
+    second_call_started = scanner.start_scan()
+    assert second_call_started is False
+
+    _wait_for_scan_chain_decision()
+    _wait_for_batch()
+
+    assert len(calls) == 1, (
+        f"expected one bulk pass for the whole chain, got {len(calls)}: {calls}"
+    )
+    conn = db.connect()
+    ids = {r["id"] for r in conn.execute("SELECT id FROM scores")}
+    assert len(ids) == 2
+    assert set(calls[0]) == ids
+
+    batch = transcribe_batch.batch_status()
+    assert batch["total"] == 2
+    assert batch["transcribed"] == 2
+
+
+def test_an_upload_starts_exactly_one_bulk_pass_over_exactly_the_uploaded_scores_id(
+    client, library, extractable_pdf, monkeypatch
+):
+    """#190: POST /api/upload already triggers a scan (see api.upload) -
+    this is the one hook covering uploads too, proven directly through the
+    real endpoint rather than only inferred from the scan-triggered tests
+    above."""
+    calls = []
+    real_start_batch = transcribe_batch.start_batch
+
+    def recording_start_batch(process_one, score_ids, reconvert=False):
+        calls.append(list(score_ids))
+        return real_start_batch(process_one, score_ids, reconvert)
+
+    monkeypatch.setattr(transcribe_batch, "start_batch", recording_start_batch)
+
+    res = client.post(
+        "/api/upload?folder=Uploads",
+        files={"file": ("fresh.pdf", extractable_pdf.read_bytes(), "application/pdf")},
+    )
+    assert res.status_code == 200
+
+    _wait_for_scan_chain_decision()
+    _wait_for_batch()
+
+    conn = db.connect()
+    uploaded_id = conn.execute(
+        "SELECT id FROM scores WHERE path='Uploads/fresh.pdf'"
+    ).fetchone()["id"]
+
+    assert len(calls) == 1, f"expected exactly one bulk pass, got {len(calls)}: {calls}"
+    assert calls[0] == [uploaded_id]
+
+    status = transcribe_batch.batch_status()
+    assert status["total"] == 1
+    assert status["transcribed"] == 1

--- a/server/tests/test_transcribe_batch_api.py
+++ b/server/tests/test_transcribe_batch_api.py
@@ -739,3 +739,235 @@ def test_an_upload_starts_exactly_one_bulk_pass_over_exactly_the_uploaded_scores
     status = transcribe_batch.batch_status()
     assert status["total"] == 1
     assert status["transcribed"] == 1
+
+
+def test_a_scan_landing_right_after_the_chain_decision_does_not_lose_the_chains_ids(
+    library, extractable_pdf, monkeypatch
+):
+    """#190 review, F2. `scanning` used to clear (and the lock release)
+    BEFORE anything decided whether the chain continues or ends, so an
+    ordinary start_scan() landing in exactly that gap reset
+    `_chain_added_ids` before the chain's own decision ever read it - see
+    scanner._decide_and_settle_chain's own comment for the full argument.
+
+    Pinned deterministically, not by racing real threads against real lock
+    timing (tried first: spawning a genuinely concurrent intruder thread
+    almost never wins against the SAME thread's own uninterrupted
+    continuation under CPython's GIL, which favours whichever thread is
+    already running - the fix's own atomicity could not be shown to matter
+    that way without an artificial sleep inside production code). Instead:
+    wrap scanner._finish_scan_chain - the first thing that runs once the
+    decision's lock is released - and have the wrapper call a SECOND,
+    intruding start_scan() SYNCHRONOUSLY, in the same thread, before
+    calling through to the real _finish_scan_chain. This is exactly the
+    reproduction shape a gap between "clear scanning" and "decide the
+    ids" has: whatever runs immediately once the lock opens gets first
+    claim on `_chain_added_ids`, and the assertion below is that the
+    real ids - not whatever the intruder leaves behind - are what actually
+    reach transcribe_batch.
+    """
+    import shutil
+
+    shutil.copy(extractable_pdf, library / "one.pdf")
+
+    calls = []
+    real_start_batch = transcribe_batch.start_batch
+
+    def recording_start_batch(process_one, score_ids, reconvert=False):
+        calls.append(list(score_ids))
+        return real_start_batch(process_one, score_ids, reconvert)
+
+    monkeypatch.setattr(transcribe_batch, "start_batch", recording_start_batch)
+
+    real_finish = scanner._finish_scan_chain
+    intruder_started = []
+    fired = False
+
+    def intruding_finish(ids):
+        # Fires exactly ONCE - the intruder's own chain finishes through
+        # this same wrapper too (it is patched module-wide), and without
+        # the guard each intruder would start another, cascading forever
+        # and never letting the scan settle.
+        nonlocal fired
+        if not fired:
+            fired = True
+            intruder_started.append(scanner.start_scan())
+        return real_finish(ids)
+
+    monkeypatch.setattr(scanner, "_finish_scan_chain", intruding_finish)
+
+    scan_started = scanner.start_scan()
+    assert scan_started is True
+    _wait_for_scan()
+    _wait_for_scan()  # the intruder's own scan, started from inside the wrapper
+    _wait_for_batch()
+
+    assert intruder_started == [True], "the intruding scan never actually ran"
+    assert len(calls) == 1, f"expected exactly one bulk pass, got {len(calls)}: {calls}"
+    conn = db.connect()
+    one_id = conn.execute("SELECT id FROM scores WHERE path='one.pdf'").fetchone()["id"]
+    assert calls[0] == [one_id]
+
+
+def test_a_scan_that_adds_one_score_does_not_transcribe_a_pre_existing_untranscribed_one(
+    library, extractable_pdf, monkeypatch
+):
+    """#190 review, F5, mutation C: _finish_scan_chain must hand
+    transcribe_batch exactly the ids THIS CHAIN added - never every live
+    score in the library. Every earlier test of this claim scanned a
+    library that started EMPTY, so "everything the chain added" and
+    "every live score" were the same set and a mutation broadening the
+    scope to the latter would have passed unnoticed. Pinned here with a
+    score already on record, untranscribed, before this scan runs at all.
+    """
+    import shutil
+
+    pre_existing_path = "pre-existing.pdf"
+    shutil.copy(extractable_pdf, library / pre_existing_path)
+    scanner._scan()
+    conn = db.connect()
+    pre_existing_id = conn.execute(
+        "SELECT id FROM scores WHERE path=?", (pre_existing_path,)
+    ).fetchone()["id"]
+
+    calls = []
+    real_start_batch = transcribe_batch.start_batch
+
+    def recording_start_batch(process_one, score_ids, reconvert=False):
+        calls.append(list(score_ids))
+        return real_start_batch(process_one, score_ids, reconvert)
+
+    monkeypatch.setattr(transcribe_batch, "start_batch", recording_start_batch)
+
+    shutil.copy(extractable_pdf, library / "fresh.pdf")
+    scan_started = scanner.start_scan()
+    assert scan_started is True
+    _wait_for_scan_chain_decision()
+    _wait_for_batch()
+
+    assert len(calls) == 1, f"expected exactly one bulk pass, got {len(calls)}: {calls}"
+    fresh_id = conn.execute("SELECT id FROM scores WHERE path='fresh.pdf'").fetchone()["id"]
+    assert calls[0] == [fresh_id], (
+        f"expected the pass to run over exactly the added id, got {calls[0]} - "
+        f"the pre-existing score's id was {pre_existing_id}"
+    )
+
+    # The pre-existing score was never part of this chain's own pass, and
+    # stays exactly as untranscribed as it started.
+    assert conn.execute(
+        "SELECT COUNT(*) FROM transcriptions WHERE score_id=?", (pre_existing_id,)
+    ).fetchone()[0] == 0
+
+
+def test_the_chain_never_reconverts_a_score_transcribed_out_of_band_before_it_finishes(
+    library, extractable_pdf, monkeypatch
+):
+    """#190 review, F5, mutation D: the hook must call transcribe_batch.
+    start_batch with reconvert=False (the default), never True. Ordinarily
+    every id a chain adds is a brand-new row with no transcription of its
+    own yet, so reconvert cannot make an observable difference for it -
+    except across a CHAINED rescan (#190's own subject): a score added by
+    an early pass sits in `_chain_added_ids` until the chain's LAST pass
+    finishes, and something else can genuinely transcribe it by hand in
+    that window. reconvert=True would silently replace that real content;
+    reconvert=False (correct) reports it as already_transcribed and
+    leaves it alone.
+
+    Built the same way test_a_chained_rescan_starts_one_bulk_pass_over_
+    the_union_of_every_id_the_chain_added builds a chain of two passes:
+    hash_file slowed down enough that a second file's own start_scan()
+    call is genuinely declined for re-entrancy (see
+    scanner._rescan_pending) and picked up by a follow-up pass in the
+    same chain, giving a real window between "one.pdf" being added and
+    the chain finishing.
+    """
+    import shutil
+
+    shutil.copy(extractable_pdf, library / "one.pdf")
+
+    real_hash_file = scanner.hash_file
+
+    def slow_hash_file(path):
+        time.sleep(0.3)
+        return real_hash_file(path)
+
+    monkeypatch.setattr(scanner, "hash_file", slow_hash_file)
+
+    scan_started = scanner.start_scan()
+    assert scan_started is True
+    time.sleep(0.1)  # let it start hashing one.pdf
+    assert scanner.scan_status()["scanning"] is True
+
+    shutil.copy(extractable_pdf, library / "two.pdf")
+    second_call_started = scanner.start_scan()
+    assert second_call_started is False  # declined - merges into the same chain
+
+    # one.pdf is added by the FIRST pass and sits in _chain_added_ids while
+    # the SECOND pass (hashing two.pdf, also slowed) is still running - the
+    # window this test needs. Waited for by polling for its row rather than
+    # assumed from a sleep: the first pass's own 0.3s hash is itself only a
+    # lower bound on when the row actually lands.
+    conn = db.connect()
+    deadline = time.monotonic() + 5.0
+    one_id = None
+    while one_id is None:
+        row = conn.execute("SELECT id FROM scores WHERE path='one.pdf'").fetchone()
+        if row:
+            one_id = row["id"]
+            break
+        if time.monotonic() > deadline:
+            raise AssertionError("one.pdf's row never appeared")
+        time.sleep(0.02)
+    # Transcribed by hand, out of band, right now - while the chain is
+    # still mid-flight on its second pass.
+    api.transcribe(one_id, body=None)
+    hand_made = api.get_transcription(one_id)
+    assert hand_made["source"] == "extracted"
+
+    _wait_for_scan_chain_decision()
+    _wait_for_batch()
+
+    status = transcribe_batch.batch_status()
+    two_id = conn.execute("SELECT id FROM scores WHERE path='two.pdf'").fetchone()["id"]
+    by_id = {line["score_id"]: line for line in status["results"]}
+    assert set(by_id) == {one_id, two_id}, by_id
+    # one.pdf reports already_transcribed, not transcribed a second time -
+    # the reconvert=False claim, in the one scenario that can tell the
+    # difference.
+    assert by_id[one_id]["outcome"] == "already_transcribed", by_id[one_id]
+    assert by_id[two_id]["outcome"] == "transcribed", by_id[two_id]
+
+    # And the hand-made content genuinely survived, not merely the outcome
+    # label.
+    still = api.get_transcription(one_id)
+    assert still["source"] == "extracted"
+    assert still["updated_at"] == hand_made["updated_at"]
+    assert still["content"] == hand_made["content"]
+
+
+def test_a_chain_with_no_hook_registered_still_clears_its_own_ids(
+    library, extractable_pdf, monkeypatch
+):
+    """#190 review nit: _finish_scan_chain does nothing when nobody has
+    registered a transcribe hook (see register_transcribe_hook - a test
+    that imports scanner.py without api.py has nothing to call this
+    with), but the chain's own ids must still be consumed by
+    _decide_and_settle_chain regardless of whether a hook exists - or a
+    LATER chain (once a hook is registered, e.g. because api.py gets
+    imported later in the same process) would inherit ids from a chain
+    that already finished, as though that later chain had added them."""
+    import shutil
+
+    monkeypatch.setattr(scanner, "_transcribe_process_one", None)
+    shutil.copy(extractable_pdf, library / "one.pdf")
+
+    scan_started = scanner.start_scan()
+    assert scan_started is True
+    _wait_for_scan()  # not _wait_for_scan_chain_decision - with no hook,
+    # transcribe_batch_started/note never leave None for this chain
+
+    assert scanner._chain_added_ids == []
+    assert transcribe_batch.batch_status()["running"] is False
+    status = scanner.scan_status()
+    assert status["transcribe_batch_started"] is None
+    assert status["transcribe_batch_note"] is None

--- a/server/tests/test_transcribe_batch_api.py
+++ b/server/tests/test_transcribe_batch_api.py
@@ -766,17 +766,27 @@ def test_a_scan_landing_right_after_the_chain_decision_does_not_lose_the_chains_
     real ids - not whatever the intruder leaves behind - are what actually
     reach transcribe_batch.
 
-    ALSO PINS F2-1 (#190 review, third pass), for free, from this exact
-    construction: the intruding start_scan() (scan B) is accepted and bumps
-    `scanner._scan_generation` SYNCHRONOUSLY, before `real_finish` (scan A's
-    own) ever gets to check it - deterministic regardless of when B's own
-    background thread gets around to actually walking the library - so
-    scan A's write of transcribe_batch_started/note is guaranteed stale by
-    the time it tries. B adds nothing new (the file scan A already added is
-    still the only one on disk), so B's own _finish_scan_chain is a no-op
-    too (`ids` empty) - meaning the FINAL status, once both chains settle,
-    must be exactly what B's own `_scan()` reset left it (None/None), never
-    scan A's "started transcribing 1", the clobber the review measured.
+    ALSO ASSERTS the FINAL status, once both chains settle, is None/None
+    (#190 review, third pass) - but this does NOT pin F2-1 on its own, and
+    is not claimed to: measured by dropping the generation check itself
+    (`if False:` in _finish_scan_chain), this assertion still passes, 8/8.
+    Why: scan B's own `_scan()` pass resets transcribe_batch_started/note to
+    None UNCONDITIONALLY, as the very first thing it does, regardless of
+    whether scan A's write was ever skipped - so if B's reset happens to run
+    AFTER scan A's write (which, un-fixed, lands scan A's stale "started
+    transcribing 1"), B's reset simply overwrites it right back to None
+    before this test's own assertion ever reads it. The status the
+    assertion sees is what B's reset guarantees either way, not evidence
+    that scan A's write was actually prevented from landing. What this test
+    DOES still pin, on its own construction: the ids atomicity fix above
+    (`calls[0] == [one_id]`) - the status assertion is left in as a
+    consistency check on the observable end state, not a substitute proof
+    of F2-1. See test_a_newer_chain_accepted_after_start_batch_returns_
+    does_not_have_its_status_clobbered below for the actual F2-1 pin, which
+    forces the ORDER that matters (the newer chain's generation bump lands
+    before scan A's own write is even attempted, with nothing after it to
+    launder the result) rather than relying on the value both orders happen
+    to produce.
     """
     import shutil
 

--- a/server/tests/test_transcribe_batch_api.py
+++ b/server/tests/test_transcribe_batch_api.py
@@ -765,6 +765,18 @@ def test_a_scan_landing_right_after_the_chain_decision_does_not_lose_the_chains_
     claim on `_chain_added_ids`, and the assertion below is that the
     real ids - not whatever the intruder leaves behind - are what actually
     reach transcribe_batch.
+
+    ALSO PINS F2-1 (#190 review, third pass), for free, from this exact
+    construction: the intruding start_scan() (scan B) is accepted and bumps
+    `scanner._scan_generation` SYNCHRONOUSLY, before `real_finish` (scan A's
+    own) ever gets to check it - deterministic regardless of when B's own
+    background thread gets around to actually walking the library - so
+    scan A's write of transcribe_batch_started/note is guaranteed stale by
+    the time it tries. B adds nothing new (the file scan A already added is
+    still the only one on disk), so B's own _finish_scan_chain is a no-op
+    too (`ids` empty) - meaning the FINAL status, once both chains settle,
+    must be exactly what B's own `_scan()` reset left it (None/None), never
+    scan A's "started transcribing 1", the clobber the review measured.
     """
     import shutil
 
@@ -783,7 +795,7 @@ def test_a_scan_landing_right_after_the_chain_decision_does_not_lose_the_chains_
     intruder_started = []
     fired = False
 
-    def intruding_finish(ids):
+    def intruding_finish(ids, generation):
         # Fires exactly ONCE - the intruder's own chain finishes through
         # this same wrapper too (it is patched module-wide), and without
         # the guard each intruder would start another, cascading forever
@@ -792,7 +804,7 @@ def test_a_scan_landing_right_after_the_chain_decision_does_not_lose_the_chains_
         if not fired:
             fired = True
             intruder_started.append(scanner.start_scan())
-        return real_finish(ids)
+        return real_finish(ids, generation)
 
     monkeypatch.setattr(scanner, "_finish_scan_chain", intruding_finish)
 
@@ -807,6 +819,14 @@ def test_a_scan_landing_right_after_the_chain_decision_does_not_lose_the_chains_
     conn = db.connect()
     one_id = conn.execute("SELECT id FROM scores WHERE path='one.pdf'").fetchone()["id"]
     assert calls[0] == [one_id]
+
+    status = scanner.scan_status()
+    assert status["transcribe_batch_started"] is None, (
+        f"chain A's stale write clobbered chain B's own status: {status}"
+    )
+    assert status["transcribe_batch_note"] is None, (
+        f"chain A's stale write clobbered chain B's own status: {status}"
+    )
 
 
 def test_a_scan_that_adds_one_score_does_not_transcribe_a_pre_existing_untranscribed_one(
@@ -1159,4 +1179,53 @@ def test_a_mutation_landing_right_after_a_chain_continues_does_not_lose_the_chai
     two_id = conn.execute("SELECT id FROM scores WHERE path='two.pdf'").fetchone()["id"]
     assert set(calls[0]) == {one_id, two_id}, (
         f"expected the union {{one_id, two_id}}, got {calls[0]}"
+    )
+
+
+def test_a_newer_chain_accepted_after_start_batch_returns_does_not_have_its_status_clobbered(
+    library, extractable_pdf, monkeypatch
+):
+    """#190 review, F2-1 (third pass). _finish_scan_chain calls
+    transcribe_batch.start_batch OUTSIDE any lock, deliberately - see its
+    own docstring - which leaves a window between that call returning and
+    this chain's own write of transcribe_batch_started/note. A plain
+    start_scan() landing in exactly that window is accepted (bumping
+    scanner._scan_generation and resetting those two keys to None for
+    itself, via its own _scan() pass) before this OLDER chain's write ever
+    lands - measured (the reviewer's own reproduction): a newer chain that
+    added nothing had its status read "started transcribing 1", the OLDER
+    chain's own count, because the older chain's write landed last and
+    clobbered the newer chain's fresh None.
+
+    Pinned via scanner._before_finish_writes_status - a hook that is a
+    no-op in production, the one seam between start_batch returning and the
+    generation check immediately before the write. Simulates the newer
+    chain being ACCEPTED via _begin_scan_locked directly (the moment
+    _scan_generation actually changes - see its own comment) rather than
+    running a second real scan end to end, which is both unnecessary to
+    prove the mechanism and, as the sibling test above notes, not
+    reliably orderable via real thread timing.
+    """
+    import shutil
+
+    shutil.copy(extractable_pdf, library / "one.pdf")
+
+    def intruding_hook(ids):
+        with scanner._state_lock:
+            scanner._begin_scan_locked(_continuing_chain=False)
+            scanner._state["scanning"] = False
+
+    monkeypatch.setattr(scanner, "_before_finish_writes_status", intruding_hook)
+
+    scan_started = scanner.start_scan()
+    assert scan_started is True
+    _wait_for_scan()
+    _wait_for_batch()
+
+    status = scanner.scan_status()
+    assert status["transcribe_batch_started"] is None, (
+        f"the older chain's write clobbered the newer chain's status: {status}"
+    )
+    assert status["transcribe_batch_note"] is None, (
+        f"the older chain's write clobbered the newer chain's status: {status}"
     )

--- a/web/src/lib/Library.svelte
+++ b/web/src/lib/Library.svelte
@@ -10,6 +10,7 @@
   let tag = $state("");
   let favorite = $state(false);
   let practiced = $state("");
+  let transcribed = $state("");
   let scan = $state(null);
   let loading = $state(true);
   let uploadInput;
@@ -272,11 +273,22 @@
     ["unknown", "Unsorted"],
   ];
 
+  // A freshly scanned library transcribes itself (#190), and this is how a
+  // person sees which of it that reached: narrow to "Transcribed" and the
+  // grid is exactly the scores a bulk pass could read; narrow to "Not
+  // transcribed" and it is exactly the complement - whatever a scan judged
+  // non-extractable, plus anything a manual pass has not reached yet.
+  const TRANSCRIBED = [
+    ["", "Any transcription"],
+    ["yes", "Transcribed"],
+    ["no", "Not transcribed"],
+  ];
+
   async function refresh() {
     loading = true;
     try {
       [scores, collections, tags] = await Promise.all([
-        api.scores({ search, collection, kind, tag, favorite, practiced }),
+        api.scores({ search, collection, kind, tag, favorite, practiced, transcribed }),
         api.collections(),
         api.tags(),
       ]);
@@ -287,7 +299,7 @@
 
   $effect(() => {
     // re-query whenever a filter changes
-    void search, collection, kind, tag, favorite, practiced;
+    void search, collection, kind, tag, favorite, practiced, transcribed;
     const t = setTimeout(refresh, 150);
     return () => clearTimeout(t);
   });
@@ -753,6 +765,11 @@
             <option {value}>{label}</option>
           {/each}
         </select>
+        <select class="transcribed-filter" bind:value={transcribed}>
+          {#each TRANSCRIBED as [value, label]}
+            <option {value}>{label}</option>
+          {/each}
+        </select>
         <button
           class="organise-toggle"
           class:on={organising}
@@ -817,6 +834,14 @@
                   <div class="sheet-icon">𝄞</div>
                 {/if}
                 <button class="fav" class:on={score.favorite} onclick={(e) => toggleFavorite(score, e)} title="Favorite">★</button>
+                {#if score.has_transcription}
+                  <!-- Whether it came from a scan's own bulk pass or a hand
+                       edit makes no difference here on purpose (#190's own
+                       No-gos) - this says only that a transcription exists,
+                       which is what the transcription filter beside it
+                       narrows the grid to. -->
+                  <span class="transcribed-mark" title="This score has a transcription">♪</span>
+                {/if}
                 {#if kindLabel[score.content_kind]}
                   <span class="kind">{kindLabel[score.content_kind]}</span>
                 {/if}
@@ -1301,6 +1326,20 @@
 
   .fav.on {
     color: var(--brass-bright);
+  }
+
+  /* Top-left is otherwise empty on a card: .fav sits top-right, .kind and
+     .missing-flag sit along the bottom. */
+  .transcribed-mark {
+    position: absolute;
+    left: 8px;
+    top: 8px;
+    font-size: 13px;
+    line-height: 1;
+    background: rgba(22, 19, 14, 0.75);
+    color: var(--brass-bright);
+    padding: 4px 7px;
+    border-radius: 99px;
   }
 
   .kind {

--- a/web/src/lib/Library.svelte
+++ b/web/src/lib/Library.svelte
@@ -330,6 +330,33 @@
     return () => clearTimeout(timer);
   });
 
+  // The same shape as the scan poll above, for a bulk pass THIS page never
+  // started (#190 review, F3) - a scan's own automatic one, or one started
+  // from another tab or client. Without this the library page polled
+  // nothing and showed nothing while such a pass ran, so the one moment a
+  // person's own click here would be refused (startTranscribeBatch's
+  // `!result.started` branch) was invisible until they tried.
+  $effect(() => {
+    let timer;
+    async function poll() {
+      const status = await api.transcribeBatchStatus();
+      if (status.running) {
+        backgroundBatch = status;
+        timer = setTimeout(poll, 1500);
+      } else {
+        backgroundBatch = null;
+        refresh();
+      }
+    }
+    api.transcribeBatchStatus().then((s) => {
+      if (s.running) {
+        backgroundBatch = s;
+        poll();
+      }
+    });
+    return () => clearTimeout(timer);
+  });
+
   async function triggerScan() {
     await api.scan();
     scan = { ...(scan ?? {}), scanning: true };
@@ -363,6 +390,13 @@
   let transcribeError = $state("");
   let transcribeStatus = $state(null);
   let transcribePollTimer;
+  // A pass this page did not start - a scan's own automatic one (#190), or
+  // someone else's - running right now. Polled independently of the dialog
+  // above, which only ever knows about a pass THIS page started: without
+  // this, the one moment a click here would be refused (see
+  // startTranscribeBatch's own `!result.started` branch) was invisible until
+  // the click itself failed.
+  let backgroundBatch = $state(null);
 
   const OUTCOME_LABEL = {
     already_transcribed: "already had one",
@@ -416,7 +450,23 @@
       const opts = { reconvert: transcribeReconvert };
       if (transcribeTarget.kind === "collection") opts.collection = transcribeTarget.collection;
       const ids = transcribeTarget.kind === "ids" ? transcribeTarget.ids : null;
-      transcribeStatus = await api.transcribeBatch(ids, opts);
+      const result = await api.transcribeBatch(ids, opts);
+      if (!result.started) {
+        // Refused - a pass is already running, and what came back is THAT
+        // pass's own status (api.transcribeBatch's own shape: "the status
+        // left behind by whichever pass - this one, or one already running -
+        // is current"), not one for the selection just made. Adopting it
+        // here would show somebody else's progress and results as though
+        // they belonged to this selection, and close having silently
+        // transcribed nothing this person chose - reachable with one click
+        // right after an upload or a boot scan starts its own pass (#190).
+        transcribeError =
+          `a pass over ${result.total} score${result.total === 1 ? "" : "s"} is already ` +
+          "running in the background - your selection was not started. Try again once it " +
+          "finishes.";
+        return;
+      }
+      transcribeStatus = result;
       pollTranscribeBatch();
     } catch (err) {
       transcribeError = err?.message ?? "Fermata could not start that.";
@@ -672,6 +722,29 @@
       <p class="scan-note">
         Last scan: {scan.restored} score{scan.restored === 1 ? "" : "s"} found again
         {scan.restored === 1 ? "at the path it" : "at the paths they"} went missing from.
+      </p>
+    {/if}
+
+    {#if !scan?.scanning && scan?.transcribe_batch_note}
+      <!-- A freshly scanned library transcribes itself (#190) - what its
+           chain's own bulk pass decided, said the same way the scan's other
+           after-the-fact notes are: attributed to the LAST SCAN, because the
+           note is replaced the next time a chain decides anything. Produced
+           since the feature shipped but never rendered anywhere until this
+           review (F3) - the one place a person could otherwise learn a
+           background pass was declined was by noticing nothing got marked. -->
+      <p class="scan-note">Last scan: {scan.transcribe_batch_note}.</p>
+    {/if}
+
+    {#if backgroundBatch && !transcribeOpen}
+      <!-- Live, not after-the-fact: a bulk pass is running RIGHT NOW that
+           this page did not start (#190 review, F3) - the scan's own
+           automatic one, or one from another tab or client. Unobtrusive on
+           purpose - this is ambient awareness, not the dialog's own detailed
+           progress, which is why it steps aside while that dialog is open. -->
+      <p class="scan-note">
+        Transcribing {backgroundBatch.total} score{backgroundBatch.total === 1 ? "" : "s"} in
+        the background…
       </p>
     {/if}
 

--- a/web/src/lib/Library.svelte
+++ b/web/src/lib/Library.svelte
@@ -1,4 +1,6 @@
 <script>
+  import { untrack } from "svelte";
+
   import { api } from "./api.js";
 
   let scores = $state([]);
@@ -321,6 +323,12 @@
         timer = setTimeout(poll, 1500);
       } else {
         refresh();
+        // A scan this page is tracking just finished - the single instant
+        // most likely to have just started an automatic transcription pass
+        // (#190's own hook). Check right away rather than wait out
+        // whatever is left of the background poll's own idle interval -
+        // see nudgeBackgroundBatchPoll's own comment.
+        nudgeBackgroundBatchPoll();
       }
     }
     api.scanStatus().then((s) => {
@@ -330,56 +338,98 @@
     return () => clearTimeout(timer);
   });
 
-  // For a bulk pass THIS page never started (#190 review, F3) - a scan's
-  // own automatic one, or one started from another tab or client. UNLIKE
-  // the scan poll above, this does not read any reactive state and does
-  // not stop once idle: an effect that only checked once, at mount (the
-  // first version of this), or that only rechecked when a scan already
-  // being watched by THIS page finished, both left a real gap - a person
-  // clicking "Scan library" and then watching the page saw nothing for as
-  // long as the pass ran (measured: 250 files, provably running, no live
-  // line after 8s), and a pass neither started nor watched by this page
-  // (another tab, another client) was never noticed at all. Polling
-  // continuously at a low rate, for as long as the page is open, is what
-  // actually covers every one of those - the same "low rate poll whenever
-  // open" the scan status could use too, but does not need to: a scan
-  // reliably outlives its own trigger long enough for the mount-time
-  // check in that effect to catch it, which is not true here (a pass this
-  // page did not start could begin and end between any two checks a
-  // slower interval would take).
+  // For a bulk pass THIS page never started (#190 review, F3, three
+  // passes) - a scan's own automatic one, or one started from another tab
+  // or client. Polled independently of both the scan poll above and the
+  // transcribe dialog's own poll (see `backgroundBatch`'s own comment).
   //
-  // Skips a beat while the transcribe dialog is open (`transcribeOpen`,
-  // read fresh on every tick rather than as an effect dependency, so this
-  // loop itself never restarts) - that dialog runs its own poll of the
-  // exact same endpoint at a faster rate for whatever it started, and this
-  // one's only job is ambient awareness of a pass THIS page did not start,
-  // which the dialog already covers while it is open. Refreshes the grid
-  // once when a background-only pass it was watching finishes, the same
-  // way the scan poll above does for a scan - the one place the newly
-  // transcribed cards' marks would otherwise wait for an unrelated refetch.
-  $effect(() => {
-    let cancelled = false;
-    let timer;
-    let wasRunning = false;
-    async function poll() {
-      if (!transcribeOpen) {
+  // RATE: 3s while a pass is confirmed running, 15s while idle. Idle
+  // forever at 3s (an earlier version of this) was roughly 1200
+  // requests/hour/tab with nothing running at all; backing off to 15s
+  // while idle - measured over 60s with nothing running: 4 requests, once
+  // every ~15s, as designed - cuts that by roughly 80% while a pass is
+  // NOT running, which is the overwhelmingly common case. Backing off
+  // rather than stopping outright (which the brief also allowed) is what
+  // still catches a pass THIS PAGE neither started nor is watching, from
+  // another tab or another client, without waiting for this page's own
+  // next reload to notice it.
+  //
+  // NUDGED - an immediate check, replacing whatever is left of the idle
+  // wait - the moment a scan this page is tracking finishes (both the
+  // mount-time scan poll above and pollUntilDone below call
+  // nudgeBackgroundBatchPoll() in their own "not scanning any more"
+  // branch). That is what keeps the 15s idle floor from being a real gap
+  // for the single most common case this feature is FOR - clicking "Scan
+  // library" and watching: the automatic pass this page's own scan may
+  // have started is checked within one request round trip of the scan
+  // itself finishing, not after up to 15s of nothing. A pass from
+  // elsewhere still relies on the 15s idle floor - there is no local
+  // signal for those to nudge on.
+  //
+  // RESILIENT to one failed request (#190 review, F3-1). api.js throws
+  // ApiError on a non-2xx response and fetch itself rejects on a dropped
+  // connection - a self-hosted server restarting with this page open is
+  // the ordinary way to see one - so without the try/finally below, ONE
+  // failed request ended this loop for the rest of the page's life
+  // (measured: baseline 2 requests/9s; after one aborted response, 0
+  // requests in the following 15s, plus an unhandled rejection). The
+  // reschedule lives in `finally` specifically so it runs whether the
+  // request above it succeeded or not. Logged and otherwise swallowed,
+  // nothing louder: this poll is ambient awareness, not a request a
+  // person is waiting on, and the ordinary scan poll and every other
+  // request on this page already surface a real outage of their own.
+  //
+  // `transcribeOpen` is read through `untrack` rather than as an ordinary
+  // reactive read, on purpose: reading it as a normal reactive value here
+  // would make this effect's own synchronous setup one of
+  // `transcribeOpen`'s dependents, so Svelte would tear this whole loop
+  // down and restart it - one extra request - every time the dialog opens
+  // or closes, exactly backwards from "skip a beat while it's open".
+  // `untrack` reads the current value without subscribing to it, so
+  // opening or closing the dialog no longer touches this loop at all; the
+  // next already-scheduled tick simply sees the new value when it runs.
+  let backgroundBatchTimer;
+  let backgroundBatchCancelled = true;
+  let wasBackgroundBatchRunning = false;
+
+  async function pollBackgroundBatch() {
+    clearTimeout(backgroundBatchTimer);
+    let nextDelay = 15000;
+    try {
+      if (!untrack(() => transcribeOpen)) {
         const status = await api.transcribeBatchStatus();
-        if (cancelled) return;
+        if (backgroundBatchCancelled) return;
         if (status.running) {
           backgroundBatch = status;
-          wasRunning = true;
+          wasBackgroundBatchRunning = true;
+          nextDelay = 3000;
         } else {
-          if (wasRunning) refresh();
-          wasRunning = false;
+          if (wasBackgroundBatchRunning) refresh();
+          wasBackgroundBatchRunning = false;
           backgroundBatch = null;
         }
       }
-      timer = setTimeout(poll, 3000);
+    } catch (err) {
+      console.error("background transcription status check did not complete", err);
+    } finally {
+      if (!backgroundBatchCancelled) {
+        backgroundBatchTimer = setTimeout(pollBackgroundBatch, nextDelay);
+      }
     }
-    poll();
+  }
+
+  function nudgeBackgroundBatchPoll() {
+    if (backgroundBatchCancelled) return;
+    clearTimeout(backgroundBatchTimer);
+    backgroundBatchTimer = setTimeout(pollBackgroundBatch, 0);
+  }
+
+  $effect(() => {
+    backgroundBatchCancelled = false;
+    pollBackgroundBatch();
     return () => {
-      cancelled = true;
-      clearTimeout(timer);
+      backgroundBatchCancelled = true;
+      clearTimeout(backgroundBatchTimer);
     };
   });
 
@@ -392,8 +442,17 @@
   function pollUntilDone() {
     const poll = async () => {
       scan = await api.scanStatus();
-      if (scan.scanning) setTimeout(poll, 1500);
-      else refresh();
+      if (scan.scanning) {
+        setTimeout(poll, 1500);
+      } else {
+        refresh();
+        // This page's own click just finished scanning - nudge the
+        // background-batch poll rather than leave it to its own idle
+        // interval, since this is exactly the moment #190's own hook may
+        // have started an automatic pass. See nudgeBackgroundBatchPoll's
+        // own comment.
+        nudgeBackgroundBatchPoll();
+      }
     };
     setTimeout(poll, 800);
   }

--- a/web/src/lib/Library.svelte
+++ b/web/src/lib/Library.svelte
@@ -330,31 +330,57 @@
     return () => clearTimeout(timer);
   });
 
-  // The same shape as the scan poll above, for a bulk pass THIS page never
-  // started (#190 review, F3) - a scan's own automatic one, or one started
-  // from another tab or client. Without this the library page polled
-  // nothing and showed nothing while such a pass ran, so the one moment a
-  // person's own click here would be refused (startTranscribeBatch's
-  // `!result.started` branch) was invisible until they tried.
+  // For a bulk pass THIS page never started (#190 review, F3) - a scan's
+  // own automatic one, or one started from another tab or client. UNLIKE
+  // the scan poll above, this does not read any reactive state and does
+  // not stop once idle: an effect that only checked once, at mount (the
+  // first version of this), or that only rechecked when a scan already
+  // being watched by THIS page finished, both left a real gap - a person
+  // clicking "Scan library" and then watching the page saw nothing for as
+  // long as the pass ran (measured: 250 files, provably running, no live
+  // line after 8s), and a pass neither started nor watched by this page
+  // (another tab, another client) was never noticed at all. Polling
+  // continuously at a low rate, for as long as the page is open, is what
+  // actually covers every one of those - the same "low rate poll whenever
+  // open" the scan status could use too, but does not need to: a scan
+  // reliably outlives its own trigger long enough for the mount-time
+  // check in that effect to catch it, which is not true here (a pass this
+  // page did not start could begin and end between any two checks a
+  // slower interval would take).
+  //
+  // Skips a beat while the transcribe dialog is open (`transcribeOpen`,
+  // read fresh on every tick rather than as an effect dependency, so this
+  // loop itself never restarts) - that dialog runs its own poll of the
+  // exact same endpoint at a faster rate for whatever it started, and this
+  // one's only job is ambient awareness of a pass THIS page did not start,
+  // which the dialog already covers while it is open. Refreshes the grid
+  // once when a background-only pass it was watching finishes, the same
+  // way the scan poll above does for a scan - the one place the newly
+  // transcribed cards' marks would otherwise wait for an unrelated refetch.
   $effect(() => {
+    let cancelled = false;
     let timer;
+    let wasRunning = false;
     async function poll() {
-      const status = await api.transcribeBatchStatus();
-      if (status.running) {
-        backgroundBatch = status;
-        timer = setTimeout(poll, 1500);
-      } else {
-        backgroundBatch = null;
-        refresh();
+      if (!transcribeOpen) {
+        const status = await api.transcribeBatchStatus();
+        if (cancelled) return;
+        if (status.running) {
+          backgroundBatch = status;
+          wasRunning = true;
+        } else {
+          if (wasRunning) refresh();
+          wasRunning = false;
+          backgroundBatch = null;
+        }
       }
+      timer = setTimeout(poll, 3000);
     }
-    api.transcribeBatchStatus().then((s) => {
-      if (s.running) {
-        backgroundBatch = s;
-        poll();
-      }
-    });
-    return () => clearTimeout(timer);
+    poll();
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
   });
 
   async function triggerScan() {

--- a/web/tests/browser/zzzz-library-auto-transcribe.spec.js
+++ b/web/tests/browser/zzzz-library-auto-transcribe.spec.js
@@ -1,0 +1,184 @@
+// A freshly scanned library transcribes itself, and says so (issue #190).
+//
+// WHAT server/tests/test_transcribe_batch_api.py CANNOT PROVE: that any of
+// this reaches the screen. That file (and test_scanner.py) pin the scan's
+// own hook - one bulk pass over exactly the ids a chain of scans added, never
+// one per scan, never a second pass while one is already running by hand -
+// at the process level. #95's lesson, recorded in zz-library-missing.spec.js,
+// is that a guarantee nothing renders is a guarantee nobody has. So what is
+// asserted here is the seam:
+//
+//   1. uploading an extractable PDF (which triggers its own scan - see
+//      api.upload) ends with that score transcribed, with no bulk-
+//      transcription click anywhere in this test, and the library card
+//      shows a mark for it; an upload that is NOT extractable ends with no
+//      transcription and no mark, so the mark is not merely "the card was
+//      touched by a scan";
+//   2. the transcription filter narrows the grid to exactly the transcribed
+//      set, and its complement to exactly the untranscribed one.
+//
+// WHY IT IS NAMED TO SORT AMONG THE OTHER zzzz-library-* SPECS: it uploads
+// and deletes scores the same way they do, and carries the same refusal-
+// unless-throwaway-instance guard zzz-library-organise.spec.js's own header
+// explains. Fully emptying the library in both beforeEach and afterAll -
+// rather than tracking its own small "OWN" list, the way zz-library-missing
+// does - is deliberate here: this file's whole subject is what a FRESH scan
+// does, so starting one from a library that already has a transcribed score
+// in it would silently defeat its own premise.
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { expect, test } from "@playwright/test";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const ENGRAVED_DIR = path.join(here, "..", "..", "..", "server", "tests", "fixtures", "engraved");
+
+// Real committed fixtures (see server/tests/conftest.py's extractable_pdf /
+// non_extractable_pdf) - a genuine tab-staff score and a genuine notation-
+// only one, so "transcribed itself" and "did not" are both real extractor
+// outcomes rather than something this file has to fake.
+const EXTRACTABLE_PDF = fs.readFileSync(path.join(ENGRAVED_DIR, "notation_and_tab.pdf"));
+const NON_EXTRACTABLE_PDF = fs.readFileSync(path.join(ENGRAVED_DIR, "notation_only.pdf"));
+
+const DEADLINE_MS = 30_000;
+
+async function sleep(ms) {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function scanStatus(request) {
+  return (await request.get("/api/scan/status")).json();
+}
+
+async function batchStatus(request) {
+  return (await request.get("/api/transcribe/batch/status")).json();
+}
+
+/**
+ * The barrier this whole file needs, and the exact race
+ * zz-library-missing.spec.js's own scanAndWait warns about, one layer
+ * further down: `scanning` going false only means the SCAN is done, not
+ * that its own chain-completion hook (scanner._finish_scan_chain) has
+ * decided anything about a bulk pass, and certainly not that a bulk pass it
+ * started has finished. `transcribe_batch_started` moving away from `null`
+ * IS that hook having decided (see scanner.py and ScanStatusOut) - only
+ * once it has is polling /api/transcribe/batch/status for `running` to go
+ * false actually about the pass this upload's own scan may have started,
+ * rather than one from earlier that just happened to still be running.
+ */
+async function autoTranscribePassSettled(request) {
+  const deadline = Date.now() + DEADLINE_MS;
+  let status;
+  for (;;) {
+    status = await scanStatus(request);
+    if (!status.scanning && status.transcribe_batch_started !== null) break;
+    if (Date.now() > deadline) {
+      throw new Error(
+        `the scan's own chain never finished deciding about a bulk pass: ${JSON.stringify(status)}`,
+      );
+    }
+    await sleep(100);
+  }
+  for (;;) {
+    const b = await batchStatus(request);
+    if (!b.running) return { scan: status, batch: b };
+    if (Date.now() > deadline) throw new Error("the automatic bulk transcription pass never finished");
+    await sleep(100);
+  }
+}
+
+/** Upload a real PDF, wait for its row to appear, and wait out everything a
+ * fresh upload can set in motion - its own scan (api.upload triggers one)
+ * AND the bulk transcription pass that scan's chain may have started on its
+ * own (#190) - before handing back the score exactly as the library holds
+ * it now. */
+async function uploadAndSettle(request, buffer, name, title) {
+  const res = await request.post("/api/upload?folder=Uploads", {
+    multipart: { file: { name, mimeType: "application/pdf", buffer } },
+  });
+  expect(res.ok(), await res.text()).toBe(true);
+  let found;
+  await expect(async () => {
+    const scores = await (await request.get("/api/scores")).json();
+    found = scores.find((s) => s.path === `Uploads/${name}`);
+    expect(found, `${name} never appeared in the library`).toBeTruthy();
+  }).toPass({ timeout: DEADLINE_MS });
+  await autoTranscribePassSettled(request);
+  const patched = await request.patch(`/api/scores/${found.id}`, { data: { title } });
+  expect(patched.ok(), await patched.text()).toBe(true);
+  return patched.json();
+}
+
+async function emptyTheLibrary(request) {
+  for (const score of await (await request.get("/api/scores")).json()) {
+    await request.delete(`/api/scores/${score.id}`);
+  }
+  for (const score of await (await request.get("/api/trash")).json()) {
+    await request.delete(`/api/trash/${score.id}`);
+  }
+}
+
+test.beforeEach(async ({ request }) => {
+  const existing = await (await request.get("/api/scores")).json();
+  expect(
+    existing,
+    "refusing to run: this backend already has scores in its library, so it is not the " +
+      "throwaway instance the suite creates - and this file's whole subject is what a FRESH " +
+      "scan does",
+  ).toEqual([]);
+});
+
+// After EVERY test, not only at the end - each test in this file starts from
+// a library that reads as genuinely fresh (see beforeEach above), which a
+// later test in the same file could not claim if an earlier one's uploads
+// were still sitting in it.
+test.afterEach(async ({ request }) => {
+  await emptyTheLibrary(request);
+});
+
+test("an uploaded extractable score transcribes itself, and the card shows it", async ({
+  page,
+  request,
+}) => {
+  const good = await uploadAndSettle(
+    request, EXTRACTABLE_PDF, "auto-extractable.pdf", "Auto extractable score",
+  );
+  expect(good.has_transcription, JSON.stringify(good)).toBe(true);
+
+  const bad = await uploadAndSettle(
+    request, NON_EXTRACTABLE_PDF, "auto-non-extractable.pdf", "Auto non-extractable score",
+  );
+  expect(bad.has_transcription, JSON.stringify(bad)).toBe(false);
+
+  await page.goto("/#/");
+  await expect(page.locator(`.card[href="#/score/${good.id}"] .transcribed-mark`)).toBeVisible();
+  await expect(page.locator(`.card[href="#/score/${bad.id}"] .transcribed-mark`)).toHaveCount(0);
+});
+
+test("the transcription filter narrows the grid to the transcribed set and its complement", async ({
+  page,
+  request,
+}) => {
+  const good = await uploadAndSettle(
+    request, EXTRACTABLE_PDF, "filter-extractable.pdf", "Filter extractable score",
+  );
+  const bad = await uploadAndSettle(
+    request, NON_EXTRACTABLE_PDF, "filter-non-extractable.pdf", "Filter non-extractable score",
+  );
+  expect(good.has_transcription).toBe(true);
+  expect(bad.has_transcription).toBe(false);
+
+  await page.goto("/#/");
+  await expect(page.locator(".card")).toHaveCount(2);
+
+  await page.locator(".transcribed-filter").selectOption("yes");
+  await expect(page.locator(".card")).toHaveCount(1);
+  await expect(page.locator(`.card[href="#/score/${good.id}"]`)).toBeVisible();
+  await expect(page.locator(`.card[href="#/score/${bad.id}"]`)).toHaveCount(0);
+
+  await page.locator(".transcribed-filter").selectOption("no");
+  await expect(page.locator(".card")).toHaveCount(1);
+  await expect(page.locator(`.card[href="#/score/${bad.id}"]`)).toBeVisible();
+  await expect(page.locator(`.card[href="#/score/${good.id}"]`)).toHaveCount(0);
+});

--- a/web/tests/browser/zzzz-library-auto-transcribe.spec.js
+++ b/web/tests/browser/zzzz-library-auto-transcribe.spec.js
@@ -20,11 +20,11 @@
 // WHY IT IS NAMED TO SORT AMONG THE OTHER zzzz-library-* SPECS: it uploads
 // and deletes scores the same way they do, and carries the same refusal-
 // unless-throwaway-instance guard zzz-library-organise.spec.js's own header
-// explains. Fully emptying the library in both beforeEach and afterAll -
-// rather than tracking its own small "OWN" list, the way zz-library-missing
-// does - is deliberate here: this file's whole subject is what a FRESH scan
-// does, so starting one from a library that already has a transcribed score
-// in it would silently defeat its own premise.
+// explains. Fully emptying the library after EVERY test - rather than
+// tracking its own small "OWN" list, the way zz-library-missing does - is
+// deliberate here: this file's whole subject is what a FRESH scan does, so
+// starting one from a library that already has a transcribed score in it
+// would silently defeat its own premise.
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";

--- a/web/tests/browser/zzzz-library-auto-transcribe.spec.js
+++ b/web/tests/browser/zzzz-library-auto-transcribe.spec.js
@@ -55,6 +55,17 @@ async function batchStatus(request) {
   return (await request.get("/api/transcribe/batch/status")).json();
 }
 
+/** The throwaway library's root on disk (see playwright.config.js) - needed
+ * only by the unmocked F3 test below, to place many files WITHOUT going
+ * through POST /api/upload (which would scan each one immediately, one at a
+ * time), so a single "Scan library" click discovers all of them together and
+ * the automatic pass it starts has real, multi-second work to do. */
+const libraryDir = () => {
+  const dir = process.env.FERMATA_TEST_LIBRARY_DIR;
+  if (!dir) throw new Error("FERMATA_TEST_LIBRARY_DIR is not set - see playwright.config.js");
+  return dir;
+};
+
 /**
  * The barrier this whole file needs, and the exact race
  * zz-library-missing.spec.js's own scanAndWait warns about, one layer
@@ -345,12 +356,18 @@ test("a pass this page did not start is visible while it runs and after it is re
   await page.goto("/#/");
 
   // The live indicator: ambient awareness of a pass this page never
-  // started, visible with no dialog open at all. Matched on "in the
-  // background" rather than "Transcribing" - hasText is case-insensitive,
-  // and the static note just below also contains the word "transcribing",
-  // which would otherwise match both.
-  await expect(page.locator(".scan-note", { hasText: "in the background" })).toContainText(
-    "Transcribing 7",
+  // started, visible with no dialog open at all. Matched on "Transcribing
+  // 7" rather than "in the background" - hasText is a case-insensitive
+  // substring match, and the SUCCESS note (`_finish_scan_chain`'s own
+  // "started transcribing N newly scanned score(s) in the background")
+  // contains "in the background" too, so that phrase alone does not
+  // distinguish the live line from a chain's own after-the-fact note when
+  // both could plausibly render together. "Transcribing 7" is the live
+  // line's own template start (`Transcribing {total} score(s) in the
+  // background…`) and never appears in the backend's differently-worded
+  // note.
+  await expect(page.locator(".scan-note", { hasText: "Transcribing 7" })).toContainText(
+    "in the background",
   );
   // The static note: what the scan's own chain decided, in words, since a
   // scan runs unattended on every boot and this is the one place anybody
@@ -358,4 +375,87 @@ test("a pass this page did not start is visible while it runs and after it is re
   await expect(page.locator(".scan-note", { hasText: "did not start" })).toContainText(
     "already running",
   );
+});
+
+test("clicking Scan while the page is open shows the live background-pass line, unmocked", async ({
+  page,
+  request,
+}) => {
+  // #190 review, F3, unmocked. The two tests above prove the LIBRARY PAGE
+  // renders `backgroundBatch` correctly given a canned response; neither
+  // proves the actual reactive poll (Library.svelte's own $effect) ever
+  // NOTICES a real pass that starts AFTER the page is already open - the
+  // exact scenario the review measured directly against the real build: 250
+  // files, click Scan, the pass provably running, no live line on screen
+  // after 8s, because the first version of that effect only checked once,
+  // at mount, before the click that starts the pass had even happened.
+  //
+  // Many real files, placed on disk directly (never through POST /api/upload,
+  // which would scan and auto-transcribe each one individually the instant
+  // it lands) so ONE "Scan library" click discovers all of them together and
+  // the automatic pass that scan's own chain starts has real, multi-second
+  // work to do - long enough to outlast this page's own 3s poll interval by
+  // a wide margin, the same reasoning zzzz-library-transcribe-batch.spec.js's
+  // WARMUP_COUNT uses for the same reason, scaled up here because a poll that
+  // only rechecks every 3s (rather than that file's own 100ms out-of-band
+  // wait) needs a wider margin to reliably catch the pass before it ends.
+  // Measured directly on this box (server/tests/fixtures/engraved/
+  // notation_and_tab.pdf, the same fixture EXTRACTABLE_PDF loads):
+  // tabextract.extract() alone runs ~15ms/file, but the FULL scan+transcribe
+  // pipeline this test actually exercises (hashing, DB writes, the scan's
+  // own walk) runs closer to the ~90ms/score the PR body's 293-file
+  // reference-library run measured end to end. 120 undershot that margin
+  // once (measured: the occupying pass had already finished by the time
+  // this test reached the Apply click, so it succeeded instead of being
+  // refused) - 400 keeps the pass running for tens of seconds, comfortably
+  // outlasting this page's own 3s poll interval and every round trip below.
+  const BULK_COUNT = 400;
+  const dir = path.join(libraryDir(), "Uploads");
+  fs.mkdirSync(dir, { recursive: true });
+  for (let i = 0; i < BULK_COUNT; i++) {
+    fs.writeFileSync(path.join(dir, `bulk${i}.pdf`), EXTRACTABLE_PDF);
+  }
+
+  await page.goto("/#/");
+  await page.locator("button", { hasText: "Scan library" }).click();
+
+  // Out of band, via the API directly rather than the page's own poll -
+  // this is the moment a real pass this page did not (yet) know about
+  // starts running, confirmed independently of whatever the UI shows.
+  await expect(async () => {
+    const b = await batchStatus(request);
+    expect(b.running, JSON.stringify(b)).toBe(true);
+  }).toPass({ timeout: DEADLINE_MS });
+
+  // The live line, on the real page, having noticed a pass it did not
+  // start on its own. Matched with a regex rather than a literal string:
+  // the template that renders it (Library.svelte) wraps across two source
+  // lines with no <br>, so the rendered text carries a literal newline
+  // between "in" and "the background" - \s+ absorbs that (and any other
+  // whitespace collapsing a browser applies) instead of asserting on it.
+  await expect(
+    page.locator(".scan-note", { hasText: /Transcribing \d+ scores? in\s+the background/ }),
+  ).toBeVisible({ timeout: DEADLINE_MS });
+
+  // Selecting a score while that real pass is still running is refused,
+  // not silently adopted - F1's own claim, unmocked: a real occupying pass
+  // this click did not start, a real refusal from the real backend.
+  await page.locator(".organise-toggle").click();
+  const anyCard = page.locator(".card").first();
+  await expect(anyCard).toBeVisible({ timeout: DEADLINE_MS });
+  await anyCard.click();
+  await page.locator(".transcribe-open").click();
+  const dialog = page.locator(".dialog.transcribe");
+  await expect(dialog).toBeVisible();
+  await dialog.locator(".transcribe-apply").click();
+  await expect(dialog.locator(".alert-error")).toContainText(
+    "already running in the background",
+  );
+  await expect(dialog.locator(".alert-error")).toContainText("your selection was not started");
+
+  // Settled before this test ends, not left running - a leftover pass over
+  // BULK_COUNT files would occupy the batch slot for whatever the suite
+  // runs next, the same reasoning uploadAndSettle uses throughout this file.
+  await dialog.locator(".dialog-cancel").click();
+  await autoTranscribePassSettled(request);
 });

--- a/web/tests/browser/zzzz-library-auto-transcribe.spec.js
+++ b/web/tests/browser/zzzz-library-auto-transcribe.spec.js
@@ -110,6 +110,25 @@ async function uploadAndSettle(request, buffer, name, title) {
   return patched.json();
 }
 
+/** Upload a real PDF and wait only for its row to appear - never for
+ * whatever automatic pass its own scan might start (see uploadAndSettle,
+ * above, for the version that does). Used by the F1 test below, which
+ * mocks POST /api/transcribe/batch itself and so needs a score to select
+ * but not the automatic pass its upload would otherwise start. */
+async function uploadRowOnly(request, buffer, name) {
+  const res = await request.post("/api/upload?folder=Uploads", {
+    multipart: { file: { name, mimeType: "application/pdf", buffer } },
+  });
+  expect(res.ok(), await res.text()).toBe(true);
+  let found;
+  await expect(async () => {
+    const scores = await (await request.get("/api/scores")).json();
+    found = scores.find((s) => s.path === `Uploads/${name}`);
+    expect(found, `${name} never appeared in the library`).toBeTruthy();
+  }).toPass({ timeout: DEADLINE_MS });
+  return found;
+}
+
 async function emptyTheLibrary(request) {
   for (const score of await (await request.get("/api/scores")).json()) {
     await request.delete(`/api/scores/${score.id}`);
@@ -154,6 +173,14 @@ test("an uploaded extractable score transcribes itself, and the card shows it", 
   await page.goto("/#/");
   await expect(page.locator(`.card[href="#/score/${good.id}"] .transcribed-mark`)).toBeVisible();
   await expect(page.locator(`.card[href="#/score/${bad.id}"] .transcribed-mark`)).toHaveCount(0);
+
+  // scan.transcribe_batch_note reaches the screen (#190 review, F3) - the
+  // one place a person could otherwise learn what the last scan's own
+  // automatic pass decided was by noticing which cards got marked, or not
+  // noticing at all when it was refused rather than started.
+  await expect(page.locator(".scan-note", { hasText: "transcribing" })).toContainText(
+    "started transcribing",
+  );
 });
 
 test("the transcription filter narrows the grid to the transcribed set and its complement", async ({
@@ -181,4 +208,154 @@ test("the transcription filter narrows the grid to the transcribed set and its c
   await expect(page.locator(".card")).toHaveCount(1);
   await expect(page.locator(`.card[href="#/score/${bad.id}"]`)).toBeVisible();
   await expect(page.locator(`.card[href="#/score/${good.id}"]`)).toHaveCount(0);
+});
+
+// Both tests below reproduce #190 review's F1 and F3 by mocking the ONE
+// response each needs, rather than racing a real background pass against
+// the dialog or the page. Measured directly (server/tests/fixtures/engraved
+// /notation_and_tab.pdf, three runs): tabextract.extract() over it takes
+// 15-40ms - far too fast, against ordinary HTTP and scan round trips, to
+// hold the batch slot open reliably from a black-box test even with a large
+// occupying selection; an earlier version of this file tried exactly that
+// and lost the race. What F1 and F3 are actually about - what the LIBRARY
+// PAGE does with a given API response - does not need a real pass behind
+// it: server/tests/test_transcribe_batch_api.py already proves the real
+// pass produces these responses (a scan's own hook setting
+// transcribe_batch_started/note, and POST /transcribe/batch answering
+// `started: false` with the running pass's own status - see
+// TranscribeBatchTriggerOut) at the process level.
+
+test("selecting a score while a pass is already running is refused, not silently adopted", async ({
+  page,
+  request,
+}) => {
+  // #190 review, F1. On main this needed two people; the automatic pass
+  // (#190 itself) makes it reachable with one ordinary click, right after
+  // an upload or a boot scan: select a score, click Apply while SOME OTHER
+  // pass is running, and POST /api/transcribe/batch answers 200 with the
+  // OTHER pass's own status (`started: false`) rather than one for this
+  // selection. The dialog used to bind that straight to its own state
+  // regardless, showing somebody else's progress and results as though
+  // they belonged to what was just chosen, and closing having transcribed
+  // nothing this person selected - with nothing saying so.
+  const target = await uploadRowOnly(request, EXTRACTABLE_PDF, "target.pdf");
+
+  // The refusal shape POST /api/transcribe/batch/status actually answers
+  // when a DIFFERENT pass is running - TranscribeBatchTriggerOut's own
+  // fields, `started: false` and the RUNNING pass's own totals (2 scores
+  // that are not "target.pdf" at all, which is exactly the point: nothing
+  // about this selection).
+  await page.route("**/api/transcribe/batch", (route) =>
+    route.fulfill({
+      json: {
+        started: false,
+        running: true,
+        total: 2,
+        processed: 0,
+        transcribed: 0,
+        already_transcribed: 0,
+        non_extractable: 0,
+        errored: 0,
+        with_defective_bars: 0,
+        reconvert: false,
+        results: [],
+        started_at: Date.now() / 1000,
+        finished_at: null,
+      },
+    }),
+  );
+
+  await page.goto("/#/");
+  await page.locator(".organise-toggle").click();
+  const card = page.locator(`.card[href="#/score/${target.id}"]`);
+  await expect(card).toBeVisible();
+  await card.click();
+  await page.locator(".transcribe-open").click();
+  const dialog = page.locator(".dialog.transcribe");
+  await expect(dialog).toBeVisible();
+  await dialog.locator(".transcribe-apply").click();
+
+  await expect(dialog.locator(".alert-error")).toContainText(
+    "already running in the background",
+  );
+  await expect(dialog.locator(".alert-error")).toContainText("your selection was not started");
+  // Never adopted the running pass's own progress or results - the bug
+  // this pins: 2 scores, 0 processed, would have rendered as "Transcribing…
+  // 0/2" and closed with a "0 transcribed..." summary belonging to nothing
+  // this person chose, had the fix not checked `started`.
+  await expect(dialog.locator(".transcribe-progress")).toHaveCount(0);
+  await expect(dialog.locator(".transcribe-line")).toHaveCount(0);
+});
+
+test("a pass this page did not start is visible while it runs and after it is refused", async ({
+  page,
+}) => {
+  // #190 review, F3: transcribe_batch_started/note were produced (scanner.
+  // _finish_scan_chain sets them) but reached no reader anywhere in
+  // web/src, and while a pass this page never started was running, the
+  // page polled nothing and showed nothing about it - the one moment F1
+  // happens was invisible until the click itself failed.
+  await page.route("**/api/transcribe/batch/status", (route) =>
+    route.fulfill({
+      json: {
+        running: true,
+        total: 7,
+        processed: 3,
+        transcribed: 2,
+        already_transcribed: 1,
+        non_extractable: 0,
+        errored: 0,
+        with_defective_bars: 0,
+        reconvert: false,
+        results: [],
+        started_at: Date.now() / 1000,
+        finished_at: null,
+      },
+    }),
+  );
+  await page.route("**/api/scan/status", (route) =>
+    route.fulfill({
+      json: {
+        scanning: false,
+        total: 1,
+        processed: 1,
+        added: 1,
+        updated: 0,
+        missing: 0,
+        restored: 0,
+        unmatched_moves: 0,
+        refused: false,
+        refused_reason: null,
+        unmatched_paths: [],
+        unmatched_count: 0,
+        acknowledge_token: null,
+        errors: 0,
+        last_error: null,
+        started_at: Date.now() / 1000,
+        finished_at: Date.now() / 1000,
+        transcribe_batch_started: false,
+        transcribe_batch_note:
+          "did not start transcribing the newly scanned scores because a bulk " +
+          "transcription pass was already running - start one by hand from the " +
+          "library view to pick them up",
+      },
+    }),
+  );
+
+  await page.goto("/#/");
+
+  // The live indicator: ambient awareness of a pass this page never
+  // started, visible with no dialog open at all. Matched on "in the
+  // background" rather than "Transcribing" - hasText is case-insensitive,
+  // and the static note just below also contains the word "transcribing",
+  // which would otherwise match both.
+  await expect(page.locator(".scan-note", { hasText: "in the background" })).toContainText(
+    "Transcribing 7",
+  );
+  // The static note: what the scan's own chain decided, in words, since a
+  // scan runs unattended on every boot and this is the one place anybody
+  // could read that it declined to start a pass.
+  await expect(page.locator(".scan-note", { hasText: "did not start" })).toContainText(
+    "already running",
+  );
 });

--- a/web/tests/browser/zzzz-library-auto-transcribe.spec.js
+++ b/web/tests/browser/zzzz-library-auto-transcribe.spec.js
@@ -356,17 +356,19 @@ test("a pass this page did not start is visible while it runs and after it is re
   await page.goto("/#/");
 
   // The live indicator: ambient awareness of a pass this page never
-  // started, visible with no dialog open at all. Matched on "Transcribing
-  // 7" rather than "in the background" - hasText is a case-insensitive
-  // substring match, and the SUCCESS note (`_finish_scan_chain`'s own
-  // "started transcribing N newly scanned score(s) in the background")
-  // contains "in the background" too, so that phrase alone does not
-  // distinguish the live line from a chain's own after-the-fact note when
-  // both could plausibly render together. "Transcribing 7" is the live
-  // line's own template start (`Transcribing {total} score(s) in the
-  // background…`) and never appears in the backend's differently-worded
-  // note.
-  await expect(page.locator(".scan-note", { hasText: "Transcribing 7" })).toContainText(
+  // started, visible with no dialog open at all. Matched on the trailing
+  // ellipsis "…" the live line's own template ends with
+  // (`Transcribing {total} score(s) in the background…`), not on
+  // "Transcribing 7" or "in the background" alone: hasText is a
+  // case-insensitive SUBSTRING match, and the SUCCESS note
+  // (`_finish_scan_chain`'s own "started transcribing 7 newly scanned
+  // score(s) in the background") would contain both of those literally,
+  // count and all, if it were the one rendering here - it happens not to
+  // be, in THIS test (the mock below uses the refusal note, which has no
+  // count at all), but the ellipsis is absent from every backend note
+  // regardless (they end in a period, from the "Last scan: ...." template),
+  // so it does not depend on that coincidence.
+  await expect(page.locator(".scan-note", { hasText: "…" })).toContainText(
     "in the background",
   );
   // The static note: what the scan's own chain decided, in words, since a
@@ -394,21 +396,22 @@ test("clicking Scan while the page is open shows the live background-pass line, 
   // which would scan and auto-transcribe each one individually the instant
   // it lands) so ONE "Scan library" click discovers all of them together and
   // the automatic pass that scan's own chain starts has real, multi-second
-  // work to do - long enough to outlast this page's own 3s poll interval by
-  // a wide margin, the same reasoning zzzz-library-transcribe-batch.spec.js's
-  // WARMUP_COUNT uses for the same reason, scaled up here because a poll that
-  // only rechecks every 3s (rather than that file's own 100ms out-of-band
-  // wait) needs a wider margin to reliably catch the pass before it ends.
-  // Measured directly on this box (server/tests/fixtures/engraved/
-  // notation_and_tab.pdf, the same fixture EXTRACTABLE_PDF loads):
-  // tabextract.extract() alone runs ~15ms/file, but the FULL scan+transcribe
-  // pipeline this test actually exercises (hashing, DB writes, the scan's
-  // own walk) runs closer to the ~90ms/score the PR body's 293-file
-  // reference-library run measured end to end. 120 undershot that margin
-  // once (measured: the occupying pass had already finished by the time
-  // this test reached the Apply click, so it succeeded instead of being
-  // refused) - 400 keeps the pass running for tens of seconds, comfortably
-  // outlasting this page's own 3s poll interval and every round trip below.
+  // work to do - long enough to still be running once this page notices it
+  // and clicks Apply below. 120 undershot that once (measured: the occupying
+  // pass had already finished by the time this test reached the Apply
+  // click, so it succeeded instead of being refused).
+  //
+  // 400 - MEASURED, not estimated (#190 review, third pass): 6.6-6.7s of
+  // real occupied time across repeated runs on this box, against this
+  // page's own poll effect, which - since this round - is NUDGED into an
+  // immediate check the moment pollUntilDone sees this test's own scan
+  // finish (see nudgeBackgroundBatchPoll's own comment in Library.svelte),
+  // rather than waiting out whatever is left of its idle interval. That
+  // nudge is most of why this margin holds: the worst-case slack between
+  // "the automatic pass is confirmed running" and "this test has clicked
+  // Apply" measured around 3.2s, well inside the 6.6-6.7s window, and does
+  // not depend on the poll's own 3s/15s cadence the way an un-nudged design
+  // would have.
   const BULK_COUNT = 400;
   const dir = path.join(libraryDir(), "Uploads");
   fs.mkdirSync(dir, { recursive: true });
@@ -458,4 +461,80 @@ test("clicking Scan while the page is open shows the live background-pass line, 
   // runs next, the same reasoning uploadAndSettle uses throughout this file.
   await dialog.locator(".dialog-cancel").click();
   await autoTranscribePassSettled(request);
+});
+
+test("a failed background-poll request does not end polling for the rest of the page's life", async ({
+  page,
+}) => {
+  // #190 review, F3-1. api.js throws ApiError on a non-2xx response and
+  // fetch itself rejects outright on a dropped connection - a self-hosted
+  // server restarting with this page open is the ordinary way to see one -
+  // and the poll used to have no try/catch around the request at all: ONE
+  // failed request ended the loop for the rest of the page's life (measured
+  // directly against the real build before this fix: baseline 2 requests in
+  // 9s; after one aborted response, 0 requests in the following 15s, plus
+  // an unhandled "Failed to fetch"). Reproduced here with a genuine network
+  // abort via page.route, fired exactly once, on the very first request the
+  // poll makes at mount - the worst case, since nothing has succeeded yet
+  // to prove the loop was ever alive.
+  let requestCount = 0;
+  let aborted = false;
+  let reportRunning = false;
+
+  await page.route("**/api/transcribe/batch/status", (route) => {
+    requestCount += 1;
+    if (!aborted) {
+      aborted = true;
+      return route.abort("failed");
+    }
+    return route.fulfill({
+      json: reportRunning
+        ? {
+            running: true,
+            total: 3,
+            processed: 1,
+            transcribed: 1,
+            already_transcribed: 0,
+            non_extractable: 0,
+            errored: 0,
+            with_defective_bars: 0,
+            reconvert: false,
+            results: [],
+            started_at: Date.now() / 1000,
+            finished_at: null,
+          }
+        : {
+            running: false,
+            total: 0,
+            processed: 0,
+            transcribed: 0,
+            already_transcribed: 0,
+            non_extractable: 0,
+            errored: 0,
+            with_defective_bars: 0,
+            reconvert: false,
+            results: [],
+            started_at: null,
+            finished_at: null,
+          },
+    });
+  });
+
+  await page.goto("/#/");
+
+  // Polling continues: at least one more request lands after the aborted
+  // one - the loop is not dead. Waits out the idle backoff's own 15s
+  // interval (nothing is "running" yet, so the poll is at its slowest).
+  await expect
+    .poll(() => requestCount, { timeout: DEADLINE_MS, intervals: [500] })
+    .toBeGreaterThanOrEqual(2);
+
+  // And the loop is not merely alive but still doing its actual job: once
+  // a pass "starts", the live line still appears - proving the one earlier
+  // failure left no half-broken state behind (a stuck `wasBackgroundBatchRunning`,
+  // a poll wedged at the wrong rate, or similar).
+  reportRunning = true;
+  await expect(
+    page.locator(".scan-note", { hasText: "…" }),
+  ).toContainText("in the background", { timeout: DEADLINE_MS });
 });

--- a/web/tests/browser/zzzz-library-transcribe-batch.spec.js
+++ b/web/tests/browser/zzzz-library-transcribe-batch.spec.js
@@ -39,6 +39,17 @@ const NON_EXTRACTABLE_PDF = fs.readFileSync(path.join(ENGRAVED_DIR, "notation_on
 
 const SCAN_DEADLINE_MS = 30_000;
 
+/** The throwaway library's root on disk (see playwright.config.js) - needed
+ * only by the mixed-selection test below, to place a file WITHOUT going
+ * through POST /api/upload, so that file's own first scan can be triggered
+ * at a moment the test controls precisely rather than through the upload
+ * endpoint's own immediate scan. */
+const libraryDir = () => {
+  const dir = process.env.FERMATA_TEST_LIBRARY_DIR;
+  if (!dir) throw new Error("FERMATA_TEST_LIBRARY_DIR is not set - see playwright.config.js");
+  return dir;
+};
+
 async function scanSettled(request) {
   const deadline = Date.now() + SCAN_DEADLINE_MS;
   for (;;) {
@@ -133,11 +144,97 @@ async function waitForBatchDone(page) {
   });
 }
 
+async function apiBatchSettled(request, timeout = SCAN_DEADLINE_MS) {
+  const deadline = Date.now() + timeout;
+  for (;;) {
+    const status = await (await request.get("/api/transcribe/batch/status")).json();
+    if (!status.running) return status;
+    if (Date.now() > deadline) throw new Error("a bulk transcription pass never finished");
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+}
+
 test("a bulk pass over a mixed selection shows live progress and every score's real outcome", async ({
   page,
   request,
 }) => {
-  const fresh = await upload(request, EXTRACTABLE_PDF, "fresh.pdf", "Uploads", "Fresh score");
+  // #190 means uploading an extractable PDF transcribes it automatically,
+  // almost immediately - so getting a genuinely first-time "transcribed"
+  // outcome for "fresh.pdf" below (rather than a reconvert of one the
+  // automatic pass already did) means keeping that automatic pass from
+  // ever reaching it. Attempted first with a single throwaway score to
+  // occupy the batch slot and lost: a single small PDF's real re-extraction
+  // is fast enough (measured directly: 15-40ms) that it had already
+  // finished by the time a scan triggered right after "confirmed running"
+  // reached its own chain decision - "confirmed running at some instant" is
+  // not "still running a few round trips later". WARMUP_COUNT real
+  // re-extractions, fired together as ONE explicit pass this test starts
+  // itself, is what actually holds the slot open long enough: still
+  // genuine PDF work (not a sleep a future refactor could silently race
+  // again), just enough of it that the margin is measured in whole seconds
+  // rather than milliseconds.
+  //
+  // "fresh.pdf" itself is placed on disk directly (never through POST
+  // /api/upload, which would trigger its own scan immediately) so this test
+  // controls exactly when its scan happens: only once the occupying pass is
+  // CONFIRMED running - so its own automatic attempt (#190) is refused the
+  // same way a hand-started pass refuses a second one (see
+  // scanner._finish_scan_chain), not merely likely to be.
+  const WARMUP_COUNT = 15;
+  const warmups = await Promise.all(
+    Array.from({ length: WARMUP_COUNT }, (_, i) =>
+      upload(request, EXTRACTABLE_PDF, `warmup${i}.pdf`, "Uploads", `Warmup score ${i}`),
+    ),
+  );
+  // upload() above only waits out each file's own SCAN, not whatever
+  // automatic pass (#190) that scan's chain may have started - settled
+  // explicitly here so the occupying pass below starts from a known idle
+  // state, not racing an auto-batch of unpredictable timing (an earlier
+  // version of this test raced exactly that and was flaky).
+  await apiBatchSettled(request);
+
+  const freshDir = path.join(libraryDir(), "Uploads");
+  fs.mkdirSync(freshDir, { recursive: true });
+  fs.writeFileSync(path.join(freshDir, "fresh.pdf"), EXTRACTABLE_PDF);
+
+  const occupyRes = await request.post("/api/transcribe/batch", {
+    data: { score_ids: warmups.map((w) => w.id), reconvert: true },
+  });
+  expect((await occupyRes.json()).started, "the occupying pass could not start").toBe(true);
+  await expect(async () => {
+    const status = await (await request.get("/api/transcribe/batch/status")).json();
+    expect(status.running, JSON.stringify(status)).toBe(true);
+  }).toPass({ timeout: 5_000 });
+
+  const scanRes = await request.post("/api/scan");
+  expect(scanRes.ok(), await scanRes.text()).toBe(true);
+  const scanBody = await scanRes.json();
+  expect(scanBody.started, JSON.stringify(scanBody)).toBe(true);
+  await scanSettled(request);
+  await apiBatchSettled(request);
+
+  let fresh;
+  await expect(async () => {
+    const scores = await (await request.get("/api/scores")).json();
+    fresh = scores.find((s) => s.path === "Uploads/fresh.pdf");
+    expect(fresh, "fresh.pdf never appeared in the library").toBeTruthy();
+  }).toPass({ timeout: SCAN_DEADLINE_MS });
+  const freshPatched = await request.patch(`/api/scores/${fresh.id}`, {
+    data: { title: "Fresh score" },
+  });
+  expect(freshPatched.ok(), await freshPatched.text()).toBe(true);
+  fresh = await freshPatched.json();
+
+  // The premise this test needs, checked rather than assumed: if the scan
+  // above had somehow landed before the occupying pass was confirmed
+  // running, "fresh.pdf" would already carry a transcription here, and the
+  // assertions below would be proving something weaker than they claim to.
+  expect(
+    fresh.has_transcription,
+    "fresh.pdf was auto-transcribed despite a bulk pass being confirmed running when its " +
+      "scan was triggered",
+  ).toBe(false);
+
   const already = await upload(
     request, EXTRACTABLE_PDF, "already.pdf", "Uploads", "Already transcribed score",
   );
@@ -153,47 +250,15 @@ test("a bulk pass over a mixed selection shows live progress and every score's r
     request, NON_EXTRACTABLE_PDF, "bad.pdf", "Uploads", "Not-extractable score",
   );
 
-  // "fresh.pdf" runs through its OWN dialog, with reconvert ticked, rather
-  // than alongside the other three below. #190 means uploading an
-  // extractable PDF now transcribes it automatically, almost immediately -
-  // upload()'s own wait for the scan to settle already gives that automatic
-  // pass time to run, so by the time Organise mode can select it, "fresh.pdf"
-  // already has an extracted transcription of its own. Reconvert is what
-  // still proves the "transcribed" outcome renders correctly here: it asks
-  // for exactly the re-extraction the automatic pass already did, and
-  // reports the same "transcribed" outcome a genuinely first-time pass
-  // would. (The automatic pass itself is asserted directly in
-  // zzzzz-library-scan-transcribes.spec.js, not here.)
   await organise(page);
   await choose(page, fresh);
-  await page.locator(".transcribe-open").click();
-  let dialog = page.locator(".dialog.transcribe");
-  await expect(dialog).toBeVisible();
-  await dialog.locator(".reconvert-option input").check();
-  await dialog.locator(".transcribe-apply").click();
-  await waitForBatchDone(page);
-  await expect(dialog.locator(".transcribe-line", { hasText: "Fresh score" })).toContainText(
-    "transcribed",
-  );
-  await expect(dialog.locator(".transcribe-progress").first()).toContainText("1 transcribed");
-  await dialog.locator(".dialog-cancel").click();
-  await expect(page.locator(".dialog.transcribe")).toHaveCount(0);
-
-  // The other three, in their own run with reconvert OFF - #190's automatic
-  // pass never touches "already.pdf" or "edited.pdf" in a way that matters
-  // here (they already carry a transcription of their own from the explicit
-  // POST /transcribe calls above, whichever pass happened to write it first)
-  // or "bad.pdf" (not extractable, so an automatic attempt has nothing to
-  // write) - and reconvert OFF is exactly what proves "already had one"
-  // rather than reconverting them regardless.
-  await organise(page);
   await choose(page, already);
   await choose(page, edited);
   await choose(page, bad);
-  await expect(page.locator(".selected-count")).toHaveText("3 selected");
+  await expect(page.locator(".selected-count")).toHaveText("4 selected");
 
   await page.locator(".transcribe-open").click();
-  dialog = page.locator(".dialog.transcribe");
+  const dialog = page.locator(".dialog.transcribe");
   await expect(dialog).toBeVisible();
   await dialog.locator(".transcribe-apply").click();
 
@@ -203,6 +268,7 @@ test("a bulk pass over a mixed selection shows live progress and every score's r
   await waitForBatchDone(page);
 
   const line = (title) => dialog.locator(".transcribe-line", { hasText: title });
+  await expect(line("Fresh score")).toContainText("transcribed");
   await expect(line("Already transcribed score")).toContainText("already had one");
   await expect(line("Already transcribed score")).toContainText("reconvert");
   await expect(line("Hand-edited score")).toContainText("already had one");
@@ -210,7 +276,7 @@ test("a bulk pass over a mixed selection shows live progress and every score's r
   await expect(line("Not-extractable score")).toContainText("not extractable");
 
   // The aggregate summary, not just the per-line detail.
-  await expect(dialog.locator(".transcribe-progress").first()).toContainText("0 transcribed");
+  await expect(dialog.locator(".transcribe-progress").first()).toContainText("1 transcribed");
   await expect(dialog.locator(".transcribe-progress").first()).toContainText(
     "2 already had one",
   );
@@ -220,7 +286,7 @@ test("a bulk pass over a mixed selection shows live progress and every score's r
 
   await dialog.locator(".dialog-cancel").click();
   await expect(page.locator(".dialog.transcribe")).toHaveCount(0);
-  await expect(page.locator(".notice")).toContainText("2 already had one");
+  await expect(page.locator(".notice")).toContainText("1 transcribed");
 
   // The edited score's hand-corrected content survived the run, literally.
   const stillEdited = await (
@@ -260,6 +326,11 @@ test("the sidebar's per-folder Transcribe button selects only that folder", asyn
   // never appears in this run's results at all.
   await expect(dialog.locator(".transcribe-line")).toHaveCount(1);
   await expect(dialog.locator(".transcribe-line")).toContainText("In the folder");
+
+  // The same claim, from the API's own results rather than only the
+  // rendered line - the exact set of ids this pass actually ran over.
+  const finished = await apiBatchSettled(request);
+  expect(finished.results.map((r) => r.score_id)).toEqual([inFolder.id]);
 
   // elsewhere.pdf was never selected for THIS bulk pass - already proven
   // above by the dialog's own result count and title, not by

--- a/web/tests/browser/zzzz-library-transcribe-batch.spec.js
+++ b/web/tests/browser/zzzz-library-transcribe-batch.spec.js
@@ -153,15 +153,47 @@ test("a bulk pass over a mixed selection shows live progress and every score's r
     request, NON_EXTRACTABLE_PDF, "bad.pdf", "Uploads", "Not-extractable score",
   );
 
+  // "fresh.pdf" runs through its OWN dialog, with reconvert ticked, rather
+  // than alongside the other three below. #190 means uploading an
+  // extractable PDF now transcribes it automatically, almost immediately -
+  // upload()'s own wait for the scan to settle already gives that automatic
+  // pass time to run, so by the time Organise mode can select it, "fresh.pdf"
+  // already has an extracted transcription of its own. Reconvert is what
+  // still proves the "transcribed" outcome renders correctly here: it asks
+  // for exactly the re-extraction the automatic pass already did, and
+  // reports the same "transcribed" outcome a genuinely first-time pass
+  // would. (The automatic pass itself is asserted directly in
+  // zzzzz-library-scan-transcribes.spec.js, not here.)
   await organise(page);
   await choose(page, fresh);
+  await page.locator(".transcribe-open").click();
+  let dialog = page.locator(".dialog.transcribe");
+  await expect(dialog).toBeVisible();
+  await dialog.locator(".reconvert-option input").check();
+  await dialog.locator(".transcribe-apply").click();
+  await waitForBatchDone(page);
+  await expect(dialog.locator(".transcribe-line", { hasText: "Fresh score" })).toContainText(
+    "transcribed",
+  );
+  await expect(dialog.locator(".transcribe-progress").first()).toContainText("1 transcribed");
+  await dialog.locator(".dialog-cancel").click();
+  await expect(page.locator(".dialog.transcribe")).toHaveCount(0);
+
+  // The other three, in their own run with reconvert OFF - #190's automatic
+  // pass never touches "already.pdf" or "edited.pdf" in a way that matters
+  // here (they already carry a transcription of their own from the explicit
+  // POST /transcribe calls above, whichever pass happened to write it first)
+  // or "bad.pdf" (not extractable, so an automatic attempt has nothing to
+  // write) - and reconvert OFF is exactly what proves "already had one"
+  // rather than reconverting them regardless.
+  await organise(page);
   await choose(page, already);
   await choose(page, edited);
   await choose(page, bad);
-  await expect(page.locator(".selected-count")).toHaveText("4 selected");
+  await expect(page.locator(".selected-count")).toHaveText("3 selected");
 
   await page.locator(".transcribe-open").click();
-  const dialog = page.locator(".dialog.transcribe");
+  dialog = page.locator(".dialog.transcribe");
   await expect(dialog).toBeVisible();
   await dialog.locator(".transcribe-apply").click();
 
@@ -171,7 +203,6 @@ test("a bulk pass over a mixed selection shows live progress and every score's r
   await waitForBatchDone(page);
 
   const line = (title) => dialog.locator(".transcribe-line", { hasText: title });
-  await expect(line("Fresh score")).toContainText("transcribed");
   await expect(line("Already transcribed score")).toContainText("already had one");
   await expect(line("Already transcribed score")).toContainText("reconvert");
   await expect(line("Hand-edited score")).toContainText("already had one");
@@ -179,7 +210,7 @@ test("a bulk pass over a mixed selection shows live progress and every score's r
   await expect(line("Not-extractable score")).toContainText("not extractable");
 
   // The aggregate summary, not just the per-line detail.
-  await expect(dialog.locator(".transcribe-progress").first()).toContainText("1 transcribed");
+  await expect(dialog.locator(".transcribe-progress").first()).toContainText("0 transcribed");
   await expect(dialog.locator(".transcribe-progress").first()).toContainText(
     "2 already had one",
   );
@@ -189,7 +220,7 @@ test("a bulk pass over a mixed selection shows live progress and every score's r
 
   await dialog.locator(".dialog-cancel").click();
   await expect(page.locator(".dialog.transcribe")).toHaveCount(0);
-  await expect(page.locator(".notice")).toContainText("1 transcribed");
+  await expect(page.locator(".notice")).toContainText("2 already had one");
 
   // The edited score's hand-corrected content survived the run, literally.
   const stillEdited = await (
@@ -230,11 +261,13 @@ test("the sidebar's per-folder Transcribe button selects only that folder", asyn
   await expect(dialog.locator(".transcribe-line")).toHaveCount(1);
   await expect(dialog.locator(".transcribe-line")).toContainText("In the folder");
 
-  // elsewhere.pdf was never selected, so it has no transcription of its own.
+  // elsewhere.pdf was never selected for THIS bulk pass - already proven
+  // above by the dialog's own result count and title, not by
+  // has_transcription: an extractable PDF gains one on its own the moment a
+  // scan reaches it, whether or not anybody ever selects it for a bulk pass
+  // (#190), so has_transcription can no longer distinguish "selected here"
+  // from "scanned at some point".
   const scores = await (await request.get("/api/scores")).json();
-  const otherScore = scores.find((s) => s.path === "OtherFolder/elsewhere.pdf");
-  expect(otherScore.has_transcription).toBe(false);
-
   const inFolderNow = scores.find((s) => s.id === inFolder.id);
   expect(inFolderNow.has_transcription).toBe(true);
 });

--- a/web/tests/spec-floors/browser-library-auto-transcribe-190.json
+++ b/web/tests/spec-floors/browser-library-auto-transcribe-190.json
@@ -1,5 +1,5 @@
 {
   "file": "tests/browser/zzzz-library-auto-transcribe.spec.js",
-  "count": 5,
-  "reason": "issue #190: an uploaded extractable score transcribes itself with no bulk-transcription click anywhere, the library card marks it, and the transcription filter narrows the grid to exactly that set and its exact complement; first review round adds F1 (a refused POST /transcribe/batch is never adopted as this selection's own progress) and F3 (a pass this page did not start is visible, both while running and after a scan's own chain is refused, mocked); second review round adds F3 unmocked (clicking Scan while the page is open shows the live background-pass line against a real occupying pass, not only a canned response)."
+  "count": 6,
+  "reason": "issue #190: an uploaded extractable score transcribes itself with no bulk-transcription click anywhere, the library card marks it, and the transcription filter narrows the grid to exactly that set and its exact complement; first review round adds F1 (a refused POST /transcribe/batch is never adopted as this selection's own progress) and F3 (a pass this page did not start is visible, both while running and after a scan's own chain is refused, mocked); second review round adds F3 unmocked (clicking Scan while the page is open shows the live background-pass line against a real occupying pass, not only a canned response); third review round adds F3-1 (a genuinely aborted status request does not end the background poll for the rest of the page's life, and the live line still appears once a pass starts afterwards)."
 }

--- a/web/tests/spec-floors/browser-library-auto-transcribe-190.json
+++ b/web/tests/spec-floors/browser-library-auto-transcribe-190.json
@@ -1,0 +1,5 @@
+{
+  "file": "tests/browser/zzzz-library-auto-transcribe.spec.js",
+  "count": 2,
+  "reason": "issue #190: an uploaded extractable score transcribes itself with no bulk-transcription click anywhere, the library card marks it, and the transcription filter narrows the grid to exactly that set and its exact complement."
+}

--- a/web/tests/spec-floors/browser-library-auto-transcribe-190.json
+++ b/web/tests/spec-floors/browser-library-auto-transcribe-190.json
@@ -1,5 +1,5 @@
 {
   "file": "tests/browser/zzzz-library-auto-transcribe.spec.js",
-  "count": 2,
-  "reason": "issue #190: an uploaded extractable score transcribes itself with no bulk-transcription click anywhere, the library card marks it, and the transcription filter narrows the grid to exactly that set and its exact complement."
+  "count": 4,
+  "reason": "issue #190: an uploaded extractable score transcribes itself with no bulk-transcription click anywhere, the library card marks it, and the transcription filter narrows the grid to exactly that set and its exact complement; review round also adds F1 (a refused POST /transcribe/batch is never adopted as this selection's own progress) and F3 (a pass this page did not start is visible, both while running and after a scan's own chain is refused)."
 }

--- a/web/tests/spec-floors/browser-library-auto-transcribe-190.json
+++ b/web/tests/spec-floors/browser-library-auto-transcribe-190.json
@@ -1,5 +1,5 @@
 {
   "file": "tests/browser/zzzz-library-auto-transcribe.spec.js",
-  "count": 4,
-  "reason": "issue #190: an uploaded extractable score transcribes itself with no bulk-transcription click anywhere, the library card marks it, and the transcription filter narrows the grid to exactly that set and its exact complement; review round also adds F1 (a refused POST /transcribe/batch is never adopted as this selection's own progress) and F3 (a pass this page did not start is visible, both while running and after a scan's own chain is refused)."
+  "count": 5,
+  "reason": "issue #190: an uploaded extractable score transcribes itself with no bulk-transcription click anywhere, the library card marks it, and the transcription filter narrows the grid to exactly that set and its exact complement; first review round adds F1 (a refused POST /transcribe/batch is never adopted as this selection's own progress) and F3 (a pass this page did not start is visible, both while running and after a scan's own chain is refused, mocked); second review round adds F3 unmocked (clicking Scan while the page is open shows the live background-pass line against a real occupying pass, not only a canned response)."
 }


### PR DESCRIPTION
## Summary

- The last scan of a chain - including the one an upload triggers - hands the ids it added to one bulk transcription pass when the chain finishes, never once per pass in a chain and never a second pass while one is already running by hand. The scan's own chain decides this atomically with clearing its `scanning` flag, so a scan or upload landing right after cannot reset the chain's own ids before they are read. Recorded into the scan's own status (`transcribe_batch_started`, `transcribe_batch_note`) in words a person can read, and rendered on the library page - both as an after-the-fact note and as a live "transcribing N scores in the background" line while a pass this page did not start is running.
- The library card marks a score that has a transcription (extracted or hand-edited, undistinguished), and `GET /api/scores` gains a `transcribed=yes|no` filter beside `kind` to narrow the grid to that set and its exact complement.
- The manual "Transcribe…" dialog now checks whether its own POST actually started a pass before adopting the response - a refusal (another pass already running) used to be bound straight into the dialog as though it were this selection's own progress and results.
- `docs/api.md` documents the new filter and the automatic pass.

## Test plan

- [x] `server/tests/test_transcribe_batch_api.py`: the scan hook starts one pass over exactly the ids a chain added; a hand-started pass is never interrupted by the scan's own hook, recorded in words; a chained rescan starts one pass over the union of every id the chain added; an upload results in exactly one pass over exactly the uploaded score's id; a scan landing right after the chain's decision cannot lose the chain's own ids (the atomicity fix); a pre-existing untranscribed score is never swept into a chain that did not add it; a score transcribed by hand in the exact window between two passes of the same chain is never reconverted; a chain with no transcribe hook registered still clears its own ids.
- [x] `web/tests/browser/zzzz-library-auto-transcribe.spec.js`: the card mark and the filter against the real build; selecting a score while another pass is running is refused, not silently adopted; a pass this page did not start is visible both while running and after a scan's own chain is refused.
- [x] `web/tests/browser/zzzz-library-transcribe-batch.spec.js`: the mixed-selection test's "fresh, never transcribed" case is now genuinely first-time (a real occupying pass, confirmed running, before the scan that adds it), not a reconvert stand-in; the per-folder test asserts the batch's own result ids directly, not only the rendered line count.
- [x] Mutation checks, red then restored to green: reverting the scanner hook entirely (4 new matrix tests red, 67 unaffected); removing the card mark (the new spec's first test red); reverting the atomicity fix specifically - two separate lock acquisitions instead of one, with `_finish_scan_chain` extracting its own ids again the pre-fix way (the new schedule test red, naming the lost ids); widening `_finish_scan_chain`'s scope to every live score id (3 tests red); forcing `reconvert=True` on the automatic pass (1 test red, the out-of-band-transcription test); reverting the dialog's `started` check (the new F1 browser test red).
- [x] Measured against the 299-file reference library on an odd port: one Scan produced 293 transcribed / 4 non-extractable / 2 non-pdf - the transcription batch itself ran in ~26.3s (started_at to finished_at), and ~32.6s elapsed from the first scan pass starting to the batch finishing (the extra ~6s is the scan's own walk plus a chained rescan). `transcribed=yes`/`no` narrowed the grid to 293 and 6 respectively (6, not 4 - the complement also includes 2 non-pdf files that were never transcription candidates at all).

## Second review round

Closed two gaps an adversarial re-review found in the first round's own fix.

- **Chain continuation could still lose ids.** The first round's atomicity fix closed the gap for a chain's LAST pass (the ENDING branch of `_decide_and_settle_chain`), but the CONTINUING branch still cleared `scanning` and released its lock before calling a separate `start_scan(_continuing_chain=True)` - its own separate lock acquisition. A plain `start_scan()`, or a move/delete taking `_mutating` in that same gap, could see a genuinely idle scanner, proceed, and reset `_chain_added_ids` before the real continuation got there: measured directly, a chain that added `{1, 2}` handed the bulk pass only `[2]`, and `transcribe_batch_note` reported that smaller count as though it were the whole chain's - worse than the first gap, because a pass still started, silently, over a subset. Fixed by handing `scanning` and `_chain_added_ids` to the continuation inside the SAME lock acquisition that decided to continue, so nothing can observe the scanner mid-transition between one pass of a chain ending and the next beginning. Two deterministic tests pin both reproductions the review named (a plain `start_scan()` and a `hold_library_still` mutation, each landing at the exact moment that lock releases), using a hook that is a no-op in production and exists purely as the one seam left for a test to try landing in.
- **The live background-pass line never appeared for the common case.** Library.svelte's poll for a pass the page did not start read no reactive state and only ever checked once, at mount - so a pass that began while the page was already open (click "Scan library", then watch) showed nothing until the pass had already finished. Measured: 250 files, click Scan, pass confirmed running, no live line after 8s. Fixed by polling continuously at a low rate for as long as the page is open, skipping a beat while the transcribe dialog runs its own poll against the same endpoint, and refreshing the grid once when a background-only pass finishes. An unmocked browser test places many real files directly in the library so one "Scan library" click starts an automatic pass with genuine multi-second work, confirms it running out of band, asserts the live line with a whitespace-tolerant locator, then confirms a selection made while it runs is refused. The existing mocked test's own discriminator (matching "in the background", which the success note also contains) was tightened to match text unique to the live line.

Also corrected: a stale comment claiming `_state`'s transcribe-batch keys are set by `_decide_and_settle_chain` (they are set by `_finish_scan_chain`), and `_run_pending_rescan`'s docstring, which is now true rather than aspirational - `_mutating` and `scanning` genuinely cannot both be true once the continuation fix lands, because `scanning` stays visibly true for a chain's entire lifetime, continuations included.

Mutation re-check, measured directly on this round's code: widening `_finish_scan_chain`'s scope to every live score id reds exactly 3 tests (`test_a_bulk_transcription_pass_runs_while_a_scan_is_in_progress`, `test_a_scan_landing_right_after_the_chain_decision_does_not_lose_the_chains_ids`, `test_a_scan_that_adds_one_score_does_not_transcribe_a_pre_existing_untranscribed_one`), confirming this test plan's original count rather than a narrower count from an earlier pass over the same mutation. Placement matters for this specific mutation: 3 red when the widening happens BEFORE `_finish_scan_chain`'s own `if not ids: return` (so the early return never fires, since "every live id" is never empty); measured directly, only 1 red (the pre-existing-untranscribed-score test) when the same widening happens AFTER that early return, since it then only ever affects a chain that had already added something of its own.

## Third review round

Closed a write race the second round's own atomicity fix left open, and made the live-line poll survive a failed request.

- **A newer chain's status could still be clobbered.** `_decide_and_settle_chain`'s lock protects `scanning` and `_chain_added_ids`, but `_finish_scan_chain` calls `transcribe_batch.start_batch` OUTSIDE any lock (deliberately - a scan and a batch are allowed to run concurrently) and only then writes `transcribe_batch_started`/`note`, in its own separate lock acquisition. A plain `start_scan()` landing in that window is accepted, runs its own `_scan()` pass, and resets those two keys to `None` for itself - before the OLDER chain's write ever lands, so the older chain's numbers clobber the newer chain's fresh `None`: measured directly, a chain that added nothing had its own status read "started transcribing 1", the older chain's own count. Closed with a generation counter (`_scan_generation`), bumped the instant a genuinely new chain is accepted; `_decide_and_settle_chain` captures it alongside `ids`, and `_finish_scan_chain` checks it again immediately before writing, skipping the write entirely if a newer chain has since been accepted. That skip is a real trade, not a clean win: if the newer chain itself adds nothing, its own `_finish_scan_chain` also returns early and writes nothing, so the OLDER chain's genuinely running pass simply goes unreported - `transcribe_batch_started`/`note` stay `None` rather than say anything, which understates reality rather than misattributing it. The dedicated test `test_a_newer_chain_accepted_after_start_batch_returns_does_not_have_its_status_clobbered` pins this mechanism directly, via a hook placed exactly between `start_batch` returning and the write. The existing "scan landing right after the chain decision" test was also extended to assert the final status - but that assertion does NOT itself pin this fix: measured by dropping the generation check entirely, it still passes, because the intruding scan's own `_scan()` reset wipes the older chain's stale write back to `None` regardless of whether the check ever ran. Left in as a consistency check on the observable end state, not a substitute proof.
- **One failed background-poll request ended the loop for the rest of the page's life.** `api.js` throws on a non-2xx response and `fetch` itself rejects on a dropped connection - a self-hosted server restarting with the library page open is the ordinary way to see one - and the poll had no try/catch around its request, so losing one tick silently ended it (measured: baseline 2 requests/9s; after one aborted response, 0 requests in the following 15s, plus an unhandled rejection). Rescheduling now happens in a `finally`, so one failed request no longer stops the next. A browser test aborts exactly one status request via `page.route` and confirms polling continues and the live line still renders once a pass starts afterwards.
- **The poll ran forever at a flat 3s, even fully idle** - roughly 1200 requests/hour/tab with nothing running. Backed off to 3s while a pass is confirmed running and 15s while idle (measured over 60s idle: 4 requests). To keep the common case - clicking "Scan library" and watching - from losing responsiveness to that backoff, both places this page learns one of its own tracked scans has finished now nudge the background poll into an immediate check rather than waiting out whatever is left of the idle interval; a pass from another tab or client still relies on the 15s idle floor, since there is no local signal for those.

Also fixed: `transcribeOpen` was genuinely becoming one of the poll effect's dependencies (a synchronous read before the request's own `await`), contrary to the comment claiming otherwise - the effect tore itself down and restarted, issuing an extra request, every time the dialog opened or closed; now read through `untrack` so it is not a dependency, matching the comment. Removed `start_scan`'s dead `_continuing_chain` parameter - nothing has called it that way since the chain-settling fix moved continuations through `_begin_scan_locked` directly, and the full suite is unaffected by its removal. Fixed the browser spec's own discriminator comment, which claimed "Transcribing 7" never appears in the success note - it can, since that note is templated with the same count - and switched the locator to the live line's own trailing ellipsis, which no backend note ever ends in. Corrected the unmocked test's own timing comment to the measured 6.6-6.7s occupied window (with roughly 3.2s of worst-case slack) rather than an "tens of seconds" estimate.

