### PR TITLE
Docs: the export archive carries every table again, drill history included

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -240,14 +240,14 @@ that ties them together.
 
 | Endpoint | What it does |
 | --- | --- |
-| `GET /api/export` | Every score row, transcription, practice session, goal, tag, instrument, setting and setlist (with its ordered membership), plus the score files themselves, as one zip. |
+| `GET /api/export` | Every score row, transcription, practice session, goal, tag, instrument, setting, setlist (with its ordered membership) and fretboard-drill attempt, plus the score files themselves, as one zip. |
 | `POST /api/import` | Restores an archive `GET /api/export` produced. **Dry run by default.** |
 
 **The archive.** A zip with `manifest.json` at its root - a JSON object naming
 the exact `schema_version` (`fermata/db.py`'s `SCHEMA_VERSION`, not the
 application's own release number) the rest of it was written against, and
-carrying the rows of the tables the endpoint table above lists, verbatim,
-under `tables` (drill history is not among them yet; see #243). Score files themselves
+carrying every table's rows verbatim under `tables`, drill history included
+(#243). Score files themselves
 live under `files/<content-hash><extension>`, named by the same identity the
 scanner already uses (`scanner.hash_file`) rather than by a person's folder
 names, which is what lets two scores that happen to share content share one

--- a/docs/api.md
+++ b/docs/api.md
@@ -246,8 +246,8 @@ that ties them together.
 **The archive.** A zip with `manifest.json` at its root - a JSON object naming
 the exact `schema_version` (`fermata/db.py`'s `SCHEMA_VERSION`, not the
 application's own release number) the rest of it was written against, and
-carrying every table's rows verbatim under `tables`, drill history included
-(#243). Score files themselves
+carrying every table's rows verbatim under `tables` (drill history included
+since #243). Score files themselves
 live under `files/<content-hash><extension>`, named by the same identity the
 scanner already uses (`scanner.hash_file`) rather than by a person's folder
 names, which is what lets two scores that happen to share content share one

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -659,10 +659,10 @@ you'd be upset to lose — weekly is reasonable for casual use.
 
 **`GET /api/export`** is the other way to get a backup, and it does not need
 the container stopped: it is a live endpoint, called over the network, that
-answers with one zip holding every score, transcription, practice-session,
-goal, setlist, tag, instrument and setting row plus the score files
-themselves — a portable archive rather than a copy of the database file.
-(Fretboard-drill history is not in it yet; #243 tracks that.) It
+answers with one zip holding every row Fermata keeps — scores, transcriptions,
+practice sessions, goals, setlists, tags, instruments, settings and drill
+history — plus the score files themselves: a portable archive rather than a
+copy of the database file. It
 is the better choice for scripting a backup onto another machine, or for
 taking one without touching the host filesystem at all; copying `config/` is
 the better choice for a quick local snapshot before an upgrade. See [the API

--- a/server/fermata/api.py
+++ b/server/fermata/api.py
@@ -4667,8 +4667,8 @@ def _apply_import(conn, manifest: dict, file_bytes: dict[str, bytes], written_pa
 @router.post("/import", tags=[TAG_PORTABILITY], response_model=ImportOut)
 async def import_library(file: UploadFile, dry_run: bool = True):
     """Restore an archive written by `GET /api/export` - every score row,
-    transcription, practice session, goal, tag, instrument, setting and
-    setlist it carries, added to this library. A setlist's ordered membership
+    transcription, practice session, goal, tag, instrument, setting, setlist
+    and drill attempt it carries, added to this library. A setlist's ordered membership
     is restored with both its foreign keys repointed at this import's own new
     setlist and score rows, so the arrangement survives intact. See the
     module comment above this section for the archive's shape, exactly what


### PR DESCRIPTION
Follow-up to #241 and #245, part of #239's docs pass.

#241 narrowed two sentences (`docs/api.md` on the archive's contents, `docs/deployment.md` Backups) because the export left both trainer tables out. #245 added them to the round trip, so the archive is complete again and both sentences say so once more. The API endpoint table also names fretboard-drill attempts among what travels.

Checked against main `b98b47e`: `EXPORT_TABLE_NAMES` in `server/fermata/api.py` equals the twelve tables `db.SCHEMA` creates (pinned by the catalog guard test #245 added), so "every table's rows" is true. No behaviour changes: the only edit under `server/` is `import_library`'s docstring, which the review of this PR found still enumerating the pre-#245 table set.
