### PR TITLE
Cache the server job's node_modules, floor its runtime, and guard the runner's argument passing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,14 +118,21 @@ jobs:
       # playwright.config.js refuses to load without it).
       #
       # What it guards: run-browser-tests.mjs used to hand its argv to a
-      # shell, and on Windows a shell joins argv into a single command line
-      # whose quoting does not cover internal spaces. A multi-word --grep
-      # came out the far side as separate bare words, so Playwright saw only
-      # the first one and ran a wider set than the caller asked for -
-      # silently, with a green run to show for it. Six tests in this file
-      # have "gig mode" in their title and seven have "gig", so a --grep that
-      # loses its second word lists seven and this step goes red. Proven
-      # against that exact revert before it was added.
+      # shell, and a shell spawn joins argv into one unquoted command line
+      # (on every platform, not only Windows), so a multi-word --grep came
+      # out the far side as separate bare words. Playwright saw only the
+      # first one and ran a wider set than the caller asked for - silently,
+      # with a green run to show for it. Six composed titles in this file
+      # match "gig mode" (one directly, five through their describe block)
+      # and seven match "gig", so a --grep that loses its second word lists
+      # seven and this step goes red. Proven against that exact revert
+      # before it was added.
+      #
+      # Both counts are pinned, not just the good one: if the titles ever
+      # converged so that "gig" and "gig mode" listed the same six, the
+      # first assertion would stay green while proving nothing. The second
+      # makes that convergence red instead of quiet. Adding or renaming a
+      # test whose title contains "gig" moves these numbers on purpose.
       #
       # PLAYWRIGHT_ALLOW_PARTIAL because --list executes nothing at all: every
       # spec file reports zero tests run, which the runner's spec-floor guard
@@ -139,6 +146,8 @@ jobs:
             tests/browser/practice-shortcuts.spec.js --grep "gig mode" --list)
           echo "$listed"
           echo "$listed" | grep -qx "Total: 6 tests in 1 file"
+          wider=$(node scripts/run-browser-tests.mjs             tests/browser/practice-shortcuts.spec.js --grep "gig" --list)
+          echo "$wider" | grep -qx "Total: 7 tests in 1 file"
 
   browser:
     name: Browser tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,15 @@ jobs:
   server:
     name: Server tests
     runs-on: ubuntu-latest
+    # Measured on main: pytest itself is 0.8-1.3 minutes, and the whole job
+    # has run anywhere from 1.7 minutes (33887700373) to 8.7 minutes
+    # (33854927005). The entire spread is one step - `npm ci --omit=dev`,
+    # which reported "added 6 packages in 7m" on run 33845939449 against 0.0
+    # minutes on a good run. That is the same registry stall the browser job
+    # had; the cache below is the fix for it, and this is only the floor
+    # under it, so a stall that outlives the cache fails in minutes instead
+    # of holding a runner for the six-hour default.
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -22,6 +31,21 @@ jobs:
           node-version: "22"
           cache: npm
           cache-dependency-path: web/package-lock.json
+      # Its OWN key, deliberately not the browser job's. This job installs
+      # with --omit=dev, so the tree it saves has no playwright and none of
+      # the build tooling in it. Sharing a key would mean whichever job ran
+      # first decided what the other one restored - and a browser job that
+      # restored this tree would skip its own `npm ci` and then have no
+      # playwright to run the suite with. The "omit-dev" segment is what
+      # keeps the two from ever colliding; the lockfile hash and the Node
+      # major are there for the same reason as in that job, so any
+      # dependency or runtime change invalidates the entry.
+      - name: Cache node_modules
+        id: node-modules-cache
+        uses: actions/cache@v4
+        with:
+          path: web/node_modules
+          key: node-modules-omit-dev-${{ runner.os }}-node22-${{ hashFiles('web/package-lock.json') }}
       # [mcp] as well as [dev]: server/tests/test_mcp_server.py connects a
       # real protocol client to a real listener, and without the extra those
       # tests would skip - green, and proving nothing about the feature.
@@ -34,6 +58,7 @@ jobs:
       # (runtime only: this needs the importer, not playwright) is what makes
       # that check run instead of skip.
       - name: Install alphaTab
+        if: steps.node-modules-cache.outputs.cache-hit != 'true'
         working-directory: web
         run: npm ci --omit=dev
       # The emitted MusicXML is validated against the REAL MusicXML 4.0 schema,
@@ -86,6 +111,34 @@ jobs:
       - name: Build
         working-directory: web
         run: npm run build
+      # A regression check on the RUNNER, not on the product: --list starts
+      # no browser and no server and finishes in well under a second, which
+      # is why it can live in this job rather than the browser one. It needs
+      # only web/node_modules (installed above) and web/dist (built above -
+      # playwright.config.js refuses to load without it).
+      #
+      # What it guards: run-browser-tests.mjs used to hand its argv to a
+      # shell, and on Windows a shell joins argv into a single command line
+      # whose quoting does not cover internal spaces. A multi-word --grep
+      # came out the far side as separate bare words, so Playwright saw only
+      # the first one and ran a wider set than the caller asked for -
+      # silently, with a green run to show for it. Six tests in this file
+      # have "gig mode" in their title and seven have "gig", so a --grep that
+      # loses its second word lists seven and this step goes red. Proven
+      # against that exact revert before it was added.
+      #
+      # PLAYWRIGHT_ALLOW_PARTIAL because --list executes nothing at all: every
+      # spec file reports zero tests run, which the runner's spec-floor guard
+      # would otherwise, and correctly, read as the whole suite going missing.
+      - name: Check the runner passes a multi-word --grep through
+        working-directory: web
+        env:
+          PLAYWRIGHT_ALLOW_PARTIAL: "1"
+        run: |
+          listed=$(node scripts/run-browser-tests.mjs \
+            tests/browser/practice-shortcuts.spec.js --grep "gig mode" --list)
+          echo "$listed"
+          echo "$listed" | grep -qx "Total: 6 tests in 1 file"
 
   browser:
     name: Browser tests

--- a/web/scripts/run-browser-tests.mjs
+++ b/web/scripts/run-browser-tests.mjs
@@ -66,10 +66,17 @@ if (filteredArgs.length !== passedArgs.length) {
 // even starts, so a new instance of the pattern fails fast and cheaply
 // rather than waiting on a browser job to flake under load. See
 // check-out-of-band-reads.mjs for what it does and does not catch.
-const guard = spawnSync("node", ["scripts/check-out-of-band-reads.mjs"], {
+//
+// process.execPath and shell: false, for the same reason the Playwright
+// spawn below uses them: this script should not have a command line anywhere
+// in it that an argument could be re-parsed by. These args happen to be
+// fixed and space-free, so nothing was broken here - but "no shell" is the
+// property worth being able to state about the whole file rather than about
+// one call in it, and it also runs this guard under the same node binary
+// that is running this script instead of whichever one a PATH lookup finds.
+const guard = spawnSync(process.execPath, ["scripts/check-out-of-band-reads.mjs"], {
   cwd: webRoot,
   stdio: "inherit",
-  shell: true,
 });
 if (guard.status !== 0) {
   process.exit(guard.status ?? 1);


### PR DESCRIPTION
Part of #239 (the CI half of it). Separate from the reproduction gate and the docs pass, which are their own PRs.

## Why

The server job installs `web/node_modules` with `--omit=dev` so an extracted transcription is parsed back by the real alphaTab importer instead of skipping. That one step is the whole of the job's runtime variance. Measured over recent `main` runs:

| Run | Job total | `Install alphaTab` | pytest |
| --- | --- | --- | --- |
| 33887700373 | 1.7m | 0.0m | 1.3m |
| 33841324577 | 6.4m | 5.1m | 0.9m |
| 33845939449 | 8.2m | 7.0m ("added 6 packages in 7m") | 0.8m |
| 33849328258 | 8.1m | 7.0m | 0.8m |
| 33854927005 | 8.7m | 7.0m | 1.2m |

pytest stays at 0.8-1.3 minutes throughout. Everything else is the registry stall the browser job already fixed for itself by caching its installed tree.

## What changed

**`.github/workflows/ci.yml`, server job.**

- Caches `web/node_modules` under `node-modules-omit-dev-${{ runner.os }}-node22-${{ hashFiles('web/package-lock.json') }}` and skips `npm ci --omit=dev` on a hit. The `omit-dev` segment is load-bearing: this job saves a tree with no playwright and no build tooling in it, and if it shared the browser job's key then whichever job ran first would decide what the other one restored - a browser job that restored this tree would skip its own `npm ci` and then have no playwright to run the suite with. Lockfile hash and Node major are there for the same reason as in that job.
- `timeout-minutes: 20`, as a floor under the cache rather than a substitute for it: 2.3x the worst run observed above, so a stall that outlives the cache fails in minutes instead of holding a runner for the six-hour default.

**`.github/workflows/ci.yml`, Frontend build job.** A sub-second regression check on the runner's own argument handling:

```
node scripts/run-browser-tests.mjs tests/browser/practice-shortcuts.spec.js --grep "gig mode" --list
```

must print exactly `Total: 6 tests in 1 file`. `--list` starts no browser and no server, so it needs only the `node_modules` and `web/dist` this job already has, and it costs under a second.

**`web/scripts/run-browser-tests.mjs`.** The last `shell: true` spawn - the out-of-band-reads guard - now uses `process.execPath` with no shell, like the Playwright spawn beside it. Its arguments are fixed and space-free so nothing was broken there; the point is that "this script never invokes a shell" is now true of the whole file rather than of one call in it, and the guard runs under the same node binary as the script instead of whichever one a PATH lookup finds.

## Evidence that the new check can fail

The check exists because the runner used to hand argv to a shell, and on Windows a shell joins argv into a single command line whose quoting does not cover internal spaces - so `--grep "gig mode"` arrived as `--grep gig` plus a stray `mode`, and Playwright ran a wider set than the caller asked for, green. Reverted the Playwright spawn to that exact form locally:

```js
const result = spawnSync("npx", ["playwright", "test", `--reporter=${reporters}`, ...filteredArgs], {
  cwd: webRoot, stdio: "inherit", shell: true, env: { ... },
});
```

and re-ran the check:

```
  ... practice-shortcuts.spec.js:919:3  > ... is honoured in gig mode too, where a pedal tap comes from
  ... practice-shortcuts.spec.js:1049:3 > ... a half-page gig turn pressed mid-re-render is honoured, not rolled back
  ... practice-shortcuts.spec.js:1111:3 > gig mode itself > from the default (side-by-side) layout, ...
  ... practice-shortcuts.spec.js:1190:3 > gig mode itself > a half-page turn survives the pane being re-rendered ...
  ... practice-shortcuts.spec.js:1254:3 > gig mode itself > the page indicator matches the pane ...
  ... practice-shortcuts.spec.js:1290:3 > gig mode itself > a resize that changes which page is on screen ...
  ... practice-shortcuts.spec.js:1325:3 > gig mode itself > from the staff layout, gig mode keeps the staff pane ...
Total: 7 tests in 1 file
```

Seven, not six - the one extra is the test whose title contains "gig" but not "gig mode", which is exactly the degradation. Restored the spawn; the same command lists six and the step passes. The counts are not arbitrary: 6 composed titles in that file match "gig mode" (one directly, five through their describe block), 7 match "gig".

After review, the step also pins the wider count: `--grep "gig" --list` must print `Total: 7 tests in 1 file`. Without that, renaming or removing the one extra test would make both listings six and leave the step green while it proved nothing.

`PLAYWRIGHT_ALLOW_PARTIAL=1` is set on that step because `--list` executes nothing, so every spec file reports zero tests run and the runner's spec-floor guard would otherwise, and correctly, read the whole suite as having gone missing. Confirmed: without it the step fails with 60-odd "only 0 ran" lines.

## Also verified locally

- `web/scripts/run-browser-tests.mjs` has no `shell:` option left anywhere (only the comments explaining why).
- A real run still works through the changed guard spawn: `node scripts/run-browser-tests.mjs tests/browser/version.spec.js` - 2 passed, exit 0, "out-of-band read check passed (30 browser spec files)".
- `ci.yml` parses; the server job's steps are in the order cache, Install, Install alphaTab, Fetch schema, Test, and the web job's are Install, Build, Check.

## Cache behaviour to look for on this PR

The first run populates the server job's cache (a miss, `Install alphaTab` runs); a second run on the same lockfile should hit it and skip that step. Reported in a comment below once both runs exist.

