### PR TITLE
Cache the browser job's node_modules and Playwright binaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,10 +87,10 @@ jobs:
   browser:
     name: Browser tests
     runs-on: ubuntu-latest
-    # The suite itself runs in ~75s. 25 is a floor under setup-time variance
-    # (npm's registry fetches are not equally fast on every run), not the
-    # fix for it - the caching below is the fix; this just keeps a slow
-    # network from turning a passing suite into a cancelled job.
+    # The suite itself takes about 7.6 minutes; 25 covers that plus a
+    # worst-observed 7.7-minute setup, with headroom. The caching below is
+    # the fix for that setup variance - this is only the floor under it, not
+    # a substitute for it.
     timeout-minutes: 25
     steps:
       - uses: actions/checkout@v4
@@ -113,7 +113,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: web/node_modules
-          key: node-modules-${{ runner.os }}-${{ hashFiles('web/package-lock.json') }}
+          key: node-modules-${{ runner.os }}-node22-${{ hashFiles('web/package-lock.json') }}
       # This suite drives the real backend serving the real build, because a
       # passing build proves nothing about whether anything rendered - so both
       # halves are installed here. Playwright starts the server itself; see
@@ -134,7 +134,9 @@ jobs:
       - name: Read Playwright version
         id: playwright-version
         working-directory: web
-        run: echo "version=$(node -p "require('./package-lock.json').packages['node_modules/playwright'].version")" >> "$GITHUB_OUTPUT"
+        run: |
+          version=$(node -p "require('./package-lock.json').packages['node_modules/playwright'].version")
+          echo "version=$version" >> "$GITHUB_OUTPUT"
       - name: Cache browser
         uses: actions/cache@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,9 +87,11 @@ jobs:
   browser:
     name: Browser tests
     runs-on: ubuntu-latest
-    # Well above the ~75s this takes, and below the six-hour default a hung
-    # browser would otherwise sit burning.
-    timeout-minutes: 15
+    # The suite itself runs in ~75s. 25 is a floor under setup-time variance
+    # (npm's registry fetches are not equally fast on every run), not the
+    # fix for it - the caching below is the fix; this just keeps a slow
+    # network from turning a passing suite into a cancelled job.
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -100,6 +102,18 @@ jobs:
           node-version: "22"
           cache: npm
           cache-dependency-path: web/package-lock.json
+      # setup-node's cache above only persists npm's download cache, which
+      # still leaves `npm ci` making per-package registry calls whose
+      # latency varies run to run. Caching the installed tree itself, keyed
+      # on the lockfile so any dependency change invalidates it, lets a hit
+      # skip the network entirely and land on PR branches the same as main
+      # pushes.
+      - name: Cache node_modules
+        id: node-modules-cache
+        uses: actions/cache@v4
+        with:
+          path: web/node_modules
+          key: node-modules-${{ runner.os }}-${{ hashFiles('web/package-lock.json') }}
       # This suite drives the real backend serving the real build, because a
       # passing build proves nothing about whether anything rendered - so both
       # halves are installed here. Playwright starts the server itself; see
@@ -108,16 +122,27 @@ jobs:
         working-directory: server
         run: pip install -e .
       - name: Install web
+        if: steps.node-modules-cache.outputs.cache-hit != 'true'
         working-directory: web
         run: npm ci
       - name: Build
         working-directory: web
         run: npm run build
+      # Keyed on Playwright's own version rather than the whole lockfile, so
+      # a change to an unrelated dependency doesn't force a re-download of
+      # the browser binaries this cache exists to avoid.
+      - name: Read Playwright version
+        id: playwright-version
+        working-directory: web
+        run: echo "version=$(node -p "require('./package-lock.json').packages['node_modules/playwright'].version")" >> "$GITHUB_OUTPUT"
       - name: Cache browser
         uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ hashFiles('web/package-lock.json') }}
+          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
+      # --with-deps installs OS packages (fonts, libgtk, ...) that live
+      # outside the cached path above, so this always has to run - a browser
+      # cache hit only skips the binary download inside it, not this step.
       - name: Install browser
         working-directory: web
         run: npx playwright install --with-deps chromium


### PR DESCRIPTION
## Summary
- Fixes #225: the browser job's setup time swung from 2.5 to 7.7 minutes run to run because `npm ci` was making per-package registry calls with variable latency, even with npm's download cache hit (that cache holds tarballs, not the extracted install). On a slow run this ate the whole 15-minute ceiling and cancelled a job whose tests had already passed (measured: 7m of the 7m40s setup on PR #222's run was `npm ci` alone, versus 2m on the same-lockfile main push).
- Cache `web/node_modules` keyed on the lockfile hash so a hit skips `npm ci`'s network calls entirely and PR branches land on the same cache main pushes populate.
- Re-key the existing Playwright binary cache on Playwright's own version (read from `web/package-lock.json`) instead of the whole lockfile, so a bump to an unrelated dependency doesn't force a browser re-download.
- Raise `timeout-minutes` to 25 as a stated floor under remaining setup variance, not as the fix for it.
- No change to what the job tests, its test command, or its port.

## Test plan
- [x] `python -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` - YAML parses
- [ ] First CI run on this PR populates both new/re-keyed caches (expect cache misses)
- [ ] A rerun of the browser job shows cache hits on both `Cache node_modules` and `Cache browser`, with setup duration comparable to a main push
- [ ] All four checks green