### PR TITLE
Fix multi-word --grep being split before it reaches Playwright

### DIFF
--- a/web/scripts/run-browser-tests.mjs
+++ b/web/scripts/run-browser-tests.mjs
@@ -33,6 +33,7 @@ import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { createRequire } from "node:module";
 import { fileURLToPath } from "node:url";
 
 import { loadSpecFloors } from "../tests/spec-floors.js";
@@ -79,10 +80,22 @@ const reporters = process.env.CI
   ? "list,github,html,./tests/minimum-tests.js,json"
   : "list,./tests/minimum-tests.js,json";
 
-const result = spawnSync("npx", ["playwright", "test", `--reporter=${reporters}`, ...filteredArgs], {
+// Resolved directly and run through node (process.execPath) with shell: false
+// rather than handed to `npx playwright test … --grep "<phrase>"` under
+// shell: true. On Windows, spawnSync with shell: true does not invoke argv
+// as separate process-creation arguments - it joins them into one cmd.exe
+// command line, and Node's quoting only covers characters cmd.exe treats
+// specially, not internal spaces. A multi-word --grep value came out on the
+// far side as several bare words, so Playwright saw --grep followed by only
+// its first word and ran the whole file instead of the one matching test.
+// Resolving the CLI entry point and invoking it without a shell hands argv
+// to the child process array-for-array on every platform - there is no
+// command line for a space to get lost in, on Windows or POSIX.
+const playwrightCli = createRequire(import.meta.url).resolve("@playwright/test/cli");
+
+const result = spawnSync(process.execPath, [playwrightCli, "test", `--reporter=${reporters}`, ...filteredArgs], {
   cwd: webRoot,
   stdio: "inherit",
-  shell: true,
   env: { ...process.env, PLAYWRIGHT_JSON_OUTPUT_NAME: summaryPath },
 });
 


### PR DESCRIPTION
## Summary
Fixes #227.

`web/scripts/run-browser-tests.mjs` spawned `npx playwright test …` with `shell: true`. On Windows, `spawnSync` with a shell joins `argv` into a single `cmd.exe` command line without re-quoting it, so a quoted multi-word `--grep` value ("a half-page turn survives") arrived on the far side as several bare words - only the first stayed attached to `--grep`, and the rest became extra positional file-path patterns that Playwright ORs against every spec file. The intended single test never ran; the whole spec file - or, when a stray word happened to match another file's path, more than that file - ran instead.

## Fix
Resolve the Playwright CLI entry point directly (`require.resolve("@playwright/test/cli")` via a `createRequire`) and run it through `node` (`process.execPath`) with no shell. `argv` then reaches the child process array-for-array on every platform, so there is no command line left for a space to get lost in, on Windows or POSIX.

Every other behaviour of the runner is unchanged: the `--reporter` strip, the out-of-band-read guard, the JSON summary read-back, the spec-floor guard, `PLAYWRIGHT_ALLOW_PARTIAL`, and exit codes all use the same code paths as before - only the mechanics of the `playwright test` spawn itself changed.

## Test plan
- [x] `npm ci && npm run build` in `web/`
- [x] Before the fix: `node scripts/run-browser-tests.mjs tests/browser/practice-shortcuts.spec.js --grep "T cycles the staff theme"` (a stand-in for the issue's exact phrase, which no longer exists in the spec file) printed `Running 36 tests` - the whole file plus extra files pulled in by stray positional args.
- [x] After the fix: the same command prints `Running 1 test` and runs exactly `T cycles the staff theme`.
- [x] A regex `--grep` with a special character and a space (`"ArrowRight turns|gig mode"`) reaches Playwright intact after the fix: `Running 3 tests`, exactly the three matching titles.
- [x] Previously-working invocations still work after the fix: a bare spec path (`Running 26 tests`), `--repeat-each 3` on a single `--grep`-selected test (`Running 3 tests`, same test three times).
- [x] Mutation: reverting the spawn change reproduces `Running 36 tests` again for the same command; restoring the fix goes back to `Running 1 test`.
- [x] No args (whole suite): confirmed the invocation still enforces the spec-floor guard by inspection - the diff only changes how `playwright test` is spawned, not the JSON summary read-back or `checkSpecFloors` call that implements the guard, and the no-args case passes the same (empty) `filteredArgs` before and after.
