### PR TITLE
Keep a half-page turn where the reader put it across a re-render (#219)

### DIFF
--- a/web/src/lib/PdfViewer.svelte
+++ b/web/src/lib/PdfViewer.svelte
@@ -82,6 +82,19 @@
   // indicator independent of whether that one callback survives.
   let intendedPage = null;
   let settleTimer;
+  // The scroll position this component last asked for on the reader's
+  // behalf, as a page plus a fraction down it, and a counter of how many
+  // times that has happened.
+  //
+  // intendedPage above answers "which page does the INDICATOR belong on
+  // while a turn settles". This answers the different question a resize
+  // re-render has to ask: "did the reader ask to be somewhere else while I
+  // was busy, and where". A whole-page turn and a half-page one are both
+  // recorded here, in the same shape, so the re-render's restore does not
+  // have to know which kind it is putting back - which is the reason the
+  // half-page branch went uncovered by #169 and #175 in the first place.
+  let requestedScroll = null;
+  let scrollRequestSeq = 0;
 
   // half-page advance defaults on each time gig mode is entered, but the
   // performer can still turn it off without it snapping back mid-set
@@ -147,21 +160,11 @@
       }
     }
 
-    // Where a page's top edge sits in the scroller's own coordinates. Read
-    // off rects rather than offsetTop, which is measured against whichever
-    // ancestor happens to be positioned - .wrap here, not the scroller - and
-    // so would carry that element's own offset into the arithmetic below.
-    function pageTop(canvas) {
-      return (
-        canvas.getBoundingClientRect().top - container.getBoundingClientRect().top + container.scrollTop
-      );
-    }
-
     async function rerenderAtWidth(width) {
       renderedWidth = width;
       const dpr = window.devicePixelRatio || 1;
-      // How far down the current page the reader actually is, as a fraction
-      // of that page's height, captured BEFORE the canvases change size.
+      // Where the reader is, as a page plus a fraction down it, captured
+      // BEFORE the canvases change size.
       //
       // The restore below used to aim at the page's TOP, which discards
       // every within-page position there is - and in gig mode that is most
@@ -171,12 +174,21 @@
       // turned to, with nothing left to retry it: the same shape as #168 and
       // #175, on the one branch of turn() neither of them covered, and
       // entering gig mode is exactly the moment both happen together
-      // (widening the pane forces the re-render). Measured on this branch, a
-      // 2-page score entering gig mode: the tap left the scroller at 313px
-      // and the re-render's restore put it back to 24px, page one's top.
-      const anchor = container.querySelector(`[data-page="${currentPage}"]`);
-      const anchorHeight = anchor ? anchor.getBoundingClientRect().height : 0;
-      const fractionDownPage = anchorHeight ? (container.scrollTop - pageTop(anchor)) / anchorHeight : 0;
+      // (widening the pane forces the re-render). Measured, a 2-page score
+      // entering gig mode: the tap left the scroller at 313px and the
+      // restore put it back to 24px, page one's top.
+      //
+      // Read off the geometry rather than off currentPage, which is a moving
+      // target: the awaits below take hundreds of milliseconds, a key press
+      // inside them runs goto() and changes currentPage synchronously, and
+      // measuring the fraction against the page BEFORE and restoring against
+      // the page AFTER silently adds one page's intra-page offset to a
+      // different page's top. Measured on a 20-page score, reader a third
+      // down page one and a turn pressed mid-re-render: the restore landed
+      // 140px past page two's top, scaling with how far down page one they
+      // had been.
+      const before = positionAt(container.scrollTop);
+      const seqBefore = scrollRequestSeq;
       // re-render the existing canvases in place (same elements, same
       // order) so the IntersectionObserver's page tracking keeps working
       // without needing to be torn down and reattached
@@ -188,12 +200,19 @@
         await renderPageInto(page, canvas, width, dpr);
       }
       if (cancelled) return;
-      // canvases changed height, so restore scroll to wherever the reader
-      // was rather than let it drift to an arbitrary pixel offset - to the
-      // same fraction down the same page, not merely to that page's top
-      const restored = container.querySelector(`[data-page="${currentPage}"]`);
+      // A turn taken DURING the re-render outranks where the reader was when
+      // it started - it is the most recent thing they asked for, and it is
+      // the one with nothing to retry it if this restore overwrites it. A
+      // whole-page turn asks for that page's top; a half-page one asks for
+      // an offset within a page, and both say so the same way, so this does
+      // not have to know which kind it was.
+      const target = scrollRequestSeq !== seqBefore ? requestedScroll : before;
+      // canvases changed height, so restore scroll to wherever that position
+      // now is rather than let it drift to an arbitrary pixel offset - the
+      // same fraction down the same page, not merely that page's top
+      const restored = target && container.querySelector(`[data-page="${target.page}"]`);
       if (restored) {
-        container.scrollTop = pageTop(restored) + fractionDownPage * restored.getBoundingClientRect().height;
+        container.scrollTop = pageTop(restored) + target.fraction * restored.getBoundingClientRect().height;
       }
     }
 
@@ -293,6 +312,7 @@
       // permission to skip the new one's last_page restore
       pendingPage = null;
       turnedBeforeRestore = false;
+      requestedScroll = null;
       observer?.disconnect();
       resizeObserver?.disconnect();
       clearTimeout(saveTimer);
@@ -310,6 +330,41 @@
     saveTimer = setTimeout(() => api.patch(score.id, { last_page: currentPage }).catch(() => {}), 1200);
   }
 
+  // Where a page's top edge sits in the scroller's own coordinates. Read off
+  // rects rather than offsetTop, which is measured against whichever
+  // ancestor happens to be positioned - .wrap here, not the scroller - and
+  // so would carry that element's own offset into the arithmetic.
+  function pageTop(canvas) {
+    return canvas.getBoundingClientRect().top - container.getBoundingClientRect().top + container.scrollTop;
+  }
+
+  // A scroll offset said as a page plus a fraction down it, which is the
+  // only form that survives the pages being re-rendered at another height.
+  // The gap between two pages is attributed to the one above it (a fraction
+  // slightly over 1) so that every offset belongs to exactly one page and
+  // the mapping stays monotonic.
+  function positionAt(scrollTop) {
+    for (let n = pageCount; n >= 1; n--) {
+      const canvas = container.querySelector(`[data-page="${n}"]`);
+      if (!canvas) continue;
+      const top = pageTop(canvas);
+      if (scrollTop >= top || n === 1) {
+        const height = canvas.getBoundingClientRect().height;
+        return { page: n, fraction: height ? (scrollTop - top) / height : 0 };
+      }
+    }
+    return null;
+  }
+
+  // Records a scroll this component is about to perform, so a resize
+  // re-render already in flight puts the reader where they just asked to be
+  // rather than back where they were when it started.
+  function requestScroll(position) {
+    if (!position) return;
+    requestedScroll = position;
+    scrollRequestSeq += 1;
+  }
+
   function goto(page) {
     // pageCount is 0 until the document's metadata has parsed. Clamping
     // against it then would fold every early turn onto page 1 - which is
@@ -325,6 +380,8 @@
       // asked for rather than the last one that happened to be seen.
       intendedPage = target;
       setPage(target);
+      // The top of that page, which is what scrollIntoView below asks for.
+      requestScroll({ page: target, fraction: 0 });
       canvas.scrollIntoView({ block: "start", behavior: "smooth" });
     } else {
       pendingPage = target;
@@ -342,7 +399,13 @@
       // step off the current page's actual rendered height (plus its share
       // of the gap) rather than the viewport, so repeated half-turns track
       // bar lines instead of drifting against page/container padding
-      container.scrollBy({ top: dir * (current.getBoundingClientRect().height + 18) * 0.5, behavior: "smooth" });
+      const step = dir * (current.getBoundingClientRect().height + 18) * 0.5;
+      // Where that leaves the reader, recorded before the scroll is asked
+      // for. Same reason goto() records its own target: a resize re-render
+      // in flight will otherwise put them back where this step started, and
+      // a pedal tap has nothing to retry it with.
+      requestScroll(positionAt(container.scrollTop + step));
+      container.scrollBy({ top: step, behavior: "smooth" });
     } else {
       goto(currentPage + dir);
     }

--- a/web/src/lib/PdfViewer.svelte
+++ b/web/src/lib/PdfViewer.svelte
@@ -147,9 +147,36 @@
       }
     }
 
+    // Where a page's top edge sits in the scroller's own coordinates. Read
+    // off rects rather than offsetTop, which is measured against whichever
+    // ancestor happens to be positioned - .wrap here, not the scroller - and
+    // so would carry that element's own offset into the arithmetic below.
+    function pageTop(canvas) {
+      return (
+        canvas.getBoundingClientRect().top - container.getBoundingClientRect().top + container.scrollTop
+      );
+    }
+
     async function rerenderAtWidth(width) {
       renderedWidth = width;
       const dpr = window.devicePixelRatio || 1;
+      // How far down the current page the reader actually is, as a fraction
+      // of that page's height, captured BEFORE the canvases change size.
+      //
+      // The restore below used to aim at the page's TOP, which discards
+      // every within-page position there is - and in gig mode that is most
+      // of them, because a half-page turn exists precisely to leave the
+      // reader halfway down a page. So a re-render landing shortly after a
+      // pedal tap scrolled them straight back off the half they had just
+      // turned to, with nothing left to retry it: the same shape as #168 and
+      // #175, on the one branch of turn() neither of them covered, and
+      // entering gig mode is exactly the moment both happen together
+      // (widening the pane forces the re-render). Measured on this branch, a
+      // 2-page score entering gig mode: the tap left the scroller at 313px
+      // and the re-render's restore put it back to 24px, page one's top.
+      const anchor = container.querySelector(`[data-page="${currentPage}"]`);
+      const anchorHeight = anchor ? anchor.getBoundingClientRect().height : 0;
+      const fractionDownPage = anchorHeight ? (container.scrollTop - pageTop(anchor)) / anchorHeight : 0;
       // re-render the existing canvases in place (same elements, same
       // order) so the IntersectionObserver's page tracking keeps working
       // without needing to be torn down and reattached
@@ -162,8 +189,12 @@
       }
       if (cancelled) return;
       // canvases changed height, so restore scroll to wherever the reader
-      // was rather than let it drift to an arbitrary pixel offset
-      container.querySelector(`[data-page="${currentPage}"]`)?.scrollIntoView({ block: "start" });
+      // was rather than let it drift to an arbitrary pixel offset - to the
+      // same fraction down the same page, not merely to that page's top
+      const restored = container.querySelector(`[data-page="${currentPage}"]`);
+      if (restored) {
+        container.scrollTop = pageTop(restored) + fractionDownPage * restored.getBoundingClientRect().height;
+      }
     }
 
     async function flushResize() {

--- a/web/tests/browser/practice-shortcuts.spec.js
+++ b/web/tests/browser/practice-shortcuts.spec.js
@@ -158,7 +158,7 @@ const pdfGeometry = (page) =>
  * fact about the render having completed, not an interval hoped to be long
  * enough.
  */
-async function pdfPagesRenderedAtSettledWidth(page) {
+async function pdfPagesRenderedAtSettledWidth(page, timeout) {
   await expect
     .poll(() =>
       page.evaluate(() => {
@@ -168,7 +168,7 @@ async function pdfPagesRenderedAtSettledWidth(page) {
         const want = Math.min(scroller.clientWidth - 32, 1100);
         const widths = [...new Set(pages.map((p) => Math.round(p.getBoundingClientRect().width)))];
         return widths.length === 1 && widths[0] === want ? "settled" : `rendered ${widths} of ${want}`;
-      }),
+      }, timeout ? { timeout } : undefined),
     )
     .toBe("settled");
 }
@@ -804,6 +804,47 @@ test.describe("a page turn pressed before the PDF has rendered", () => {
     await expect(page.locator(".hud span")).toHaveText("2 / 2");
   });
 
+  // The same press, in gig mode, which is where it actually comes from: a
+  // pedal tap on a score that has just been opened, with no mouse to fall
+  // back on (issue #106's reasoning, and #92's).
+  //
+  // Gig mode is not the same code path. turn() takes its half-page branch
+  // there, and only falls through to goto() - the one that can remember a
+  // turn it cannot yet perform - while no canvas exists to measure a half
+  // page against. So "a press is honoured once the pane settles" has to be
+  // held open in gig mode too rather than inferred from the side-by-side
+  // test above. #219's rewrite of the gig page-turn test deliberately waits
+  // for the pane before pressing, which is right for what that test is
+  // about and leaves nothing standing here; this is that cover, and unlike
+  // the press it replaces it is held open rather than raced for.
+  test("is honoured in gig mode too, where a pedal tap comes from", async ({ page }) => {
+    await stubScoreApi(page, transcriptionResponse({ warnings: [], confidence: CLEAN_CONFIDENCE }));
+    let release;
+    const held = new Promise((resolve) => (release = resolve));
+    await page.route("**/api/scores/1/file", async (route) => {
+      await held;
+      await route.fulfill({ body: buildMultiPagePdf(2), contentType: "application/pdf" });
+    });
+    await page.goto("/#/score/1");
+    await expect(playButton(page)).toBeEnabled({ timeout: 15_000 });
+
+    await page.keyboard.press("f");
+    // The layout picker only renders outside gig mode, so its disappearance
+    // is the evidence gig mode is genuinely on - same check, same reason, as
+    // the gig describe below.
+    await expect(page.getByRole("button", { name: "Side by side", exact: true })).toHaveCount(0);
+    // Nothing of the document has been read yet: no page count, no canvases,
+    // and so nothing for a half page to be measured against.
+    await expect(page.locator(".hud span")).toHaveText("1 / …");
+    await expect(page.locator(".pdf-page")).toHaveCount(0);
+
+    await page.keyboard.press("ArrowRight");
+    release();
+
+    await expect(page.locator(".pdf-page")).toHaveCount(2);
+    await expect(page.locator(".hud span")).toHaveText("2 / 2");
+  });
+
   // The residual the test above does not reach, and the one that took CI on
   // #173's branch three times running. That test proves a turn pressed
   // before any canvas EXISTS is remembered. This one is about a turn pressed
@@ -841,6 +882,113 @@ test.describe("a page turn pressed before the PDF has rendered", () => {
     await page.keyboard.press("ArrowRight");
 
     await expect(page.locator(".hud span")).toHaveText("2 / 20");
+  });
+
+  // The same press, but from a reader who was PART WAY DOWN a page when it
+  // landed - which the test above never is, and which is what tells a
+  // restore that puts the reader back where they were from one that puts
+  // them where they asked to go.
+  //
+  // A re-render measures where to put the reader back before it starts and
+  // acts on it several hundred milliseconds later, after every canvas has
+  // been redrawn. A turn pressed inside that gap moves the reader between
+  // the two, so the two halves have to be talking about the same place: a
+  // fraction measured down page one and then applied to page two's top puts
+  // them a third of a page past where they asked to be, and the error grows
+  // with how far down the previous page they had been. A whole-page turn
+  // asks for the TOP of its page and has to arrive there exactly.
+  test("a turn pressed mid-re-render lands on the top of the page it asked for", async ({ page }) => {
+    await stubScoreApi(page, transcriptionResponse({ warnings: [], confidence: CLEAN_CONFIDENCE }));
+    await page.route("**/api/scores/1/file", (route) =>
+      route.fulfill({ body: buildMultiPagePdf(20), contentType: "application/pdf" }),
+    );
+    await page.goto("/#/score/1");
+    await expect(playButton(page)).toBeEnabled({ timeout: 15_000 });
+    await expect(page.locator(".pdf-page")).toHaveCount(20, { timeout: 15_000 });
+    await expect(page.locator(".hud span")).toHaveText("1 / 20");
+    await page.waitForTimeout(600);
+
+    // A third of the way down page one, the way a reader who has been
+    // reading gets there. Nothing about the turn below depends on the exact
+    // fraction; it only has to be a position the old restore could smear
+    // onto the next page's top, which any non-zero one is.
+    const start = await pdfGeometry(page);
+    await page.evaluate((to) => (document.querySelector(".pages").scrollTop = to), start.pageOneTop + start.pageHeight / 3);
+    await expect(page.locator(".hud span")).toHaveText("1 / 20");
+
+    await page.setViewportSize({ width: 900, height: 720 });
+    await page.waitForTimeout(230);
+    await page.keyboard.press("ArrowRight");
+
+    await pdfPagesRenderedAtSettledWidth(page);
+    await expect(page.locator(".hud span")).toHaveText("2 / 20");
+    const after = await pdfGeometry(page);
+    expect(after.pageHeight).toBeLessThan(start.pageHeight);
+    await pdfScrollSettlesAt(page, after.pageTwoTop, "the top of page two");
+  });
+
+  // The gig-mode counterpart, and the order a pedal actually produces. The
+  // two tests above press a WHOLE-page turn, which asks for a page's top; a
+  // gig-mode tap asks for an offset half way down one, and that is a
+  // different thing for a restore to preserve. It is also the sequence
+  // entering gig mode creates all by itself: widening the pane starts a
+  // re-render, so the first tap of the set lands inside it.
+  //
+  // Preserving where the reader WAS is not enough here. That position is
+  // half a page behind where the tap just asked to be, so putting them back
+  // there is the press being thrown away by a second route, after the one
+  // #219's first commit closed. Measured against that commit: the tap left
+  // the reader at -0.022 of a page down, the same place a restore aiming at
+  // the page's top leaves them.
+  //
+  // Twenty pages, and the resize is issued 230ms before the key, for the
+  // same reason as the test above it: so the re-render is provably still in
+  // flight when the press lands rather than only on a slow runner. A
+  // two-page score re-renders faster than the press arrives and proves
+  // nothing - checked, and it passes against the very commit it is meant to
+  // fail.
+  test("a half-page gig turn pressed mid-re-render is honoured, not rolled back", async ({ page }) => {
+    await stubScoreApi(page, transcriptionResponse({ warnings: [], confidence: CLEAN_CONFIDENCE }));
+    await page.route("**/api/scores/1/file", (route) =>
+      route.fulfill({ body: buildMultiPagePdf(20), contentType: "application/pdf" }),
+    );
+    await page.goto("/#/score/1");
+    await expect(playButton(page)).toBeEnabled({ timeout: 15_000 });
+    await expect(page.locator(".pdf-page")).toHaveCount(20, { timeout: 15_000 });
+    await expect(page.locator(".hud span")).toHaveText("1 / 20");
+    await page.waitForTimeout(600);
+
+    // Windowed gig mode - the path Viewer.svelte already carries a catch for
+    // ("fullscreen denied or unavailable; gig mode still works windowed"),
+    // and the only one a test can resize: a fullscreen window refuses
+    // setViewportSize outright. Half-page turning, the pane widening and the
+    // re-render this is about are all the same either way.
+    await page.evaluate(() => {
+      Element.prototype.requestFullscreen = () => Promise.reject(new Error("denied"));
+    });
+    await page.keyboard.press("f");
+    await expect(page.getByRole("button", { name: "Side by side", exact: true })).toHaveCount(0);
+    // Gig mode's own re-render, out of the way before the one under test.
+    await pdfPagesRenderedAtSettledWidth(page, 15_000);
+    const before = await pdfGeometry(page);
+    // Still at the start of page one, so the offset measured at the end is
+    // the tap's own doing and not somewhere the reader already was.
+    expect((before.scrollTop - before.pageOneTop) / before.pageHeight).toBeLessThan(0.05);
+
+    await page.setViewportSize({ width: 900, height: 720 });
+    await page.waitForTimeout(230);
+    await page.keyboard.press("ArrowRight");
+
+    await pdfPagesRenderedAtSettledWidth(page, 15_000);
+    const after = await pdfGeometry(page);
+    expect(after.pageHeight).toBeLessThan(before.pageHeight);
+    // Half a page on from where the tap was taken, give or take which
+    // canvases had already been redrawn when it measured its step. Bounded
+    // on BOTH sides: below 0.35 the tap was rolled back, above 0.65 it would
+    // have been counted twice.
+    const fraction = (after.scrollTop - after.pageOneTop) / after.pageHeight;
+    expect(fraction).toBeGreaterThan(0.35);
+    expect(fraction).toBeLessThan(0.65);
   });
 });
 
@@ -914,6 +1062,11 @@ test.describe("gig mode itself", () => {
     // The key reached the PDF pane, and moved it by exactly a half turn.
     await pdfScrollSettlesAt(page, before.scrollTop + step, "half a page on");
     // Deliberately still page one: half a page in, with half of it left.
+    // This one line does depend on the geometry it is asserting about - half
+    // a page leaves page two under PdfViewer's 0.4 intersection threshold at
+    // this viewport, so a change to that threshold, to the 18px inter-page
+    // gap, or to the suite's viewport reds it for a reason that has nothing
+    // to do with the keys. The scroll assertions either side of it do not.
     await expect(page.locator(".hud span")).toHaveText("1 / 2");
 
     await page.keyboard.press("ArrowRight");

--- a/web/tests/browser/practice-shortcuts.spec.js
+++ b/web/tests/browser/practice-shortcuts.spec.js
@@ -120,6 +120,74 @@ const speedSelect = (page) => page.locator('select[title="Playback speed"]');
 const themeSelect = (page) => page.locator(".theme-picker");
 const profileButtons = (page) => page.locator(".seg button");
 
+/**
+ * The PDF pane's live scroll geometry: where the scroller is, and how tall
+ * each page has actually rendered. Everything the page-turn tests below
+ * measure comes from here rather than from a screenshot or a fixed sleep.
+ */
+const pdfGeometry = (page) =>
+  page.evaluate(() => {
+    const scroller = document.querySelector(".pages");
+    const first = document.querySelector('.pdf-page[data-page="1"]');
+    const rect = scroller.getBoundingClientRect();
+    const topOf = (el) => el.getBoundingClientRect().top - rect.top + scroller.scrollTop;
+    return {
+      scrollTop: scroller.scrollTop,
+      pageHeight: first.getBoundingClientRect().height,
+      pageOneTop: topOf(first),
+      pageTwoTop: topOf(document.querySelector('.pdf-page[data-page="2"]')),
+    };
+  });
+
+/**
+ * Waits for the PDF pane to have finished re-rendering its canvases at the
+ * width it is going to keep - the readiness barrier the page-turn tests
+ * below need and #168's did not.
+ *
+ * Any layout change that widens or narrows the pane (entering gig mode,
+ * which drops the staff pane; a viewport resize) makes PdfViewer re-render
+ * every canvas at a new width, 200ms after the resize stops. Until that
+ * lands, the pages on screen are still the OLD ones, at the old height - and
+ * a half-page turn is measured off the current rendered height, so the same
+ * keypress moves the reader a different distance either side of it.
+ *
+ * The condition is PdfViewer's own: `Math.min(clientWidth - 32, 1100)` (see
+ * its computeWidth), read back off the DOM rather than restated as a number,
+ * so a change to how the pane sizes itself moves both together. Waiting on
+ * the width the component computes for the container it is actually in is a
+ * fact about the render having completed, not an interval hoped to be long
+ * enough.
+ */
+async function pdfPagesRenderedAtSettledWidth(page) {
+  await expect
+    .poll(() =>
+      page.evaluate(() => {
+        const scroller = document.querySelector(".pages");
+        const pages = [...document.querySelectorAll(".pdf-page")];
+        if (!scroller || !pages.length) return "no pages yet";
+        const want = Math.min(scroller.clientWidth - 32, 1100);
+        const widths = [...new Set(pages.map((p) => Math.round(p.getBoundingClientRect().width)))];
+        return widths.length === 1 && widths[0] === want ? "settled" : `rendered ${widths} of ${want}`;
+      }),
+    )
+    .toBe("settled");
+}
+
+/**
+ * Waits for the PDF pane's scroll to come to rest at `target`, naming what
+ * that target is so a failure says where the pane went instead of only that
+ * two numbers differ. A tolerance of a pixel, because a smooth scroll lands
+ * on device pixels and the targets here are computed in CSS ones.
+ */
+async function pdfScrollSettlesAt(page, target, what) {
+  await expect
+    .poll(async () => {
+      const at = (await pdfGeometry(page)).scrollTop;
+      return Math.abs(at - target) <= 1 ? what : `at ${Math.round(at)}, not ${what} (${Math.round(target)})`;
+    })
+    .toBe(what);
+}
+
 async function openDemo(page) {
   await page.goto("/#/demo");
   // All three profile buttons is the signal the sample actually finished
@@ -807,8 +875,104 @@ test.describe("gig mode itself", () => {
     // (#168) - this test shares the hole and only wins the race more often.
     await expect(page.locator(".pdf-page")).toHaveCount(2);
     await expect(page.locator(".hud span")).toHaveText("1 / 2");
+    // And one barrier that test does not need. Gig mode drops the staff
+    // pane, so the PDF pane roughly doubles in width and every canvas is
+    // re-rendered; both presses below have to land on the SAME rendered
+    // geometry or they are two different distances (see the helper).
+    await pdfPagesRenderedAtSettledWidth(page);
+
+    // Two presses, not one - and this is the whole of issue #219.
+    //
+    // A gig-mode arrow key turns a HALF page: PdfViewer's `halfPage` is
+    // switched on the moment gig mode is entered (that is the point of gig
+    // mode - a performer reads down a page, not from page top to page top),
+    // and a half turn is half the current page's rendered height plus its
+    // share of the gap. Whether ONE of those moves the page INDICATOR is
+    // therefore pure geometry: it moves only when half a page is taller than
+    // whatever is left of the current page on screen. At the narrow
+    // side-by-side render this test starts from, that is true; at the wide
+    // gig render it is false, and the reader is legitimately still on the
+    // bottom half of page one with the indicator correctly saying so.
+    //
+    // So the old single-press assertion on "2 / 2" was resting on the press
+    // beating the re-render - an accident of runner speed, not a property of
+    // the product. It is what failed on 3 of 36 main CI runs while every
+    // pull-request run of the same trees was green. The barrier above
+    // deliberately removes that accident, which makes a single press read
+    // "1 / 2" every time; two presses are what actually turn the page.
+    //
+    // Two is not an arbitrary retry. A step is exactly half of a page plus
+    // half of the gap between pages - half the page PITCH - so two of them
+    // advance the pane by exactly one page whatever the pages measure, and
+    // page two ends up sitting where page one was. That is what keeps this
+    // an assertion about the keys reaching the PDF pane in gig mode rather
+    // than about the height the pages happen to have rendered at.
+    const before = await pdfGeometry(page);
+    const step = (before.pageTwoTop - before.pageOneTop) / 2;
+
     await page.keyboard.press("ArrowRight");
+    // The key reached the PDF pane, and moved it by exactly a half turn.
+    await pdfScrollSettlesAt(page, before.scrollTop + step, "half a page on");
+    // Deliberately still page one: half a page in, with half of it left.
+    await expect(page.locator(".hud span")).toHaveText("1 / 2");
+
+    await page.keyboard.press("ArrowRight");
+    await pdfScrollSettlesAt(page, before.scrollTop + 2 * step, "a whole page on");
     await expect(page.locator(".hud span")).toHaveText("2 / 2");
+  });
+
+  // The product half of #219, and the one that matters at the stand. The
+  // test above waits for gig mode's re-render; a performer does not, and a
+  // pedal sends nothing but arrow keys with no mouse to recover with.
+  //
+  // A half-page turn leaves the reader mid-page by design. PdfViewer's
+  // re-render then had to put them back, and it aimed at the top of the page
+  // they were on - which threw the half turn away entirely. Entering gig
+  // mode is exactly when the two collide: it widens the pane, so a re-render
+  // is already queued when the first tap arrives.
+  //
+  // Not raced for here. The resize is issued while the reader is provably
+  // half a page down and the assertion is on where the re-render leaves
+  // them, so this fails on every run against the old restore rather than on
+  // a slow one - the race only decided how often a real reader met it.
+  test("a half-page turn survives the pane being re-rendered at a new width", async ({ page }) => {
+    // Windowed gig mode - the path Viewer.svelte already carries a catch for
+    // ("fullscreen denied or unavailable; gig mode still works windowed"),
+    // and the only one a test can resize: a fullscreen window refuses
+    // setViewportSize outright. Half-page turning, the pane widening and the
+    // re-render this is about are all the same either way; only the window
+    // chrome differs.
+    await page.evaluate(() => {
+      Element.prototype.requestFullscreen = () => Promise.reject(new Error("denied"));
+    });
+    await page.keyboard.press("f");
+    await expect(page.getByRole("button", { name: "Side by side", exact: true })).toHaveCount(0);
+    await expect(page.locator(".pdf-page")).toHaveCount(2);
+    await pdfPagesRenderedAtSettledWidth(page);
+
+    const before = await pdfGeometry(page);
+    const step = (before.pageTwoTop - before.pageOneTop) / 2;
+    await page.keyboard.press("ArrowRight");
+    await pdfScrollSettlesAt(page, before.scrollTop + step, "half a page on");
+    // How far down page one the reader now is - the thing that has to
+    // survive the re-render, expressed as a fraction because the pixel
+    // count will not: the pages are about to change height.
+    const mid = await pdfGeometry(page);
+    const fraction = (mid.scrollTop - mid.pageOneTop) / mid.pageHeight;
+    expect(fraction).toBeGreaterThan(0.3);
+
+    // Narrower pane -> shorter pages -> a re-render, the same one entering
+    // gig mode causes, with the reader already mid-page.
+    await page.setViewportSize({ width: 900, height: 720 });
+    await pdfPagesRenderedAtSettledWidth(page);
+    const after = await pdfGeometry(page);
+    expect(after.pageHeight).toBeLessThan(before.pageHeight);
+
+    const want = after.pageOneTop + fraction * after.pageHeight;
+    expect(Math.abs(after.scrollTop - want)).toBeLessThanOrEqual(2);
+    // Stated the blunt way too: not scrolled back to the top of page one,
+    // which is where the old restore put it on every run.
+    expect(after.scrollTop).toBeGreaterThan(after.pageOneTop + 1);
   });
 
   test("from the staff layout, gig mode keeps the staff pane and Space still plays/pauses it", async ({ page }) => {

--- a/web/tests/spec-floors/browser-practice-shortcuts-219-review.json
+++ b/web/tests/spec-floors/browser-practice-shortcuts-219-review.json
@@ -1,0 +1,5 @@
+{
+  "file": "tests/browser/practice-shortcuts.spec.js",
+  "count": 3,
+  "reason": "issue #219 review: a whole-page turn pressed mid-re-render lands on its page's top rather than one page's intra-page offset added to another page's top; a half-page turn pressed mid-re-render is honoured rather than rolled back to where the re-render started; and a gig-mode page turn pressed before the pane has rendered at all is honoured once it does, which the rewritten gig page-turn test no longer covers because it waits for the pane on purpose."
+}

--- a/web/tests/spec-floors/browser-practice-shortcuts-219.json
+++ b/web/tests/spec-floors/browser-practice-shortcuts-219.json
@@ -1,0 +1,5 @@
+{
+  "file": "tests/browser/practice-shortcuts.spec.js",
+  "count": 1,
+  "reason": "issue #219: a gig-mode half-page turn survives the pane being re-rendered at a new width, rather than the re-render's scroll restore aiming at the page's top and throwing the half turn away."
+}


### PR DESCRIPTION
## What

Closes #219 - the gig-mode arrow-key page-turn spec that went red on 3 of 36
main runs.

The issue's hypothesis was that a key press is lost while the pane settles, the
same family as #168/#175. **Half of that is right and half of it is not**, and
the disproof is the more useful half: the flake itself is a spec defect, and
the press-loss the hypothesis describes is a real but *separate* product bug in
the same code. Both are fixed here, each shown separately load-bearing below.

Two commits: the first fixes #219; the second fixes three findings from review
of the first.

## Why the spec flaked

A gig-mode arrow key does not turn a page. It turns a **half** page:
`halfPage` switches on the moment gig mode is entered
(`web/src/lib/PdfViewer.svelte:89-92`), and `turn()` takes the half-page branch,
which scrolls by half the current page's *rendered* height plus half the gap -
it never calls `goto()` and never touches the page number.

So whether ONE press moves the page indicator is pure geometry: it moves only
when half a page is taller than whatever is left of the current page on screen.
Entering gig mode drops the staff pane, so the PDF pane roughly doubles in
width and every canvas is re-rendered 200ms later - and the two sides of that
re-render answer differently. Measured, at the suite's 1280x720 viewport:

| press lands | page height | half step | page 2 visible | indicator |
|---|---|---|---|---|
| before the re-render | 608px | 313px | 383px (0.63) | **2 / 2** |
| after the re-render | 1100px | 559px | 161px (0.15, under the 0.4 threshold) | **1 / 2** |

The old spec pressed once and asserted `2 / 2`, so it was asserting that the
press had beaten gig mode's own re-render. On a loaded runner it does not, and
`1 / 2` is then the **correct** answer - the reader is on the bottom half of
page one.

Evidence the press is not lost: an instrumented run under CPU throttling logged
`scrollTop` 24 -> 583 on the failing press (exactly one half step, so the key
landed and acted) and a second press reaching 1142, page two's top, with the
indicator then reading `2 / 2`.

## The product defects

A re-render captures where to put the reader back **before** it starts and acts
on it several hundred milliseconds later, after every canvas is redrawn.
Everything below is that gap.

**1. Any within-page position was discarded.** The restore aimed at
`[data-page].scrollIntoView({block:"start"})`. In gig mode that is most
positions, because a half-page turn exists precisely to leave the reader
mid-page. Measured: a tap left the scroller at 313px and the restore put it
back to 24px, page one's top. Not only a race - **any** resize taken mid-page
did this, on every run.

**2. A turn landing mid-re-render was rolled back** to where the re-render
started, which for a half-page turn is half a page behind where the tap asked
to be. Measured at **-0.022** of a page down - the same place a restore aiming
at the page top leaves it. Entering gig mode produces exactly this order,
because widening the pane is itself what starts the re-render. (Found in review
of the first commit; present before it and not closed by it.)

**3. The first commit's own regression**: it read `currentPage` twice - once to
pick the page whose fraction it measured, once to pick the page it restored
against - and `goto()` moves `currentPage` synchronously on a key press. A turn
landing inside the re-render measured a fraction down page A and applied it to
page B's top. Measured, 20-page score, reader a third down page one: main lands
at **460** (page two's top, correct), the first commit at **600**.

## Fix

**Product** (`web/src/lib/PdfViewer.svelte`). All three are one missing idea: a
turn had no way to say where it was going that outlived the scroll it
performed. `goto()` and `turn()`'s half-page branch now both record their
target as a page plus a fraction down it, in one shape, and the re-render
prefers a target recorded while it was awaiting over the position it started
from. The anchor is read off the geometry rather than off `currentPage`, so the
two halves cannot disagree about which page they mean. Page tops come from
rects, not `offsetTop` (which measures against `.wrap`, not the scroller).

**Spec** (`web/tests/browser/practice-shortcuts.spec.js`). A barrier on gig
mode's re-render having landed - the pages having reached
`Math.min(clientWidth - 32, 1100)`, the width the component itself computes for
the container it is in, read back off the DOM rather than restated as a number.
Not a longer timeout, and not an interval. Then two presses instead of one: a
step is half the page *pitch*, so two of them advance exactly one page whatever
the pages measure. The intermediate `1 / 2` is asserted too, with a note that
that one line depends on the 0.4 threshold and the viewport.

**Four new tests**:

- `a half-page turn survives the pane being re-rendered at a new width`
- `a turn pressed mid-re-render lands on the top of the page it asked for`
- `a half-page gig turn pressed mid-re-render is honoured, not rolled back`
- `is honoured in gig mode too, where a pedal tap comes from` - restores the
  cover the rewritten gig test gave up by waiting for the pane on purpose.
  Held open (the PDF body is not released until after the press) rather than
  raced for, which is the difference from the press it replaces.

The three mid-re-render tests are deterministic, not raced: the resize is
issued 230ms before the key so the re-render is provably in flight. Two of them
use a 20-page score - a 2-page one re-renders faster than the press arrives and
passes against the very commit it is meant to fail, which is checked and noted
in the test.

Gig-mode tests that need to resize run gig **windowed** (`requestFullscreen`
rejected, a path `Viewer.svelte:64-67` already carries a catch for), because a
fullscreen window refuses `setViewportSize`.

## Verification

All runs on a rebuilt `web/dist`. CPU throttling via CDP
`Emulation.setCPUThrottlingRate`, applied after load so the gig transition is
what slows down; the hook was temporary and is not in the diff.

| condition | result |
|---|---|
| spec at `:796`, `--repeat-each 30`, unthrottled, **before any change** | 30 passed, 0 failed |
| standalone repro of the same sequence, throttle 8x, 30 runs, **before** | **19 failed**, 11 passed (`Received: "1 / 2"`, the CI symptom); a second attempt gave 28 failed |
| gig describe, throttle 8x, `--repeat-each 30` (90 runs), **with the fix** | **90 passed, 0 failed** |
| gig describe, throttle 20x, `--repeat-each 30` (90 runs), **with the fix** | **90 passed, 0 failed** |
| spec fix reverted, product kept, throttle 8x, 30 runs | **29 failed**, 1 passed |
| within-page restore reverted, unthrottled, 10 runs | **10 failed** - `expected <= 2, received 441.1` |
| the three new mid-re-render / held-open tests, `--repeat-each 20` (60 runs) | **60 passed, 0 failed** |
| full browser suite | **565 passed** |

Against the **first commit** (the reviewed head), with the new tests present:

| test | result |
|---|---|
| `a turn pressed mid-re-render lands on the top of the page it asked for` | **red** - `at 600, not the top of page two (460)` |
| `a half-page gig turn pressed mid-re-render is honoured, not rolled back` | **red** - `expected > 0.35, received -0.0219` |

Mutation, `turn()` a no-op for the first 300ms after gig mode is entered:
`is honoured in gig mode too` is the **only** test in the file to go red
(1 failed, 29 passed), which is what says the other gig tests do not cover it.

Suite count 561 -> 565, four new tests, with matching spec-floor entries
(`browser-practice-shortcuts-219.json` at 1, `-219-review.json` at 3).

## Note on the issue's numbers

The 3-of-36 occurrence count stands. The hypothesis ("a page-turn key is pressed
while the PDF pane is still settling and the turn is consumed without effect")
is **not** what fails the spec - the turn is neither consumed nor lost, and the
barrier the issue asks for makes a single press read `1 / 2` *every* time rather
than fixing it. The alternative the issue said to rule out first (a 5s timeout
too short under load) is also ruled out: the indicator never arrives, at any
timeout. The hypothesis does describe real adjacent defects, which are the three
product ones above.
