### PR TITLE
Refuse a multi-part document at open in the note editor

### DIFF
--- a/web/src/lib/TabViewer.svelte
+++ b/web/src/lib/TabViewer.svelte
@@ -1581,6 +1581,15 @@
     </p>
   {/if}
 
+  {#if editError && !editMode}
+    <!-- enterEdit() (above) catches createDocument's refusal, sets editError
+    and returns before editMode ever flips true - so the {#if editMode} panel
+    below, which is the only other place editError renders, never mounts for
+    this case. Without this paragraph the refusal was silent: the "Edit
+    notes" button just stayed enabled and did nothing (#226 follow-up). -->
+    <p class="error">{editError}</p>
+  {/if}
+
   {#if editMode}
     <div class="edit-panel">
       {#if editError}

--- a/web/src/lib/editor/document.js
+++ b/web/src/lib/editor/document.js
@@ -114,7 +114,7 @@ export function createDocument(xml) {
   }
   const root = doc.documentElement;
   if (!root || root.tagName !== "score-partwise") {
-    throw new Error("The note editor works on partwise MusicXML transcriptions only.");
+    throw new Error("The note editor works on partwise MusicXML transcriptions.");
   }
 
   // This profile writes exactly one <part> (the docstring's "one part");

--- a/web/src/lib/editor/document.js
+++ b/web/src/lib/editor/document.js
@@ -117,6 +117,16 @@ export function createDocument(xml) {
     throw new Error("The note editor works on partwise MusicXML transcriptions only.");
   }
 
+  // This profile writes exactly one <part> (the docstring's "one part");
+  // a document with more than one is refused here, at open, the same way an
+  // unparseable or non-partwise document already is above - plainly, before
+  // any edit-mode state is entered - rather than silently mapping only the
+  // first part while drawing every one (#226).
+  const partCount = doc.getElementsByTagName("part").length;
+  if (partCount > 1) {
+    throw new Error(`The note editor works on one part at a time; this document has ${partCount}.`);
+  }
+
   // The tuning, read once. line -> MIDI of that open string. `<staff-tuning
   // line=>` numbers from the bottom staff line (the lowest string); a note's
   // <string> numbers from the top. midiForStringFret / stringToTuningLine keep

--- a/web/test-fixtures/editor-two-part-tab.musicxml
+++ b/web/test-fixtures/editor-two-part-tab.musicxml
@@ -1,0 +1,161 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list>
+    <score-part id="P1"><part-name>Upper</part-name></score-part>
+    <score-part id="P2"><part-name>Lower</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>480</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>TAB</sign><line>5</line></clef>
+        <staff-details>
+          <staff-lines>6</staff-lines>
+          <staff-tuning line="1"><tuning-step>E</tuning-step><tuning-octave>2</tuning-octave></staff-tuning>
+          <staff-tuning line="2"><tuning-step>A</tuning-step><tuning-octave>2</tuning-octave></staff-tuning>
+          <staff-tuning line="3"><tuning-step>D</tuning-step><tuning-octave>3</tuning-octave></staff-tuning>
+          <staff-tuning line="4"><tuning-step>G</tuning-step><tuning-octave>3</tuning-octave></staff-tuning>
+          <staff-tuning line="5"><tuning-step>B</tuning-step><tuning-octave>3</tuning-octave></staff-tuning>
+          <staff-tuning line="6"><tuning-step>E</tuning-step><tuning-octave>4</tuning-octave></staff-tuning>
+        </staff-details>
+      </attributes>
+      <note id="n1-1-0-0">
+        <pitch><step>E</step><octave>4</octave></pitch>
+        <duration>480</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <notations><technical><string>1</string><fret>0</fret></technical></notations>
+      </note>
+      <note id="n1-1-1-0">
+        <pitch><step>F</step><alter>1</alter><octave>4</octave></pitch>
+        <duration>480</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <notations><technical><string>1</string><fret>2</fret></technical></notations>
+      </note>
+      <note id="n1-1-2-0">
+        <pitch><step>G</step><octave>4</octave></pitch>
+        <duration>480</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <notations><technical><string>1</string><fret>3</fret></technical></notations>
+      </note>
+      <note id="n1-1-3-0">
+        <pitch><step>A</step><octave>4</octave></pitch>
+        <duration>480</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <notations><technical><string>1</string><fret>5</fret></technical></notations>
+      </note>
+    </measure>
+    <measure number="2">
+      <note id="n2-1-0-0">
+        <pitch><step>B</step><octave>3</octave></pitch>
+        <duration>480</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <notations><technical><string>2</string><fret>0</fret></technical></notations>
+      </note>
+      <note id="n2-1-1-0">
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>480</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <notations><technical><string>2</string><fret>1</fret></technical></notations>
+      </note>
+      <note id="n2-1-2-0">
+        <pitch><step>D</step><octave>4</octave></pitch>
+        <duration>480</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <notations><technical><string>2</string><fret>3</fret></technical></notations>
+      </note>
+      <note id="n2-1-3-0">
+        <pitch><step>E</step><octave>4</octave></pitch>
+        <duration>480</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <notations><technical><string>2</string><fret>5</fret></technical></notations>
+      </note>
+    </measure>
+  </part>
+  <part id="P2">
+    <measure number="1">
+      <attributes>
+        <divisions>480</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>TAB</sign><line>5</line></clef>
+        <staff-details>
+          <staff-lines>6</staff-lines>
+          <staff-tuning line="1"><tuning-step>E</tuning-step><tuning-octave>2</tuning-octave></staff-tuning>
+          <staff-tuning line="2"><tuning-step>A</tuning-step><tuning-octave>2</tuning-octave></staff-tuning>
+          <staff-tuning line="3"><tuning-step>D</tuning-step><tuning-octave>3</tuning-octave></staff-tuning>
+          <staff-tuning line="4"><tuning-step>G</tuning-step><tuning-octave>3</tuning-octave></staff-tuning>
+          <staff-tuning line="5"><tuning-step>B</tuning-step><tuning-octave>3</tuning-octave></staff-tuning>
+          <staff-tuning line="6"><tuning-step>E</tuning-step><tuning-octave>4</tuning-octave></staff-tuning>
+        </staff-details>
+      </attributes>
+      <note id="p2-n1-1-0-0">
+        <pitch><step>E</step><octave>2</octave></pitch>
+        <duration>480</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <notations><technical><string>6</string><fret>0</fret></technical></notations>
+      </note>
+      <note id="p2-n1-1-1-0">
+        <pitch><step>F</step><alter>1</alter><octave>2</octave></pitch>
+        <duration>480</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <notations><technical><string>6</string><fret>2</fret></technical></notations>
+      </note>
+      <note id="p2-n1-1-2-0">
+        <pitch><step>G</step><octave>2</octave></pitch>
+        <duration>480</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <notations><technical><string>6</string><fret>3</fret></technical></notations>
+      </note>
+      <note id="p2-n1-1-3-0">
+        <pitch><step>A</step><octave>2</octave></pitch>
+        <duration>480</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <notations><technical><string>6</string><fret>5</fret></technical></notations>
+      </note>
+    </measure>
+    <measure number="2">
+      <note id="p2-n2-1-0-0">
+        <pitch><step>A</step><octave>2</octave></pitch>
+        <duration>480</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <notations><technical><string>5</string><fret>0</fret></technical></notations>
+      </note>
+      <note id="p2-n2-1-1-0">
+        <pitch><step>B</step><octave>2</octave></pitch>
+        <duration>480</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <notations><technical><string>5</string><fret>2</fret></technical></notations>
+      </note>
+      <note id="p2-n2-1-2-0">
+        <pitch><step>C</step><alter>1</alter><octave>3</octave></pitch>
+        <duration>480</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <notations><technical><string>5</string><fret>3</fret></technical></notations>
+      </note>
+      <note id="p2-n2-1-3-0">
+        <pitch><step>D</step><alter>1</alter><octave>3</octave></pitch>
+        <duration>480</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <notations><technical><string>5</string><fret>5</fret></technical></notations>
+      </note>
+    </measure>
+  </part>
+</score-partwise>

--- a/web/tests/browser/score-editor-multipart-226.spec.js
+++ b/web/tests/browser/score-editor-multipart-226.spec.js
@@ -1,0 +1,145 @@
+// Issue #226: the note editor's positional map was built from the first
+// <part> only, so a document with two <part>s was drawn in full but only its
+// first part could be reached - a click on the second part's heads selected
+// nothing, and the arrow keys walked ordinals past what the renderer could
+// show at all. The chosen fix (the S-appetite option the issue's bet took) is
+// to keep createDocument's own docstring's promise: refuse a document with
+// more than one part, plainly, the same way it already refuses a non-partwise
+// one (document.js ~117).
+//
+// This file was `editor-multipart-selection-probe` (commit b0d3f2b): three of
+// its four tests were red on main because they asserted every drawn note
+// stayed reachable. That premise no longer holds once the editor refuses the
+// document outright, so they are reworked here into what the refusal actually
+// does: shows a plain message and selects nothing, while the VIEWER (not the
+// editor) still draws every part read-only - refusing an edit is not the same
+// as failing to render.
+//
+// The fixture is the probe's own two-part TAB document, unchanged: the shape
+// Fermata's own emitter writes (a TAB staff, six-string standard tuning,
+// <divisions>480</divisions>) duplicated into a second <part>, moved down two
+// octaves and onto the two lowest strings so a wrongly-drawn note would be
+// obvious. 8 sounding notes per part, 16 in the document - copied into
+// web/test-fixtures/editor-two-part-tab.musicxml (original synthetic content,
+// nothing borrowed) rather than re-inlined, the same reasoning
+// fixtures/multi-part-score.js gives for reading its own fixture off disk.
+//
+// window.__scoreEditor - the read-only geometry hook the other editor specs
+// use (see score-editor.spec.js's header) - is only published once edit mode
+// is actually entered (TabViewer.svelte's own $effect gates it on `editMode`).
+// A refused document never sets editMode true, so that hook never exists here
+// - "the viewer still renders both parts" is checked the same way
+// score-multi-part.spec.js (#93) checks it: directly against the drawn SVG,
+// not through an editor-only instrumentation surface a refusal never reaches.
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { test, expect } from "@playwright/test";
+
+import { EDITOR_MUSICXML, stubEditorApi } from "./fixtures/editor-score.js";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const WEB_ROOT = path.join(here, "..", "..");
+const TWO_PART_MUSICXML = fs.readFileSync(
+  path.join(WEB_ROOT, "test-fixtures", "editor-two-part-tab.musicxml"),
+  "utf-8",
+);
+const PART_COUNT = 2;
+const REFUSAL_MESSAGE = `The note editor works on one part at a time; this document has ${PART_COUNT}.`;
+
+const wrap = (page) => page.locator(".staff-render .wrap");
+const host = (page) => page.locator(".staff-render .at-host");
+
+async function renderedOk(page) {
+  await expect(host(page)).toHaveAttribute("data-score-render-ok", "true", { timeout: 30_000 });
+}
+
+async function openStaff(page, content) {
+  await stubEditorApi(page, content);
+  await page.goto("/#/score/1");
+  await page.waitForSelector(".staff-render");
+  await page.getByRole("button", { name: "Staff", exact: true }).click();
+  await renderedOk(page);
+}
+
+// Trimmed the same way score-multi-part.spec.js's own drawnText() is - track
+// names come back padded and NBSP-joined for a two-word name, and neither has
+// anything to do with a string's identity here.
+async function drawnTexts(page) {
+  return await page.evaluate(() =>
+    [...document.querySelectorAll(".at-host svg text")].map((t) => t.textContent.replace(/ /g, " ").trim()),
+  );
+}
+
+// Staff lines: the thin horizontal rects alphaTab draws (score-multi-part.spec.js's
+// own technique, and its own comment on why height - not colour - is what
+// identifies one). A six-string TAB staff draws 6; two of them, unambiguously,
+// draw 12 - measured directly against this fixture below, not assumed.
+async function staffLineRowCount(page) {
+  return await page.evaluate(() => {
+    const rects = [...document.querySelectorAll(".at-host svg rect")];
+    const lines = rects.filter((r) => Number(r.getAttribute("height")) < 1.3);
+    return new Set(lines.map((r) => Number(r.getAttribute("y")).toFixed(1))).size;
+  });
+}
+
+test.describe("a two-part transcription is refused by the note editor (#226)", () => {
+  test("opening it in the editor shows the refusal and selects nothing", async ({ page }) => {
+    await openStaff(page, TWO_PART_MUSICXML);
+    await page.getByRole("button", { name: "Edit notes" }).click();
+    // Never entered edit mode - createDocument threw before enterEdit() got to
+    // set editMode true, so the panel that would show editError never mounts
+    // either (it lives behind `{#if editMode}`); data-editor-error is the one
+    // place the message reaches the DOM regardless, the same as it already
+    // does for the pre-existing partwise-only refusal.
+    await expect(wrap(page)).toHaveAttribute("data-editor-active", "false");
+    await expect(wrap(page)).toHaveAttribute("data-editor-error", REFUSAL_MESSAGE);
+    await expect(wrap(page)).not.toHaveAttribute("data-editor-selected", /.*/);
+  });
+
+  test("no note is selected after clicking the staff or pressing arrow keys", async ({ page }) => {
+    await openStaff(page, TWO_PART_MUSICXML);
+    await page.getByRole("button", { name: "Edit notes" }).click();
+    await expect(wrap(page)).toHaveAttribute("data-editor-active", "false");
+
+    // A click on the render surface: with editMode false, the wrap's own
+    // onclick is `undefined` (TabViewer.svelte's `editMode ? (e) => selectAt(...) :
+    // undefined`), so nothing here can select anything - not the wrong note,
+    // nothing at all.
+    const box = await host(page).boundingBox();
+    await page.mouse.click(box.x + box.width / 2, box.y + box.height / 2);
+    await expect(wrap(page)).not.toHaveAttribute("data-editor-selected", /.*/);
+    await expect(wrap(page)).toHaveAttribute("data-editor-active", "false");
+
+    // Arrow keys: onKey only lets the editor claim them while editMode is true
+    // AND a note or rest is already selected - neither holds here, so every
+    // press either falls through to the transport or does nothing; either way
+    // no selection appears.
+    for (let i = 0; i < 8; i++) await page.keyboard.press("ArrowRight");
+    await expect(wrap(page)).not.toHaveAttribute("data-editor-selected", /.*/);
+    await expect(wrap(page)).toHaveAttribute("data-editor-active", "false");
+  });
+
+  test("the viewer still draws both parts, read-only", async ({ page }) => {
+    await openStaff(page, TWO_PART_MUSICXML);
+    // Never touches "Edit notes" - this is what the plain viewer draws, which
+    // the refusal above is not allowed to withhold (the refusal is the
+    // editor's; the viewer is a different consumer of the same document).
+    const texts = await drawnTexts(page);
+    expect(texts).toContain("Upper");
+    expect(texts).toContain("Lower");
+    // Measured directly against this fixture (two six-string TAB staves):
+    // 12 thin rows with both parts drawn, 6 if only the first one were.
+    expect(await staffLineRowCount(page)).toBe(12);
+  });
+
+  test("a single-part document still opens in the editor", async ({ page }) => {
+    await openStaff(page, EDITOR_MUSICXML);
+    await page.getByRole("button", { name: "Edit notes" }).click();
+    await expect(wrap(page)).toHaveAttribute("data-editor-active", "true");
+    await expect(wrap(page)).not.toHaveAttribute("data-editor-error", /.*/);
+    await expect
+      .poll(() => page.evaluate(() => window.__scoreEditor?.noteCount() ?? 0))
+      .toBe(8);
+  });
+});

--- a/web/tests/browser/score-editor-multipart-226.spec.js
+++ b/web/tests/browser/score-editor-multipart-226.spec.js
@@ -47,6 +47,18 @@ const TWO_PART_MUSICXML = fs.readFileSync(
 const PART_COUNT = 2;
 const REFUSAL_MESSAGE = `The note editor works on one part at a time; this document has ${PART_COUNT}.`;
 
+// The refusal counts <part> elements (document.js's `partCount`), not
+// <score-part> entries in <part-list> - a document can legitimately list more
+// score-parts than it actually writes as <part>s (or the reverse, an
+// under-specified upload), and only the latter is what the editor cannot map.
+// Built from EDITOR_MUSICXML - still exactly one <part id="P1">, with a
+// second <score-part> appended to <part-list> so it names two parts while
+// writing one.
+const TWO_SCORE_PART_LIST_MUSICXML = EDITOR_MUSICXML.replace(
+  '<score-part id="P1"><part-name>Guitar</part-name></score-part>',
+  '<score-part id="P1"><part-name>Guitar</part-name></score-part>\n    <score-part id="P2"><part-name>Ghost</part-name></score-part>',
+);
+
 const wrap = (page) => page.locator(".staff-render .wrap");
 const host = (page) => page.locator(".staff-render .at-host");
 
@@ -88,13 +100,18 @@ test.describe("a two-part transcription is refused by the note editor (#226)", (
     await openStaff(page, TWO_PART_MUSICXML);
     await page.getByRole("button", { name: "Edit notes" }).click();
     // Never entered edit mode - createDocument threw before enterEdit() got to
-    // set editMode true, so the panel that would show editError never mounts
-    // either (it lives behind `{#if editMode}`); data-editor-error is the one
-    // place the message reaches the DOM regardless, the same as it already
-    // does for the pre-existing partwise-only refusal.
+    // set editMode true, so the panel that would show editError inline never
+    // mounts either (it lives behind `{#if editMode}`). data-editor-error
+    // carries the message regardless, the same as it already does for the
+    // pre-existing partwise-only refusal - but a guitarist reads the page, not
+    // an attribute, so the refusal also has to be actual rendered text (#226
+    // follow-up: this used to be a silent no-op, the button just staying
+    // enabled with nothing visibly happening).
     await expect(wrap(page)).toHaveAttribute("data-editor-active", "false");
     await expect(wrap(page)).toHaveAttribute("data-editor-error", REFUSAL_MESSAGE);
     await expect(wrap(page)).not.toHaveAttribute("data-editor-selected", /.*/);
+    await expect(page.locator(".wrap p.error", { hasText: REFUSAL_MESSAGE })).toBeVisible();
+    await expect(page.locator("body")).toContainText(REFUSAL_MESSAGE);
   });
 
   test("no note is selected after clicking the staff or pressing arrow keys", async ({ page }) => {
@@ -141,5 +158,36 @@ test.describe("a two-part transcription is refused by the note editor (#226)", (
     await expect
       .poll(() => page.evaluate(() => window.__scoreEditor?.noteCount() ?? 0))
       .toBe(8);
+  });
+
+  test("a document with one <part> but two <score-part> entries still opens in the editor", async ({ page }) => {
+    // The refusal counts <part> elements, not <part-list>'s <score-part>
+    // entries (document.js's partCount) - this document names two parts in
+    // its <part-list> but writes only one <part>, so it must open exactly
+    // like EDITOR_MUSICXML, unaffected by the extra score-part entry.
+    await openStaff(page, TWO_SCORE_PART_LIST_MUSICXML);
+    await page.getByRole("button", { name: "Edit notes" }).click();
+    await expect(wrap(page)).toHaveAttribute("data-editor-active", "true");
+    await expect(wrap(page)).not.toHaveAttribute("data-editor-error", /.*/);
+    await expect
+      .poll(() => page.evaluate(() => window.__scoreEditor?.noteCount() ?? 0))
+      .toBe(8);
+  });
+
+  test("after the refusal, the viewer still renders both parts", async ({ page }) => {
+    // Clicking "Edit notes" and seeing the refusal must not disturb the plain
+    // viewer's own render of the document underneath - refusing an EDIT is not
+    // the same as failing to render, so the staff stays exactly as the
+    // read-only test above measures it (both part names, 12 TAB staff rows),
+    // even after the editor has rejected this same document.
+    await openStaff(page, TWO_PART_MUSICXML);
+    await page.getByRole("button", { name: "Edit notes" }).click();
+    await expect(wrap(page)).toHaveAttribute("data-editor-active", "false");
+    await expect(page.locator("body")).toContainText(REFUSAL_MESSAGE);
+    await renderedOk(page);
+    const texts = await drawnTexts(page);
+    expect(texts).toContain("Upper");
+    expect(texts).toContain("Lower");
+    expect(await staffLineRowCount(page)).toBe(12);
   });
 });

--- a/web/tests/spec-floors/browser-score-editor-multipart-226.json
+++ b/web/tests/spec-floors/browser-score-editor-multipart-226.json
@@ -1,5 +1,5 @@
 {
   "file": "tests/browser/score-editor-multipart-226.spec.js",
-  "count": 4,
-  "reason": "issue #226: reworked from the editor-multipart-selection-probe branch (b0d3f2b) once createDocument refused a document with more than one part - opening the two-part fixture shows the refusal and selects nothing (data-editor-active false, data-editor-error the refusal message, no data-editor-selected), no click or arrow key selects a note afterwards, the viewer still draws both parts read-only (both part names, 12 TAB staff-line rows), and a single-part document is unaffected."
+  "count": 6,
+  "reason": "issue #226: reworked from the editor-multipart-selection-probe branch (b0d3f2b) once createDocument refused a document with more than one part - opening the two-part fixture shows the refusal and selects nothing (data-editor-active false, data-editor-error the refusal message, no data-editor-selected, AND the refusal as visible rendered text), no click or arrow key selects a note afterwards, the viewer still draws both parts read-only (both part names, 12 TAB staff-line rows), a single-part document is unaffected, a document with one <part> but two <score-part> entries in <part-list> still opens (the count is of <part> elements), and the viewer still renders both parts after the refusal is shown."
 }

--- a/web/tests/spec-floors/browser-score-editor-multipart-226.json
+++ b/web/tests/spec-floors/browser-score-editor-multipart-226.json
@@ -1,0 +1,5 @@
+{
+  "file": "tests/browser/score-editor-multipart-226.spec.js",
+  "count": 4,
+  "reason": "issue #226: reworked from the editor-multipart-selection-probe branch (b0d3f2b) once createDocument refused a document with more than one part - opening the two-part fixture shows the refusal and selects nothing (data-editor-active false, data-editor-error the refusal message, no data-editor-selected), no click or arrow key selects a note afterwards, the viewer still draws both parts read-only (both part names, 12 TAB staff-line rows), and a single-part document is unaffected."
+}


### PR DESCRIPTION
Closes #226.

## Premise verdict: valid

Re-derived on main `1527d0a`: a two-part TAB MusicXML document opened in the note editor with no refusal, although `createDocument`'s docstring (`web/src/lib/editor/document.js` ~:98) already promises one part. The positional map held only the first part's notes while the render drew both, so a click below the first part's lowest head selected nothing and the arrow keys walked ordinals (8-15) with no drawn head.

## Change

`createDocument`'s parse block now counts `<part>` elements and refuses a document with more than one, in the same shape as the existing partwise-only refusal:

> The note editor works on one part at a time; this document has N.

The single-part path is unchanged. `TabViewer.svelte` needed **no change**: its existing catch (`initEditDoc`) already sets `data-editor-error` and returns before `editMode` is ever set true, for *any* thrown refusal - the new one reaches the DOM exactly the way the pre-existing partwise-only refusal does. (Side note below on where that message is/isn't shown.)

## Done-when checklist

- [x] Opening the two-part probe document in the editor shows the refusal and selects nothing - `data-editor-active="false"`, `data-editor-error` carries the message, no `data-editor-selected`.
- [x] The viewer still renders it read-only - both part names ("Upper"/"Lower") and 12 TAB staff-line rows (two six-string staves) drawn, without ever entering edit mode.
- [x] The probe spec (`editor-multipart-selection-probe`, b0d3f2b) reworked into a passing spec pinning the refusal, with a floor file - `web/tests/browser/score-editor-multipart-226.spec.js` (4 tests) + `web/tests/spec-floors/browser-score-editor-multipart-226.json`. Fixture copied to `web/test-fixtures/editor-two-part-tab.musicxml` (original synthetic content, read to confirm nothing borrowed).
- [x] A single-part document is unaffected - full existing editor suite green (57/57, below).
- [x] Refusal string checked by hand against `practice.js`'s `FORBIDDEN_WORDS` (the editor is outside `practice.spec.js`'s `COMPONENTS` scan): no match.

## Mutation table

| Mutation | Rebuild | Result |
|---|---|---|
| Remove the new throw (`if (false && partCount > 1)`) | yes | 2 red: "shows the refusal and selects nothing", "no note selected after click/arrows" (both saw `data-editor-active="true"`) |
| Off-by-one (`partCount >= 1`) | yes | 1 red: "a single-part document still opens in the editor" (saw `data-editor-active="false"`, error "...has 1.") |
| Restored | yes | 4/4 green, `git diff` clean against the commit |

## Suite lines

- New spec alone: `4 passed (5.2s)` (`FERMATA_TEST_PORT=9145 PLAYWRIGHT_ALLOW_PARTIAL=1 npx playwright test tests/browser/score-editor-multipart-226.spec.js`)
- Full editor suite (fuzz-189, keyboard-186, multipart-226, poly-189, rest-238, rhythm-183, spelling-185, voices-182, score-editor) on the private port: `57 passed (49.8s)`
- `npm run test:browser` (full suite, unit+browser): not-run locally in the required foreground/tracked form - a run took 10.8m, over the 600s foreground cap, so CI stands in for the full-suite line. (An earlier background attempt did finish 635 passed/exit 0, but per this session's discipline that untracked run isn't reported as verified.)
- pytest: not-run (no `server/` changes).

## Hypotheses (side-finding, not filed)

`editError` is only shown as visible text inside `{#if editMode}` (`TabViewer.svelte` ~1584-1587); since a thrown `createDocument` refusal never sets `editMode` true, that paragraph never mounts for *any* open-time refusal - only `data-editor-error` reaches the DOM. This is pre-existing (true for the partwise-only refusal too, not something this PR introduces or was asked to fix), so left alone per the concurrency brief.


## After review

Review found the "Hypotheses" side-finding above understated the bug: it isn't just that the refusal's DOM attribute is the only surface - the refusal was never SHOWN to a person at all. `enterEdit()` (`TabViewer.svelte` ~:274-282) catches `createDocument`'s throw, sets `editError`, and returns before `editMode` is set true; the one place `editError` renders as text lives at ~:1587 inside `{#if editMode}` (~:1584), which this path never reaches. So clicking "Edit notes" on a two-part document was a silent no-op: the button stayed enabled, nothing appeared on the page, and `document.body.innerText` never contained the refusal - only `data-editor-error` carried it.

**Fix**: added a sibling block in `TabViewer.svelte`, immediately before `{#if editMode}`:

```svelte
{#if editError && !editMode}
  <p class="error">{editError}</p>
{/if}
```

Used `class="error"` rather than `hint warn` - `.hint`/`.hint.warn` are scoped `.edit-panel .hint` in this file's CSS, and this paragraph sits outside `.edit-panel` (same top-level slot as the pre-existing `loadError` message, which already uses `.error`).

Also reworded the pre-existing partwise-only refusal (`document.js` ~:117) so it no longer contains the forbidden word "only":
- Before: `"The note editor works on partwise MusicXML transcriptions only."`
- After: `"The note editor works on partwise MusicXML transcriptions."`
- The multi-part refusal string was already clean (`"The note editor works on one part at a time; this document has N."`).
- Checked both by hand against `practice.js`'s `FORBIDDEN_WORDS` via `forbiddenWord()`: both return `null`; the pre-fix "...only." string returns `"only"`.

**Two new tests** in `web/tests/browser/score-editor-multipart-226.spec.js` (4 → 6 tests, floor file raised to match):
- Extended the existing refusal test to assert the message is visible rendered text (`page.locator(".wrap p.error", { hasText: REFUSAL_MESSAGE })` `toBeVisible()`, plus a `body` `toContainText` check), not only the `data-editor-error` attribute.
- New: a document with ONE `<part>` but TWO `<score-part>` entries in `<part-list>` (built from `EDITOR_MUSICXML` with an extra `<score-part>` appended) still opens in the editor - confirms the count is of `<part>` elements, not `<part-list>` entries.
- New: after clicking "Edit notes" on the two-part fixture and seeing the refusal, the viewer still renders both parts read-only (render-ok true, the same 12-staff-line-row count and both part names the pre-existing read-only test uses).

**Mutations** (rebuilt each time, `git checkout --` to restore):
| Mutation | Result |
|---|---|
| Remove the new `<p class="error">` block | 2 red: the visible-text assertion in the refusal test, and the new "still renders both parts" test (its `body toContainText` check) - all 4 attribute-only tests stayed green |
| Count `score-part` instead of `part` in `document.js` | 1 red: the new one-`<part>`/two-`<score-part>` test (`data-editor-active` false where it expected true) - other 5 unaffected |
| Put "only" back into the partwise refusal string | No automated test scans the editor's strings for forbidden words (`practice.spec.js`'s scan is scoped to `practice.js`'s own components) - hand check only: `forbiddenWord("...transcriptions only.")` returns `"only"`, confirming the check would flag it if it existed |

**Suite lines** (`FERMATA_TEST_PORT=9157 PLAYWRIGHT_ALLOW_PARTIAL=1`):
- New/extended spec alone: `6 passed (5.8s)`
- Full editor suite (fuzz-189, keyboard-186, multipart-226, poly-189, rest-238, rhythm-183, spelling-185, voices-182, score-editor): `59 passed (48.8s)`
