### PR TITLE
Re-derive the page indicator once a resize re-render settles

### DIFF
--- a/web/src/lib/PdfViewer.svelte
+++ b/web/src/lib/PdfViewer.svelte
@@ -227,7 +227,28 @@
       rerendering = false;
       // wait for the final scrollIntoView to actually paint before trusting
       // the observer again, so it doesn't fire on the mid-resize layout
-      requestAnimationFrame(() => requestAnimationFrame(() => (suppressTracking = false)));
+      requestAnimationFrame(() =>
+        requestAnimationFrame(() => {
+          if (cancelled) return;
+          suppressTracking = false;
+          // Handing the observer back is not enough on its own: the geometry
+          // it was blanked THROUGH is the geometry now on screen, and an
+          // IntersectionObserver only ever fires on a CHANGE. Every crossing
+          // the resize caused was delivered while suppressed and thrown
+          // away, and nothing re-delivers them - so the indicator kept
+          // saying whatever it last said before the pane changed shape,
+          // with no scroll left to come and correct it. Measured on a
+          // 2-page score entering gig mode with a tap inside the 200ms
+          // debounce: at the narrow pre-render geometry the tap put page two
+          // at ratio 0.63 and the indicator at "2 / 2"; the re-render then
+          // left the reader at scrollTop 547 - 47% down page ONE, page two
+          // down to 0.11 - and the HUD read "2 / 2" for as long as the score
+          // stayed open. Re-deriving it once, here, is what closes that:
+          // there is no crossing left to wait for.
+          const seen = visiblePage();
+          if (seen !== null) trackVisible(seen);
+        }),
+      );
     }
 
     (async () => {
@@ -251,20 +272,7 @@
               best = e;
             }
           }
-          if (best) {
-            const seen = Number(best.target.dataset.page);
-            // A turn this component performed is already recorded (see
-            // intendedPage). Until that scroll settles, the frames it passes
-            // through are not the reader going anywhere - taking them would
-            // drag the indicator back onto the page being LEFT, which is the
-            // same wrong answer by a different route. The arrival itself is
-            // what hands tracking back to the reader.
-            if (intendedPage !== null) {
-              if (seen === intendedPage) intendedPage = null;
-              return;
-            }
-            setPage(seen);
-          }
+          if (best) trackVisible(Number(best.target.dataset.page));
         },
         { root: container, threshold: 0.4 },
       );
@@ -328,6 +336,49 @@
     currentPage = n;
     clearTimeout(saveTimer);
     saveTimer = setTimeout(() => api.patch(score.id, { last_page: currentPage }).catch(() => {}), 1200);
+  }
+
+  // Which page the pane is actually showing, read straight off the rects: of
+  // the pages intersecting the scroller, the one showing the largest fraction
+  // of ITSELF, which is what an intersection ratio measures. null when the
+  // pane has nothing on screen (no canvases yet).
+  //
+  // Deliberately the same answer the observer's callback arrives at from its
+  // entries - most visible of the intersecting ones - and the same answer
+  // re-observing every canvas would deliver, since a fresh observation
+  // reports every target at once. The 0.4 threshold decides WHEN the observer
+  // is run, not which page it then picks, so leaving it out here is not a
+  // second opinion about what "visible" means; it is the same opinion asked
+  // at a moment when there is no crossing left to be delivered.
+  function visiblePage() {
+    const view = container.getBoundingClientRect();
+    let best = null;
+    for (const canvas of container.querySelectorAll(".pdf-page")) {
+      const rect = canvas.getBoundingClientRect();
+      if (!rect.height) continue;
+      const overlap = Math.min(rect.bottom, view.bottom) - Math.max(rect.top, view.top);
+      if (overlap <= 0) continue;
+      const ratio = overlap / rect.height;
+      if (!best || ratio > best.ratio) best = { page: Number(canvas.dataset.page), ratio };
+    }
+    return best ? best.page : null;
+  }
+
+  // A page seen to be the one on screen, whichever route noticed it - an
+  // observer crossing, or the re-derive after a resize re-render. One
+  // function so the two cannot come to differ over the case below, which is
+  // the whole of why the indicator is not simply assigned at either site.
+  function trackVisible(seen) {
+    // A turn this component performed is already recorded (see intendedPage).
+    // Until that scroll settles, the frames it passes through are not the
+    // reader going anywhere - taking them would drag the indicator back onto
+    // the page being LEFT, which is the same wrong answer by a different
+    // route. The arrival itself is what hands tracking back to the reader.
+    if (intendedPage !== null) {
+      if (seen === intendedPage) intendedPage = null;
+      return;
+    }
+    setPage(seen);
   }
 
   // Where a page's top edge sits in the scroller's own coordinates. Read off

--- a/web/src/lib/PdfViewer.svelte
+++ b/web/src/lib/PdfViewer.svelte
@@ -275,7 +275,18 @@
             // where a turn can still be travelling when the flush ends, and
             // there the two differ.
             intendedPage = null;
-            setPage(seen);
+            // Only when it has actually moved, and ONLY here. This is the
+            // one caller that speaks after every re-render rather than on a
+            // change - the observer fires on a crossing, which is a change
+            // by definition, and every other caller is recording an intent
+            // worth saving even when it names the page already showing (a
+            // turn pressed before any canvas exists resolves to page one on
+            // a score stored at page eight, and that write is the whole
+            // point of it). Gating inside setPage instead swallowed that
+            // one: measured, the reader sat on page one while the database
+            // kept eight. Ungated here, a reader who never leaves page one
+            // still wrote it once per resize - 10 writes for 10 resizes.
+            if (seen !== currentPage) setPage(seen);
           }
         }),
       );
@@ -363,15 +374,6 @@
   // including the debounced last_page write, which used to live only on the
   // observer's path and so was skipped for any turn the observer missed.
   function setPage(n) {
-    // Only when it actually moves. The write below is what makes this worth
-    // stating: the re-derive after a resize (see flushResize) asks this
-    // question after EVERY re-render, where the observer only ever spoke on
-    // a crossing - which is a change by definition. Without this, a reader
-    // who never leaves page one still writes the page they are already on
-    // once per resize (measured: 10 writes for 10 resizes, against none on
-    // main). Every other caller is a turn, and a turn that does not move the
-    // page has nothing to save either.
-    if (n === currentPage) return;
     currentPage = n;
     clearTimeout(saveTimer);
     saveTimer = setTimeout(() => api.patch(score.id, { last_page: currentPage }).catch(() => {}), 1200);

--- a/web/src/lib/PdfViewer.svelte
+++ b/web/src/lib/PdfViewer.svelte
@@ -229,7 +229,13 @@
       // the observer again, so it doesn't fire on the mid-resize layout
       requestAnimationFrame(() =>
         requestAnimationFrame(() => {
-          if (cancelled) return;
+          // Not this flush's frame any more if another resize has started one
+          // of its own in the two frames since: it would hand the observer
+          // back in the middle of somebody else's re-render, and re-derive
+          // the page off canvases that are being resized one at a time as it
+          // reads them. That flush schedules its own frame and does both when
+          // its own geometry is final.
+          if (cancelled || rerendering) return;
           suppressTracking = false;
           // Handing the observer back is not enough on its own: the geometry
           // it was blanked THROUGH is the geometry now on screen, and an
@@ -246,7 +252,31 @@
           // stayed open. Re-deriving it once, here, is what closes that:
           // there is no crossing left to wait for.
           const seen = visiblePage();
-          if (seen !== null) trackVisible(seen);
+          if (seen !== null) {
+            // Deliberately NOT deferred to a turn still marked in flight,
+            // the way the observer's own crossings are (see trackVisible).
+            // The restore above assigns scrollTop, which aborts any scroll
+            // that was still running, so by this frame the pane is AT REST:
+            // its geometry is the whole truth and there is no arrival left
+            // to hand tracking back. Deferring here would leave the
+            // indicator waiting on a scroll that was cancelled - which is
+            // this bug again, one route further along - so the flag is
+            // cleared rather than obeyed.
+            //
+            // In this suite's browser the two spellings cannot be told
+            // apart, and that is a fact about the geometry rather than a
+            // gap in the tests: the restore lands on the requested page's
+            // TOP, where that page is by construction the most visible one
+            // (it fills the pane from the top down, and a tie goes to the
+            // lower page number), so `seen` always equals the turn's target
+            // when a turn is in flight at all. It is a browser that animates
+            // `behavior: "smooth"` - which this one does not, measured: a
+            // 6910px scrollIntoView is complete in the frame it is issued -
+            // where a turn can still be travelling when the flush ends, and
+            // there the two differ.
+            intendedPage = null;
+            setPage(seen);
+          }
         }),
       );
     }
@@ -333,6 +363,15 @@
   // including the debounced last_page write, which used to live only on the
   // observer's path and so was skipped for any turn the observer missed.
   function setPage(n) {
+    // Only when it actually moves. The write below is what makes this worth
+    // stating: the re-derive after a resize (see flushResize) asks this
+    // question after EVERY re-render, where the observer only ever spoke on
+    // a crossing - which is a change by definition. Without this, a reader
+    // who never leaves page one still writes the page they are already on
+    // once per resize (measured: 10 writes for 10 resizes, against none on
+    // main). Every other caller is a turn, and a turn that does not move the
+    // page has nothing to save either.
+    if (n === currentPage) return;
     currentPage = n;
     clearTimeout(saveTimer);
     saveTimer = setTimeout(() => api.patch(score.id, { last_page: currentPage }).catch(() => {}), 1200);
@@ -350,6 +389,22 @@
   // is run, not which page it then picks, so leaving it out here is not a
   // second opinion about what "visible" means; it is the same opinion asked
   // at a moment when there is no crossing left to be delivered.
+  //
+  // Two places where "the same" is a statement about this pane rather than
+  // about the two rules in general, both worth saying out loud:
+  //
+  //   - the ratio here is vertical overlap over height, where the observer's
+  //     is an AREA ratio. They agree because a canvas is centred in the
+  //     scroller and never wider than it (computeWidth subtracts the
+  //     padding), so no page is ever clipped horizontally and the widths
+  //     cancel. A page wider than the pane would need this to measure area.
+  //   - an exact tie goes to the lower page number here (`>` keeps the first
+  //     seen, and pages are walked in document order), where the observer's
+  //     callback ties to the first such entry in a batch whose order is not
+  //     defined. A tie means the pane is split precisely down the middle of
+  //     the gap; the reader is arriving at the lower page's end rather than
+  //     the upper page's start, so this is the better of the two answers
+  //     anyway, and it is at least always the SAME answer.
   function visiblePage() {
     const view = container.getBoundingClientRect();
     let best = null;
@@ -364,10 +419,10 @@
     return best ? best.page : null;
   }
 
-  // A page seen to be the one on screen, whichever route noticed it - an
-  // observer crossing, or the re-derive after a resize re-render. One
-  // function so the two cannot come to differ over the case below, which is
-  // the whole of why the indicator is not simply assigned at either site.
+  // What the observer does with a crossing it has just been handed. Kept
+  // apart from the callback so the rule can be stated once and read at the
+  // one other place that has to reason about it - the re-derive above, which
+  // deliberately does NOT follow it, and says why.
   function trackVisible(seen) {
     // A turn this component performed is already recorded (see intendedPage).
     // Until that scroll settles, the frames it passes through are not the

--- a/web/tests/browser/practice-shortcuts.spec.js
+++ b/web/tests/browser/practice-shortcuts.spec.js
@@ -140,6 +140,52 @@ const pdfGeometry = (page) =>
   });
 
 /**
+ * What the PDF pane is showing, and what its indicator says about it, read
+ * in ONE evaluate so the two can never be sampled either side of a change.
+ *
+ * "Showing" is measured here rather than asked of the component: the page
+ * displaying the largest fraction of itself, which is what an intersection
+ * ratio is and what PdfViewer's own observer ranks its entries by. Reading
+ * it off the rects is what makes an assertion that the two agree an
+ * assertion about the pane rather than the indicator being compared with
+ * itself.
+ */
+const pdfIndicatorState = (page) =>
+  page.evaluate(() => {
+    const scroller = document.querySelector(".pages");
+    const view = scroller.getBoundingClientRect();
+    const ratios = [...document.querySelectorAll(".pdf-page")].map((canvas) => {
+      const rect = canvas.getBoundingClientRect();
+      const overlap = Math.min(rect.bottom, view.bottom) - Math.max(rect.top, view.top);
+      return { page: Number(canvas.dataset.page), ratio: rect.height ? Math.max(0, overlap) / rect.height : 0 };
+    });
+    const best = ratios.reduce((a, b) => (b.ratio > a.ratio ? b : a));
+    return {
+      hud: document.querySelector(".hud span").textContent.trim(),
+      shown: best.page,
+      ratios: ratios.map((r) => `${r.page}:${r.ratio.toFixed(2)}`).join(" "),
+    };
+  });
+
+/**
+ * Waits for the PDF pane's indicator to agree with the page the pane is
+ * actually showing, reporting both when it does not. Polled rather than read
+ * once, because the correction is made a couple of frames after the
+ * re-render's own scroll restore; a disagreement that is never corrected -
+ * the bug this covers - simply never agrees.
+ */
+async function pdfIndicatorAgrees(page, pageCount) {
+  await expect
+    .poll(async () => {
+      const at = await pdfIndicatorState(page);
+      return at.hud === `${at.shown} / ${pageCount}`
+        ? "agrees"
+        : `HUD reads "${at.hud}" over a pane showing page ${at.shown} (ratios ${at.ratios})`;
+    })
+    .toBe("agrees");
+}
+
+/**
  * Waits for the PDF pane to have finished re-rendering its canvases at the
  * width it is going to keep - the readiness barrier the page-turn tests
  * below need and #168's did not.
@@ -1126,6 +1172,101 @@ test.describe("gig mode itself", () => {
     // Stated the blunt way too: not scrolled back to the top of page one,
     // which is where the old restore put it on every run.
     expect(after.scrollTop).toBeGreaterThan(after.pageOneTop + 1);
+  });
+
+  // Issue #229, and the half of a page turn the test above does not look at:
+  // it proves where the reader ENDS UP, and says nothing about what the
+  // indicator claims about that place. The two came apart here.
+  //
+  // A tap taken before gig mode's own re-render is measured against the
+  // narrow pre-render geometry, where half a page is short enough to bring
+  // page two past the 0.4 intersection threshold - so the observer sets the
+  // indicator to "2 / 2", correctly, for the pane as it stands. The
+  // re-render then blanks the observer (suppressTracking) and doubles every
+  // page's height underneath it: the reader is left half way down page ONE
+  // with page two barely on screen. That change was delivered as a crossing
+  // while the observer was blanked and dropped, and an IntersectionObserver
+  // only ever fires on a change, so nothing re-delivered it. Measured on
+  // main before this fix, 3 of 3: the pane at scrollTop 547 - 47% down page
+  // one, page one at ratio 0.52 against page two's 0.11 - and the HUD
+  // reading "2 / 2" for as long as the score stayed open.
+  //
+  // Not a race, despite pressing without a barrier. The assertion is that
+  // the indicator matches the pane's OWN geometry, which is true of a
+  // correct viewer whichever side of the re-render the press lands on - all
+  // three orderings (before the 200ms debounce fires, inside the re-render,
+  // after it) leave the reader half a page down page one. Winning the race
+  // is what makes this test reach the dropped crossing; losing it can only
+  // make it prove less, never fail.
+  test("the page indicator matches the pane after a turn taken inside gig mode's re-render", async ({ page }) => {
+    // Windowed gig mode, for the reason the test above states.
+    await page.evaluate(() => {
+      Element.prototype.requestFullscreen = () => Promise.reject(new Error("denied"));
+    });
+    await expect(page.locator(".pdf-page")).toHaveCount(2);
+    await pdfPagesRenderedAtSettledWidth(page);
+
+    await page.keyboard.press("f");
+    await expect(page.getByRole("button", { name: "Side by side", exact: true })).toHaveCount(0);
+    // Deliberately no barrier: this is the tap a performer actually makes,
+    // straight into the pane that is still about to re-render.
+    await page.keyboard.press("ArrowRight");
+
+    await pdfPagesRenderedAtSettledWidth(page);
+    await pdfIndicatorAgrees(page, 2);
+
+    // And the geometry that makes the line above worth asserting: the reader
+    // really is mid-page-one, not parked somewhere the two would agree
+    // trivially. Half a page on, whichever geometry the step was measured
+    // against, with page two left well under the 0.4 threshold.
+    const at = await pdfGeometry(page);
+    const fraction = (at.scrollTop - at.pageOneTop) / at.pageHeight;
+    expect(fraction).toBeGreaterThan(0.35);
+    expect(fraction).toBeLessThan(0.65);
+    const state = await pdfIndicatorState(page);
+    expect(state.shown).toBe(1);
+    await expect(page.locator(".hud span")).toHaveText("1 / 2");
+  });
+
+  // The same defect reached without pressing anything into a live re-render,
+  // so it fails on every run rather than on a run that wins a race: the turn
+  // is fully settled and correct BEFORE the pane changes shape, and it is
+  // the resize alone that moves which page is on screen.
+  //
+  // A window resized mid-set is the ordinary way this happens off the stand.
+  test("a resize that changes which page is on screen moves the indicator with it", async ({ page }) => {
+    await page.evaluate(() => {
+      Element.prototype.requestFullscreen = () => Promise.reject(new Error("denied"));
+    });
+    await page.keyboard.press("f");
+    await expect(page.getByRole("button", { name: "Side by side", exact: true })).toHaveCount(0);
+    await expect(page.locator(".pdf-page")).toHaveCount(2);
+    await pdfPagesRenderedAtSettledWidth(page);
+
+    // A narrow pane renders short pages, and half of a short page is enough
+    // to bring page two past the threshold - which is what gives the resize
+    // below something to change its mind about.
+    await page.setViewportSize({ width: 700, height: 720 });
+    await pdfPagesRenderedAtSettledWidth(page);
+    const before = await pdfGeometry(page);
+    await page.keyboard.press("ArrowRight");
+    await pdfScrollSettlesAt(page, before.scrollTop + (before.pageTwoTop - before.pageOneTop) / 2, "half a page on");
+    // Right, and asserted as such: page two IS the page most of the pane is
+    // showing here. Without this the test could not tell the indicator being
+    // re-derived from it never having moved at all.
+    await pdfIndicatorAgrees(page, 2);
+    await expect(page.locator(".hud span")).toHaveText("2 / 2");
+
+    // Widen: the pages grow back, the reader keeps their place half way down
+    // page one (#224), and page two drops off the bottom of the pane.
+    await page.setViewportSize({ width: 1280, height: 720 });
+    await pdfPagesRenderedAtSettledWidth(page);
+    await pdfIndicatorAgrees(page, 2);
+    const after = await pdfGeometry(page);
+    expect(after.pageHeight).toBeGreaterThan(before.pageHeight);
+    const state = await pdfIndicatorState(page);
+    expect(state.shown).toBe(1);
+    await expect(page.locator(".hud span")).toHaveText("1 / 2");
   });
 
   test("from the staff layout, gig mode keeps the staff pane and Space still plays/pauses it", async ({ page }) => {

--- a/web/tests/browser/practice-shortcuts.spec.js
+++ b/web/tests/browser/practice-shortcuts.spec.js
@@ -850,6 +850,59 @@ test.describe("a page turn pressed before the PDF has rendered", () => {
     await expect(page.locator(".hud span")).toHaveText("2 / 2");
   });
 
+  // The write that turn owes the library, which is not the same claim as the
+  // page it lands on (#229 review).
+  //
+  // A turn pressed before any canvas exists is remembered and honoured, and
+  // honouring it also REVOKES the stored-page restore (turnedBeforeRestore):
+  // the reader asked to be somewhere, so they are not to be yanked off it.
+  // On a score stored at page eight, ArrowLeft resolves to page one - which
+  // is the page the indicator already named - so the turn moves the reader
+  // without moving the indicator, and only the debounced save records that
+  // the reader is no longer where the database thinks. Skip that save and
+  // the two disagree silently until the score is reopened, at which point
+  // the reader is thrown to page eight by a restore that is now wrong.
+  //
+  // Held open, not raced: the PDF body is released only after the press.
+  test("a turn honoured before the pages existed is saved, even when it names the page already shown", async ({
+    page,
+  }) => {
+    await stubScoreApi(page, transcriptionResponse({ warnings: [], confidence: CLEAN_CONFIDENCE }));
+    // Overrides stubScoreApi's own /api/scores/1 route (most recent wins) to
+    // give the score a stored page far from page one, and to record what the
+    // viewer writes back to it.
+    const written = [];
+    await page.route("**/api/scores/1", (route) => {
+      if (route.request().method() === "PATCH") written.push(route.request().postDataJSON());
+      return route.fulfill({ json: { ...SCORE, last_page: 8 } });
+    });
+    let release;
+    const held = new Promise((resolve) => (release = resolve));
+    await page.route("**/api/scores/1/file", async (route) => {
+      await held;
+      await route.fulfill({ body: buildMultiPagePdf(20), contentType: "application/pdf" });
+    });
+    await page.goto("/#/score/1");
+    await expect(playButton(page)).toBeEnabled({ timeout: 15_000 });
+    await expect(page.locator(".pdf-page")).toHaveCount(0);
+
+    // Backwards from page one: goto() clamps it to page one, so this is the
+    // turn that asks for the page the indicator is already showing.
+    await page.keyboard.press("ArrowLeft");
+    release();
+
+    await expect(page.locator(".pdf-page")).toHaveCount(20, { timeout: 15_000 });
+    await expect(page.locator(".hud span")).toHaveText("1 / 20");
+    // The turn was honoured: page one, not the stored page eight.
+    const at = await pdfGeometry(page);
+    expect(Math.abs(at.scrollTop - at.pageOneTop)).toBeLessThanOrEqual(2);
+    // And the library was told, which is the half a page-turn that does not
+    // move the indicator can still lose. Polled: the save is debounced.
+    await expect
+      .poll(() => written.map((body) => body.last_page).join(","))
+      .toBe("1");
+  });
+
   // The same press, in gig mode, which is where it actually comes from: a
   // pedal tap on a score that has just been opened, with no mouse to fall
   // back on (issue #106's reasoning, and #92's).

--- a/web/tests/spec-floors/browser-practice-shortcuts-229.json
+++ b/web/tests/spec-floors/browser-practice-shortcuts-229.json
@@ -1,5 +1,5 @@
 {
   "file": "tests/browser/practice-shortcuts.spec.js",
-  "count": 2,
-  "reason": "issue #229: after a resize re-render the page indicator is re-derived from the pane's own geometry, so it cannot be left reading a page the pane is no longer showing - once for a gig-mode turn taken inside the re-render, and once for a resize alone changing which page is on screen."
+  "count": 3,
+  "reason": "issue #229: after a resize re-render the page indicator is re-derived from the pane's own geometry, so it cannot be left reading a page the pane is no longer showing - once for a gig-mode turn taken inside the re-render, and once for a resize alone changing which page is on screen; plus, from the review of that fix, that a turn honoured before the pages existed is still SAVED when it lands on the page the indicator already named, which is the one write the visible-page gate must not swallow."
 }

--- a/web/tests/spec-floors/browser-practice-shortcuts-229.json
+++ b/web/tests/spec-floors/browser-practice-shortcuts-229.json
@@ -1,0 +1,5 @@
+{
+  "file": "tests/browser/practice-shortcuts.spec.js",
+  "count": 2,
+  "reason": "issue #229: after a resize re-render the page indicator is re-derived from the pane's own geometry, so it cannot be left reading a page the pane is no longer showing - once for a gig-mode turn taken inside the re-render, and once for a resize alone changing which page is on screen."
+}


### PR DESCRIPTION
## What

Closes #229. After a resize re-render the PDF pane's page indicator could be
left naming a page the pane is no longer showing, for as long as the score
stayed open. The issue reproduced exactly as filed, 3 of 3, on `origin/main`
(4164ad8, #224 included).

## The mechanism

`web/src/lib/PdfViewer.svelte`:

- `flushResize()` sets `suppressTracking = true` for the whole re-render
  (`:221`), and the IntersectionObserver callback returns early while it is set
  (`:243` on main).
- An IntersectionObserver only ever fires on a **change**. The crossings the
  resize itself causes - every page's ratio moves, because every canvas changes
  height - are delivered inside that blanked window and thrown away. The
  observer's internal state has moved on with them, so nothing re-delivers them
  afterwards.
- Nothing else re-derived the visible page once the resize settled. The
  indicator therefore kept whatever value it held before the pane changed
  shape.

Measured on main, a 2-page score, gig mode entered windowed with ArrowRight
pressed 24-40ms later (inside the 200ms re-render debounce), 3 of 3 runs:

| | scrollTop | page 1 ratio | page 2 ratio | HUD |
|---|---|---|---|---|
| at the press, pre-render (608px pages) | 313 | 0.52 | **0.63** | 2 / 2 - correct |
| after the re-render (1100px pages) | **547** (47% down page 1) | **0.52** | **0.11** | **2 / 2** - wrong, permanently |

The issue's numbers reproduce to the pixel (it reports scrollTop 547 and the
same two ratios).

A second, un-raced route to the same disagreement, also 3 of 3 on main: settle
gig mode, narrow the window so a half turn genuinely brings page two past the
0.4 threshold (HUD "2 / 2", and right to be), then widen it again. The restore
keeps the reader half way down page one (ratios 0.51 / 0.13) and the HUD still
reads "2 / 2".

## Fix

One re-derive, at the moment tracking is handed back:

```
requestAnimationFrame(() => requestAnimationFrame(() => {
  if (cancelled) return;
  suppressTracking = false;
  const seen = visiblePage();
  if (seen !== null) trackVisible(seen);
}));
```

- `visiblePage()` reads the answer off the rects: of the pages intersecting the
  scroller, the one showing the largest fraction of itself. That is the same
  measure the observer's callback ranks its entries by, and the same answer
  re-observing every canvas would deliver (the other fix the issue offers) -
  the 0.4 threshold decides *when* the observer runs, not which page it then
  picks. Done synchronously here, there is no round trip and no second
  definition of "visible".
- The re-derive clears `intendedPage` and reads the page off the geometry; it
  does NOT defer to a turn still marked in flight, the way the observer's own
  crossings do (`trackVisible`, which stays the observer's rule and is used
  only there). By the time this frame runs, the restore has assigned
  `scrollTop`, which aborts any scroll still running - so the pane is at rest
  and there is no arrival left to hand tracking back to. Measured in review, on
  a narrow pane where the travel is slow enough for the restore to abort the
  turn: the deferring spelling left the indicator wrong for all 30 tail frames
  sampled, permanently; clearing it is correct there. On a wide pane the
  clearing spelling can show a ~100ms flicker before the arrival corrects it,
  which no Playwright mode can exercise (this browser does not animate smooth
  scrolling at all).
- Nothing is papered over from the turn's side: the indicator is never forced
  from a turn's target, it is read from what the pane shows.

The reader is not moved: scrollTop is 547 before and after the fix in the case
above. What changes is the indicator - and, because `turn()` computes a whole
page turn as `goto(currentPage + dir)`, where the NEXT turn goes. Measured on a
20-page score, same tap, then half-page turns switched off and one more press:

| | after the tap | after the next whole-page turn |
|---|---|---|
| main | scrollTop 547, HUD "2 / 20", pane showing page 1 | scrollTop 2260 - **page 3, skipping page 2** |
| this branch | scrollTop 547, HUD "1 / 20", pane showing page 1 | scrollTop 1142 - page 2 |

So the stale indicator was not only a wrong label: it silently cost the reader
a page at the next turn.

## Tests

Two, both in `practice-shortcuts.spec.js`'s gig-mode describe, both asserting
the invariant rather than a fixed string - the HUD must equal the page the pane
shows, computed from rects in the same evaluate so the two cannot be sampled
either side of a change (`pdfIndicatorState` / `pdfIndicatorAgrees`).

- **the page indicator matches the pane after a turn taken inside gig mode's
  re-render** - the issue's own sequence, pressed with no barrier. Not a race
  that can flake: all three orderings (before the debounce fires, inside the
  re-render, after it) leave the reader half a page down page one, and the
  assertion is true of a correct viewer in each. Losing the race makes it prove
  less, never fail. It is asserted afterwards that the reader really is
  mid-page-one (fraction 0.35-0.65) and that page one is the page shown, so it
  cannot pass vacuously.
- **a resize that changes which page is on screen moves the indicator with it**
  - the un-raced route. The turn is settled and correct first (asserted: page
  two IS the page most of the pane shows, HUD "2 / 2"), and it is the resize
  alone that changes the answer.

## Verification

All runs against a rebuilt `web/dist`, `FERMATA_TEST_PORT` odd, 127.0.0.1.

| check | result |
|---|---|
| the two new tests against **pristine main's** `PdfViewer.svelte` (tests present) | **2 failed**, 3 passed in that describe: `HUD reads "2 / 2" over a pane showing page 1 (ratios 1:0.52 2:0.11)` and `(ratios 1:0.51 2:0.13)` |
| mutation: the two `visiblePage()/trackVisible()` lines removed from this branch, everything else kept | the **same 2 red**, 3 passed - nothing else in the file covers it |
| the two new tests, CPU throttle 8x, `--repeat-each 20` | **40 passed, 0 failed** |
| throttling actually applied (in-page spin loop) | 14ms unthrottled -> 119ms at 8x |
| test 1 against pristine main, throttle 8x, 5 runs | **5 red** - the press still lands inside the debounce under load, so the test does not quietly stop proving anything on a slow runner |
| `practice-shortcuts.spec.js` in full | **32 passed** (30 + 2) |
| full browser suite | **569 passed, 0 failed** (6.1m) |
| suite size | main `--list` **567**, this branch **569** - exactly the two added |

Attacks, measured (HUD vs the page the pane shows, 20-page score unless said):

| attack | outcome |
|---|---|
| wheel scroll issued 230ms into the re-render | agree (`1 / 20` over page 1) - the un-recorded wheel is still rolled back by the restore, unchanged from #224 |
| wheel scroll after the re-render | agree (`8 / 20` over page 8) - ordinary tracking untouched |
| resize with no movement | agree, indicator unchanged at `1 / 20` |
| resize while parked on page 3 | agree, indicator unchanged at `3 / 20` |
| desk-mode side-by-side load re-render | agree (`1 / 2`) |
| #224's three mid-re-render tests + the gig half-page restore | green in the file run above |

Suite count 567 -> 569, with a matching floor entry
(`tests/spec-floors/browser-practice-shortcuts-229.json`, count 2).

One honest note on the suite: the FIRST full run came back 568 passed / 1
failed - `viewer-practice.spec.js:208 closing the panel keeps the session it
was about`, `.session-detail` never appearing, 17.6s against its usual 12.5s.
That spec drives a MusicXML score, so `PdfViewer` is not mounted in it at all
and this change cannot reach it. Re-run alone: 6 passed. Re-run of the whole
suite: 569 passed, 0 failed. Reported rather than quietly re-run.


---

## Review round

**1. Redundant write.** The re-derive runs after every re-render, where the
observer only ever spoke on a crossing - a change by definition - so writing
the page through unconditionally re-armed the debounced `last_page` save on
every resize. `setPage` now returns when the page has not moved. Re-measured
(PATCH requests to `/api/scores/1` counted off `page.on("request")`): **10
resizes parked on one page -> 0 writes**; **a resize that changes the visible
page -> 1**. Placed in `setPage` rather than in `trackVisible` as suggested,
because of item 3 below - the re-derive no longer goes through `trackVisible`,
so the gate has to sit where every caller passes.

**2. Stale frame.** A second resize starting inside the two frames the first
one waits out would have had flush #1's frame hand the observer back, and
re-derive the page, in the middle of flush #2's half-resized canvases. The
frame now stands down (`if (cancelled || rerendering) return;`); the running
flush does both when its own geometry is final. The two new tests and #224's
three mid-re-render tests stay green (10 passed for the gig describe plus the
pre-render/mid-re-render describe).

**3. Instancing the shared tracker - not constructible, and the branch is gone
instead.** The requested test cannot discriminate, and the reason is geometry
rather than a gap:

- The restore assigns `container.scrollTop` before the two frames, and the
  target it assigns for a turn taken during the flush is that turn's page at
  fraction 0 - the page's TOP. At a page's top that page is by construction the
  most visible one (it fills the pane downwards; the next page can only match
  it, and a tie goes to the lower page number). So whenever `intendedPage` is
  non-null at the re-derive, `visiblePage()` equals it, and the guard is
  unreachable.
- The only way past that is a turn still travelling when the flush ends, which
  needs an animated smooth scroll. **This browser does not animate one at all**
  - measured, twelve consecutive frames after a 6910px
  `scrollIntoView({behavior:"smooth"})`: `6910,6910,6910,...` from frame zero.
- Both candidate orders were run anyway (whole-page turns, half-page toggled
  off via the HUD button): pressed inside the re-render, and pressed just
  before the resize. Both end at page 2's top with the HUD reading "2 / 20" -
  identical under either spelling.

Rather than add a test that would be asserting something other than its name,
the unproven branch is removed: the re-derive now clears `intendedPage` and
sets the page from geometry. That is also the better rule, and for a stated
reason - by the time it runs, the restore has aborted any scroll still in
flight, so the pane is at rest and there is no arrival left to defer to;
deferring would leave the indicator waiting on a scroll that was cancelled,
which is this bug again one route further along. `trackVisible` stays as the
observer's own rule, where a later arrival genuinely does come.

**4. Comments and body.** `visiblePage`'s comment now names both places its
"same answer as the observer" claim rests on this pane: the ratio is vertical
overlap over height rather than area (equal only because a canvas is never
wider than the scroller, `computeWidth` having subtracted the padding), and an
exact tie goes to the lower page number, where the observer's batch order is
undefined. The page-skip measurement is in the Fix section above.

Re-verified after these three changes: `practice-shortcuts.spec.js` **32
passed**; mutation (the re-derive's two lines removed) **the same 2 red, 30
passed**; the two new tests at CPU throttle 8x `--repeat-each 20` **40 passed**;
full browser suite **569 passed, 0 failed**.


---

## Second review round

**1. The write gate was in the wrong place.** Putting `if (n === currentPage)
return;` inside `setPage` swallowed a write that has nothing to do with
resizes: a turn pressed before any canvas exists is honoured AND revokes the
stored-page restore, so on a score stored at page eight an ArrowLeft resolves
to page one, the reader stays on page one, and that debounced save is the only
record that they are no longer where the row says. It named the page already
shown, so the gate dropped it - the reader on page one, the row still eight,
and reopening the score throwing them back to eight. The gate now sits at the
re-derive alone, which is the one caller that speaks after every re-render
rather than on a change; `setPage` is unconditional again for every caller that
is recording an intent.

Re-measured, PATCHes of `last_page` to `/api/scores/1`:

| case | writes |
|---|---|
| ten resizes parked on one page | **0** (the one write in that run is at load, from the observer's first crossing - main makes the same one, measured) |
| a resize that changes the visible page | **1**, `{"last_page":1}` |
| the pre-render ArrowLeft on a score stored at page eight | **1**, `{"last_page":1}` - **0** with the gate inside `setPage` |

That last case is now a test rather than a probe: *a turn honoured before the
pages existed is saved, even when it names the page already shown*, in the
pre-render describe, holding the PDF body until after the press. It asserts
both halves - the reader on page one rather than the stored page eight, and the
write that says so - and it is the **only** test in the file to go red with the
gate put back inside `setPage` (1 failed, 32 passed).

**2. Text.** `setPage`'s comment (with its false "every other caller is a turn"
sentence) is gone; the reasoning now sits at the re-derive, where the gate is.
The Fix section above no longer claims a shared tracker, and states the
measured reason the deferral was wrong.

Counts after this round: `practice-shortcuts.spec.js` **33 passed** (30 + 3),
floor entry raised to **3**, suite **570**.
