### PR TITLE
Save a drill scope by name, and pick it up again in either drill

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -341,7 +341,7 @@ layer's own correctness depends on this one meaning what it says.
 
 That server (issue #31, `server/fermata/mcp_server.py`) is off unless
 `FERMATA_MCP` is set, and when it runs it is a CLIENT of this API like any
-other: each of its thirteen read-only tools is one documented `GET` from the
+other: each of its fourteen read-only tools is one documented `GET` from the
 list above, called over HTTP, answering with that route's own JSON
 unchanged. It never adds an operation to this document - it reads it. The
 tool list and every tool's input schema are generated from `app.openapi()`

--- a/docs/api.md
+++ b/docs/api.md
@@ -240,14 +240,14 @@ that ties them together.
 
 | Endpoint | What it does |
 | --- | --- |
-| `GET /api/export` | Every score row, transcription, practice session, goal, tag, instrument, setting, setlist (with its ordered membership) and fretboard-drill attempt, plus the score files themselves, as one zip. |
+| `GET /api/export` | Every score row, transcription, practice session, goal, tag, instrument, setting, setlist (with its ordered membership), fretboard-drill attempt and named drill scope, plus the score files themselves, as one zip. |
 | `POST /api/import` | Restores an archive `GET /api/export` produced. **Dry run by default.** |
 
 **The archive.** A zip with `manifest.json` at its root - a JSON object naming
 the exact `schema_version` (`fermata/db.py`'s `SCHEMA_VERSION`, not the
 application's own release number) the rest of it was written against, and
 carrying every table's rows verbatim under `tables` (drill history included
-since #243). Score files themselves
+since #243, named drill scopes since #236). Score files themselves
 live under `files/<content-hash><extension>`, named by the same identity the
 scanner already uses (`scanner.hash_file`) rather than by a person's folder
 names, which is what lets two scores that happen to share content share one

--- a/docs/api.md
+++ b/docs/api.md
@@ -289,6 +289,60 @@ leaves the library exactly as it was.
 API uses (see the five rules above). It validates the archive completely and
 reports what it found without opening a transaction or writing a file.
 
+## The fretboard drills (issues #27, #28, #236)
+
+Two drills run on the neck — fret to note, and chord flash cards — and both
+write the same two kinds of thing. Every answered question is its own
+structured row (`POST /api/trainer/attempts` and
+`POST /api/trainer/chord-attempts`, listed back by the matching `GET`s), so
+"which positions get missed" is a `WHERE` clause rather than something a
+reader parses out of prose. The drill's *time* is an ordinary practice session
+(`POST /api/practice/sessions`, activity `fretboard` or `chords`) — there is
+no separate drill-session row.
+
+**A scope, saved under a name.** What a drill asks about is narrowed by a
+scope: which strings, which fret range, and optionally which key. That used to
+live in the browser and reset on every page load, leaving nothing behind but
+an English sentence in the session's `note`. It is now a row.
+
+| Endpoint | What it does |
+| --- | --- |
+| `GET /api/trainer/presets` | Every named scope, newest first, each with the strings it allows. |
+| `POST /api/trainer/presets` | Save a scope under a name. |
+| `DELETE /api/trainer/presets/{id}` | Delete a named scope. The practice logged under it is **not** touched — `sessions_kept` counts it. |
+
+The string set is **one row per string**, in a child table, never a list in a
+column and never JSON: "which strings does this scope allow" has to be
+answerable by the database (see [docs/practice-data.md](practice-data.md)).
+That is also why `strings` is required and may not be empty on the way in —
+"every string" is stored by naming every string, so a saved scope can never be
+confused with one whose strings failed to write. `key_root` and `key_quality`
+travel together or not at all; both absent means every note, which is the
+ordinary case.
+
+**Presets are shared, not per-drill.** There is no `drill` column: a scope is a
+thing a person is working on, so one saved while naming notes is the same one
+the chord drill offers. A name must be unique per owner — a duplicate is
+refused with `409`, unlike a setlist, because a preset is picked in order to
+change what the next question will be and two identically named entries make
+"which scope am I about to practise" unanswerable from the screen.
+
+**A practice session carries `preset_id`.** A drill run on a named scope logs
+it on the session, and every session read-back returns it — so "how much time
+went into the first five frets in the key of G" is a join rather than a text
+search. It is null on almost every row, and that is not a missing value: a
+session logged from anywhere but a drill, or from a drill on a scope nobody
+named, genuinely has none. Deleting a preset clears the reference and leaves
+the session whole: the minutes were still practised. A drill run on an
+*unnamed* scope still writes the scope sentence into `note`, because for that
+session it is the only trace there is; existing notes are left exactly as they
+were.
+
+Named scopes **travel in the portable archive** (issue #58's export / import):
+a backup carries each preset, its string set, and each session's reference to
+it, and a restore repoints all three at the new rows. An archive written before
+these tables existed still imports, with no named scopes and nothing dangling.
+
 ## Setlists (issue #6)
 
 A setlist is an ordered collection of scores a player works through — a gig

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -500,7 +500,7 @@ being a second copy of the API. With
 every request that did not come from your trusted proxy carrying the
 identity header is refused, and the tools' requests are exactly that. So
 every tool would answer `401` while the tool list went on advertising
-thirteen working tools — a failure with no symptom except an emptiness that
+fourteen working tools — a failure with no symptom except an emptiness that
 looks like an empty library.
 
 The two obvious workarounds are both worse than the fault, which is why
@@ -547,7 +547,7 @@ docker compose up -d
 
 The tools are then reachable at **http://127.0.0.1:8765/mcp**, over the
 protocol's Streamable HTTP transport. Point a client that speaks the Model
-Context Protocol at that URL; it will list thirteen tools, each named after
+Context Protocol at that URL; it will list fourteen tools, each named after
 what it reads (`list_scores`, `get_practice_summary`, and so on).
 
 The four settings, only the first of which turns anything on:

--- a/docs/practice-data.md
+++ b/docs/practice-data.md
@@ -29,6 +29,7 @@ One table, `practice_sessions`, for every kind of practice.
 | `target_tempo_bpm` | The tempo being worked towards. |
 | `rating` | 1-5, the player's own sense of how it went. `NULL` for not rated. |
 | `note` | Free text, up to 2000 characters. |
+| `preset_id` | The named drill scope this was practised under (see **Trainer scope presets** below), or `NULL`. |
 
 ### Why there is one table and not one per kind
 
@@ -471,6 +472,72 @@ equality, not label equality and not fingering equality, either way.
   the raw, queryable record, newest first - the same shape
   `GET /api/trainer/attempts` offers, with `root`/`quality` added so "which
   chords am I weak on" is a filter rather than a client-side group-by.
+
+## Trainer scope presets
+
+A **scope** is what narrows a drill to what somebody is actually working on:
+which strings, which fret range, and optionally which key. Both fretboard
+drills have always had one. Until issue #236 it lived only in the browser and
+reset on every page load, and the only trace it left was an English sentence
+in the session's `note` - which is exactly the free-text blob this document's
+rules exist to keep facts out of. It is two tables now.
+
+`trainer_scope_presets`:
+
+| Column | Meaning |
+| --- | --- |
+| `id` | `AUTOINCREMENT`, so a deleted preset's id is never handed to the next one. |
+| `owner` | `'local'`, as everywhere else here. |
+| `name` | What the person called it. Unique per owner. |
+| `start_fret`, `end_fret` | The fret range, 0-36, `start_fret` never past `end_fret`. |
+| `key_root`, `key_quality` | The key, `major` or `minor` - both set or both `NULL`, and both `NULL` means every note. |
+| `created_at` | UTC timestamp. |
+
+`trainer_scope_preset_strings`, one row per string:
+
+| Column | Meaning |
+| --- | --- |
+| `preset_id` | The preset. `ON DELETE CASCADE` - a row saying "(this preset) includes (string 3)" states nothing once the preset is gone. |
+| `string_number` | 1-24. `PRIMARY KEY (preset_id, string_number)`, so a string is in a preset at most once. |
+
+**A set is not a column, and it is not JSON.** "Which strings does this scope
+allow" has to be answerable by the database, for the same reason
+`trainer_attempts` has columns rather than a blob: a reader that must parse
+`"[1,2,3]"` out of a text field cannot ask anything about it. That is also why
+an empty string set is refused on the way in - "every string" is stored by
+naming every string, so a saved scope can never be confused with one whose
+strings failed to write.
+
+**Shared, not per-drill.** There is no `drill` column and there will not be
+one: a scope is a thing a person is working on, not a thing one question
+format owns, so a scope saved while naming notes is the same row the chord
+drill offers.
+
+**What this does to `note`.** A drill run on a named scope logs
+`practice_sessions.preset_id` and stops writing the scope sentence into
+`note` - the fret range, the strings and the key are in a row to join on, and
+repeating them as prose would put the same fact in two places, one of them
+free text. The counts stay in `note`: they are about how the session went, not
+about what it was scoped to. A drill run on an *unnamed* scope still writes
+the whole sentence, because for that session it is the only trace there is,
+and notes already stored are left exactly as they were.
+
+`preset_id` is `ON DELETE SET NULL`, decided the way every other reference
+here is - by asking whether the row still says anything once the thing it
+names is gone. It does: the minutes were still practised, on that day, in that
+activity. Deleting a preset is a tidy-up, never a statement that the practice
+did not happen.
+
+### Asking questions
+
+- `GET /api/trainer/presets` - every named scope, newest first, each with its
+  string set.
+- `POST /api/trainer/presets` - save one. A duplicate name is `409`.
+- `DELETE /api/trainer/presets/{id}` - delete one; `sessions_kept` counts the
+  practice it leaves behind.
+- "How much time went into this scope" is a filter over `practice_sessions` on
+  `preset_id`, joined to the preset - not a bespoke aggregate endpoint, the
+  same rule the rest of this surface holds to.
 
 ## What is not here yet
 

--- a/server/fermata/api.py
+++ b/server/fermata/api.py
@@ -5258,7 +5258,9 @@ def create_trainer_preset(body: TrainerPresetIn):
     purpose (see create_setlist). The difference is what the list is FOR: a
     setlist is a thing you open, while a preset is picked in order to change
     what the next question will be, and two identically named entries make
-    "which scope am I about to practise" unanswerable from the screen.
+    "which scope am I about to practise" unanswerable from the screen. The
+    comparison ignores case for the same reason: "Jazz box" and "jazz box"
+    are one entry to a reader, so they are one entry here.
     """
     try:
         values = trainer.normalise_preset(**body.model_dump())
@@ -5267,7 +5269,7 @@ def create_trainer_preset(body: TrainerPresetIn):
     preset = values["preset"]
     with write_tx() as conn:
         clash = conn.execute(
-            "SELECT id FROM trainer_scope_presets WHERE owner = ? AND name = ?",
+            "SELECT id FROM trainer_scope_presets WHERE owner = ? AND name = ? COLLATE NOCASE",
             (DEFAULT_OWNER, preset["name"]),
         ).fetchone()
         if clash:

--- a/server/fermata/api.py
+++ b/server/fermata/api.py
@@ -71,6 +71,8 @@ from .api_models import (
     TrainerAttemptOut,
     TrainerChordAttemptListOut,
     TrainerChordAttemptOut,
+    TrainerPresetDeleteOut,
+    TrainerPresetOut,
     TranscribeBatchStatusOut,
     TranscribeBatchTriggerOut,
     TranscribeResultOut,
@@ -933,6 +935,12 @@ class PracticeIn(BaseModel):
     target_tempo_bpm: Count | None = None
     rating: Count | None = None
     note: str | None = Field(default=None, max_length=practice.MAX_NOTE_CHARS)
+    # The named drill scope this practice was done under (issue #236). A
+    # fretboard or chord drill run on a saved preset sends its id here, and
+    # from then on "what was practised" is a row this can be joined on rather
+    # than a sentence in `note` - see docs/practice-data.md's rule about what
+    # may and may not live in free text.
+    preset_id: Count | None = Field(default=None, ge=1, le=SQLITE_MAX_INTEGER)
 
 
 class SessionIn(PracticeIn):
@@ -962,6 +970,7 @@ class SessionPatch(BaseModel):
     target_tempo_bpm: Count | None = None
     rating: Count | None = None
     note: str | None = Field(default=None, max_length=practice.MAX_NOTE_CHARS)
+    preset_id: Count | None = Field(default=None, ge=1, le=SQLITE_MAX_INTEGER)
 
 
 _SESSION_COLUMNS = (
@@ -978,6 +987,7 @@ _SESSION_COLUMNS = (
     "target_tempo_bpm",
     "rating",
     "note",
+    "preset_id",
 )
 
 
@@ -986,6 +996,12 @@ def _normalise_session(
 ) -> dict:
     if fields.get("score_id") is not None:
         _live_score_row(conn, fields["score_id"], "log practice against it")
+    if fields.get("preset_id") is not None:
+        # Checked here rather than left to the foreign key, for the reason
+        # every other reference in this file is: a raised IntegrityError is a
+        # 500 and says nothing a person could act on, whereas this is a 404
+        # naming what was not found (see _trainer_preset_row).
+        _trainer_preset_row(conn, fields["preset_id"])
     try:
         return practice.normalise_session(
             recorded_on=_server_today(),
@@ -4008,6 +4024,17 @@ EXPORT_TABLE_NAMES = (
     # because neither one references a score at all.
     "trainer_attempts",
     "trainer_chord_attempts",
+    # #236's two. A named scope is exactly the kind of thing this feature
+    # exists for: a person arranged it by hand, nothing on disk can
+    # regenerate it, and practice_sessions.preset_id points at it - so an
+    # archive that carried the sessions but not the presets would restore a
+    # history whose "what was practised" column named rows that no longer
+    # exist. `trainer_scope_preset_strings` rides ON its preset exactly as
+    # setlist_scores rides on its setlist: its `preset_id` follows this
+    # import's id remap, and so does practice_sessions.preset_id. Neither
+    # table references a score, so neither is filtered by one.
+    "trainer_scope_presets",
+    "trainer_scope_preset_strings",
 )
 
 # Tables added to EXPORT_TABLE_NAMES after some archives already on disk were
@@ -4017,7 +4044,21 @@ EXPORT_TABLE_NAMES = (
 # taken before today because a table it never knew about is absent would be
 # worse than importing with an empty drill history). Every OTHER name still
 # has to match exactly, per the comment above EXPORT_TABLE_NAMES.
-LEGACY_OPTIONAL_TABLES = ("trainer_attempts", "trainer_chord_attempts")
+#
+# #236's two are here for the identical reason #243's two are, and the
+# reasoning carries over unchanged: an archive written yesterday cannot have
+# a `trainer_scope_presets` key, and refusing every backup a person already
+# holds - the ones this feature exists to make restorable - because a table
+# that did not exist when they took it is absent would be a far worse
+# outcome than restoring with no named scopes. A session in such an archive
+# has no `preset_id` either (the column did not exist), so importing one
+# with these two empty leaves nothing dangling and nothing to guess.
+LEGACY_OPTIONAL_TABLES = (
+    "trainer_attempts",
+    "trainer_chord_attempts",
+    "trainer_scope_presets",
+    "trainer_scope_preset_strings",
+)
 
 
 def _dump_table(conn, sql: str, params=()) -> list[dict]:
@@ -4113,6 +4154,25 @@ def _build_export_manifest(conn, *, include_trash: bool) -> dict:
         (DEFAULT_OWNER,),
     )
 
+    # #236's two: every named scope, and the string set of each. The child
+    # rows are filtered to the presets actually travelling - the same filter
+    # setlist_scores/score_tags use, and here it can only ever be a no-op
+    # (presets are filtered by owner alone, exactly as their strings are),
+    # which is the point: it states the invariant rather than assuming it.
+    trainer_scope_presets = _dump_table(
+        conn,
+        "SELECT * FROM trainer_scope_presets WHERE owner = ? ORDER BY id",
+        (DEFAULT_OWNER,),
+    )
+    preset_ids = {row["id"] for row in trainer_scope_presets}
+    trainer_scope_preset_strings = [
+        dict(row)
+        for row in conn.execute(
+            "SELECT * FROM trainer_scope_preset_strings ORDER BY preset_id, string_number"
+        )
+        if row["preset_id"] in preset_ids
+    ]
+
     return {
         "format": EXPORT_FORMAT,
         "schema_version": SCHEMA_VERSION,
@@ -4135,6 +4195,8 @@ def _build_export_manifest(conn, *, include_trash: bool) -> dict:
             "setlist_scores": setlist_scores,
             "trainer_attempts": trainer_attempts,
             "trainer_chord_attempts": trainer_chord_attempts,
+            "trainer_scope_presets": trainer_scope_presets,
+            "trainer_scope_preset_strings": trainer_scope_preset_strings,
         },
     }
 
@@ -4407,6 +4469,26 @@ def _read_and_validate_manifest(zf: zipfile.ZipFile) -> dict:
                 422,
                 "the archive's setlist_scores table names a score that is not in the archive",
             )
+    # Named drill scopes and their string sets (#236), checked the same way:
+    # a string-set row naming a preset that is not in the archive, or a
+    # practice session naming one, cannot be inserted without dropping the
+    # reference or crashing partway through write_tx().
+    preset_ids = {_require_id(row, "trainer_scope_presets") for row in tables["trainer_scope_presets"]}
+    for row in tables["trainer_scope_preset_strings"]:
+        if row.get("preset_id") not in preset_ids:
+            raise HTTPException(
+                422,
+                "the archive's trainer_scope_preset_strings table names a preset that is not "
+                "in the archive",
+            )
+    for row in tables["practice_sessions"]:
+        pid = row.get("preset_id")
+        if pid is not None and pid not in preset_ids:
+            raise HTTPException(
+                422,
+                "the archive's practice_sessions table names a preset that is not in the "
+                "archive",
+            )
     return manifest
 
 
@@ -4551,9 +4633,29 @@ def _apply_import(conn, manifest: dict, file_bytes: dict[str, bytes], written_pa
     # id before the trainer tables existed, so nothing needed its
     # lastrowid - now trainer_attempts/trainer_chord_attempts do, the same
     # way score_id_map exists for everything that references a score.
+    # #236's presets go in BEFORE the sessions that name them, for the same
+    # reason instruments and tags go in before the scores that name them: a
+    # session's `preset_id` is repointed at this import's own new preset row,
+    # so that row has to exist and its new id has to be known first. The
+    # string set follows its preset, exactly as setlist_scores follows its
+    # setlist.
+    preset_id_map: dict[int, int] = {}
+    for row in tables["trainer_scope_presets"]:
+        preset_id_map[row["id"]] = _insert_row(
+            conn, "trainer_scope_presets", row, overrides={"owner": DEFAULT_OWNER}
+        )
+    for row in tables["trainer_scope_preset_strings"]:
+        _insert_row(
+            conn,
+            "trainer_scope_preset_strings",
+            row,
+            overrides={"preset_id": preset_id_map[row["preset_id"]]},
+        )
+
     session_id_map: dict[int, int] = {}
     for row in tables["practice_sessions"]:
         sid = row.get("score_id")
+        pid = row.get("preset_id")
         session_id_map[row["id"]] = _insert_row(
             conn,
             "practice_sessions",
@@ -4561,6 +4663,7 @@ def _apply_import(conn, manifest: dict, file_bytes: dict[str, bytes], written_pa
             overrides={
                 "owner": DEFAULT_OWNER,
                 "score_id": score_id_map.get(sid) if sid is not None else None,
+                "preset_id": preset_id_map.get(pid) if pid is not None else None,
             },
         )
 
@@ -4661,6 +4764,8 @@ def _apply_import(conn, manifest: dict, file_bytes: dict[str, bytes], written_pa
         "setlist_scores_imported": len(tables["setlist_scores"]),
         "trainer_attempts_imported": len(tables["trainer_attempts"]),
         "trainer_chord_attempts_imported": len(tables["trainer_chord_attempts"]),
+        "trainer_presets_imported": len(tables["trainer_scope_presets"]),
+        "trainer_preset_strings_imported": len(tables["trainer_scope_preset_strings"]),
     }
 
 
@@ -4745,6 +4850,8 @@ async def import_library(file: UploadFile, dry_run: bool = True):
             "setlist_scores_imported": len(tables["setlist_scores"]),
             "trainer_attempts_imported": len(tables["trainer_attempts"]),
             "trainer_chord_attempts_imported": len(tables["trainer_chord_attempts"]),
+            "trainer_presets_imported": len(tables["trainer_scope_presets"]),
+            "trainer_preset_strings_imported": len(tables["trainer_scope_preset_strings"]),
         }
 
     _require_library()
@@ -5059,6 +5166,147 @@ def list_trainer_chord_attempts(
         "total": total,
         "truncated": total > len(rows),
     }
+
+
+# ---------------------------------------------------------------------------
+# Trainer: named drill scopes (issue #236)
+#
+# A scope - which strings, which fret range, which key - saved under a name.
+# Until this surface existed a scope was browser state that reset on every
+# page load, and the only trace it left behind was an English sentence in
+# practice_sessions.note, which docs/practice-data.md's rule for this data
+# layer forbids: "what was practised" has to be a row a reader can query, not
+# prose it has to parse.
+#
+# THREE ROUTES AND NO UPDATE, deliberately. A preset is a small, whole thing:
+# saving the current scope under a new name is what "change it" means in both
+# drills, and an edit route would need a shape (replace the string set? merge
+# it?) that nothing is asking for. Delete and save again is the operation.
+#
+# ONE LIST FOR BOTH DRILLS, which is the point of the bet - see db.py's note
+# on why trainer_scope_presets has no `drill` column.
+# ---------------------------------------------------------------------------
+
+
+class TrainerPresetIn(BaseModel):
+    """A scope to save under a name.
+
+    `strings` is required and must not be empty - "every string" is spelled
+    by naming every string, see trainer._preset_strings for why a saved
+    preset cannot use the browser's "empty means no filter" convention.
+    `key_root`/`key_quality` are given together or not at all; omitting both
+    is a scope over every note, which is the ordinary case.
+    """
+
+    name: str = Field(max_length=trainer.MAX_PRESET_NAME_CHARS)
+    start_fret: StrictInt
+    end_fret: StrictInt
+    strings: list[StrictInt]
+    key_root: str | None = None
+    key_quality: str | None = None
+
+
+def _trainer_preset_row(conn, preset_id: int):
+    row = conn.execute(
+        "SELECT * FROM trainer_scope_presets WHERE id = ? AND owner = ?",
+        (preset_id, DEFAULT_OWNER),
+    ).fetchone()
+    if not row:
+        raise HTTPException(404, "preset not found")
+    return row
+
+
+def _trainer_preset_strings(conn, preset_id: int) -> list[int]:
+    return [
+        r["string_number"]
+        for r in conn.execute(
+            "SELECT string_number FROM trainer_scope_preset_strings "
+            "WHERE preset_id = ? ORDER BY string_number",
+            (preset_id,),
+        )
+    ]
+
+
+def _trainer_preset_dict(conn, row) -> dict:
+    return trainer.preset_dict(row, _trainer_preset_strings(conn, row["id"]))
+
+
+@router.get("/trainer/presets", tags=[TAG_TRAINER], response_model=list[TrainerPresetOut])
+def list_trainer_presets():
+    """Every named drill scope, newest first, each with the strings it
+    allows.
+
+    The strings come along here rather than on a detail endpoint: a scope is
+    small, and a picker that has to make a second request per entry before it
+    can say what any of them mean would be a list nobody can read.
+    """
+    conn = connect()
+    rows = conn.execute(
+        "SELECT * FROM trainer_scope_presets WHERE owner = ? ORDER BY created_at DESC, id DESC",
+        (DEFAULT_OWNER,),
+    ).fetchall()
+    return [_trainer_preset_dict(conn, r) for r in rows]
+
+
+@router.post("/trainer/presets", tags=[TAG_TRAINER], response_model=TrainerPresetOut)
+def create_trainer_preset(body: TrainerPresetIn):
+    """Save the current drill scope under a name, so it can be picked up
+    again tomorrow and in the other drill.
+
+    A name already in use is refused with 409 rather than accepted as a
+    second entry - unlike a setlist, whose duplicate names are allowed on
+    purpose (see create_setlist). The difference is what the list is FOR: a
+    setlist is a thing you open, while a preset is picked in order to change
+    what the next question will be, and two identically named entries make
+    "which scope am I about to practise" unanswerable from the screen.
+    """
+    try:
+        values = trainer.normalise_preset(**body.model_dump())
+    except ValueError as e:
+        raise HTTPException(422, str(e)) from None
+    preset = values["preset"]
+    with write_tx() as conn:
+        clash = conn.execute(
+            "SELECT id FROM trainer_scope_presets WHERE owner = ? AND name = ?",
+            (DEFAULT_OWNER, preset["name"]),
+        ).fetchone()
+        if clash:
+            raise HTTPException(409, f"there is already a preset called {preset['name']}")
+        columns = ", ".join(preset)
+        placeholders = ", ".join("?" * len(preset))
+        row = conn.execute(
+            f"""INSERT INTO trainer_scope_presets(owner, {columns})
+                VALUES (?, {placeholders}) RETURNING *""",
+            [DEFAULT_OWNER, *preset.values()],
+        ).fetchone()
+        conn.executemany(
+            "INSERT INTO trainer_scope_preset_strings(preset_id, string_number) VALUES (?, ?)",
+            [(row["id"], n) for n in values["strings"]],
+        )
+        return _trainer_preset_dict(conn, row)
+
+
+@router.delete(
+    "/trainer/presets/{preset_id}", tags=[TAG_TRAINER], response_model=TrainerPresetDeleteOut
+)
+def delete_trainer_preset(preset_id: RowId):
+    """Delete a named scope. The practice logged under it is NOT touched -
+    `sessions_kept` counts the sessions that keep their day, their length and
+    their activity and lose only the reference (db.py's ON DELETE SET NULL
+    note says why). Its string set goes with it, by cascade, because a row
+    saying "(this preset) includes (string 3)" states nothing once the preset
+    is gone."""
+    with write_tx() as conn:
+        _trainer_preset_row(conn, preset_id)
+        kept = conn.execute(
+            "SELECT COUNT(*) AS n FROM practice_sessions WHERE preset_id = ? AND owner = ?",
+            (preset_id, DEFAULT_OWNER),
+        ).fetchone()["n"]
+        conn.execute(
+            "DELETE FROM trainer_scope_presets WHERE id = ? AND owner = ?",
+            (preset_id, DEFAULT_OWNER),
+        )
+    return {"deleted": preset_id, "sessions_kept": kept}
 
 
 # ---------------------------------------------------------------------------

--- a/server/fermata/api_models.py
+++ b/server/fermata/api_models.py
@@ -242,6 +242,10 @@ class PracticeSessionOut(BaseModel):
     target_tempo_bpm: int | None
     rating: int | None
     note: str | None
+    # The named drill scope this session was practised under (issue #236), or
+    # null - which is the ordinary case: only a fretboard or chord drill run
+    # on a saved scope carries one. See db.py's note on the column.
+    preset_id: int | None
     local_date_source: str
     reached_target: bool | None
     score_missing: bool
@@ -1064,6 +1068,12 @@ class ImportOut(BaseModel):
     # lost, it simply never existed in the first place.
     trainer_attempts_imported: int
     trainer_chord_attempts_imported: int
+    # #236's two: how many named drill scopes the archive carried, and how
+    # many string-set rows across them - 0 for an archive written before
+    # these tables existed, the same way the two above read for one written
+    # before drill history travelled.
+    trainer_presets_imported: int
+    trainer_preset_strings_imported: int
 
 
 # ---------------------------------------------------------------------------
@@ -1158,6 +1168,53 @@ class TrainerChordAttemptListOut(BaseModel):
     attempts: list[TrainerChordAttemptOut]
     total: int
     truncated: bool
+
+
+# ---------------------------------------------------------------------------
+# Named drill scopes (issue #236)
+#
+# The scope a drill is narrowed to - which strings, which frets, which key -
+# saved under a name, so it survives a reload and so the same one narrows
+# BOTH drills. Shapes mirror trainer.preset_dict exactly, the same discipline
+# the rest of this module keeps.
+# ---------------------------------------------------------------------------
+
+
+class TrainerPresetOut(BaseModel):
+    """One named scope, as trainer.preset_dict presents it - the stored row
+    plus its string set, gathered from the child table it lives in (a set is
+    not a column and is not JSON; see db.py's note on
+    trainer_scope_preset_strings).
+
+    `key_root` and `key_quality` are null TOGETHER and mean "every note" -
+    the key filter is off by default in both drills, so a scope naming no key
+    is not one with a field missing. `strings` is never empty: "every string"
+    is stored by naming every string, so that a saved row can never be
+    confused with one whose strings failed to write (trainer._preset_strings
+    says why that convention differs from the browser's).
+    """
+
+    id: int
+    owner: str
+    name: str
+    start_fret: int
+    end_fret: int
+    key_root: str | None
+    key_quality: str | None
+    strings: list[int]
+    created_at: str
+
+
+class TrainerPresetDeleteOut(BaseModel):
+    """DELETE /api/trainer/presets/{id}. `sessions_kept` counts the practice
+    sessions that were logged under this scope and are NOT going anywhere -
+    each keeps its day, its length and its activity, and loses only the
+    reference (db.py's ON DELETE SET NULL note says why that is the right
+    trade). Counted and returned so a client can say so plainly rather than
+    leaving somebody to wonder what a delete just reached."""
+
+    deleted: int
+    sessions_kept: int
 
 
 # ---------------------------------------------------------------------------

--- a/server/fermata/db.py
+++ b/server/fermata/db.py
@@ -265,7 +265,7 @@ _TRAINER_PRESET_SCHEMA = (
     "CREATE TABLE IF NOT EXISTS trainer_scope_presets "
     + _TRAINER_SCOPE_PRESETS_COLUMNS + ";\n"
     + "CREATE UNIQUE INDEX IF NOT EXISTS idx_trainer_presets_name"
-    " ON trainer_scope_presets(owner, name);\n"
+    " ON trainer_scope_presets(owner, name COLLATE NOCASE);\n"
     + "CREATE TABLE IF NOT EXISTS trainer_scope_preset_strings "
     + _TRAINER_SCOPE_PRESET_STRINGS_COLUMNS + ";\n"
 )

--- a/server/fermata/db.py
+++ b/server/fermata/db.py
@@ -71,6 +71,25 @@ DEFAULT_OWNER = "local"
 # carry their day, their length, their tempo, their bars and their note, which
 # is enough to be practice that happened. See practice.session_dict's
 # `score_missing`.
+#
+# `preset_id` (issue #236) is the named drill scope this session was practised
+# under - see _TRAINER_SCOPE_PRESETS_COLUMNS below. It is what turns "what was
+# practised" from a sentence in `note` into a row: a reader asking "how much
+# time went into the first five frets in the key of G" joins this column
+# rather than parsing English out of a free-text field.
+#
+# NULLABLE, and null on almost every row: every session logged before this
+# column existed has none, every session logged from anywhere but a fretboard
+# drill has none, and a drill run on a scope nobody chose to name has none
+# either. That is not a missing value - "no named scope" is the ordinary case
+# and the honest answer.
+#
+# ON DELETE SET NULL, chosen the same way score_id above was: the test is
+# whether the row still says anything once the thing it names is gone. It
+# does - the minutes were still practised, on that day, in that activity - so
+# deleting a preset must not reach the history, only the reference. Deleting
+# a preset is a tidy-up ("I no longer work on that"), never a statement that
+# the practice did not happen.
 _PRACTICE_SESSIONS_COLUMNS = """(
     id INTEGER PRIMARY KEY,
     owner TEXT NOT NULL DEFAULT 'local',
@@ -87,7 +106,8 @@ _PRACTICE_SESSIONS_COLUMNS = """(
     tempo_bpm INTEGER,
     target_tempo_bpm INTEGER,
     rating INTEGER,
-    note TEXT
+    note TEXT,
+    preset_id INTEGER REFERENCES trainer_scope_presets(id) ON DELETE SET NULL
 )"""
 
 # Kept as separate statements rather than one script so SCHEMA can be
@@ -167,6 +187,87 @@ _PRACTICE_GOALS_COLUMNS = """(
 _PRACTICE_GOALS_INDEXES = (
     "CREATE UNIQUE INDEX IF NOT EXISTS idx_practice_goals_period"
     " ON practice_goals(owner, period_start)",
+)
+
+# A named drill scope (issue #236): the strings, the fret range and the key a
+# player is working inside, saved under a name so it can be picked up again
+# tomorrow and in the OTHER drill. Until this table existed a scope lived only
+# in the browser's own state and left no trace but an English sentence in
+# practice_sessions.note - a free-text blob, which docs/practice-data.md's
+# rule for the structured-data interface forbids.
+#
+# SHARED, NOT PER-DRILL, and that is the whole design (see
+# web/src/lib/trainer/constraints.js's own module comment, which factored the
+# scope model out of one drill for exactly this reason). There is no `drill`
+# column here on purpose: "strings 1-2, frets 5-9, key of G major" is a thing
+# a person is working on, not a thing a particular question format owns, so a
+# scope saved while naming notes is the same row the chord drill reads.
+#
+# AUTOINCREMENT, for the same reason instruments, goals and setlists have it:
+# presets are routinely deleted, and a plain INTEGER PRIMARY KEY hands a
+# deleted row's id to the next one - so practice_sessions.preset_id, held on
+# rows that outlive the preset they named, could silently start describing a
+# different scope than the one that was actually practised. (It does not,
+# because the ON DELETE SET NULL below clears it - but the two guarantees are
+# independent, and an id also travels in an open browser tab and in an
+# archive being restored.)
+#
+# `key_root` and `key_quality` are nullable TOGETHER and mean "every note":
+# the key filter is off by default in both drills, and a scope that names no
+# key is not a scope with a missing field. Nothing here stores the key's
+# NOTES - constraints.js's keyNotes computes them from the two, and a stored
+# note list would be a second copy of that arithmetic, free to drift.
+#
+# One name per owner (the unique index). Setlists deliberately allow
+# duplicate names - a setlist is a thing you open and look at, so two called
+# "Sunday" are merely confusing - but a preset is a thing you PICK from a
+# list in order to change what the next question will be, and two identically
+# named entries there make "which scope am I about to practise" unanswerable
+# from what is on screen. api.create_trainer_preset answers a collision with
+# 409, the status this codebase already uses for a write refused because of
+# what is already there.
+_TRAINER_SCOPE_PRESETS_COLUMNS = """(
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    owner TEXT NOT NULL DEFAULT 'local',
+    name TEXT NOT NULL,
+    start_fret INTEGER NOT NULL,
+    end_fret INTEGER NOT NULL,
+    key_root TEXT,
+    key_quality TEXT,
+    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+)"""
+
+# The string set, one row per string - the setlist_scores of this pair.
+#
+# A SET DOES NOT FIT A COLUMN, and it is not going in as JSON. "Which strings
+# does this preset allow" has to be a WHERE clause for the same reason
+# trainer_attempts' columns are columns and not a blob (see that table's own
+# note): a reader that has to parse "[1,2,3]" out of a text field cannot ask
+# the database anything about it, and docs/practice-data.md's rule for this
+# data layer is that structured practice data stays queryable.
+#
+# PRIMARY KEY (preset_id, string_number): a string is in a preset at most
+# once, exactly as a score is in a setlist at most once, and for the same
+# reason - "remove it" would otherwise be ambiguous about which copy is
+# meant. No `position` column: unlike a setlist this really is a SET, and the
+# order strings are listed in carries no meaning a player chose.
+#
+# ON DELETE CASCADE, the setlist_scores rule applied unchanged: a membership
+# row is pure association - "(this preset) includes (this string)" - and says
+# nothing at all once the preset it names is gone.
+_TRAINER_SCOPE_PRESET_STRINGS_COLUMNS = """(
+    preset_id INTEGER NOT NULL REFERENCES trainer_scope_presets(id) ON DELETE CASCADE,
+    string_number INTEGER NOT NULL,
+    PRIMARY KEY (preset_id, string_number)
+)"""
+
+_TRAINER_PRESET_SCHEMA = (
+    "CREATE TABLE IF NOT EXISTS trainer_scope_presets "
+    + _TRAINER_SCOPE_PRESETS_COLUMNS + ";\n"
+    + "CREATE UNIQUE INDEX IF NOT EXISTS idx_trainer_presets_name"
+    " ON trainer_scope_presets(owner, name);\n"
+    + "CREATE TABLE IF NOT EXISTS trainer_scope_preset_strings "
+    + _TRAINER_SCOPE_PRESET_STRINGS_COLUMNS + ";\n"
 )
 
 _PRACTICE_SCHEMA = (
@@ -643,7 +744,7 @@ CREATE TABLE IF NOT EXISTS setlist_scores (
     PRIMARY KEY (setlist_id, score_id)
 );
 CREATE INDEX IF NOT EXISTS idx_setlist_scores_order ON setlist_scores(setlist_id, position);
-""" + _PRACTICE_SCHEMA + _TRAINER_SCHEMA + _TRAINER_CHORD_SCHEMA
+""" + _TRAINER_PRESET_SCHEMA + _PRACTICE_SCHEMA + _TRAINER_SCHEMA + _TRAINER_CHORD_SCHEMA
 
 # The schema this code expects. Stamped into PRAGMA user_version once a startup
 # has finished bringing a database up to date.
@@ -735,6 +836,20 @@ CREATE INDEX IF NOT EXISTS idx_setlist_scores_order ON setlist_scores(setlist_id
 # the old release misbehave - say a scanner that reconciles setlist membership -
 # that change is what bumps this, with the forward-path test the bump then
 # needs; adding these tables is not that change.)
+#
+# SCOPE PRESETS (#236) DO NOT BUMP THIS EITHER, by the same rule, and the one
+# part worth spelling out is the new practice_sessions COLUMN rather than the
+# two new tables. The tables are pure additions the previous release has no
+# code for at all, exactly like setlists. `practice_sessions.preset_id` is a
+# column on a table that release does read and write - so the question is
+# whether not knowing about it makes that release do harm, and it does not:
+# it never selects the column, so a session it writes simply has none (which
+# is what NULL already means here), and its own export dumps `SELECT *`, so
+# an archive it takes carries the column across intact rather than dropping
+# it. The one cross-table path is deleting a preset, which that release
+# cannot do because it has no route to. Nothing is resurrected, hidden or
+# destroyed by the older code, so bumping would only strand a rollback over
+# data that was never at risk.
 SCHEMA_VERSION = 5
 
 # Columns added to a table that had already shipped. CREATE TABLE IF NOT EXISTS
@@ -805,6 +920,23 @@ COLUMN_ADDITIONS = {
         "key": "INTEGER",
         "tempo": "INTEGER",
         "difficulty": "INTEGER",
+    },
+    # #236's one, on a table that shipped long ago. It is exactly the kind of
+    # change this mechanism is for - nullable, and needing no backfill because
+    # NULL is already true of every row that exists: no session written before
+    # today was practised under a named scope, because there were no named
+    # scopes. It DOES carry a foreign key, which this mechanism supports (see
+    # _add_missing_columns, which checks the REFERENCES really landed) as long
+    # as the added column's default is NULL - and it is, which is also what the
+    # column means. The trainer_scope_presets table it points at arrives on the
+    # same startup through SCHEMA's own CREATE TABLE IF NOT EXISTS, which runs
+    # before this does (see init_db).
+    #
+    # _PRACTICE_SESSIONS_COLUMNS IS THE DEFINITION OF RECORD, the same rule
+    # `missing_since` states above; this entry exists only because CREATE TABLE
+    # IF NOT EXISTS cannot reach a table that is already there.
+    "practice_sessions": {
+        "preset_id": "INTEGER REFERENCES trainer_scope_presets(id) ON DELETE SET NULL",
     },
 }
 

--- a/server/fermata/mcp_tools.py
+++ b/server/fermata/mcp_tools.py
@@ -76,6 +76,14 @@ READ_TOOLS: dict[str, str] = {
     "get_current_goal": "current_goal_api_practice_goals_current_get",
     "list_trainer_attempts": "list_trainer_attempts_api_trainer_attempts_get",
     "list_trainer_chord_attempts": "list_trainer_chord_attempts_api_trainer_chord_attempts_get",
+    # Issue #236's named drill scopes. A READ, so the no-write rule this set
+    # is built on is untouched - and it earns its place rather than merely
+    # passing the census: practice_sessions now carries `preset_id`, which
+    # list_practice_sessions hands back, and without this a caller reading
+    # that number has no way to learn what scope it names. Recording it in
+    # NOT_EXPOSED would have left the practice history describing itself with
+    # an id nothing in the tool set can resolve.
+    "list_trainer_presets": "list_trainer_presets_api_trainer_presets_get",
 }
 
 # Every OTHER readable route under /api, each with the reason it is not a
@@ -265,7 +273,7 @@ def build_tools(document: dict) -> list[ToolSpec]:
     Called once at startup with `app.openapi()`. Raises ToolMappingError
     (via check_tool_mapping) rather than silently shipping a shorter list if
     the document and READ_TOOLS have parted company - a server that quietly
-    served twelve tools where thirteen were meant is the failure this whole
+    served thirteen tools where fourteen were meant is the failure this whole
     design exists to make impossible.
     """
     check_tool_mapping(document)

--- a/server/fermata/practice.py
+++ b/server/fermata/practice.py
@@ -105,6 +105,11 @@ MAX_TEMPO_BPM = 400
 MAX_BAR = 100_000
 MAX_PAGE = 10_000
 MAX_NOTE_CHARS = 2_000
+# The largest value a SQLite INTEGER holds, which is the only bound a row id
+# has to obey - matches api.SQLITE_MAX_INTEGER. Restated rather than imported
+# because this module deliberately imports nothing from api.py (the dependency
+# runs the other way), and a foreign key's real check is the database's.
+MAX_ROW_ID = 2**63 - 1
 MAX_INTENT_CHARS = 200
 MAX_REFLECTION_CHARS = 2_000
 
@@ -274,6 +279,7 @@ def normalise_session(
     target_tempo_bpm=None,
     rating=None,
     note=None,
+    preset_id=None,
     allow_missing_score=False,
     check_day_window=True,
 ) -> dict:
@@ -347,6 +353,13 @@ def normalise_session(
         ),
         "rating": _optional_int(rating, "rating", MIN_RATING, MAX_RATING),
         "note": _optional_text(note, "note", MAX_NOTE_CHARS),
+        # Issue #236's named drill scope. Only its SHAPE is checked here - a
+        # whole number, or nothing at all. Whether that id names a preset this
+        # owner really has is a question about rows, which this module cannot
+        # see and api._normalise_session answers with the connection it has,
+        # exactly the way score_id's own existence check lives there rather
+        # than here.
+        "preset_id": _optional_int(preset_id, "preset_id", 1, MAX_ROW_ID),
     }
 
 

--- a/server/fermata/trainer.py
+++ b/server/fermata/trainer.py
@@ -18,6 +18,7 @@ meet.
 """
 
 import json
+import re
 from typing import Any
 
 # The one drill that writes here today. A widened tuple, not a migration, is
@@ -377,4 +378,152 @@ def chord_attempt_dict(row) -> dict:
     d["correct"] = bool(d["correct"])
     for field in ("target_shape", "given_shape", "given_notes"):
         d[field] = json.loads(d[field]) if d[field] is not None else None
+    return d
+
+
+# ---------------------------------------------------------------------------
+# Named drill scopes (issue #236) - the validation half of
+# trainer_scope_presets / trainer_scope_preset_strings.
+#
+# A SCOPE is what narrows a drill to what somebody is actually working on:
+# which strings, which frets, and optionally which key. Both drills have
+# always had one (web/src/lib/trainer/constraints.js); until #236 it lived
+# only in the browser and vanished on reload. This module validates the saved
+# form of it, the same way normalise_attempt validates an answered question,
+# and for the same reason: the rules belong beside the data rather than in a
+# route handler.
+#
+# CHECKED AGAINST THE BOUNDS ANY INSTRUMENT COULD HAVE, never against one
+# live instrument row - exactly the rule MIN_STRING_NUMBER/MAX_FRET above
+# already state for an attempt, and here it is not a convenience but the
+# design: a preset is SHARED infrastructure (db.py's note on why there is no
+# `drill` column says the same about drills). A scope named while a
+# seven-string guitar was selected is still the scope somebody wants when
+# they pick the six-string up, and pinning it to whichever instrument
+# happened to be chosen when Save was pressed would make half a person's
+# presets refuse to load for reasons they never asked about. What a drill
+# does with a string its current tuning does not have is a rendering
+# question, answered where the neck is drawn (constraints.js's stringInScope
+# simply never matches it), not a reason to refuse the row.
+# ---------------------------------------------------------------------------
+
+# The two scales a key can name, character for character
+# web/src/lib/trainer/constraints.js's KEY_QUALITIES. Fixed here rather than
+# accepting any string for the same reason PITCH_CLASSES is fixed: "the key of
+# G major" has to be a GROUP BY, not a value each client spells its own way.
+KEY_QUALITIES = ("major", "minor")
+
+# Long enough for any name a person would type, bounded so a stored name stays
+# a label - the same rule, and the same number, api.MAX_SETLIST_NAME_CHARS
+# applies to a setlist's.
+MAX_PRESET_NAME_CHARS = 200
+
+# How many strings one preset may name. The bound is MAX_STRING_NUMBER,
+# because naming every string of the widest instrument this app accepts is a
+# real scope ("all of them") and naming more than that is a mistake.
+MAX_PRESET_STRINGS = MAX_STRING_NUMBER
+
+
+def _preset_name(name) -> str:
+    """A preset's name, cleaned the way api._clean_setlist_name cleans a
+    setlist's: unprintable characters dropped, runs of whitespace collapsed,
+    the ends trimmed, the length bounded. A name that was only whitespace is a
+    ValueError rather than a stored blank - an unnamed entry in a list of
+    named scopes is one nobody can pick on purpose."""
+    if not isinstance(name, str):
+        raise ValueError("a preset needs a name")
+    cleaned = re.sub(r"\s+", " ", "".join(ch for ch in name if ch.isprintable())).strip()
+    if not cleaned:
+        raise ValueError("a preset needs a name")
+    return cleaned[:MAX_PRESET_NAME_CHARS]
+
+
+def _preset_strings(string_numbers) -> list[int]:
+    """The string set, deduplicated and sorted.
+
+    EMPTY IS REFUSED, and that is the one rule here worth spelling out.
+    Everywhere else in the scope model an empty string list means "no filter
+    at all" rather than "no strings" (constraints.js's stringInScope, and
+    FretToNote.svelte's toggleString, which will not let the last box be
+    unchecked for exactly this reason). A SAVED preset cannot use that
+    convention: a row with no strings would be indistinguishable from a row
+    whose strings failed to write, so "every string" is stored by naming every
+    string, and nothing downstream has to guess which of the two was meant.
+    """
+    if not isinstance(string_numbers, (list, tuple)):
+        raise ValueError("strings must be a list of string numbers")
+    numbers = set()
+    for value in string_numbers:
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise ValueError("every string number must be a whole number")
+        if not MIN_STRING_NUMBER <= value <= MAX_STRING_NUMBER:
+            raise ValueError(
+                f"every string number must be between {MIN_STRING_NUMBER} "
+                f"and {MAX_STRING_NUMBER}"
+            )
+        numbers.add(value)
+    if not numbers:
+        raise ValueError("a preset needs at least one string")
+    if len(numbers) > MAX_PRESET_STRINGS:
+        raise ValueError(f"a preset may name at most {MAX_PRESET_STRINGS} strings")
+    return sorted(numbers)
+
+
+def _preset_key(key_root, key_quality) -> tuple[str | None, str | None]:
+    """The key, or no key at all. Both fields or neither: a root with no
+    quality does not name a key, and a quality with no root names nothing -
+    the same both-or-neither rule _position applies to a string and a fret,
+    and for the same reason (otherwise "does this scope have a key" is
+    answered by whichever column happens to be non-null)."""
+    if key_root is None and key_quality is None:
+        return None, None
+    if key_root is None or key_quality is None:
+        raise ValueError("key_root and key_quality must both be given, or neither")
+    if key_root not in PITCH_CLASSES:
+        raise ValueError(f"key_root must be one of {list(PITCH_CLASSES)}")
+    if key_quality not in KEY_QUALITIES:
+        raise ValueError(f"key_quality must be one of {list(KEY_QUALITIES)}")
+    return key_root, key_quality
+
+
+def normalise_preset(
+    *, name, start_fret, end_fret, strings, key_root=None, key_quality=None
+) -> dict:
+    """Check a named scope and return what to store: the preset's own row
+    under 'preset', and its string set under 'strings' (one row each, in the
+    child table - db.py says why a set is not a column).
+
+    Raises ValueError with a message meant for a person to read, the same
+    contract normalise_attempt has.
+    """
+    for value, field in ((start_fret, "start_fret"), (end_fret, "end_fret")):
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise ValueError(f"{field} must be a whole number")
+        if not MIN_FRET <= value <= MAX_FRET:
+            raise ValueError(f"{field} must be between {MIN_FRET} and {MAX_FRET}")
+    if start_fret > end_fret:
+        # Not a range at all. Stored, it would be a preset that can never ask
+        # a question, and nothing downstream could tell that from a scope that
+        # is merely narrow.
+        raise ValueError("start_fret must not be past end_fret")
+    root, quality = _preset_key(key_root, key_quality)
+    return {
+        "preset": {
+            "name": _preset_name(name),
+            "start_fret": start_fret,
+            "end_fret": end_fret,
+            "key_root": root,
+            "key_quality": quality,
+        },
+        "strings": _preset_strings(strings),
+    }
+
+
+def preset_dict(row, string_numbers) -> dict:
+    """One preset as the API presents it - the stored row plus its string set,
+    which lives in its own table and so is passed in rather than read off the
+    row. Sorted ascending, always: a set has no order of its own, and a stable
+    one is what lets a client compare two presets without sorting first."""
+    d = dict(row)
+    d["strings"] = sorted(string_numbers)
     return d

--- a/server/tests/test_api_docs.py
+++ b/server/tests/test_api_docs.py
@@ -303,8 +303,9 @@ def test_every_route_has_exactly_the_expected_operation_count(openapi_schema):
     # two: start a bulk transcription pass, poll its status. Plus issue #28's
     # two: log a chord flash card attempt, and list them. Plus issue #6's
     # eight setlist routes: list, create, get one, rename, delete, add a
-    # score, remove a score, reorder.
-    assert count == 68
+    # score, remove a score, reorder. Plus issue #236's three: list the named
+    # drill scopes, save one, delete one.
+    assert count == 71
 
 
 def test_binary_routes_do_not_advertise_a_json_content_type(openapi_schema):

--- a/server/tests/test_mcp_server.py
+++ b/server/tests/test_mcp_server.py
@@ -307,7 +307,7 @@ def test_the_flag_on_without_the_extra_says_so_instead_of_a_traceback():
 def test_the_feature_and_reverse_proxy_auth_are_refused_together(tmp_path):
     """Both on is not a working deployment: the tools read the API as an
     anonymous loopback client, so reverse-proxy auth would 401 every one of
-    them while the tool list still advertised thirteen. Refusing to start
+    them while the tool list still advertised fourteen. Refusing to start
     says that out loud - see
     authproxy.check_mcp_is_not_configured_behind_proxy_auth for why neither
     workaround is offered instead.

--- a/server/tests/test_portability_api.py
+++ b/server/tests/test_portability_api.py
@@ -356,7 +356,7 @@ def test_export_table_names_matches_every_table_the_schema_creates(client):
     # query stopped seeing real tables, which would let this test pass for the
     # wrong reason (a tiny live_tables trivially failing to catch anything left
     # out of EXPORT_TABLE_NAMES).
-    assert len(live_tables) >= 12
+    assert len(live_tables) >= 14
     assert live_tables == set(api.EXPORT_TABLE_NAMES)
 
 

--- a/server/tests/test_portability_api.py
+++ b/server/tests/test_portability_api.py
@@ -513,6 +513,164 @@ def test_import_accepts_an_archive_from_before_the_trainer_tables_existed(client
     assert client.get("/api/trainer/chord-attempts").json()["total"] == 0
 
 
+# ---------------------------------------------------------------------------
+# #236: named drill scopes and their string sets ride the same round trip,
+# and practice_sessions.preset_id follows the id remap.
+# ---------------------------------------------------------------------------
+
+
+def test_export_import_round_trip_carries_presets_their_strings_and_the_sessions_reference(
+    client, tmp_path, monkeypatch
+):
+    """Save two scopes, log a session under the SECOND one (so a broken remap
+    that carried the raw source id across would land on the wrong preset
+    rather than merely on a valid one), export, and import into a fresh
+    library that already holds a preset and a session of its own - so the
+    imported rows cannot coincidentally get the ids they had in the source.
+
+    The strings are the half that would be silently lost: a preset row can
+    arrive intact while its string set does not, and the restored scope would
+    then narrow nothing while looking perfectly well-formed. So the assertion
+    is on the string sets, per preset, by name.
+    """
+    decoy = client.post(
+        "/api/trainer/presets",
+        json={"name": "Open position", "start_fret": 0, "end_fret": 3, "strings": [6, 5, 4]},
+    ).json()
+    real = client.post(
+        "/api/trainer/presets",
+        json={
+            "name": "Fifth position",
+            "start_fret": 5,
+            "end_fret": 9,
+            "strings": [1, 2, 3],
+            "key_root": "G",
+            "key_quality": "minor",
+        },
+    ).json()
+    assert real["id"] != decoy["id"]
+    session = client.post(
+        "/api/practice/sessions",
+        json={"seconds": 120, "activity": "fretboard", "preset_id": real["id"]},
+    ).json()
+    assert session["preset_id"] == real["id"]
+
+    manifest = json.loads(_zip_of(client.get("/api/export")).read("manifest.json"))
+    assert [r["id"] for r in manifest["tables"]["trainer_scope_presets"]] == [
+        decoy["id"], real["id"],
+    ]
+    # One row per string, never a list in a column.
+    assert len(manifest["tables"]["trainer_scope_preset_strings"]) == 6
+
+    archive = client.get("/api/export").content
+
+    _switch_to_a_fresh_environment(monkeypatch, tmp_path, "target")
+    preexisting = client.post(
+        "/api/trainer/presets",
+        json={"name": "Already here", "start_fret": 0, "end_fret": 12, "strings": [6]},
+    ).json()
+    client.post("/api/practice/sessions", json={"seconds": 999, "activity": "ear_training"})
+
+    import_resp = client.post(
+        "/api/import", params={"dry_run": "false"},
+        files={"file": ("export.zip", archive, "application/zip")},
+    )
+    assert import_resp.status_code == 200, import_resp.text
+    summary = import_resp.json()
+    assert summary["trainer_presets_imported"] == 2
+    assert summary["trainer_preset_strings_imported"] == 6
+
+    by_name = {p["name"]: p for p in client.get("/api/trainer/presets").json()}
+    assert set(by_name) == {"Already here", "Open position", "Fifth position"}
+    assert by_name["Open position"]["strings"] == [4, 5, 6]
+    assert by_name["Fifth position"]["strings"] == [1, 2, 3]
+    assert by_name["Fifth position"]["start_fret"] == 5
+    assert by_name["Fifth position"]["end_fret"] == 9
+    assert by_name["Fifth position"]["key_root"] == "G"
+    assert by_name["Fifth position"]["key_quality"] == "minor"
+    # Fresh ids on both sides of the join, and the session names the RIGHT one.
+    imported_real = by_name["Fifth position"]
+    assert imported_real["id"] not in {real["id"], preexisting["id"]}
+    imported_session = next(
+        s
+        for s in client.get("/api/practice/sessions").json()["sessions"]
+        if s["seconds"] == 120
+    )
+    assert imported_session["preset_id"] == imported_real["id"]
+    assert imported_session["preset_id"] != by_name["Open position"]["id"]
+    assert imported_session["preset_id"] != preexisting["id"]
+
+
+def test_import_accepts_an_archive_from_before_named_scopes_existed(client, add_score):
+    """The LEGACY_OPTIONAL_TABLES tolerance, extended to #236's two for the
+    same reason #243's two have it: an archive taken yesterday cannot carry a
+    table that did not exist, and refusing every backup a person already
+    holds would be strictly worse than restoring one with no named scopes. A
+    session in such an archive has no `preset_id` either, so nothing dangles.
+    Engineered by deleting the two keys - and the column - from an
+    otherwise-real manifest."""
+    add_score("Prelude.pdf", title="Prelude")
+    client.post("/api/practice/sessions", json={"seconds": 300, "activity": "fretboard"})
+    manifest = json.loads(
+        _zip_of(client.get("/api/export?include_files=false")).read("manifest.json")
+    )
+    assert set(manifest["tables"]) == set(api.EXPORT_TABLE_NAMES)
+    del manifest["tables"]["trainer_scope_presets"]
+    del manifest["tables"]["trainer_scope_preset_strings"]
+    for row in manifest["tables"]["practice_sessions"]:
+        del row["preset_id"]
+    archive = _bytes_of_zip({"manifest.json": json.dumps(manifest).encode()})
+
+    resp = client.post(
+        "/api/import", params={"dry_run": "false"},
+        files={"file": ("legacy-twelve-table.zip", archive, "application/zip")},
+    )
+    assert resp.status_code == 200, resp.text
+    summary = resp.json()
+    assert summary["trainer_presets_imported"] == 0
+    assert summary["trainer_preset_strings_imported"] == 0
+    assert summary["practice_sessions_imported"] == 1
+    assert client.get("/api/scores").json()[0]["title"] == "Prelude"
+    assert client.get("/api/trainer/presets").json() == []
+    # Import ADDS, so the source session and its restored copy are both here;
+    # what matters is that neither ended up naming a scope this archive never
+    # carried.
+    restored = client.get("/api/practice/sessions").json()["sessions"]
+    assert [s["seconds"] for s in restored] == [300, 300]
+    assert [s["preset_id"] for s in restored] == [None, None]
+
+
+def test_an_archive_naming_a_preset_it_does_not_carry_is_refused_before_anything_is_written(
+    client, add_score
+):
+    """Referential integrity WITHIN the archive, the same check every other
+    reference gets: a session naming a preset the archive left out cannot be
+    inserted without dropping the reference silently or crashing partway
+    through write_tx()."""
+    add_score("Prelude.pdf", title="Prelude")
+    preset = client.post(
+        "/api/trainer/presets",
+        json={"name": "Fifth position", "start_fret": 5, "end_fret": 9, "strings": [1, 2]},
+    ).json()
+    client.post(
+        "/api/practice/sessions",
+        json={"seconds": 120, "activity": "fretboard", "preset_id": preset["id"]},
+    )
+    manifest = json.loads(
+        _zip_of(client.get("/api/export?include_files=false")).read("manifest.json")
+    )
+    manifest["tables"]["trainer_scope_presets"] = []
+    manifest["tables"]["trainer_scope_preset_strings"] = []
+    archive = _bytes_of_zip({"manifest.json": json.dumps(manifest).encode()})
+
+    resp = client.post(
+        "/api/import", params={"dry_run": "false"},
+        files={"file": ("broken.zip", archive, "application/zip")},
+    )
+    assert resp.status_code == 422, resp.text
+    assert "preset" in resp.json()["detail"]
+
+
 def test_export_can_leave_the_trash_out(client, add_score):
     live_id = add_score("Keeper.pdf", title="Keeper")
     trashed_id = add_score("Doomed.pdf", title="Doomed")

--- a/server/tests/test_trainer_presets_api.py
+++ b/server/tests/test_trainer_presets_api.py
@@ -1,0 +1,295 @@
+"""Named drill scopes (issue #236): trainer.normalise_preset directly, and the
+three /api/trainer/presets routes end to end, plus the practice_sessions
+column that makes "what was practised" a row rather than a sentence.
+
+Literal-value assertions on stored rows and real round trips, not shape checks
+alone - the same discipline test_trainer_api.py sets out and for the same
+reason (#146): a field that validates against its model is not the same claim
+as a field that reaches the wire carrying what was stored.
+"""
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from fermata import api, db, trainer
+
+# ---------------------------------------------------------------- trainer.py, directly
+
+
+def make(**overrides):
+    base = dict(name="Fifth position", start_fret=5, end_fret=9, strings=[1, 2])
+    return {**base, **overrides}
+
+
+def test_a_whole_scope_normalises_to_a_row_and_a_string_set():
+    values = trainer.normalise_preset(**make(key_root="G", key_quality="minor"))
+    assert values["preset"] == {
+        "name": "Fifth position",
+        "start_fret": 5,
+        "end_fret": 9,
+        "key_root": "G",
+        "key_quality": "minor",
+    }
+    assert values["strings"] == [1, 2]
+
+
+def test_a_scope_with_no_key_stores_two_nulls():
+    values = trainer.normalise_preset(**make())
+    assert values["preset"]["key_root"] is None
+    assert values["preset"]["key_quality"] is None
+
+
+def test_the_string_set_is_deduplicated_and_sorted():
+    """A set, stored as one row per member - so the same string twice is one
+    row, and the order a client happened to send is not a fact about the
+    scope."""
+    values = trainer.normalise_preset(**make(strings=[3, 1, 3, 2]))
+    assert values["strings"] == [1, 2, 3]
+
+
+def test_a_name_is_cleaned_the_way_a_setlist_name_is():
+    values = trainer.normalise_preset(**make(name="  Fifth   position  "))
+    assert values["preset"]["name"] == "Fifth position"
+
+
+@pytest.mark.parametrize(
+    "overrides, fragment",
+    [
+        (dict(name="   "), "needs a name"),
+        (dict(name=""), "needs a name"),
+        (dict(name=None), "needs a name"),
+        (dict(strings=[]), "at least one string"),
+        (dict(strings="1,2"), "list of string numbers"),
+        (dict(strings=[0]), "between 1 and 24"),
+        (dict(strings=[25]), "between 1 and 24"),
+        (dict(strings=[True]), "whole number"),
+        (dict(start_fret=-1), "between 0 and 36"),
+        (dict(end_fret=37), "between 0 and 36"),
+        (dict(start_fret=9, end_fret=5), "must not be past"),
+        (dict(start_fret=1.5), "whole number"),
+        (dict(key_root="G"), "both be given, or neither"),
+        (dict(key_quality="major"), "both be given, or neither"),
+        (dict(key_root="H", key_quality="major"), "key_root must be one of"),
+        (dict(key_root="G", key_quality="dorian"), "key_quality must be one of"),
+    ],
+)
+def test_every_rejection_names_what_is_wrong(overrides, fragment):
+    with pytest.raises(ValueError) as caught:
+        trainer.normalise_preset(**make(**overrides))
+    assert fragment in str(caught.value)
+
+
+def test_a_one_fret_range_is_a_range():
+    """start_fret == end_fret is a real scope (one fret across some strings),
+    not the degenerate case the ordering rule refuses."""
+    values = trainer.normalise_preset(**make(start_fret=7, end_fret=7))
+    assert values["preset"]["start_fret"] == 7
+    assert values["preset"]["end_fret"] == 7
+
+
+# ---------------------------------------------------------------- the routes
+
+
+@pytest.fixture()
+def client(app_env):
+    app = FastAPI()
+    app.include_router(api.router)
+    return TestClient(app)
+
+
+def save(client, **overrides):
+    resp = client.post("/api/trainer/presets", json=make(**overrides))
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+def test_saving_a_scope_stores_it_and_returns_it(client):
+    body = save(client, key_root="G", key_quality="major")
+    assert body["id"] > 0
+    assert body["owner"] == db.DEFAULT_OWNER
+    assert body["name"] == "Fifth position"
+    assert body["start_fret"] == 5
+    assert body["end_fret"] == 9
+    assert body["key_root"] == "G"
+    assert body["key_quality"] == "major"
+    assert body["strings"] == [1, 2]
+    assert body["created_at"]
+
+
+def test_the_string_set_is_stored_as_rows_rather_than_as_text(client):
+    """The rule db.py's note states, checked at the storage layer: "which
+    strings does this scope allow" is a WHERE clause, so there is one row per
+    string and no column anywhere holding a list."""
+    body = save(client, strings=[6, 5, 4])
+    conn = db.connect()
+    rows = conn.execute(
+        "SELECT string_number FROM trainer_scope_preset_strings WHERE preset_id = ? "
+        "ORDER BY string_number",
+        (body["id"],),
+    ).fetchall()
+    assert [r["string_number"] for r in rows] == [4, 5, 6]
+    stored = conn.execute(
+        "SELECT * FROM trainer_scope_presets WHERE id = ?", (body["id"],)
+    ).fetchone()
+    assert "strings" not in stored.keys()
+
+
+def test_listing_gives_every_scope_newest_first_with_its_strings(client):
+    first = save(client, name="Open position", start_fret=0, end_fret=3, strings=[6, 5, 4])
+    second = save(client, name="Fifth position", strings=[1, 2])
+    listed = client.get("/api/trainer/presets")
+    assert listed.status_code == 200, listed.text
+    body = listed.json()
+    assert [p["id"] for p in body] == [second["id"], first["id"]]
+    assert body[1]["strings"] == [4, 5, 6]
+    assert body[1]["start_fret"] == 0
+    assert body[1]["end_fret"] == 3
+
+
+def test_an_empty_list_is_an_empty_list(client):
+    assert client.get("/api/trainer/presets").json() == []
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        dict(name="   "),
+        dict(strings=[]),
+        dict(strings=[0]),
+        dict(start_fret=9, end_fret=5),
+        dict(end_fret=37),
+        dict(key_root="G"),
+        dict(key_quality="major"),
+        dict(key_root="H", key_quality="major"),
+        dict(key_root="G", key_quality="dorian"),
+    ],
+)
+def test_a_scope_that_does_not_describe_anything_is_refused_with_422(client, overrides):
+    resp = client.post("/api/trainer/presets", json=make(**overrides))
+    assert resp.status_code == 422, resp.text
+    # And nothing was stored - a refused save leaves the list as it was.
+    assert client.get("/api/trainer/presets").json() == []
+
+
+def test_a_name_already_in_use_is_refused_with_409_and_stores_nothing(client):
+    """409, not 422: nothing is wrong with the request, it collides with what
+    is already there - the status this codebase uses for exactly that (see
+    api.rename_folder, api.delete_score). Deliberately unlike setlists, whose
+    duplicate names are allowed; see create_trainer_preset's docstring."""
+    save(client)
+    resp = client.post("/api/trainer/presets", json=make(start_fret=0, end_fret=3))
+    assert resp.status_code == 409, resp.text
+    assert "Fifth position" in resp.json()["detail"]
+    listed = client.get("/api/trainer/presets").json()
+    assert len(listed) == 1
+    # The FIRST one is untouched - a refused duplicate is not a rename.
+    assert listed[0]["start_fret"] == 5
+
+
+def test_a_name_that_cleans_to_an_existing_one_collides_too(client):
+    """The clash is checked on the CLEANED name, not the raw one, or "Fifth
+    position" and "Fifth   position" would sit in the picker as two entries
+    nobody could tell apart."""
+    save(client)
+    resp = client.post("/api/trainer/presets", json=make(name="  Fifth   position  "))
+    assert resp.status_code == 409, resp.text
+
+
+def test_deleting_a_scope_removes_it_and_its_strings(client):
+    body = save(client)
+    resp = client.delete(f"/api/trainer/presets/{body['id']}")
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == {"deleted": body["id"], "sessions_kept": 0}
+    assert client.get("/api/trainer/presets").json() == []
+    conn = db.connect()
+    assert (
+        conn.execute(
+            "SELECT COUNT(*) AS n FROM trainer_scope_preset_strings WHERE preset_id = ?",
+            (body["id"],),
+        ).fetchone()["n"]
+        == 0
+    )
+
+
+def test_deleting_a_scope_that_is_not_there_is_a_404(client):
+    assert client.delete("/api/trainer/presets/9999").status_code == 404
+
+
+# ------------------------------------------- the practice session's own column
+
+
+def log(client, **overrides):
+    body = {"activity": "fretboard", "seconds": 600, **overrides}
+    resp = client.post("/api/practice/sessions", json=body)
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+def test_a_session_carries_the_scope_it_was_practised_under_and_reads_it_back(client):
+    preset = save(client)
+    session = log(client, preset_id=preset["id"])
+    assert session["preset_id"] == preset["id"]
+    # Read back through the LIST route as well, not only off the write's own
+    # response - the claim is about what a later reader sees.
+    listed = client.get("/api/practice/sessions?limit=10").json()["sessions"]
+    assert [s["preset_id"] for s in listed] == [preset["id"]]
+
+
+def test_a_session_with_no_named_scope_carries_none(client):
+    session = log(client)
+    assert session["preset_id"] is None
+
+
+def test_a_session_naming_a_scope_that_is_not_there_is_a_404(client):
+    """Answered as a 404 naming what was not found, rather than left for the
+    foreign key to raise an IntegrityError nobody could act on."""
+    resp = client.post(
+        "/api/practice/sessions", json={"activity": "fretboard", "seconds": 600, "preset_id": 9999}
+    )
+    assert resp.status_code == 404, resp.text
+
+
+def test_a_patch_can_add_or_clear_the_scope_on_a_session_already_logged(client):
+    preset = save(client)
+    session = log(client)
+    patched = client.patch(
+        f"/api/practice/sessions/{session['id']}", json={"preset_id": preset["id"]}
+    )
+    assert patched.status_code == 200, patched.text
+    assert patched.json()["preset_id"] == preset["id"]
+    cleared = client.patch(
+        f"/api/practice/sessions/{session['id']}", json={"preset_id": None}
+    )
+    assert cleared.status_code == 200, cleared.text
+    assert cleared.json()["preset_id"] is None
+
+
+def test_deleting_a_scope_keeps_the_practice_and_clears_only_the_reference(client):
+    """The claim db.py's ON DELETE SET NULL note makes, end to end: the
+    minutes were still practised, so the session stays whole and loses only
+    the name of the scope it ran under."""
+    preset = save(client)
+    session = log(client, preset_id=preset["id"], seconds=1234, note="Fret to note. 8 questions.")
+
+    resp = client.delete(f"/api/trainer/presets/{preset['id']}")
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["sessions_kept"] == 1
+
+    after = client.get("/api/practice/sessions?limit=10").json()["sessions"]
+    assert len(after) == 1
+    assert after[0]["id"] == session["id"]
+    assert after[0]["seconds"] == 1234
+    assert after[0]["activity"] == "fretboard"
+    assert after[0]["note"] == "Fret to note. 8 questions."
+    assert after[0]["preset_id"] is None
+
+
+def test_sessions_kept_counts_every_session_the_delete_leaves_behind(client):
+    preset = save(client)
+    for _ in range(3):
+        log(client, preset_id=preset["id"])
+    log(client)
+    resp = client.delete(f"/api/trainer/presets/{preset['id']}")
+    assert resp.json()["sessions_kept"] == 3
+    assert len(client.get("/api/practice/sessions?limit=10").json()["sessions"]) == 4

--- a/server/tests/test_trainer_presets_api.py
+++ b/server/tests/test_trainer_presets_api.py
@@ -196,6 +196,16 @@ def test_a_name_that_cleans_to_an_existing_one_collides_too(client):
     assert resp.status_code == 409, resp.text
 
 
+def test_a_name_differing_only_in_case_collides_too(client):
+    """"Fifth position" and "fifth position" are one entry to a reader, so
+    they are one entry here: the clash check compares without case, and the
+    unique index underneath it does the same (see the schema test)."""
+    save(client)
+    resp = client.post("/api/trainer/presets", json=make(name="FIFTH POSITION"))
+    assert resp.status_code == 409, resp.text
+    assert len(client.get("/api/trainer/presets").json()) == 1
+
+
 def test_deleting_a_scope_removes_it_and_its_strings(client):
     body = save(client)
     resp = client.delete(f"/api/trainer/presets/{body['id']}")

--- a/server/tests/test_trainer_presets_schema.py
+++ b/server/tests/test_trainer_presets_schema.py
@@ -1,0 +1,229 @@
+"""The named-scope tables themselves (issue #236): that a fresh install builds
+them, that an existing database gains them and the practice_sessions column on
+the next startup, that COLUMN_ADDITIONS really is idempotent across repeated
+startups, and that the two ON DELETE actions the feature relies on are the ones
+actually stored - the properties db.py's comments claim, checked rather than
+trusted.
+
+WHY NO SCHEMA_VERSION FORWARD-PATH TEST HERE, the same reasoning
+test_setlists_schema.py sets out: the stamp is not bumped (see the long note
+above SCHEMA_VERSION in db.py), so there is no version step to test. What IS
+load-bearing about that decision is checked below - the tables and the column
+arrive on an existing database with no migration, and the SET NULL that keeps
+practice history intact when a preset goes is stored in the file rather than
+enforced by code that an older release would not be running.
+"""
+
+import pytest
+
+from fermata import db
+
+
+def _table_names(conn) -> set[str]:
+    return {
+        r["name"]
+        for r in conn.execute("SELECT name FROM sqlite_master WHERE type = 'table'")
+    }
+
+
+def _columns(conn, table: str) -> set[str]:
+    return {r["name"] for r in conn.execute(f"PRAGMA table_info({table})")}
+
+
+def _on_delete(conn, table: str, column: str) -> str | None:
+    for r in conn.execute(f"PRAGMA foreign_key_list({table})"):
+        if r["from"] == column:
+            return r["on_delete"]
+    return None
+
+
+def _a_session(conn, preset_id=None) -> int:
+    return conn.execute(
+        """INSERT INTO practice_sessions(owner, activity, started_at, seconds, preset_id)
+           VALUES ('local', 'fretboard', datetime('now'), 600, ?)""",
+        (preset_id,),
+    ).lastrowid
+
+
+def _a_preset(conn, name="Fifth position", strings=(1, 2)) -> int:
+    preset_id = conn.execute(
+        """INSERT INTO trainer_scope_presets(owner, name, start_fret, end_fret)
+           VALUES ('local', ?, 5, 9)""",
+        (name,),
+    ).lastrowid
+    conn.executemany(
+        "INSERT INTO trainer_scope_preset_strings(preset_id, string_number) VALUES (?, ?)",
+        [(preset_id, n) for n in strings],
+    )
+    return preset_id
+
+
+def test_fresh_install_has_both_preset_tables_and_the_session_column(app_env):
+    conn = db.connect()
+    names = _table_names(conn)
+    assert "trainer_scope_presets" in names
+    assert "trainer_scope_preset_strings" in names
+    assert "preset_id" in _columns(conn, "practice_sessions")
+
+
+def test_a_name_is_unique_per_owner(app_env):
+    """The unique index is real, not merely intended - api.create_trainer_preset
+    checks for a clash and answers 409, and this is the guard underneath that
+    check for anything writing rows another way."""
+    conn = db.connect()
+    _a_preset(conn, name="Fifth position")
+    conn.commit()
+    with pytest.raises(Exception) as caught:
+        _a_preset(conn, name="Fifth position")
+    assert "UNIQUE" in str(caught.value).upper()
+    conn.rollback()
+
+
+def test_a_string_is_in_a_preset_at_most_once(app_env):
+    conn = db.connect()
+    preset_id = _a_preset(conn, strings=(1,))
+    conn.commit()
+    with pytest.raises(Exception) as caught:
+        conn.execute(
+            "INSERT INTO trainer_scope_preset_strings(preset_id, string_number) VALUES (?, 1)",
+            (preset_id,),
+        )
+    assert "UNIQUE" in str(caught.value).upper()
+    conn.rollback()
+
+
+def test_the_two_foreign_keys_are_the_actions_the_feature_depends_on(app_env):
+    """Flip either in db.SCHEMA and this goes red. The string set CASCADEs
+    because a row saying "(this preset) includes (string 3)" states nothing
+    once the preset is gone; the session SET NULLs because "forty minutes of
+    fretboard practice on Tuesday" is still true when the scope it was named
+    under is deleted."""
+    conn = db.connect()
+    assert _on_delete(conn, "trainer_scope_preset_strings", "preset_id") == "CASCADE"
+    assert _on_delete(conn, "practice_sessions", "preset_id") == "SET NULL"
+
+
+def test_deleting_a_preset_row_takes_its_strings_and_spares_the_practice(app_env):
+    """The row-level proof under the API-level test in
+    test_trainer_presets_api.py: with PRAGMA foreign_keys=ON (which
+    db.connect() sets), a raw DELETE removes the string set and clears the
+    session's reference while leaving the session itself whole."""
+    conn = db.connect()
+    preset_id = _a_preset(conn)
+    session_id = _a_session(conn, preset_id)
+    conn.commit()
+
+    conn.execute("DELETE FROM trainer_scope_presets WHERE id = ?", (preset_id,))
+    conn.commit()
+
+    assert (
+        conn.execute("SELECT COUNT(*) AS n FROM trainer_scope_preset_strings").fetchone()["n"]
+        == 0
+    )
+    row = conn.execute(
+        "SELECT * FROM practice_sessions WHERE id = ?", (session_id,)
+    ).fetchone()
+    assert row is not None
+    assert row["preset_id"] is None
+    assert row["seconds"] == 600
+    assert row["activity"] == "fretboard"
+
+
+def test_tables_and_column_are_created_on_an_existing_database(app_env):
+    """The auto-upgrade path, both halves of it. The two tables arrive through
+    SCHEMA's own CREATE TABLE IF NOT EXISTS; the practice_sessions column
+    arrives through COLUMN_ADDITIONS, which is the mechanism that reaches a
+    table CREATE TABLE IF NOT EXISTS cannot touch. Simulated by taking an
+    up-to-date database back to the shape a pre-#236 file has - drop the
+    tables, and rebuild practice_sessions without the column - and re-running
+    init_db."""
+    conn = db.connect()
+    conn.execute("DROP TABLE trainer_scope_preset_strings")
+    conn.execute("DROP TABLE trainer_scope_presets")
+    # A practice_sessions with no preset_id, carrying a row across, which is
+    # exactly what an older install has.
+    conn.execute("PRAGMA foreign_keys=OFF")
+    conn.execute(
+        """CREATE TABLE old_sessions (
+               id INTEGER PRIMARY KEY,
+               owner TEXT NOT NULL DEFAULT 'local',
+               score_id INTEGER REFERENCES scores(id) ON DELETE SET NULL,
+               activity TEXT NOT NULL DEFAULT 'piece',
+               mode TEXT, started_at TEXT NOT NULL, local_date TEXT,
+               seconds INTEGER NOT NULL, from_bar INTEGER, to_bar INTEGER,
+               from_page INTEGER, to_page INTEGER, tempo_bpm INTEGER,
+               target_tempo_bpm INTEGER, rating INTEGER, note TEXT
+           )"""
+    )
+    conn.execute(
+        """INSERT INTO old_sessions(owner, activity, started_at, seconds, note)
+           VALUES ('local', 'fretboard', datetime('now'), 900, 'Fret to note. Frets 0-5.')"""
+    )
+    conn.execute("DROP TABLE practice_sessions")
+    conn.execute("ALTER TABLE old_sessions RENAME TO practice_sessions")
+    conn.commit()
+    conn.execute("PRAGMA foreign_keys=ON")
+    assert "trainer_scope_presets" not in _table_names(conn)
+    assert "preset_id" not in _columns(conn, "practice_sessions")
+
+    db.init_db()
+
+    names = _table_names(conn)
+    assert "trainer_scope_presets" in names
+    assert "trainer_scope_preset_strings" in names
+    assert "preset_id" in _columns(conn, "practice_sessions")
+    # The pre-existing row survived with its column added as NULL, which is
+    # what "no backfill needed" means here: nothing was practised under a
+    # named scope before there were any.
+    old = conn.execute("SELECT * FROM practice_sessions").fetchone()
+    assert old["seconds"] == 900
+    assert old["preset_id"] is None
+    # And the new column is usable, not merely present.
+    preset_id = _a_preset(conn)
+    new_id = _a_session(conn, preset_id)
+    conn.commit()
+    stored = conn.execute(
+        "SELECT preset_id FROM practice_sessions WHERE id = ?", (new_id,)
+    ).fetchone()
+    assert stored["preset_id"] == preset_id
+
+
+def test_the_added_column_survives_repeated_startups_unchanged(app_env):
+    """COLUMN_ADDITIONS runs on EVERY startup, which is the only reason it is
+    safe to express an upgrade through it - so running it again must be a
+    no-op, not a second ALTER TABLE (an error) and not anything that touches a
+    row. Three more init_db calls, with data in the table."""
+    conn = db.connect()
+    preset_id = _a_preset(conn)
+    session_id = _a_session(conn, preset_id)
+    conn.commit()
+    before = _columns(conn, "practice_sessions")
+
+    for _ in range(3):
+        db.init_db()
+
+    assert _columns(conn, "practice_sessions") == before
+    assert (
+        conn.execute(
+            "SELECT COUNT(*) AS n FROM pragma_table_info('practice_sessions') "
+            "WHERE name = 'preset_id'"
+        ).fetchone()["n"]
+        == 1
+    )
+    row = conn.execute(
+        "SELECT * FROM practice_sessions WHERE id = ?", (session_id,)
+    ).fetchone()
+    assert row["preset_id"] == preset_id
+    assert row["seconds"] == 600
+    # The foreign key is still there after the repeat runs - the check
+    # _add_missing_columns makes on an existing column, seen to hold.
+    assert _on_delete(conn, "practice_sessions", "preset_id") == "SET NULL"
+
+
+def test_schema_version_is_unchanged_by_named_scopes(app_env):
+    """#236 did not bump the stamp - the deliberate decision documented at
+    SCHEMA_VERSION. Pinned so a later change cannot quietly move it without a
+    reviewer seeing this assertion and the reasoning it points at."""
+    conn = db.connect()
+    assert conn.execute("PRAGMA user_version").fetchone()[0] == db.SCHEMA_VERSION
+    assert db.SCHEMA_VERSION == 5

--- a/server/tests/test_trainer_presets_schema.py
+++ b/server/tests/test_trainer_presets_schema.py
@@ -77,6 +77,12 @@ def test_a_name_is_unique_per_owner(app_env):
         _a_preset(conn, name="Fifth position")
     assert "UNIQUE" in str(caught.value).upper()
     conn.rollback()
+    # The index compares without case, like the API's own clash check, so a
+    # row written another way cannot slip a case variant past it either.
+    with pytest.raises(Exception) as caught:
+        _a_preset(conn, name="fifth POSITION")
+    assert "UNIQUE" in str(caught.value).upper()
+    conn.rollback()
 
 
 def test_a_string_is_in_a_preset_at_most_once(app_env):

--- a/web/src/lib/api.js
+++ b/web/src/lib/api.js
@@ -285,6 +285,18 @@ export const api = {
     );
     return fetch(`/api/trainer/chord-attempts?${q}`).then(j);
   },
+  // Named drill scopes (issue #236) - which strings, which frets, which key,
+  // saved under a name and shared by BOTH drills. The scope used to be
+  // browser state that reset on reload; these three are the whole of what
+  // replaced it.
+  trainerPresets: () => fetch("/api/trainer/presets").then(j),
+  createTrainerPreset: (body) =>
+    fetch("/api/trainer/presets", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }).then(j),
+  deleteTrainerPreset: (id) => fetch(`/api/trainer/presets/${id}`, { method: "DELETE" }).then(j),
   version: () => fetch("/api/version").then(j),
   settings: () => fetch("/api/settings").then(j),
   putSettings: (values) =>

--- a/web/src/lib/trainer/ChordFlashCards.svelte
+++ b/web/src/lib/trainer/ChordFlashCards.svelte
@@ -49,6 +49,7 @@
   } from "./chords.js";
   import { KEY_QUALITY_LIST } from "./constraints.js";
   import Neck from "./Neck.svelte";
+  import ScopePresets from "./ScopePresets.svelte";
   import { DEFAULT_FRET_COUNT, fretCountFromInstrument, noteAt, stringsFromInstrument } from "./neck.js";
 
   const instruments = getInstruments();
@@ -94,8 +95,41 @@
     endFret = fretCount;
   });
 
+  // Which saved scope is in force, or null (issue #236). Cleared by every
+  // hand-turned scope control below: once somebody moves a fret selector the
+  // scope is no longer the one that preset describes, and a session logged
+  // under it must not claim otherwise. Identical to FretToNote.svelte's, on
+  // purpose - the picker is one shared component, and so is the rule for
+  // when a selection stops being true.
+  let selectedPresetId = $state(null);
+
+  function handTurned() {
+    selectedPresetId = null;
+  }
+
+  /** Adopt a saved scope: its strings, its fret range and its key, all at
+   * once. Marks each dimension customized so the "follow the instrument's
+   * own defaults" effects above stop overwriting what was just restored.
+   * The chord FAMILY is deliberately untouched - a preset is the shared
+   * string/fret/key scope, not this drill's own idea of what to ask about. */
+  function applyPreset(restored, id) {
+    selectedPresetId = id;
+    if (!restored) return;
+    customizedStrings = true;
+    customizedFretRange = true;
+    selectedStrings = [...restored.stringNumbers];
+    startFret = restored.startFret;
+    endFret = restored.endFret;
+    keyEnabled = Boolean(restored.key);
+    if (restored.key) {
+      keyRoot = restored.key.root;
+      keyQuality = restored.key.quality;
+    }
+  }
+
   function toggleString(number) {
     customizedStrings = true;
+    handTurned();
     if (selectedStrings.includes(number)) {
       if (selectedStrings.length <= 1) return;
       selectedStrings = selectedStrings.filter((n) => n !== number);
@@ -106,11 +140,13 @@
 
   function setStartFret(value) {
     customizedFretRange = true;
+    handTurned();
     startFret = Number(value);
   }
 
   function setEndFret(value) {
     customizedFretRange = true;
+    handTurned();
     endFret = Number(value);
   }
 
@@ -121,6 +157,21 @@
   let keyEnabled = $state(false);
   let keyRoot = $state("C");
   let keyQuality = $state("major");
+
+  function setKeyEnabled(value) {
+    handTurned();
+    keyEnabled = value;
+  }
+
+  function setKeyRoot(value) {
+    handTurned();
+    keyRoot = value;
+  }
+
+  function setKeyQuality(value) {
+    handTurned();
+    keyQuality = value;
+  }
 
   const scope = $derived({
     startFret,
@@ -153,8 +204,27 @@
     return Math.max(1, Math.round((Date.now() - startedAt) / 1000));
   }
 
-  function drillNote() {
-    return sessionNote({ asked, correct: correctCount, direction, strings, scope, family });
+  /** What the session carries about the scope it ran on - the same rule
+   * FretToNote.svelte's own sessionFields states, and see chords.js's
+   * sessionNote for why the chord family stays in the sentence even when the
+   * region does not. */
+  function sessionFields() {
+    if (selectedPresetId != null) {
+      return {
+        preset_id: selectedPresetId,
+        note: sessionNote({
+          asked,
+          correct: correctCount,
+          direction,
+          strings,
+          scope: null,
+          family,
+        }),
+      };
+    }
+    return {
+      note: sessionNote({ asked, correct: correctCount, direction, strings, scope, family }),
+    };
   }
 
   function nextQuestion() {
@@ -273,7 +343,7 @@
         activity: "chords",
         seconds,
         local_date: localDay(),
-        note: drillNote(),
+        ...sessionFields(),
       });
       logged = { seconds: session?.seconds ?? seconds, id: session?.id ?? null };
       unlogged = null;
@@ -297,7 +367,7 @@
         activity: "chords",
         seconds: elapsed(),
         local_date: localDay(),
-        note: drillNote(),
+        ...sessionFields(),
       })
       .catch(() => {});
   });
@@ -323,6 +393,11 @@
       data-given-correct={round?.given != null ? (round.correct ? "1" : "0") : ""}
       data-tapped-count={tapped.length}
       data-attempt-log-failures={attemptLogFailures}
+      data-start-fret={startFret}
+      data-end-fret={endFret}
+      data-strings={[...selectedStrings].sort((a, b) => a - b).join(",")}
+      data-key={keyEnabled ? `${keyRoot} ${keyQuality}` : ""}
+      data-preset={selectedPresetId ?? ""}
     >
       <p class="hint">
         Shown a shape, name the chord - or name a chord, tap its notes onto the neck. Both
@@ -415,20 +490,44 @@
 
       <div class="row key-row">
         <label class="key-toggle">
-          <input type="checkbox" bind:checked={keyEnabled} disabled={running} class="key-enabled" />
+          <input
+            type="checkbox"
+            checked={keyEnabled}
+            disabled={running}
+            class="key-enabled"
+            onchange={(e) => setKeyEnabled(e.currentTarget.checked)}
+          />
           <span>Key</span>
         </label>
-        <select class="key-root" bind:value={keyRoot} disabled={running || !keyEnabled}>
+        <select
+          class="key-root"
+          value={keyRoot}
+          disabled={running || !keyEnabled}
+          onchange={(e) => setKeyRoot(e.currentTarget.value)}
+        >
           {#each ROOTS as root (root)}
             <option value={root}>{root}</option>
           {/each}
         </select>
-        <select class="key-quality" bind:value={keyQuality} disabled={running || !keyEnabled}>
+        <select
+          class="key-quality"
+          value={keyQuality}
+          disabled={running || !keyEnabled}
+          onchange={(e) => setKeyQuality(e.currentTarget.value)}
+        >
           {#each KEY_QUALITY_LIST as quality (quality)}
             <option value={quality}>{quality}</option>
           {/each}
         </select>
       </div>
+
+      <ScopePresets
+        {strings}
+        {scope}
+        selectedId={selectedPresetId}
+        disabled={running}
+        onSelect={applyPreset}
+      />
 
       {#if instruments.error}
         <p class="notice instruments-error">

--- a/web/src/lib/trainer/FretToNote.svelte
+++ b/web/src/lib/trainer/FretToNote.svelte
@@ -17,14 +17,21 @@
   //   Every question is a structured row (POST /api/trainer/attempts), not
   //   only a count folded into the session's note - issue #32's promise for
   //   this drill. The session logged at the end still carries a human-
-  //   readable summary in its own `note`, the same as every other activity.
+  //   readable summary in its own `note`, the same as every other activity -
+  //   EXCEPT when the scope it ran on is a saved one, in which case the
+  //   session carries that preset's id instead and the sentence is not
+  //   written at all (issue #236). Which scope was practised is then a row
+  //   to join on rather than prose to parse; see docs/practice-data.md.
   import { onDestroy } from "svelte";
 
   import { api } from "../api.js";
   import { getInstruments, loadInstruments } from "../instruments.svelte.js";
   import { localDay } from "../practice.js";
+  import { ROOTS } from "./chord-theory.js";
+  import { KEY_QUALITY_LIST } from "./constraints.js";
   import Neck from "./Neck.svelte";
   import PositionCounts from "./PositionCounts.svelte";
+  import ScopePresets from "./ScopePresets.svelte";
   import {
     DEFAULT_FRET_COUNT,
     PITCH_CLASSES,
@@ -93,8 +100,48 @@
     endFret = fretCount;
   });
 
+  // Key scope: ported from ChordFlashCards.svelte for issue #236, unchanged
+  // in behaviour - off by default (every note in play), a real constraint
+  // only once a person turns it on. It was always part of the shared
+  // constraint model (constraints.js's noteInScope, #26); this drill simply
+  // had no control for it, which meant a scope saved here could not carry a
+  // key and the same preset would have meant two different things in the two
+  // drills.
+  let keyEnabled = $state(false);
+  let keyRoot = $state("C");
+  let keyQuality = $state("major");
+
+  // Which saved scope is in force, or null. Cleared by every hand-turned
+  // scope control below (see `handTurned`): once somebody moves a fret
+  // selector the scope is no longer the one that preset describes, and a
+  // session logged under it must not claim otherwise.
+  let selectedPresetId = $state(null);
+
+  function handTurned() {
+    selectedPresetId = null;
+  }
+
+  /** Adopt a saved scope: its strings, its fret range and its key, all at
+   * once. Marks each dimension customized so the "follow the instrument's
+   * own defaults" effects above stop overwriting what was just restored. */
+  function applyPreset(restored, id) {
+    selectedPresetId = id;
+    if (!restored) return;
+    customizedStrings = true;
+    customizedFretRange = true;
+    selectedStrings = [...restored.stringNumbers];
+    startFret = restored.startFret;
+    endFret = restored.endFret;
+    keyEnabled = Boolean(restored.key);
+    if (restored.key) {
+      keyRoot = restored.key.root;
+      keyQuality = restored.key.quality;
+    }
+  }
+
   function toggleString(number) {
     customizedStrings = true;
+    handTurned();
     if (selectedStrings.includes(number)) {
       // At least one string must stay selected - an empty list does not mean
       // "nothing asked", it means "no filter at all" (see fret-to-note.js's
@@ -110,15 +157,37 @@
 
   function setStartFret(value) {
     customizedFretRange = true;
+    handTurned();
     startFret = Number(value);
   }
 
   function setEndFret(value) {
     customizedFretRange = true;
+    handTurned();
     endFret = Number(value);
   }
 
-  const scope = $derived({ startFret, endFret, stringNumbers: selectedStrings });
+  function setKeyEnabled(value) {
+    handTurned();
+    keyEnabled = value;
+  }
+
+  function setKeyRoot(value) {
+    handTurned();
+    keyRoot = value;
+  }
+
+  function setKeyQuality(value) {
+    handTurned();
+    keyQuality = value;
+  }
+
+  const scope = $derived({
+    startFret,
+    endFret,
+    stringNumbers: selectedStrings,
+    key: keyEnabled ? { root: keyRoot, quality: keyQuality } : undefined,
+  });
   const askable = $derived(scopeIsAskable(strings, scope));
 
   let running = $state(false);
@@ -146,8 +215,28 @@
     return Math.max(1, Math.round((Date.now() - startedAt) / 1000));
   }
 
-  function drillNote() {
-    return sessionNote({ asked, correct: correctCount, direction, strings, scope });
+  /** What the session carries about the scope it ran on.
+   *
+   * A drill on a SAVED scope sends `preset_id` and no scope sentence at all
+   * (issue #236): the row says which named scope it was, and a reader asking
+   * "how much time went into this scope" joins that column instead of
+   * parsing English out of `note`. The counts still go in the note, because
+   * they are about how the session went rather than about what it was
+   * scoped to.
+   *
+   * A drill on an unnamed scope is unchanged - the sentence is all there is,
+   * and dropping it would lose the one trace such a session has. Sessions
+   * already stored keep whatever they were written with; #236 lists
+   * migrating them as a rabbit hole and does not.
+   */
+  function sessionFields() {
+    if (selectedPresetId != null) {
+      return {
+        preset_id: selectedPresetId,
+        note: sessionNote({ asked, correct: correctCount, direction, strings, scope: null }),
+      };
+    }
+    return { note: sessionNote({ asked, correct: correctCount, direction, strings, scope }) };
   }
 
   function nextQuestion() {
@@ -251,7 +340,7 @@
         activity: "fretboard",
         seconds,
         local_date: localDay(),
-        note: drillNote(),
+        ...sessionFields(),
       });
       logged = { seconds: session?.seconds ?? seconds, id: session?.id ?? null };
       unlogged = null;
@@ -278,7 +367,7 @@
         activity: "fretboard",
         seconds: elapsed(),
         local_date: localDay(),
-        note: drillNote(),
+        ...sessionFields(),
       })
       .catch(() => {});
   });
@@ -303,6 +392,11 @@
       data-question-fret={round?.question?.fret ?? ""}
       data-given-note={round?.given?.note ?? ""}
       data-attempt-log-failures={attemptLogFailures}
+      data-start-fret={startFret}
+      data-end-fret={endFret}
+      data-strings={[...selectedStrings].sort((a, b) => a - b).join(",")}
+      data-key={keyEnabled ? `${keyRoot} ${keyQuality}` : ""}
+      data-preset={selectedPresetId ?? ""}
     >
       <p class="hint">
         Shown a position, name its note - or shown a note, tap where it lives on the neck. Both
@@ -379,6 +473,47 @@
         {/each}
       </div>
 
+      <div class="row key-row">
+        <label class="key-toggle">
+          <input
+            type="checkbox"
+            checked={keyEnabled}
+            disabled={running}
+            class="key-enabled"
+            onchange={(e) => setKeyEnabled(e.currentTarget.checked)}
+          />
+          <span>Key</span>
+        </label>
+        <select
+          class="key-root"
+          value={keyRoot}
+          disabled={running || !keyEnabled}
+          onchange={(e) => setKeyRoot(e.currentTarget.value)}
+        >
+          {#each ROOTS as root (root)}
+            <option value={root}>{root}</option>
+          {/each}
+        </select>
+        <select
+          class="key-quality"
+          value={keyQuality}
+          disabled={running || !keyEnabled}
+          onchange={(e) => setKeyQuality(e.currentTarget.value)}
+        >
+          {#each KEY_QUALITY_LIST as quality (quality)}
+            <option value={quality}>{quality}</option>
+          {/each}
+        </select>
+      </div>
+
+      <ScopePresets
+        {strings}
+        {scope}
+        selectedId={selectedPresetId}
+        disabled={running}
+        onSelect={applyPreset}
+      />
+
       {#if instruments.error}
         <p class="notice instruments-error">
           {instruments.error} The drill below uses the standard guitar instead.
@@ -387,7 +522,7 @@
 
       {#if !askable}
         <p class="statement narrow-scope">
-          Nothing is selected to ask about - choose at least one fret in range.
+          Nothing is selected to ask about - widen the fret range, the strings, or the key.
         </p>
       {/if}
 
@@ -450,7 +585,7 @@
         </div>
       {:else if running && !round}
         <p class="statement narrow-scope">
-          Nothing is selected to ask about - choose at least one fret in range.
+          Nothing is selected to ask about - widen the fret range, the strings, or the key.
         </p>
         <div class="row controls">
           <button class="ghost stop-drill" onclick={stopAndLog} disabled={logging}>
@@ -559,7 +694,8 @@
     flex-wrap: wrap;
   }
 
-  .scope-row label {
+  .scope-row label,
+  .key-row .key-toggle {
     display: flex;
     align-items: center;
     gap: 8px;
@@ -574,6 +710,10 @@
     padding: 5px 8px;
     font: inherit;
     font-size: 14px;
+  }
+
+  .key-quality {
+    text-transform: capitalize;
   }
 
   /* Big touch targets throughout - this app's tablet-at-a-music-stand rule

--- a/web/src/lib/trainer/ScopePresets.svelte
+++ b/web/src/lib/trainer/ScopePresets.svelte
@@ -1,0 +1,283 @@
+<script>
+  // Named drill scopes (issue #236) - the picker BOTH drills use.
+  //
+  // A scope (which strings, which fret range, which key) used to live in
+  // whichever component held it and reset on every page load, leaving behind
+  // nothing but an English sentence in the practice session's own `note`.
+  // This is the control that saves one as a row instead
+  // (POST /api/trainer/presets) and picks it up again - in this drill, or in
+  // the other one, because the presets table has no `drill` column by
+  // design. See server/fermata/db.py's note on trainer_scope_presets.
+  //
+  // ONE COMPONENT, USED TWICE, not a shape each drill re-implements. That is
+  // the whole reason the scope arithmetic was factored into constraints.js in
+  // the first place (see its module comment), and the same rule applies to
+  // the interface over it: a second copy of "save this, pick that" is a
+  // second copy free to drift.
+  //
+  // TONE, the same rule practice.js's vocabulary list states: nothing here
+  // grades or nudges. A saved scope is a thing a person chose to keep, so the
+  // words are about choosing and keeping - never about how much of the neck
+  // somebody is or is not covering.
+  import { api } from "../api.js";
+  import { presetFromScope, scopeFromPreset } from "./constraints.js";
+
+  let {
+    // The instrument's own strings, so an unfiltered string set can be
+    // spelled out by name when it is saved - see presetFromScope.
+    strings = [],
+    // The scope as it stands right now, which is what Save stores.
+    scope = {},
+    // The id of the preset currently in force, or null. Held by the parent
+    // (it is the parent that knows when a hand-turned control has taken the
+    // scope somewhere the preset no longer describes) and passed back down.
+    selectedId = null,
+    // Nothing here may be touched mid-drill, the same rule every other scope
+    // control in both drills follows.
+    disabled = false,
+    onSelect = () => {},
+  } = $props();
+
+  let presets = $state([]);
+  let loaded = $state(false);
+  let name = $state("");
+  let saving = $state(false);
+  let problem = $state("");
+
+  async function load() {
+    try {
+      presets = await api.trainerPresets();
+      problem = "";
+    } catch (e) {
+      problem = e?.message || "Saved scopes could not be loaded.";
+    } finally {
+      loaded = true;
+    }
+  }
+
+  $effect(() => {
+    load();
+  });
+
+  async function save() {
+    const typed = name.trim();
+    if (!typed || saving || disabled) return;
+    saving = true;
+    problem = "";
+    try {
+      const saved = await api.createTrainerPreset(presetFromScope(typed, strings, scope));
+      presets = [saved, ...presets];
+      name = "";
+      // Saving is also choosing: the scope that was stored is the scope the
+      // drill is on, so the new entry is the selected one immediately rather
+      // than needing a second tap to become true.
+      onSelect(scopeFromPreset(saved), saved.id);
+    } catch (e) {
+      problem = e?.message || "That scope could not be saved.";
+    } finally {
+      saving = false;
+    }
+  }
+
+  function choose(preset) {
+    if (disabled) return;
+    onSelect(scopeFromPreset(preset), preset.id);
+  }
+
+  async function remove(preset) {
+    if (disabled) return;
+    problem = "";
+    try {
+      await api.deleteTrainerPreset(preset.id);
+      presets = presets.filter((p) => p.id !== preset.id);
+      if (selectedId === preset.id) onSelect(null, null);
+    } catch (e) {
+      problem = e?.message || "That scope could not be removed.";
+    }
+  }
+
+  /** What a saved scope covers, said plainly: the strings it names (all of
+   * them is not stated - it is the ordinary case), its fret range, and its
+   * key when it has one. Deliberately NOT scopeLabel from constraints.js:
+   * that one takes a live instrument's string list to decide what "every
+   * string" is, and a preset is shared across instruments by design. */
+  function presetLabel(preset) {
+    const parts = [];
+    const named = preset.strings ?? [];
+    if (named.length && named.length !== (strings ?? []).length) {
+      parts.push(`string${named.length === 1 ? "" : "s"} ${named.join(", ")}`);
+    }
+    parts.push(`frets ${preset.start_fret}-${preset.end_fret}`);
+    if (preset.key_root) {
+      parts.push(`key of ${preset.key_root} ${preset.key_quality ?? "major"}`);
+    }
+    return parts.join(", ");
+  }
+</script>
+
+<div class="presets" data-preset-count={presets.length} data-selected-preset={selectedId ?? ""}>
+  <div class="row save-row">
+    <label>
+      <span>Save this scope as</span>
+      <input
+        class="preset-name"
+        type="text"
+        bind:value={name}
+        {disabled}
+        placeholder="A name for it"
+      />
+    </label>
+    <button class="save-preset" onclick={save} disabled={disabled || saving || !name.trim()}>
+      {saving ? "Saving…" : "Save"}
+    </button>
+  </div>
+
+  {#if loaded && presets.length}
+    <ul class="preset-list">
+      {#each presets as preset (preset.id)}
+        <li class="preset" data-preset-id={preset.id}>
+          <button
+            class="preset-choice"
+            class:active={selectedId === preset.id}
+            data-preset-name={preset.name}
+            {disabled}
+            onclick={() => choose(preset)}
+          >
+            <span class="preset-title">{preset.name}</span>
+            <span class="preset-scope">{presetLabel(preset)}</span>
+          </button>
+          <button
+            class="delete-preset"
+            {disabled}
+            aria-label={`Remove ${preset.name}`}
+            onclick={() => remove(preset)}
+          >
+            Remove
+          </button>
+        </li>
+      {/each}
+    </ul>
+  {:else if loaded}
+    <p class="quiet no-presets">
+      No scope has been saved yet. Set the strings, the frets and the key you want, give it a
+      name, and it will be here in this drill and in the other one.
+    </p>
+  {/if}
+
+  {#if problem}
+    <p class="notice preset-problem">{problem}</p>
+  {/if}
+</div>
+
+<style>
+  .presets {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+
+  .row {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    flex-wrap: wrap;
+  }
+
+  .save-row label {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 14px;
+  }
+
+  input[type="text"] {
+    background: var(--surface);
+    color: var(--ink);
+    border: 1px solid var(--line);
+    border-radius: 6px;
+    padding: 8px 10px;
+    font: inherit;
+    font-size: 14px;
+    min-height: 44px;
+    min-width: 12ch;
+  }
+
+  .preset-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .preset {
+    display: flex;
+    align-items: stretch;
+    gap: 8px;
+  }
+
+  /* Big touch targets throughout - this app's tablet-at-a-music-stand rule
+     (issue #25/#119): every tappable control here is at least 44px tall. */
+  button {
+    min-height: 44px;
+    background: var(--surface);
+    color: var(--ink);
+    border: 1px solid var(--line);
+    border-radius: 6px;
+    padding: 8px 14px;
+    font: inherit;
+    font-size: 14px;
+    cursor: pointer;
+  }
+
+  button:hover:enabled {
+    border-color: var(--brass);
+  }
+
+  button:disabled {
+    opacity: 0.55;
+    cursor: default;
+  }
+
+  .preset-choice {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 2px;
+    text-align: left;
+  }
+
+  .preset-choice.active {
+    border-color: var(--brass);
+    color: var(--brass-bright);
+  }
+
+  .preset-title {
+    font-size: 15px;
+  }
+
+  .preset-scope {
+    font-size: 13px;
+    color: var(--ink-dim);
+    font-variant-numeric: tabular-nums;
+  }
+
+  .quiet {
+    margin: 0;
+    color: var(--ink-dim);
+    font-size: 13px;
+    line-height: 1.5;
+  }
+
+  .notice {
+    margin: 0;
+    font-size: 14px;
+    color: var(--ink);
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: 6px;
+    padding: 8px 12px;
+  }
+</style>

--- a/web/src/lib/trainer/chords.js
+++ b/web/src/lib/trainer/chords.js
@@ -258,13 +258,22 @@ export function progressStatement({ asked = 0, correct = 0 } = {}) {
 
 /** What goes in the practice session's free-text `note` - a human-readable
  * summary beside the structured per-question rows this drill also writes
- * (see attemptPayload and the module docstring on why both exist). */
+ * (see attemptPayload and the module docstring on why both exist).
+ *
+ * `scope: null` DROPS THE REGION SENTENCE, and is how a session that carries
+ * a preset id asks for its note (issue #236) - the strings, frets and key it
+ * ran on are then in practice_sessions.preset_id, joined to the named scope,
+ * rather than repeated here as prose. THE CHORD FAMILY STAYS, because a
+ * preset does not carry one: a family is what this drill asks ABOUT, not
+ * what a shared scope narrows, so dropping it would lose a fact nothing else
+ * records. The counts stay too, for the same reason fret-to-note.js's own
+ * sessionNote keeps them.
+ *
+ * An unnamed scope still gets the whole sentence, unchanged. */
 export function sessionNote({ asked = 0, correct = 0, direction, strings, scope, family } = {}) {
-  return `Chord flash cards, ${directionLabel(direction)}. ${progressStatement({ asked, correct })} ${scopeLabel(
-    strings,
-    scope,
-    family,
-  )}.`;
+  const summary = `Chord flash cards, ${directionLabel(direction)}. ${progressStatement({ asked, correct })}`;
+  if (scope === null) return `${summary} ${familyLabel(family)}.`;
+  return `${summary} ${scopeLabel(strings, scope, family)}.`;
 }
 
 /** What was logged, said back once the drill has stopped. */

--- a/web/src/lib/trainer/constraints.js
+++ b/web/src/lib/trainer/constraints.js
@@ -129,3 +129,58 @@ export function scopeLabel(strings, scope = {}) {
   }
   return parts.join(", ");
 }
+
+// --------------------------------------------------------------------------
+// Named scopes (issue #236): the same scope object, as a row.
+//
+// A scope used to live only here, in whichever component happened to hold it,
+// and vanished on reload - the drill it narrowed left behind nothing but a
+// sentence in the practice session's own `note`. GET/POST /api/trainer/presets
+// stores it instead (server/fermata/db.py's trainer_scope_presets), and these
+// two functions are the whole translation between the two shapes. Kept HERE
+// rather than in either drill for the same reason everything else in this
+// module is: two drills need it, and a second copy of a mapping is a second
+// copy free to drift.
+//
+// THE ONE PLACE THE TWO SHAPES REALLY DIFFER is the string set. In a scope, an
+// empty or missing stringNumbers means "no filter at all" (see stringInScope);
+// in a stored preset it cannot, because a row with no strings would be
+// indistinguishable from one whose strings failed to write. So presetFromScope
+// spells "every string" out by naming every string the current instrument has,
+// which is why it takes `strings` at all.
+// --------------------------------------------------------------------------
+
+/** A scope, as the body POST /api/trainer/presets wants. `strings` is the
+ * instrument's own string list, used to spell out an unfiltered string set;
+ * `name` is what the person typed. */
+export function presetFromScope(name, strings, scope = {}) {
+  const all = (strings ?? []).map((s) => s.number);
+  const selected = Array.isArray(scope.stringNumbers) && scope.stringNumbers.length
+    ? [...new Set(scope.stringNumbers)]
+    : all;
+  return {
+    name,
+    start_fret: Math.max(0, Number(scope.startFret ?? 0)),
+    end_fret: Number(scope.endFret ?? DEFAULT_FRET_COUNT),
+    strings: selected.sort((a, b) => a - b),
+    key_root: scope.key?.root ?? null,
+    key_quality: scope.key ? (scope.key.quality ?? "major") : null,
+  };
+}
+
+/** A stored preset row, as a scope the drills already understand. A row with
+ * no key_root yields a scope with no `key` at all - not `key: null`, which
+ * noteInScope would read the same way but which would make a saved
+ * every-note scope look like a different kind of object from a fresh one. */
+export function scopeFromPreset(preset) {
+  if (!preset) return null;
+  const scope = {
+    startFret: Number(preset.start_fret ?? 0),
+    endFret: Number(preset.end_fret ?? DEFAULT_FRET_COUNT),
+    stringNumbers: [...(preset.strings ?? [])].sort((a, b) => a - b),
+  };
+  if (preset.key_root) {
+    scope.key = { root: preset.key_root, quality: preset.key_quality ?? "major" };
+  }
+  return scope;
+}

--- a/web/src/lib/trainer/fret-to-note.js
+++ b/web/src/lib/trainer/fret-to-note.js
@@ -144,12 +144,22 @@ export function progressStatement({ asked = 0, correct = 0 } = {}) {
 
 /** What goes in the practice session's free-text `note` - a human-readable
  * summary beside the structured per-question rows this drill also writes
- * (see attemptPayload and the module docstring on why both exist). */
+ * (see attemptPayload and the module docstring on why both exist).
+ *
+ * `scope: null` DROPS THE SCOPE SENTENCE, and is how a session that carries
+ * a preset id asks for its note (issue #236). What was practised is then in
+ * a column - practice_sessions.preset_id, joined to the named scope - and
+ * repeating it here as prose would put the same fact in two places, one of
+ * them the free text docs/practice-data.md's rule for this data layer exists
+ * to keep facts out of. The counts stay either way: they are about how the
+ * session went, not about what it was scoped to.
+ *
+ * An unnamed scope still gets the sentence, unchanged, because for that
+ * session it is the only trace of what was narrowed. */
 export function sessionNote({ asked = 0, correct = 0, direction, strings, scope } = {}) {
-  return `Fret to note, ${directionLabel(direction)}. ${progressStatement({ asked, correct })} ${scopeLabel(
-    strings,
-    scope,
-  )}.`;
+  const summary = `Fret to note, ${directionLabel(direction)}. ${progressStatement({ asked, correct })}`;
+  if (scope === null) return summary;
+  return `${summary} ${scopeLabel(strings, scope)}.`;
 }
 
 /** What was logged, said back once the drill has stopped. */

--- a/web/tests/browser/scope-presets.spec.js
+++ b/web/tests/browser/scope-presets.spec.js
@@ -1,0 +1,288 @@
+// Named drill scopes (issue #236), against the real backend and the real
+// build - the shared picker, both drills, and the practice row a drill run on
+// a saved scope now writes.
+//
+// WHAT THESE READ AS GROUND TRUTH. The scope a drill is actually on is read
+// off the section's own data-start-fret / data-end-fret / data-strings /
+// data-key attributes, which the component sets from the state it really
+// narrows questions with - never off the controls, which would only prove
+// that a click moved a widget. And "the session carries the preset" is read
+// back through the API rather than off the page, because the claim is about
+// what was STORED: a component that shows the right id and posts nothing
+// would pass any assertion made on the screen.
+//
+// The two drills are separate components with separate state, so "saved in
+// one, offered in the other" is a real crossing rather than a re-render.
+import { expect, test } from "@playwright/test";
+
+import { forbiddenWord, localDay } from "../../src/lib/practice.js";
+
+const drill = (page) => page.locator("section.drill");
+const presets = (page) => page.locator(".presets");
+const presetName = (page) => page.locator(".preset-name");
+const savePreset = (page) => page.locator(".save-preset");
+
+const today = localDay();
+
+async function reset(request) {
+  const existing = await (await request.get("/api/instruments")).json();
+  for (const instrument of existing) await request.delete(`/api/instruments/${instrument.id}`);
+  const goals = (await (await request.get(`/api/practice/goals?today=${today}`)).json()).goals;
+  for (const goal of goals) await request.delete(`/api/practice/goals/${goal.id}`);
+  const sessions = (
+    await (await request.get("/api/practice/sessions?limit=1000")).json()
+  ).sessions;
+  for (const session of sessions) await request.delete(`/api/practice/sessions/${session.id}`);
+  // Presets last: a session referencing one is deleted above, so nothing here
+  // depends on the ON DELETE SET NULL that the deletion test exercises.
+  for (const preset of await (await request.get("/api/trainer/presets")).json()) {
+    await request.delete(`/api/trainer/presets/${preset.id}`);
+  }
+}
+
+test.beforeEach(async ({ page, request }) => {
+  const scores = await (await request.get("/api/scores")).json();
+  expect(
+    scores,
+    "refusing to run: this backend has scores in its library, so it is not the " +
+      "throwaway instance the suite creates - and these tests delete practice history",
+  ).toEqual([]);
+  await reset(request);
+});
+
+/** Narrow the drill on screen by hand: a fret range, a string set, and a key.
+ * Every control here is one a person uses; nothing is written into component
+ * state from the test. */
+async function narrowScope(page, { startFret, endFret, keepStrings, keyRoot, keyQuality }) {
+  await page.locator(".scope-start-fret").selectOption(String(startFret));
+  await page.locator(".scope-end-fret").selectOption(String(endFret));
+  const buttons = page.locator(".string-choice");
+  const count = await buttons.count();
+  for (let i = 0; i < count; i += 1) {
+    const button = buttons.nth(i);
+    const number = Number(await button.textContent());
+    const selected = (await button.getAttribute("class")).includes("active");
+    if (selected && !keepStrings.includes(number)) await button.click();
+  }
+  await page.locator(".key-enabled").check();
+  await page.locator(".key-root").selectOption(keyRoot);
+  await page.locator(".key-quality").selectOption(keyQuality);
+}
+
+/** Save the scope on screen under a name, and wait for the save to land -
+ * the id the drill then reports is the one the server actually assigned,
+ * which is what every assertion downstream is about. */
+async function saveScopeAs(page, name) {
+  const before = Number(await presets(page).getAttribute("data-preset-count"));
+  await presetName(page).fill(name);
+  await savePreset(page).click();
+  await expect(presets(page)).toHaveAttribute("data-preset-count", String(before + 1));
+  await expect(drill(page)).not.toHaveAttribute("data-preset", "");
+  return Number(await drill(page).getAttribute("data-preset"));
+}
+
+const NARROW = {
+  startFret: 5,
+  endFret: 9,
+  keepStrings: [1, 2],
+  keyRoot: "G",
+  keyQuality: "major",
+};
+
+async function expectScopeOnScreen(page, scope) {
+  await expect(drill(page)).toHaveAttribute("data-start-fret", String(scope.startFret));
+  await expect(drill(page)).toHaveAttribute("data-end-fret", String(scope.endFret));
+  await expect(drill(page)).toHaveAttribute(
+    "data-strings",
+    [...scope.keepStrings].sort((a, b) => a - b).join(","),
+  );
+  await expect(drill(page)).toHaveAttribute(
+    "data-key",
+    `${scope.keyRoot} ${scope.keyQuality}`,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Saved here, offered there.
+// ---------------------------------------------------------------------------
+
+test("a scope saved in one drill is offered in the other, and picking it restores the strings, the fret range and the key", async ({
+  page,
+}) => {
+  await page.goto("/#/fretboard");
+  await expect(drill(page)).toBeVisible();
+  await narrowScope(page, NARROW);
+  await expectScopeOnScreen(page, NARROW);
+
+  await saveScopeAs(page, "Top two, fifth position");
+  await expect(presets(page)).toHaveAttribute("data-preset-count", "1");
+  // Saving is also choosing - the scope stored is the scope the drill is on.
+  await expect(page.locator(".preset-choice")).toHaveClass(/active/);
+
+  // The OTHER drill. A separate component with separate state, reached by a
+  // real navigation, so what it shows is what it loaded from the server.
+  await page.goto("/#/chords");
+  await expect(drill(page)).toBeVisible();
+  await expect(presets(page)).toHaveAttribute("data-preset-count", "1");
+  const choice = page.locator('.preset-choice[data-preset-name="Top two, fifth position"]');
+  await expect(choice).toBeVisible();
+
+  // Before picking it, the chord drill is on its own untouched defaults -
+  // which is what makes the assertions after the click mean something.
+  await expect(drill(page)).toHaveAttribute("data-start-fret", "0");
+  await expect(drill(page)).toHaveAttribute("data-key", "");
+
+  await choice.click();
+  await expectScopeOnScreen(page, NARROW);
+  // The controls agree with the state, so a person sees what the drill is on
+  // rather than a stale widget beside a narrowed drill.
+  await expect(page.locator(".key-enabled")).toBeChecked();
+  await expect(page.locator(".key-root")).toHaveValue("G");
+  await expect(page.locator(".scope-start-fret")).toHaveValue("5");
+  await expect(page.locator(".string-choice.active")).toHaveCount(2);
+});
+
+test("turning a scope control by hand stops the drill claiming it is still on the saved scope", async ({
+  page,
+}) => {
+  // The rule a session's preset_id depends on: a preset is in force only
+  // while the scope really is the one it describes.
+  await page.goto("/#/fretboard");
+  await expect(drill(page)).toBeVisible();
+  await narrowScope(page, NARROW);
+  await saveScopeAs(page, "Top two, fifth position");
+
+  await page.locator(".scope-end-fret").selectOption("11");
+  await expect(drill(page)).toHaveAttribute("data-preset", "");
+  await expect(page.locator(".preset-choice.active")).toHaveCount(0);
+});
+
+// ---------------------------------------------------------------------------
+// The practice row.
+// ---------------------------------------------------------------------------
+
+test("practice logged on a saved scope carries its id, and the note stops repeating what the id says", async ({
+  page,
+  request,
+}) => {
+  await page.goto("/#/fretboard");
+  await expect(drill(page)).toBeVisible();
+  await narrowScope(page, NARROW);
+  const presetId = await saveScopeAs(page, "Top two, fifth position");
+  expect(presetId).toBeGreaterThan(0);
+
+  await page.locator(".start-drill").click();
+  const note = await drill(page).getAttribute("data-question-note");
+  await page.locator(`.choice[data-note="${note}"]`).click();
+  await expect(drill(page)).toHaveAttribute("data-asked", "1");
+  await page.locator(".stop-drill").click();
+  await expect(page.locator(".logged")).toBeVisible();
+
+  const { sessions } = await (
+    await request.get("/api/practice/sessions?limit=1000")
+  ).json();
+  expect(sessions.length).toBe(1);
+  const [session] = sessions;
+  expect(session.activity).toBe("fretboard");
+  // The whole point of the bet: what was practised is a column.
+  expect(session.preset_id).toBe(presetId);
+  // And it is not ALSO a sentence. The counts stay - they say how the session
+  // went, not what it was scoped to - but the fret range, the strings and the
+  // key are no longer prose a reader would have to parse.
+  expect(session.note).toContain("1 question");
+  expect(session.note).not.toContain("frets");
+  expect(session.note).not.toContain("key of");
+  expect(forbiddenWord(session.note), session.note).toBeNull();
+});
+
+test("practice on a scope nobody named still says in words what it was narrowed to", async ({
+  page,
+  request,
+}) => {
+  // The other half of the same rule, and the reason the sentence was not
+  // simply deleted: a session with no preset has no other trace of its scope.
+  await page.goto("/#/fretboard");
+  await expect(drill(page)).toBeVisible();
+  await narrowScope(page, NARROW);
+  await expect(drill(page)).toHaveAttribute("data-preset", "");
+
+  await page.locator(".start-drill").click();
+  const note = await drill(page).getAttribute("data-question-note");
+  await page.locator(`.choice[data-note="${note}"]`).click();
+  await page.locator(".stop-drill").click();
+  await expect(page.locator(".logged")).toBeVisible();
+
+  const { sessions } = await (
+    await request.get("/api/practice/sessions?limit=1000")
+  ).json();
+  expect(sessions.length).toBe(1);
+  expect(sessions[0].preset_id).toBeNull();
+  expect(sessions[0].note).toContain("frets 5-9");
+  expect(sessions[0].note).toContain("key of G major");
+});
+
+// ---------------------------------------------------------------------------
+// Removing one.
+// ---------------------------------------------------------------------------
+
+test("removing a saved scope leaves the practice logged under it, without the reference", async ({
+  page,
+  request,
+}) => {
+  await page.goto("/#/fretboard");
+  await expect(drill(page)).toBeVisible();
+  await narrowScope(page, NARROW);
+  const presetId = await saveScopeAs(page, "Top two, fifth position");
+
+  await page.locator(".start-drill").click();
+  const note = await drill(page).getAttribute("data-question-note");
+  await page.locator(`.choice[data-note="${note}"]`).click();
+  await page.locator(".stop-drill").click();
+  await expect(page.locator(".logged")).toBeVisible();
+
+  const before = (await (await request.get("/api/practice/sessions?limit=1000")).json())
+    .sessions[0];
+  expect(before.preset_id).toBe(presetId);
+
+  await page.locator(".delete-preset").click();
+  await expect(presets(page)).toHaveAttribute("data-preset-count", "0");
+  await expect(drill(page)).toHaveAttribute("data-preset", "");
+  expect(await (await request.get("/api/trainer/presets")).json()).toEqual([]);
+
+  // The minutes are still there. Only the reference went.
+  const after = (await (await request.get("/api/practice/sessions?limit=1000")).json())
+    .sessions[0];
+  expect(after.id).toBe(before.id);
+  expect(after.seconds).toBe(before.seconds);
+  expect(after.activity).toBe("fretboard");
+  expect(after.preset_id).toBeNull();
+});
+
+test("a name already in use is refused in words rather than by making a second entry of it", async ({
+  page,
+}) => {
+  await page.goto("/#/fretboard");
+  await expect(drill(page)).toBeVisible();
+  await saveScopeAs(page, "Top two, fifth position");
+  await expect(presets(page)).toHaveAttribute("data-preset-count", "1");
+
+  await presetName(page).fill("Top two, fifth position");
+  await savePreset(page).click();
+  await expect(page.locator(".preset-problem")).toBeVisible();
+  await expect(presets(page)).toHaveAttribute("data-preset-count", "1");
+  const problem = await page.locator(".preset-problem").textContent();
+  expect(forbiddenWord(problem), problem).toBeNull();
+});
+
+test("the picker's own words are held to the practice vocabulary, saved and unsaved alike", async ({
+  page,
+}) => {
+  await page.goto("/#/chords");
+  await expect(drill(page)).toBeVisible();
+  const empty = await presets(page).innerText();
+  expect(forbiddenWord(empty), empty).toBeNull();
+
+  await saveScopeAs(page, "Open position");
+  const filled = await presets(page).innerText();
+  expect(forbiddenWord(filled), filled).toBeNull();
+});

--- a/web/tests/spec-floors/browser-scope-presets-236.json
+++ b/web/tests/spec-floors/browser-scope-presets-236.json
@@ -1,0 +1,5 @@
+{
+  "file": "tests/browser/scope-presets.spec.js",
+  "count": 7,
+  "reason": "issue #236: a scope saved in one drill offered in the other with strings, fret range and key all restored; a hand-turned control dropping the claim that the saved scope is still in force; practice logged on a saved scope carrying its id with the scope sentence gone from the note; practice on an unnamed scope keeping that sentence; removing a scope leaving the practice and clearing only the reference; a duplicate name refused in words; and the picker's own wording held to the practice vocabulary."
+}

--- a/web/tests/spec-floors/unit-constraints-236.json
+++ b/web/tests/spec-floors/unit-constraints-236.json
@@ -1,0 +1,5 @@
+{
+  "file": "tests/unit/constraints.spec.js",
+  "count": 6,
+  "reason": "issue #236: the mapping between a live scope and a stored preset row - a full round trip, the unfiltered string set spelled out rather than left empty, no key stored as two nulls and restored as no key at all, an implicit key quality defaulted before it reaches a column that refuses one, the position pool proved identical either side of the trip, and nothing-is-not-a-preset."
+}

--- a/web/tests/unit/constraints.spec.js
+++ b/web/tests/unit/constraints.spec.js
@@ -13,6 +13,8 @@ import {
   keyNotes,
   noteInScope,
   positionInScope,
+  presetFromScope,
+  scopeFromPreset,
   scopeIsAskable,
   scopeLabel,
   scopePositions,
@@ -143,4 +145,112 @@ test("groupInScope requires every member of the group inside the scope, and a gr
 
 test("an empty group is never in scope - a shape with nothing fretted is not a shape", () => {
   expect(groupInScope([], { startFret: 0, endFret: 12 })).toBe(false);
+});
+
+// ---------------------------------------------------------------- named scopes (#236)
+//
+// The two shapes a scope now has - the live object the drills narrow with,
+// and the row GET/POST /api/trainer/presets stores - and the whole of the
+// translation between them. What these pin is that the round trip is lossless
+// in every dimension a preset carries, and that the ONE place the two shapes
+// genuinely disagree (an unfiltered string set) is resolved on purpose rather
+// than by accident.
+
+test("a scope with every dimension set survives the round trip through a preset row", () => {
+  const scope = {
+    startFret: 5,
+    endFret: 9,
+    stringNumbers: [3, 1, 2],
+    key: { root: "G", quality: "minor" },
+  };
+  const row = presetFromScope("Middle of the neck", strings, scope);
+  expect(row).toEqual({
+    name: "Middle of the neck",
+    start_fret: 5,
+    end_fret: 9,
+    // Sorted on the way out: a set has no order, and a stable one is what
+    // lets two presets be compared without sorting first.
+    strings: [1, 2, 3],
+    key_root: "G",
+    key_quality: "minor",
+  });
+  expect(scopeFromPreset({ ...row, id: 1 })).toEqual({
+    startFret: 5,
+    endFret: 9,
+    stringNumbers: [1, 2, 3],
+    key: { root: "G", quality: "minor" },
+  });
+});
+
+test("an unfiltered string set is stored by naming every string, never as an empty set", () => {
+  // THE ONE REAL DIFFERENCE between the two shapes. In a live scope an empty
+  // or absent stringNumbers means "no filter at all" (stringInScope above); a
+  // stored row cannot use that convention, because a preset with no strings
+  // would be indistinguishable from one whose strings did not write. So the
+  // instrument's own strings are spelled out.
+  const named = presetFromScope("Everything", strings, { startFret: 0, endFret: 12 });
+  expect(named.strings).toEqual([1, 2, 3, 4, 5, 6]);
+  expect(
+    presetFromScope("Everything", strings, { startFret: 0, endFret: 12, stringNumbers: [] })
+      .strings,
+  ).toEqual([1, 2, 3, 4, 5, 6]);
+  // And what comes back still narrows nothing, which is the property that
+  // actually matters: it offers every position the unscoped neck does.
+  const restored = scopeFromPreset(named);
+  expect(scopePositions(strings, restored).length).toBe(
+    scopePositions(strings, { startFret: 0, endFret: 12 }).length,
+  );
+});
+
+test("a scope with no key stores two nulls, and comes back with no key at all", () => {
+  const row = presetFromScope("Open position", strings, { startFret: 0, endFret: 3 });
+  expect(row.key_root).toBeNull();
+  expect(row.key_quality).toBeNull();
+  const restored = scopeFromPreset(row);
+  // Not `key: null` - noteInScope would read that the same way, but a saved
+  // every-note scope would then be a different SHAPE of object from a fresh
+  // one, and something comparing the two would say they differ.
+  expect("key" in restored).toBe(false);
+  expect(noteInScope("C#", restored)).toBe(true);
+});
+
+test("a key whose quality was left implicit is stored as major rather than as nothing", () => {
+  // A live scope may carry a key with no quality - constraints.js defaults it
+  // to major everywhere it reads one. A ROW may not: key_root without
+  // key_quality is refused by the server, so the default is applied here,
+  // once, rather than left to be rejected on the way out.
+  const row = presetFromScope("Key of D", strings, {
+    startFret: 0,
+    endFret: 12,
+    key: { root: "D" },
+  });
+  expect(row.key_quality).toBe("major");
+  expect(scopeFromPreset(row).key).toEqual({ root: "D", quality: "major" });
+});
+
+test("a restored preset narrows the position pool exactly as the scope it was saved from did", () => {
+  // The claim the whole feature rests on, stated as an equality: what a
+  // person practises after picking a saved scope is what they were
+  // practising when they saved it.
+  const scope = {
+    startFret: 5,
+    endFret: 7,
+    stringNumbers: [6, 5],
+    key: { root: "A", quality: "minor" },
+  };
+  const before = scopePositions(strings, scope);
+  const after = scopePositions(
+    strings,
+    scopeFromPreset(presetFromScope("A minor box", strings, scope)),
+  );
+  expect(after.length).toBe(before.length);
+  expect(before.length).toBeGreaterThan(0);
+  expect(after.map((p) => `${p.string}:${p.fret}`).sort()).toEqual(
+    before.map((p) => `${p.string}:${p.fret}`).sort(),
+  );
+});
+
+test("nothing at all is not a preset - scopeFromPreset says so rather than inventing a scope", () => {
+  expect(scopeFromPreset(null)).toBeNull();
+  expect(scopeFromPreset(undefined)).toBeNull();
 });

--- a/web/tests/unit/practice.spec.js
+++ b/web/tests/unit/practice.spec.js
@@ -197,6 +197,11 @@ const COMPONENTS = [
   // counts about where a player keeps answering incorrectly is exactly the
   // kind of surface a verdict word slips into.
   "trainer/PositionCounts.svelte",
+  // The named-scope picker both drills use (#236). A list of scopes a person
+  // saved is a list of the things they are working on, which is one short
+  // step from a list of the things they have not covered - so the words on
+  // it are held to the same rule as everything above.
+  "trainer/ScopePresets.svelte",
 ];
 
 // The attributes a person actually reads. Every other attribute value is


### PR DESCRIPTION
## Premise: valid

Re-derived on main at `cc2e75c`, before writing anything:

- **Scope lived only in client state.** `web/src/lib/trainer/constraints.js` was pure arithmetic over a plain object; both drills held that object in their own `$state` (`FretToNote.svelte`, `ChordFlashCards.svelte`), and nothing persisted it. No table, no route, no column.
- **The only persisted trace was the sentence.** `fret-to-note.js:sessionNote()` and `chords.js:sessionNote()` both interpolated `scopeLabel(...)` into the string posted as `practice_sessions.note`. `grep` over `server/` found no other reference to a drill scope anywhere.
- **`FretToNote.svelte` had no key control.** `grep -i key FretToNote.svelte` returned zero hits; `ChordFlashCards.svelte` returned sixteen (`keyEnabled`/`keyRoot`/`keyQuality` at ~:117-129, the `.key-row` markup at ~:416-429). So a scope saved in the fret-to-note drill could not have carried a key, and the same preset would have meant two different things in the two drills.

## Schema

Two new tables, plus one column, all at `SCHEMA_VERSION = 5` — **no bump**, by the rule the setlists note in `db.py` established and which I applied again in a comment there: a pure addition the previous release has no code for, plus a column it never selects and whose `SELECT *` export carries across intact. Bumping would only strand a rollback over data that was never at risk.

```sql
CREATE TABLE trainer_scope_presets (
    id INTEGER PRIMARY KEY AUTOINCREMENT,
    owner TEXT NOT NULL DEFAULT 'local',
    name TEXT NOT NULL,
    start_fret INTEGER NOT NULL, end_fret INTEGER NOT NULL,
    key_root TEXT, key_quality TEXT,
    created_at TEXT NOT NULL DEFAULT (datetime('now'))
);
CREATE UNIQUE INDEX idx_trainer_presets_name ON trainer_scope_presets(owner, name);

CREATE TABLE trainer_scope_preset_strings (
    preset_id INTEGER NOT NULL REFERENCES trainer_scope_presets(id) ON DELETE CASCADE,
    string_number INTEGER NOT NULL,
    PRIMARY KEY (preset_id, string_number)
);

-- via COLUMN_ADDITIONS, and in _PRACTICE_SESSIONS_COLUMNS for a fresh install
practice_sessions.preset_id INTEGER REFERENCES trainer_scope_presets(id) ON DELETE SET NULL
```

**No `drill` column, deliberately** — presets are shared infrastructure, which is the whole bet. **The string set is one row per string**, never JSON: "which strings does this scope allow" has to be a `WHERE` clause. **An empty string set is refused**; "every string" is stored by naming every string, so a saved row can never be confused with one whose strings failed to write (the browser's "empty means no filter" convention cannot survive storage).

`preset_id` carries its foreign key through `COLUMN_ADDITIONS`, which supports that (the mechanism checks the `REFERENCES` really landed) as long as the added column defaults to NULL — and NULL is also what the column means.

## Routes

| Route | Notes |
| --- | --- |
| `GET /api/trainer/presets` | Every named scope, newest first, each with its string set. Classified in `mcp_tools.READ_TOOLS` as `list_trainer_presets`. |
| `POST /api/trainer/presets` | Save one. |
| `DELETE /api/trainer/presets/{id}` | Delete one; `sessions_kept` counts the practice left behind. |

Route count pinned 68 → 71 in `test_api_docs.py`.

**409, not 422, for a duplicate name.** I read `create_setlist` as instructed and it gives no precedent for refusing a duplicate at all — it allows them on purpose ("a name is a label a person chose, not an identity"). So I took the status from what this codebase actually uses for a write refused because of what is already there (`rename_folder`'s "already exists", `delete_score`'s "already in the trash"): 409. The divergence from setlists is argued in `create_trainer_preset`'s docstring — a setlist is a thing you open, a preset is picked in order to change what the next question will be, and two identically named entries in that list make "which scope am I about to practise" unanswerable from the screen.

**Fret and string bounds** are `trainer.py`'s existing `MIN_FRET`/`MAX_FRET` (0-36) and `MIN_STRING_NUMBER`/`MAX_STRING_NUMBER` (1-24) — the bounds any instrument could have, never one live instrument row. That is the rule those constants already state for an attempt, and here it is load-bearing rather than convenient: a preset is shared, so pinning it to whichever instrument happened to be selected when Save was pressed would make half a person's presets refuse to load.

**Exposed as a protocol read tool** rather than recorded in `NOT_EXPOSED`. It is a read, so the no-write-tool no-go holds — and it earns the place: `list_practice_sessions` now hands back `preset_id`, and without this a caller reading that number has no way to resolve it. Tool count prose updated 13 → 14 in `docs/api.md`, `docs/deployment.md` (×2), `mcp_tools.py` and `test_mcp_server.py`.

## Done when

| Item | How it was verified |
| --- | --- |
| A preset saved in one drill appears in the other | `scope-presets.spec.js` "a scope saved in one drill is offered in the other…" — save on `#/fretboard`, real navigation to `#/chords`, the entry is there by name. Two separate components with separate state, so it is a real crossing. |
| Selecting it restores strings, fret range and key | Same test. Asserted off `data-start-fret` / `data-end-fret` / `data-strings` / `data-key` — the state the drill really narrows with — plus the controls agreeing, and only after pinning that the chord drill was on its own untouched defaults first. Mutation (c) proves it. |
| A logged session carries the preset id and the API returns it | `scope-presets.spec.js` "practice logged on a saved scope carries its id…" reads it back through `GET /api/practice/sessions`, not off the page. Server side: `test_a_session_carries_the_scope_it_was_practised_under_and_reads_it_back`. |
| Server tests cover the table, routes, validation and deletion | `test_trainer_presets_schema.py` (9 tests: both tables, the column, the unique index, both ON DELETE actions, the auto-upgrade path, `COLUMN_ADDITIONS` idempotence over three repeat startups, the unchanged stamp) and `test_trainer_presets_api.py` (43 tests: `normalise_preset` directly with each of 16 rejections parametrised, the three routes, 409 on a clash and on a clash-after-cleaning, and the deletion behaviour). |
| A browser spec covers save, reuse across drills and delete | 7 tests, floored in `browser-scope-presets-236.json`. |
| The protocol census classifies the new GET | `test_every_readable_route_is_either_a_tool_or_recorded_as_not_exposed` green with `list_trainer_presets` in `READ_TOOLS`. |
| Key control ported into the fret-to-note drill | Same markup and defaults as the chord drill's, with `bind:` replaced by explicit handlers in both so a hand turn can clear the selected preset. |
| The scope sentence stops being written when a preset id is carried | `sessionNote({scope: null})` in both `fret-to-note.js` and `chords.js` drops the region clause. The chord drill's family clause stays — a preset does not carry a family, so dropping it would lose a fact nothing else records. Existing notes untouched (listed rabbit hole). Both halves asserted: "…the note stops repeating what the id says" and "practice on a scope nobody named still says in words what it was narrowed to". |

## Export / import

`test_export_table_names_matches_every_table_the_schema_creates` went red on adding the tables, as expected, and both are now in `EXPORT_TABLE_NAMES` and in `LEGACY_OPTIONAL_TABLES` — the same reasoning #245/#243 used, spelled out in the comment: an archive taken yesterday cannot carry a table that did not exist, and refusing every backup a person already holds would be strictly worse than restoring with no named scopes. Presets insert **before** `practice_sessions` in `_apply_import` (a session's `preset_id` is repointed at this import's own new preset), the string set follows its preset, and `_read_and_validate_manifest` refuses an archive whose sessions or string rows name a preset it does not carry.

Three tests: the full round trip with a decoy preset and a pre-existing target-side preset so a broken remap lands on the wrong row rather than merely a valid one; a twelve-table legacy archive still importing; and the internal-integrity refusal.

## Mutations

Each applied on top of a commit, browser ones after `npm run build`, reverted and rebuilt after each.

| # | Mutation | Result |
| --- | --- | --- |
| a | `trainer_scope_preset_strings` dumped as `[]` in `_build_export_manifest` | **1 red** — `test_export_import_round_trip_carries_presets_their_strings_and_the_sessions_reference` (1 failed, 1337 passed, 81 skipped) |
| b | `preset_id`'s `REFERENCES … ON DELETE SET NULL` reduced to bare `INTEGER` in both `_PRACTICE_SESSIONS_COLUMNS` and `COLUMN_ADDITIONS` | **4 red** — `test_deleting_a_scope_keeps_the_practice_and_clears_only_the_reference`, `test_the_two_foreign_keys_are_the_actions_the_feature_depends_on`, `test_deleting_a_preset_row_takes_its_strings_and_spares_the_practice`, `test_the_added_column_survives_repeated_startups_unchanged` (4 failed, 1334 passed, 81 skipped) |
| c | `applyPreset` restores frets and key but not strings, in **both** drills | **1 red** — "a scope saved in one drill is offered in the other, and picking it restores the strings, the fret range and the key" (1 failed, 6 passed) |
| d | `No scope has been saved yet` → `Only one scope has been saved so far` in `ScopePresets.svelte` | **1 red** — `practice.spec.js` "the practice interface's own words pass the same vocabulary check" (1 failed, 40 passed) |

## Suite runs

Rebased onto `origin/main` (`00f6059`) first — #247 landed `trainer/PositionCounts.svelte`, which conflicted additively with mine in `practice.spec.js`'s `COMPONENTS` and `FretToNote.svelte`'s import block; both resolved by keeping both sides. #248's export-section rewrite landed cleanly and I extended its two sentences to name presets. Rebuilt, then:

```
1338 passed, 81 skipped, 1 warning in 132.53s (0:02:12)
```
`py -3.13 -m pytest server/tests -rs -q`. `FERMATA_TEST_LIBRARY` confirmed unset in the same shell; every one of the 81 skips names `FERMATA_TEST_LIBRARY` or `FERMATA_MUSICXML_XSD`, and the count is unchanged from the pre-change baseline.

```
631 passed (8.9m)
```
`npm run test:browser` on `FERMATA_TEST_PORT=9131`, foreground, to completion — no filter, no `PLAYWRIGHT_ALLOW_PARTIAL`, spec floors satisfied (34 spec files).

## Deviations

None from the sketch. Two decisions worth a reviewer's eye, both argued in code comments rather than taken silently: the 409 (setlists gave no duplicate-refusal precedent to match, so the status came from the rest of the codebase), and exposing the new GET as a read tool rather than recording it in `NOT_EXPOSED`.

Closes #236

## After review

Verdict `go`. Two nits taken: the duplicate-name refusal compared names case-sensitively and no test pinned that, so "Jazz box" and "jazz box" could both be saved, which is the on-screen ambiguity the 409 exists to prevent. Both the API's clash check and the unique index now compare without case, each pinned (reverting either one alone turns exactly one test red; the import path inherits the rule through the index). The catalog guard's sanity floor moves from twelve to fourteen, the count this PR changes.
