### PR TITLE
Reset every skip counter between the terminal-summary tests, not just one

### DIFF
--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -293,8 +293,9 @@ def skip_without_library(reason: str):
 
 # Skips for want of `node` or the web project's installed alphaTab build get
 # the same treatment, for the same reason (issue #134 adversarial review,
-# item 7): a run with `web/node_modules` missing quietly skipped nine tests -
-# including score_s's and playback-order headline cases - and
+# item 7): a run with `web/node_modules` missing quietly skipped a
+# double-digit slice of the suite - including score_s's and playback-order
+# headline cases - and
 # nothing said so unless a reader compared this run's summary against CI's by
 # hand. See test_tabextract._parse_with_alphatab /
 # _load_musicxml_with_alphatab, the two places that actually skip.
@@ -343,8 +344,8 @@ def pytest_terminal_summary(terminalreporter, exitstatus, config):
 
     Without this the only way to notice was to compare a CI log against a
     local run by hand, which is why 36 skipped extraction tests sat
-    unnoticed - and, separately, nine more that skip on missing
-    `web/node_modules` (issue #134 adversarial review, item 7) went
+    unnoticed - and, separately, a double-digit slice of tests that skip on
+    missing `web/node_modules` (issue #134 adversarial review, item 7) went
     unannounced the same way. A count that has to be read off the screen is
     not a guarantee, but silence was not one either."""
     if not _library_skips:

--- a/server/tests/test_engraved_fixtures.py
+++ b/server/tests/test_engraved_fixtures.py
@@ -2582,12 +2582,28 @@ def _reset_skip_counters(monkeypatch):
     counters are module-level state shared across the whole run, not reset
     between tests by pytest itself. Discovering every `*_skips` list on
     `conftest` rather than naming them one at a time means a counter added
-    later is covered without anyone remembering to touch this fixture too."""
+    later is covered without anyone remembering to touch this fixture too -
+    PROVIDED it keeps to the `*_skips`-list convention. A counter that
+    doesn't (a differently named attribute, or one typed as a set rather
+    than a list) would narrow this fixture's coverage silently, which is the
+    same failure mode this fixture exists to close - so the two counters
+    `pytest_terminal_summary` is known to read today are asserted found
+    below, not just discovered ones cleared."""
     import conftest
 
+    found = set()
     for name in dir(conftest):
         if name.endswith("_skips") and isinstance(getattr(conftest, name), list):
             monkeypatch.setattr(conftest, name, [])
+            found.add(name)
+
+    known = {"_library_skips", "_node_modules_skips"}
+    assert known <= found, (
+        f"expected skip counters {sorted(known - found)} were not discovered by the "
+        "'*_skips list' convention this fixture relies on - renamed, retyped (e.g. a "
+        "set instead of a list), or removed from conftest without updating this "
+        "fixture's assumption"
+    )
 
 
 def test_the_summary_says_how_many_tests_skipped_for_want_of_a_library(
@@ -2640,8 +2656,8 @@ def test_the_summary_says_how_many_tests_skipped_for_want_of_a_library(
 def test_the_summary_says_how_many_tests_skipped_for_want_of_node_modules(
         monkeypatch, _reset_skip_counters):
     """The same loud skip as the library one above, for `web/node_modules`
-    (issue #134 adversarial review, item 7): nine tests - including
-    score_s's and playback-order headline cases - used to skip in
+    (issue #134 adversarial review, item 7): a double-digit slice of tests -
+    including score_s's and playback-order headline cases - used to skip in
     total silence when `npm ci` had not been run in web/, and nothing said
     so unless a reader compared this run's summary against CI's by hand."""
     import conftest
@@ -2666,14 +2682,12 @@ def test_the_summary_says_how_many_tests_skipped_for_want_of_node_modules(
     assert "2 test(s) skipped for want of web/node_modules" in reporter.lines[0]
 
 
-def test_the_summary_reports_node_modules_skips_alone_when_the_library_ran_clean(
+def test_the_summary_says_one_test_skipped_for_want_of_node_modules(
         monkeypatch, _reset_skip_counters):
-    """The mixed case neither test above covers: a library counter that is
-    empty because the run genuinely exercised it (or never needed it) beside
-    a node_modules counter that is not, because `web/node_modules` really is
-    missing. The summary must carry exactly the node_modules line and say
-    nothing about the library - the two counters are independent and the
-    summary must not conflate an empty one with a suppressed other."""
+    """The single-skip boundary of the node_modules counter. The sibling test
+    above only ever exercises it at 2, so a hook that special-cased "more
+    than one" (or otherwise mishandled the count=1 case) would pass there and
+    still be wrong - this pins the line at its smallest non-zero count."""
     import conftest
 
     monkeypatch.delenv("FERMATA_TEST_LIBRARY", raising=False)

--- a/server/tests/test_engraved_fixtures.py
+++ b/server/tests/test_engraved_fixtures.py
@@ -2570,7 +2570,28 @@ class _FakeReporter:
         self.lines.append(text)
 
 
-def test_the_summary_says_how_many_tests_skipped_for_want_of_a_library(monkeypatch, tmp_path):
+@pytest.fixture
+def _reset_skip_counters(monkeypatch):
+    """Snapshot-and-clear every skip counter `pytest_terminal_summary` reads,
+    not just the one a given test means to exercise.
+
+    Issue #217: the library test below used to reset only `_library_skips`,
+    so in a full run with `web/node_modules` absent, real node_modules skips
+    that happened earlier in the session were still sitting in
+    `_node_modules_skips` when this test asserted the summary was empty - the
+    counters are module-level state shared across the whole run, not reset
+    between tests by pytest itself. Discovering every `*_skips` list on
+    `conftest` rather than naming them one at a time means a counter added
+    later is covered without anyone remembering to touch this fixture too."""
+    import conftest
+
+    for name in dir(conftest):
+        if name.endswith("_skips") and isinstance(getattr(conftest, name), list):
+            monkeypatch.setattr(conftest, name, [])
+
+
+def test_the_summary_says_how_many_tests_skipped_for_want_of_a_library(
+        monkeypatch, tmp_path, _reset_skip_counters):
     """The loud skip. A suite that skipped a third of itself said so only by
     a number nobody compared against anything, which is exactly how 36
     skipped extraction tests went unnoticed. A count on the screen is not a
@@ -2583,7 +2604,6 @@ def test_the_summary_says_how_many_tests_skipped_for_want_of_a_library(monkeypat
     the one thing this must never say by accident."""
     import conftest
 
-    monkeypatch.setattr(conftest, "_library_skips", [])
     monkeypatch.delenv("FERMATA_TEST_LIBRARY", raising=False)
 
     # nothing skipped and no library configured: no claim either way
@@ -2617,7 +2637,8 @@ def test_the_summary_says_how_many_tests_skipped_for_want_of_a_library(monkeypat
     assert reporter.lines == []
 
 
-def test_the_summary_says_how_many_tests_skipped_for_want_of_node_modules(monkeypatch):
+def test_the_summary_says_how_many_tests_skipped_for_want_of_node_modules(
+        monkeypatch, _reset_skip_counters):
     """The same loud skip as the library one above, for `web/node_modules`
     (issue #134 adversarial review, item 7): nine tests - including
     score_s's and playback-order headline cases - used to skip in
@@ -2625,8 +2646,6 @@ def test_the_summary_says_how_many_tests_skipped_for_want_of_node_modules(monkey
     so unless a reader compared this run's summary against CI's by hand."""
     import conftest
 
-    monkeypatch.setattr(conftest, "_library_skips", [])
-    monkeypatch.setattr(conftest, "_node_modules_skips", [])
     monkeypatch.delenv("FERMATA_TEST_LIBRARY", raising=False)
 
     # nothing skipped: no claim either way
@@ -2645,6 +2664,29 @@ def test_the_summary_says_how_many_tests_skipped_for_want_of_node_modules(monkey
     conftest.pytest_terminal_summary(reporter, 0, None)
     assert len(reporter.lines) == 1
     assert "2 test(s) skipped for want of web/node_modules" in reporter.lines[0]
+
+
+def test_the_summary_reports_node_modules_skips_alone_when_the_library_ran_clean(
+        monkeypatch, _reset_skip_counters):
+    """The mixed case neither test above covers: a library counter that is
+    empty because the run genuinely exercised it (or never needed it) beside
+    a node_modules counter that is not, because `web/node_modules` really is
+    missing. The summary must carry exactly the node_modules line and say
+    nothing about the library - the two counters are independent and the
+    summary must not conflate an empty one with a suppressed other."""
+    import conftest
+
+    monkeypatch.delenv("FERMATA_TEST_LIBRARY", raising=False)
+
+    with pytest.raises(BaseException):
+        conftest.skip_without_node_modules("alphaTab.mjs not found")
+    assert conftest._library_skips == []
+    assert len(conftest._node_modules_skips) == 1
+
+    reporter = _FakeReporter()
+    conftest.pytest_terminal_summary(reporter, 0, None)
+    assert len(reporter.lines) == 1
+    assert "1 test(s) skipped for want of web/node_modules" in reporter.lines[0]
 
 
 def test_the_committed_musicxml_still_matches_its_generator():


### PR DESCRIPTION
Fixes #217.

## The defect

`test_the_summary_says_how_many_tests_skipped_for_want_of_a_library` monkeypatched `conftest._library_skips` to `[]` but never touched `conftest._node_modules_skips`. Both counters are module-level state shared across an entire pytest session, not reset between tests by pytest itself. In a full run with `web/node_modules` absent, earlier tests append real skips to `_node_modules_skips`; by the time this test ran, `pytest_terminal_summary` wrote the node_modules line into a reporter the test asserted was empty. It passed in isolation and failed only in the full suite - CI never saw it because its server job installs `web/` dependencies first.

## Fix shape

Added a shared `_reset_skip_counters` fixture in `test_engraved_fixtures.py` that discovers every `*_skips` list attribute on the `conftest` module and clears it, rather than naming `_library_skips` and `_node_modules_skips` individually. Both existing summary tests now use it. This was chosen over scoping each assertion to its own counter's line because the tests already assert the whole summary content by design (`reporter.lines == [...]`) - narrowing every assertion would touch more lines and lose that "nothing else got written" guarantee. The discovery-based reset also means a third counter added later is covered without anyone remembering to extend this fixture - and the fixture now asserts that `_library_skips` and `_node_modules_skips` specifically were among what it found, so a rename or a retype (a set instead of a list) reds immediately instead of silently narrowing coverage.

Added `test_the_summary_says_one_test_skipped_for_want_of_node_modules`. Its docstring first framed this as covering "the mixed case" (library empty, node_modules non-empty) - but the existing `test_the_summary_says_how_many_tests_skipped_for_want_of_node_modules` already is that case, just at count 2. What the new test actually pins, confirmed by mutating the hook, is the count=1 boundary of the node_modules line: the sibling test never exercises a single skip, so a hook that special-cased "more than one" would pass there and still be wrong.

`server/tests/conftest.py` carries one change beyond the fix itself: the "quietly skipped nine tests" figure (two spots there, and a matching one in a test docstring) was stale - measured on this branch at eleven, not nine - and is now worded to not carry a count that can drift again.

## Verification

All commands run with `PYTHONPATH=<worktree>/server`, `py -3.13`, `FERMATA_TEST_LIBRARY` unset.

- Full suite, `web/node_modules` absent: **0 failed** (was 1), 1228 passed, 92 skipped (76 library, 11 node_modules, 5 XSD).
- Full suite, `web/node_modules` present (temporary junction to a real `node_modules`, removed after): 0 failed, 1239 passed, 81 skipped.
- The previously-failing test passes in isolation and in the full run, in both `node_modules` states.
- Mutation: reverted the fix on `test_the_summary_says_how_many_tests_skipped_for_want_of_a_library` (removed the shared reset, kept only the `_library_skips` one). Full suite, `node_modules` absent, went red with the exact mechanism the issue describes: `assert reporter.lines == []` failed because `'6 test(s) skipped for want of web/node_modules ...'` leaked in. Restored, green again.
- Mutation: commented out the node_modules summary write in `conftest.pytest_terminal_summary`. Both node_modules summary tests went red by name (`assert 0 == 1`). Restored, green again.
- `_check_fixture_path_keys` (the PR #221 collection guard) still passes: `pytest --collect-only -q` collects 1320 tests with no errors.
- Independent review reproduced the two counts above and the two mutations, plus three of its own, all red by name as expected; requested three nits (assert-known-counters, the stale "nine tests" figure, and this section's wording) are addressed in this revision; CI is re-running on the new head.

## Test plan

- [x] `pytest -q -rs` full suite, `web/node_modules` absent: 0 failed
- [x] `pytest -q -rs` full suite, `web/node_modules` present: 0 failed
- [x] Previously-failing test green in isolation, both states
- [x] Summary tests forced first and last in the session (independent review) - green, banner still reads 76/11
- [x] Mutation of the test fixture reproduces the original failure
- [x] Mutation of the hook fails both node_modules summary tests
- [x] Collection guard still passes
- [ ] CI green on latest head (pending)
