### PR TITLE
Minor and major seventh chords in the chord flash cards

### DIFF
--- a/docs/practice-data.md
+++ b/docs/practice-data.md
@@ -449,7 +449,7 @@ from a request body.
 | `session_id` | The `practice_sessions` row logging the surrounding drill's TIME, when there is one yet - `NULL` otherwise, the same ordinary-not-edge case `trainer_attempts.session_id` is. |
 | `drill` | `'chord_flashcards'` today - a widened tuple, not a migration, is how a second chord-shaped drill would arrive, the same rule `trainer_attempts.drill` follows. |
 | `direction` | `shape_to_name` (shown a real fingering, asked to name the chord) or `name_to_shape` (named a chord, asked to place it on the neck). |
-| `target_root`, `target_quality` | The chord being tested, always set - a pitch class and one of `major`/`minor`/`dominant7`. |
+| `target_root`, `target_quality` | The chord being tested, always set - a pitch class and one of the five qualities `chord-theory.js` and `trainer.py` name in lockstep (`major`, `minor`, `dominant7`, `minor7`, `major7`). |
 | `target_shape` | The fingering actually SHOWN - a JSON array of `{string, fret}` - set only on `shape_to_name`; `NULL` on `name_to_shape`, which shows no shape at all. |
 | `given_root`, `given_quality` | The chord chosen by name - set only on `shape_to_name`. |
 | `given_notes` | The pitch classes a TAPPED shape actually sounded, a JSON array worked out client-side from the instrument's own tuning - never from which shape the player meant to play, mirroring `given_note`'s rule above. Set only on `name_to_shape`. |

--- a/server/fermata/trainer.py
+++ b/server/fermata/trainer.py
@@ -202,19 +202,25 @@ CHORD_DRILLS = ("chord_flashcards",)
 CHORD_DIRECTIONS = ("shape_to_name", "name_to_shape")
 
 # Interval steps from the root, in semitones - a triad for major and minor,
-# a tetrad for the one seventh chord this drill names ("majors and minors
-# first, then sevenths, then barre chords" - issue #28's own ordering).
+# a tetrad for every seventh chord this drill names ("majors and minors
+# first, then sevenths, then barre chords" - issue #28's own ordering,
+# extended by #252 to the minor and major seventh alongside the dominant).
 # MIRRORED, CHARACTER FOR CHARACTER, in web/src/lib/trainer/chord-
 # theory.js's QUALITIES - the same discipline PITCH_CLASSES above is held
 # to against neck.js's table of the same name. server/tests/
 # test_chord_theory.py and web/tests/unit/chord-theory.spec.js each check
-# every one of the 36 (root, quality) chords this can build; a drift
-# between the two would otherwise show up as a shape and its label
-# disagreeing about what chord is on screen, not as a failing test.
+# every one of the 60 (root, quality) chords this can build, and
+# test_chord_theory.py additionally parses chord-theory.js's own source to
+# pin the two tables' intervals equal, key for key, rather than trusting
+# them to stay in step by hand; a drift between the two would otherwise
+# show up as a shape and its label disagreeing about what chord is on
+# screen, not as a failing test.
 CHORD_QUALITIES = {
     "major": (0, 4, 7),
     "minor": (0, 3, 7),
     "dominant7": (0, 4, 7, 10),
+    "minor7": (0, 3, 7, 10),
+    "major7": (0, 4, 7, 11),
 }
 
 

--- a/server/tests/test_chord_theory.py
+++ b/server/tests/test_chord_theory.py
@@ -1,9 +1,13 @@
-"""Chord music theory (issue #28): trainer.chord_tones, checked exhaustively
-enough to trust it - this is the arithmetic a chord flash card's grading
-stands on, mirrored character-for-character from web/src/lib/trainer/chord-
-theory.js's chordTones. See trainer.py's own module comment on why a drift
-between the two sides is a wrong chord taught, not a display bug.
+"""Chord music theory (issue #28, extended to the minor and major seventh by
+#252): trainer.chord_tones, checked exhaustively enough to trust it - this
+is the arithmetic a chord flash card's grading stands on, mirrored
+character-for-character from web/src/lib/trainer/chord-theory.js's
+chordTones. See trainer.py's own module comment on why a drift between the
+two sides is a wrong chord taught, not a display bug.
 """
+
+import re
+from pathlib import Path
 
 from fermata import trainer
 
@@ -37,12 +41,26 @@ def test_known_dominant_sevenths_are_exactly_right():
     assert trainer.chord_tones("B", "dominant7") == ("B", "Eb", "F#", "A")
 
 
+def test_known_minor_sevenths_are_exactly_right():
+    assert trainer.chord_tones("A", "minor7") == ("A", "C", "E", "G")
+    assert trainer.chord_tones("D", "minor7") == ("D", "F", "A", "C")
+    assert trainer.chord_tones("E", "minor7") == ("E", "G", "B", "D")
+    assert trainer.chord_tones("C", "minor7") == ("C", "Eb", "G", "Bb")
+
+
+def test_known_major_sevenths_are_exactly_right():
+    assert trainer.chord_tones("C", "major7") == ("C", "E", "G", "B")
+    assert trainer.chord_tones("F", "major7") == ("F", "A", "C", "E")
+    assert trainer.chord_tones("G", "major7") == ("G", "B", "D", "F#")
+    assert trainer.chord_tones("E", "major7") == ("E", "Ab", "B", "Eb")
+
+
 # ---------------------------------------------------------------- exhaustive, every root x quality
 
 
 def test_every_root_and_quality_combination_has_the_right_note_count_and_no_repeats():
     assert len(ROOTS) == 12
-    assert QUALITIES == ["major", "minor", "dominant7"]
+    assert QUALITIES == ["major", "minor", "dominant7", "minor7", "major7"]
     for root in ROOTS:
         for quality in QUALITIES:
             tones = trainer.chord_tones(root, quality)
@@ -69,6 +87,61 @@ def test_a_dominant_seventh_is_its_major_triad_plus_one_more_note():
         assert len(seventh) == 4
 
 
+def test_a_minor_seventh_is_its_minor_triad_plus_one_more_note():
+    """Built on the MINOR triad, not the major one - the fact that
+    distinguishes it from a dominant seventh, which shares a root's major
+    triad. A mutation giving minor7 dominant7's own intervals (both are
+    (root, +7 semitones)-shaped tetrads, so a bare note-count check would
+    not catch it) fails right here, on the third."""
+    for root in ROOTS:
+        minor = trainer.chord_tones(root, "minor")
+        seventh = trainer.chord_tones(root, "minor7")
+        assert seventh[:3] == minor
+        assert len(seventh) == 4
+
+
+def test_a_major_seventh_is_its_major_triad_plus_one_more_note():
+    """Same relationship, on the major triad plus the MAJOR seventh - a
+    half step closer to the root than the dominant/minor seventh above,
+    which is the interval that gives this chord its "maj7" suffix."""
+    for root in ROOTS:
+        major = trainer.chord_tones(root, "major")
+        seventh = trainer.chord_tones(root, "major7")
+        assert seventh[:3] == major
+        assert len(seventh) == 4
+
+
 def test_an_unknown_root_or_quality_names_no_chord():
     assert trainer.chord_tones("H", "major") is None
     assert trainer.chord_tones("C", "augmented") is None
+
+
+# ---------------------------------------------------------------- cross-side parity (issue #252)
+
+
+def test_chord_qualities_mirror_chord_theory_js_interval_for_interval():
+    """CHORD_QUALITIES here and QUALITIES in chord-theory.js are two copies
+    of the same table with nothing connecting them at runtime - a drift
+    would show up as a shape and its label disagreeing about what chord is
+    on screen, not as a failing test (see this module's own docstring, and
+    trainer.py's). Parsing the frontend source is the cheapest way to keep
+    them honest without wiring a real dependency between a Python service
+    and a Svelte module - the same technique test_settings_api.py already
+    uses for SCORE_THEMES and WEEK_STARTS."""
+    js_path = (
+        Path(__file__).resolve().parents[2]
+        / "web"
+        / "src"
+        / "lib"
+        / "trainer"
+        / "chord-theory.js"
+    )
+    source = js_path.read_text(encoding="utf-8")
+    match = re.search(r"export const QUALITIES = \{([\s\S]*?)\n\};", source)
+    assert match, "could not find QUALITIES in chord-theory.js"
+    body = match.group(1)
+    frontend = {}
+    for name, intervals in re.findall(r"(\w+):\s*\{[^}]*intervals:\s*\[([^\]]*)\]", body):
+        frontend[name] = tuple(int(step.strip()) for step in intervals.split(","))
+    assert frontend, "no qualities parsed out of chord-theory.js's QUALITIES"
+    assert frontend == trainer.CHORD_QUALITIES

--- a/server/tests/test_chord_trainer_api.py
+++ b/server/tests/test_chord_trainer_api.py
@@ -317,6 +317,41 @@ def test_an_unknown_filter_value_is_refused(client):
     assert client.get("/api/trainer/chord-attempts?quality=augmented").status_code == 422
 
 
+# ---------------------------------------------------------------------------
+# The minor and major seventh (issue #252): accepted end to end, the same
+# as every quality above - not merely known to trainer.chord_tones.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("quality", "root", "given_notes"),
+    [
+        ("minor7", "A", ["A", "C", "E", "G"]),
+        ("major7", "C", ["C", "E", "G", "B"]),
+    ],
+)
+def test_the_new_seventh_qualities_are_accepted_and_round_trip(client, quality, root, given_notes):
+    resp = client.post(
+        "/api/trainer/chord-attempts",
+        json=name_to_shape(
+            target_root=root,
+            target_quality=quality,
+            given_notes=given_notes,
+            given_shape=[{"string": 6, "fret": 0}],
+        ),
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["target_quality"] == quality
+    assert body["target_root"] == root
+    assert body["correct"] is True
+
+    listed = client.get(f"/api/trainer/chord-attempts?quality={quality}").json()
+    assert listed["total"] == 1
+    assert listed["attempts"][0]["target_root"] == root
+    assert listed["attempts"][0]["target_quality"] == quality
+
+
 def test_truncation_is_reported_honestly(client):
     for root in ("C", "D", "E"):
         client.post("/api/trainer/chord-attempts", json=shape_to_name(target_root=root, given_root=root))

--- a/web/src/lib/trainer/ChordFlashCards.svelte
+++ b/web/src/lib/trainer/ChordFlashCards.svelte
@@ -29,7 +29,7 @@
   import { getInstruments, loadInstruments } from "../instruments.svelte.js";
   import { localDay } from "../practice.js";
   import { playChord } from "../score-render.js";
-  import { ROOTS } from "./chord-theory.js";
+  import { ROOTS, chordName } from "./chord-theory.js";
   import {
     NAME_TO_SHAPE,
     SHAPE_TO_NAME,
@@ -547,7 +547,7 @@
 
         {#if direction === NAME_TO_SHAPE}
           <p class="statement prompt">
-            Place <strong>{round.question.root} {round.question.quality === "dominant7" ? "7" : round.question.quality}</strong> on the neck.
+            Place <strong>{chordName(round.question.root, round.question.quality)}</strong> on the neck.
           </p>
         {:else}
           <p class="statement prompt">Name the shape shown.</p>
@@ -655,7 +655,7 @@
     <p class="quiet footnote">
       The time you spend here is logged as chord practice, in the same history as everything else.
       Every question is also kept on its own, so which chords need more time is something you can
-      look back on - not only a count for the session it happened in.
+      look back on, beyond a count for the session it happened in.
     </p>
   </main>
 </div>

--- a/web/src/lib/trainer/chord-shapes.js
+++ b/web/src/lib/trainer/chord-shapes.js
@@ -94,6 +94,23 @@ const BARRE_TEMPLATES = {
     quality: "minor",
     offsets: [[6, 0], [5, 2], [4, 2], [3, 0], [2, 0], [1, 0]],
   },
+  // The E-shape's minor-seventh and major-seventh forms (issue #252) - the
+  // open Em7 (022030-style: 0 2 0 0 0 0) and Emaj7 (0 2 1 1 0 0) fingerings,
+  // made movable the same way barre-e-major/minor already are: every fret
+  // relative to a base that slides up the neck. shape-tones.spec.js checks
+  // every instance this produces against chord-theory.js's own chordTones,
+  // the same as every other shape here - these two are not exempt for being
+  // new.
+  "barre-e-minor7": {
+    rootString: 6,
+    quality: "minor7",
+    offsets: [[6, 0], [5, 2], [4, 0], [3, 0], [2, 0], [1, 0]],
+  },
+  "barre-e-major7": {
+    rootString: 6,
+    quality: "major7",
+    offsets: [[6, 0], [5, 2], [4, 1], [3, 1], [2, 0], [1, 0]],
+  },
   "barre-a-major": {
     rootString: 5,
     quality: "major",
@@ -103,6 +120,19 @@ const BARRE_TEMPLATES = {
     rootString: 5,
     quality: "minor",
     offsets: [[5, 0], [4, 2], [3, 2], [2, 1], [1, 0]],
+  },
+  // The A-shape's minor-seventh and major-seventh forms (issue #252) - the
+  // open Am7 (x02010) and Amaj7 (x02120) fingerings, made movable the same
+  // way barre-a-major/minor already are.
+  "barre-a-minor7": {
+    rootString: 5,
+    quality: "minor7",
+    offsets: [[5, 0], [4, 2], [3, 0], [2, 1], [1, 0]],
+  },
+  "barre-a-major7": {
+    rootString: 5,
+    quality: "major7",
+    offsets: [[5, 0], [4, 2], [3, 1], [2, 2], [1, 0]],
   },
 };
 

--- a/web/src/lib/trainer/chord-theory.js
+++ b/web/src/lib/trainer/chord-theory.js
@@ -74,7 +74,8 @@ export function chordName(root, quality) {
  * this the chord that was asked for": two different (root, quality) pairs
  * that happened to name identical tone sets would otherwise grade as wrong
  * for a reason that has nothing to do with what was actually played or
- * chosen. With today's three qualities no such pair exists, but the rule
+ * chosen. With today's five qualities no such pair exists (checked: 60 distinct
+ * tone sets), but the rule
  * this drill grades by should not depend on that staying true. */
 export function chordsMatch(rootA, qualityA, rootB, qualityB) {
   const a = chordTones(rootA, qualityA);

--- a/web/src/lib/trainer/chord-theory.js
+++ b/web/src/lib/trainer/chord-theory.js
@@ -12,20 +12,25 @@
 // MIRRORED, CHARACTER FOR CHARACTER, IN server/fermata/trainer.py's
 // CHORD_QUALITIES and chord_tones - the same pair neck.js's PITCH_CLASSES
 // and trainer.py's own PITCH_CLASSES already are. tests/unit/chord-
-// theory.spec.js checks every one of the 36 (root, quality) chords this
+// theory.spec.js checks every one of the 60 (root, quality) chords this
 // module can build; server/tests/test_chord_theory.py checks the identical
-// 36 on the Python side, so a drift between the two fails a test on
+// 60 on the Python side, so a drift between the two fails a test on
 // whichever side changed rather than showing up as a shape and its label
-// disagreeing about what chord is on screen.
+// disagreeing about what chord is on screen. test_chord_theory.py also
+// parses this module's own source to pin the two tables' intervals equal,
+// key for key, rather than trusting the two lists to stay in step by hand.
 import { PITCH_CLASSES } from "./neck.js";
 
 // Interval steps from the root, in semitones - a triad for major and minor,
-// a tetrad for the one seventh chord this module names. "Majors and minors
-// first, then sevenths" (issue #28) is exactly this order.
+// a tetrad for every seventh chord this module names. "Majors and minors
+// first, then sevenths" (issue #28, extended by #252 to the minor and major
+// seventh alongside the dominant) is exactly this order.
 export const QUALITIES = {
   major: { label: "major", suffix: "", intervals: [0, 4, 7] },
   minor: { label: "minor", suffix: "m", intervals: [0, 3, 7] },
   dominant7: { label: "7th", suffix: "7", intervals: [0, 4, 7, 10] },
+  minor7: { label: "minor 7th", suffix: "m7", intervals: [0, 3, 7, 10] },
+  major7: { label: "major 7th", suffix: "maj7", intervals: [0, 4, 7, 11] },
 };
 
 export const QUALITY_LIST = Object.keys(QUALITIES);
@@ -48,15 +53,19 @@ export function chordTones(root, quality) {
   return q.intervals.map((step) => PITCH_CLASSES[(rootIndex + step) % 12]);
 }
 
-/** "C major", "A minor", "G7" - how a chord is named wherever one is shown,
- * so the flash card's prompt, its answer choices, and its structured
- * attempt row can never spell the same chord two different ways. Null for
- * an unknown root or quality, the same as chordTones. */
+/** "C major", "A minor", "G7", "Cm7", "Cmaj7" - how a chord is named
+ * wherever one is shown, so the flash card's prompt, its answer choices,
+ * and its structured attempt row can never spell the same chord two
+ * different ways. Major and minor read as a word ("C major"); every
+ * seventh reads as its own suffix run straight against the root, the
+ * style a guitarist already reads a seventh chord's name in - this is why
+ * QUALITIES carries a suffix at all rather than only a label. Null for an
+ * unknown root or quality, the same as chordTones. */
 export function chordName(root, quality) {
   const q = QUALITIES[quality];
   if (PITCH_CLASSES.indexOf(root) < 0 || !q) return null;
-  if (quality === "dominant7") return `${root}7`;
-  return `${root} ${q.label}`;
+  if (quality === "major" || quality === "minor") return `${root} ${q.label}`;
+  return `${root}${q.suffix}`;
 }
 
 /** Whether two chords - each a (root, quality) pair - are the SAME chord,

--- a/web/src/lib/trainer/chords.js
+++ b/web/src/lib/trainer/chords.js
@@ -58,8 +58,13 @@ export const FAMILIES = {
   },
   sevenths: {
     label: "Sevenths",
-    qualities: ["dominant7"],
-    shapeFamilies: ["open"],
+    // Dominant, minor and major sevenths together (issue #252) - the
+    // dominant's open shapes plus the minor and major's movable E/A-form
+    // barre shapes (chord-shapes.js has no OPEN shape for either new
+    // quality, only "one E-form and one A-form movable shape" as the
+    // issue's own appetite asks for).
+    qualities: ["dominant7", "minor7", "major7"],
+    shapeFamilies: ["open", "barre-e-minor7", "barre-a-minor7", "barre-e-major7", "barre-a-major7"],
   },
   barre: {
     label: "Barre chords",

--- a/web/tests/browser/chord-flashcards.spec.js
+++ b/web/tests/browser/chord-flashcards.spec.js
@@ -382,13 +382,18 @@ test("sevenths: a minor7 and a major7 card are each offered, answered, and logge
   expect(answered.major7, "a major7 card was drawn and answered within 40 questions").toBeTruthy();
 
   for (const quality of ["minor7", "major7"]) {
-    const { attempts, total } = await (
-      await request.get(`/api/trainer/chord-attempts?quality=${quality}&root=${answered[quality]}`)
-    ).json();
-    expect(total, `a logged ${quality} attempt`).toBeGreaterThan(0);
-    expect(attempts[0].target_quality).toBe(quality);
-    expect(attempts[0].target_root).toBe(answered[quality]);
-    expect(attempts[0].correct).toBe(true);
+    // The attempt POST is fire-and-forget from the page's own side (#110) -
+    // nothing here ordered it after the click above, so this read must
+    // retry rather than race it.
+    await expect(async () => {
+      const { attempts, total } = await (
+        await request.get(`/api/trainer/chord-attempts?quality=${quality}&root=${answered[quality]}`)
+      ).json();
+      expect(total, `a logged ${quality} attempt`).toBeGreaterThan(0);
+      expect(attempts[0].target_quality).toBe(quality);
+      expect(attempts[0].target_root).toBe(answered[quality]);
+      expect(attempts[0].correct).toBe(true);
+    }).toPass({ timeout: 10_000 });
   }
 });
 

--- a/web/tests/browser/chord-flashcards.spec.js
+++ b/web/tests/browser/chord-flashcards.spec.js
@@ -27,13 +27,21 @@ const today = localDay();
 // would show up as this suite's own assertions failing against what the
 // page renders, which is the point.
 const PITCH_CLASSES = ["C", "C#", "D", "Eb", "E", "F", "F#", "G", "Ab", "A", "Bb", "B"];
-const INTERVALS = { major: [0, 4, 7], minor: [0, 3, 7], dominant7: [0, 4, 7, 10] };
+const INTERVALS = {
+  major: [0, 4, 7],
+  minor: [0, 3, 7],
+  dominant7: [0, 4, 7, 10],
+  minor7: [0, 3, 7, 10],
+  major7: [0, 4, 7, 11],
+};
+const SEVENTH_SUFFIX = { dominant7: "7", minor7: "m7", major7: "maj7" };
 function chordTones(root, quality) {
   const i = PITCH_CLASSES.indexOf(root);
   return INTERVALS[quality].map((step) => PITCH_CLASSES[(i + step) % 12]);
 }
 function chordName(root, quality) {
-  return quality === "dominant7" ? `${root}7` : `${root} ${quality}`;
+  if (quality === "major" || quality === "minor") return `${root} ${quality}`;
+  return `${root}${SEVENTH_SUFFIX[quality]}`;
 }
 
 async function reset(request) {
@@ -337,6 +345,51 @@ test("stopping the drill also logs one chords practice session, with a human-rea
   );
   expect(forbiddenWord(sessions[0].note), sessions[0].note).toBeNull();
   expect(sessions[0].note).not.toMatch(/%/);
+});
+
+// ---------------------------------------------------------------------------
+// The new seventh qualities (issue #252): the sevenths preset now offers
+// minor7 and major7 alongside the dominant, drawn entirely from the new
+// movable barre shapes - each one answered for real and read back through
+// the API under its own quality string.
+// ---------------------------------------------------------------------------
+
+test("sevenths: a minor7 and a major7 card are each offered, answered, and logged with their own quality", async ({
+  page,
+  request,
+}) => {
+  await page.locator(".family-choice", { hasText: "Sevenths" }).click();
+  await startButton(page).click();
+
+  const answered = { minor7: null, major7: null };
+  for (let i = 0; i < 40 && (!answered.minor7 || !answered.major7); i++) {
+    const q = await question(page);
+    if ((q.quality === "minor7" || q.quality === "major7") && !answered[q.quality]) {
+      answered[q.quality] = q.root;
+      await page.locator(`.choice[data-root="${q.root}"][data-quality="${q.quality}"]`).click();
+      await expect(answerStatement(page)).toContainText(chordName(q.root, q.quality));
+    } else {
+      // Any other card (a dominant7, or a quality already captured) is
+      // still answered so the drill advances - naming the shown chord
+      // itself, which is always correct, since the point here is reaching
+      // both new qualities, not grading every card along the way.
+      await page.locator(`.choice[data-root="${q.root}"][data-quality="${q.quality}"]`).click();
+    }
+    await page.locator(".next-question").click();
+  }
+
+  expect(answered.minor7, "a minor7 card was drawn and answered within 40 questions").toBeTruthy();
+  expect(answered.major7, "a major7 card was drawn and answered within 40 questions").toBeTruthy();
+
+  for (const quality of ["minor7", "major7"]) {
+    const { attempts, total } = await (
+      await request.get(`/api/trainer/chord-attempts?quality=${quality}&root=${answered[quality]}`)
+    ).json();
+    expect(total, `a logged ${quality} attempt`).toBeGreaterThan(0);
+    expect(attempts[0].target_quality).toBe(quality);
+    expect(attempts[0].target_root).toBe(answered[quality]);
+    expect(attempts[0].correct).toBe(true);
+  }
 });
 
 test("leaving the page mid-drill still logs the practice", async ({ page, request }) => {

--- a/web/tests/browser/chord-flashcards.spec.js
+++ b/web/tests/browser/chord-flashcards.spec.js
@@ -387,7 +387,12 @@ test("sevenths: a minor7 and a major7 card are each offered, answered, and logge
     // retry rather than race it.
     await expect(async () => {
       const { attempts, total } = await (
-        await request.get(`/api/trainer/chord-attempts?quality=${quality}&root=${answered[quality]}`)
+        await request.get(
+          // A root like F# has to be encoded - a bare "#" starts a URL
+          // fragment and silently truncates everything after it, which is
+          // exactly the intermittent failure a sharp root drew here first.
+          `/api/trainer/chord-attempts?quality=${quality}&root=${encodeURIComponent(answered[quality])}`,
+        )
       ).json();
       expect(total, `a logged ${quality} attempt`).toBeGreaterThan(0);
       expect(attempts[0].target_quality).toBe(quality);

--- a/web/tests/spec-floors/browser-chord-flashcards-252.json
+++ b/web/tests/spec-floors/browser-chord-flashcards-252.json
@@ -1,0 +1,5 @@
+{
+  "file": "tests/browser/chord-flashcards.spec.js",
+  "count": 1,
+  "reason": "issue #252: against the real backend and the real build, the sevenths preset offers a minor7 and a major7 card (drawn from the new movable barre shapes, since neither quality has an open one), each one actually answered through the page, and each attempt read back through /api/trainer/chord-attempts under its own quality string rather than only asserted client-side."
+}

--- a/web/tests/spec-floors/unit-chord-shapes-252.json
+++ b/web/tests/spec-floors/unit-chord-shapes-252.json
@@ -1,0 +1,5 @@
+{
+  "file": "tests/unit/chord-shapes.spec.js",
+  "count": 2,
+  "reason": "issue #252: the new minor7 and major7 E-form and A-form movable barre shapes - a known root read off the neck at a known base fret for each new quality (F minor7, C major7), and the E-shape minor7 form naming all twelve roots across a fret range the same way the existing major-quality test already proves for its own family. Every instance's actual sounded notes against chord-theory.js's chordTones is already covered by the existing exhaustive barre-shape loop, which iterates every template with no changes needed."
+}

--- a/web/tests/spec-floors/unit-chord-theory-252.json
+++ b/web/tests/spec-floors/unit-chord-theory-252.json
@@ -1,0 +1,5 @@
+{
+  "file": "tests/unit/chord-theory.spec.js",
+  "count": 4,
+  "reason": "issue #252: the minor and major seventh added to QUALITIES - known minor and major sevenths asserted by hand, and each proven built on its own triad plus one more note at every root, the same relationship dominant7 is already held to and the one a mutation giving minor7 dominant7's own intervals would fail on the third rather than only on note count."
+}

--- a/web/tests/spec-floors/unit-chord-theory-28.json
+++ b/web/tests/spec-floors/unit-chord-theory-28.json
@@ -1,5 +1,5 @@
 {
   "file": "tests/unit/chord-theory.spec.js",
   "count": 10,
-  "reason": "issue #28: chord music theory is load-bearing, so this drill's chord tones are checked exhaustively - known major, minor and dominant-seventh triads/tetrads asserted by hand, then every one of the 36 (root, quality) chords this module can build checked for note count, no repeated tone, and starting on its own root, plus the major/minor third relationship and the dominant-seventh-is-a-major-triad-plus-one-note relationship holding at every root, chord naming, and chordsMatch (the tone-set equality the flash card grades by) refusing an unknown chord rather than throwing."
+  "reason": "issue #28: chord music theory is load-bearing, so this drill's chord tones are checked exhaustively - known major, minor, dominant-, minor- and major-seventh triads/tetrads asserted by hand, then every one of the 60 (root, quality) chords this module can build checked for note count, no repeated tone, and starting on its own root, plus the major/minor third relationship and the dominant-seventh-is-a-major-triad-plus-one-note relationship holding at every root, chord naming, and chordsMatch (the tone-set equality the flash card grades by) refusing an unknown chord rather than throwing."
 }

--- a/web/tests/spec-floors/unit-chords-252.json
+++ b/web/tests/spec-floors/unit-chords-252.json
@@ -1,0 +1,5 @@
+{
+  "file": "tests/unit/chords.spec.js",
+  "count": 1,
+  "reason": "issue #252: the sevenths family preset, widened to all three seventh qualities, actually offers minor7 and major7 chords in its pool - drawn entirely from the new movable barre shapes, since neither new quality has an open shape."
+}

--- a/web/tests/unit/chord-shapes.spec.js
+++ b/web/tests/unit/chord-shapes.spec.js
@@ -92,6 +92,29 @@ test("across twelve consecutive base frets, an E-shape major barre names every o
   expect(roots.size).toBe(12);
 });
 
+// ---------------------------------------------------------------- minor7 / major7 barre shapes (issue #252)
+
+test("the new minor7 and major7 barre shapes are generated the same way, root read off the neck at each one", () => {
+  const shapes = barreShapesFor(strings, { minBaseFret: 1, maxFret: 12 });
+  // F minor7: E-shape minor7 at fret 1 - the same "first barre chord"
+  // position as F major, one quality over.
+  const fMinor7 = shapes.find((s) => s.id === "barre-e-minor7:1");
+  expect(fMinor7.root).toBe("F");
+  expect(fMinor7.quality).toBe("minor7");
+  // C major7: A-shape major7 at fret 3, an octave-plus-a-bit up from the
+  // open-position C the A-shape's plain major form reaches at the same fret.
+  const cMajor7 = shapes.find((s) => s.id === "barre-a-major7:3");
+  expect(cMajor7.root).toBe("C");
+  expect(cMajor7.quality).toBe("major7");
+});
+
+test("across twelve consecutive base frets, an E-shape minor7 barre names every one of the twelve roots", () => {
+  const shapes = barreShapesFor(strings, { minBaseFret: 1, maxFret: 14 })
+    .filter((s) => s.id.startsWith("barre-e-minor7:"));
+  const roots = new Set(shapes.map((s) => s.root));
+  expect(roots.size).toBe(12);
+});
+
 // ---------------------------------------------------------------- shapeMatchesChord
 
 test("shapeMatchesChord is true for a shape against its own declared chord", () => {

--- a/web/tests/unit/chord-theory.spec.js
+++ b/web/tests/unit/chord-theory.spec.js
@@ -44,11 +44,25 @@ test("known dominant sevenths are exactly right", () => {
   expect(chordTones("B", "dominant7")).toEqual(["B", "Eb", "F#", "A"]);
 });
 
+test("known minor sevenths are exactly right", () => {
+  expect(chordTones("A", "minor7")).toEqual(["A", "C", "E", "G"]);
+  expect(chordTones("D", "minor7")).toEqual(["D", "F", "A", "C"]);
+  expect(chordTones("E", "minor7")).toEqual(["E", "G", "B", "D"]);
+  expect(chordTones("C", "minor7")).toEqual(["C", "Eb", "G", "Bb"]);
+});
+
+test("known major sevenths are exactly right", () => {
+  expect(chordTones("C", "major7")).toEqual(["C", "E", "G", "B"]);
+  expect(chordTones("F", "major7")).toEqual(["F", "A", "C", "E"]);
+  expect(chordTones("G", "major7")).toEqual(["G", "B", "D", "F#"]);
+  expect(chordTones("E", "major7")).toEqual(["E", "Ab", "B", "Eb"]);
+});
+
 // ---------------------------------------------------------------- exhaustive, every root x quality
 
-test("every one of the 36 (root, quality) chords has the right note count and no repeats", () => {
+test("every one of the 60 (root, quality) chords has the right note count and no repeats", () => {
   expect(ROOTS).toHaveLength(12);
-  expect(QUALITY_LIST).toEqual(["major", "minor", "dominant7"]);
+  expect(QUALITY_LIST).toEqual(["major", "minor", "dominant7", "minor7", "major7"]);
   for (const root of ROOTS) {
     for (const quality of QUALITY_LIST) {
       const tones = chordTones(root, quality);
@@ -81,12 +95,40 @@ test("a dominant seventh is its major triad plus one more note, at every root", 
   }
 });
 
+// A minor seventh is built on the MINOR triad, not the major one - this is
+// what distinguishes it from a dominant seventh, which shares a root's
+// triad but not its seventh. A mutation that gave minor7 dominant7's own
+// intervals (both are (root, +7 semitones)-shaped tetrads, so a bare note-
+// count check would not catch it) fails right here, on the third.
+test("a minor seventh is its minor triad plus one more note, at every root", () => {
+  for (const root of ROOTS) {
+    const minor = chordTones(root, "minor");
+    const seventh = chordTones(root, "minor7");
+    expect(seventh.slice(0, 3)).toEqual(minor);
+    expect(seventh).toHaveLength(4);
+  }
+});
+
+// Same relationship, on the major triad plus the MAJOR seventh (a half
+// step closer to the root than the dominant/minor seventh above) - the
+// interval that gives this chord its "maj7" suffix rather than a plain "7".
+test("a major seventh is its major triad plus one more note, at every root", () => {
+  for (const root of ROOTS) {
+    const major = chordTones(root, "major");
+    const seventh = chordTones(root, "major7");
+    expect(seventh.slice(0, 3)).toEqual(major);
+    expect(seventh).toHaveLength(4);
+  }
+});
+
 // ---------------------------------------------------------------- naming
 
 test("chordName spells every quality the way a flash card should read it", () => {
   expect(chordName("C", "major")).toBe("C major");
   expect(chordName("A", "minor")).toBe("A minor");
   expect(chordName("G", "dominant7")).toBe("G7");
+  expect(chordName("C", "minor7")).toBe("Cm7");
+  expect(chordName("C", "major7")).toBe("Cmaj7");
 });
 
 test("an unknown root or quality names no chord at all", () => {

--- a/web/tests/unit/chords.spec.js
+++ b/web/tests/unit/chords.spec.js
@@ -36,7 +36,10 @@ const fullScope = { startFret: 0, endFret: 12 };
 test("the three family presets say what issue #28 asks for, in order", () => {
   expect(FAMILY_LIST).toEqual(["major_minor", "sevenths", "barre"]);
   expect(FAMILIES.major_minor.qualities).toEqual(["major", "minor"]);
-  expect(FAMILIES.sevenths.qualities).toEqual(["dominant7"]);
+  // Sevenths widened by issue #252 to all three seventh qualities - the
+  // dominant's open shapes plus the new minor/major sevenths' movable
+  // barre forms.
+  expect(FAMILIES.sevenths.qualities).toEqual(["dominant7", "minor7", "major7"]);
   expect(FAMILIES.barre.qualities).toEqual(["major", "minor"]);
   expect(FAMILIES.major_minor.shapeFamilies).toEqual(["open"]);
   expect(FAMILIES.barre.shapeFamilies.every((f) => f.startsWith("barre"))).toBe(true);
@@ -53,14 +56,27 @@ test("the major & minor pool over the full scope contains the open C major and E
   expect(pool.every((s) => s.family === "open")).toBe(true);
 });
 
-test("the sevenths pool contains only dominant sevenths, and the barre pool only barre shapes", () => {
+test("the sevenths pool contains only the three seventh qualities, and the barre pool only barre shapes", () => {
   const sevenths = chordPool(strings, fullScope, "sevenths");
   expect(sevenths.length).toBeGreaterThan(0);
-  expect(sevenths.every((s) => s.quality === "dominant7")).toBe(true);
+  expect(sevenths.every((s) => ["dominant7", "minor7", "major7"].includes(s.quality))).toBe(true);
 
   const barre = chordPool(strings, fullScope, "barre");
   expect(barre.length).toBeGreaterThan(0);
   expect(barre.every((s) => s.family.startsWith("barre"))).toBe(true);
+});
+
+test("the sevenths pool also offers minor and major sevenths, drawn from the new barre shapes", () => {
+  const sevenths = chordPool(strings, fullScope, "sevenths");
+  const minor7 = sevenths.filter((s) => s.quality === "minor7");
+  const major7 = sevenths.filter((s) => s.quality === "major7");
+  expect(minor7.length).toBeGreaterThan(0);
+  expect(major7.length).toBeGreaterThan(0);
+  // Neither new quality has an open shape (chord-shapes.js only builds one
+  // for major, minor and dominant7) - every instance is one of the two new
+  // movable barre families.
+  expect(minor7.every((s) => s.family.startsWith("barre"))).toBe(true);
+  expect(major7.every((s) => s.family.startsWith("barre"))).toBe(true);
 });
 
 test("narrowing the fret range to open position drops a shape that needs a higher fret", () => {

--- a/web/tests/unit/practice.spec.js
+++ b/web/tests/unit/practice.spec.js
@@ -202,6 +202,11 @@ const COMPONENTS = [
   // step from a list of the things they have not covered - so the words on
   // it are held to the same rule as everything above.
   "trainer/ScopePresets.svelte",
+  // The chord flash card drill (#28), extended with the minor and major
+  // seventh (#252): its own prompt strings and every chord name it renders
+  // are held to the same vocabulary rule as the rest of the practice
+  // surface.
+  "trainer/ChordFlashCards.svelte",
 ];
 
 // The attributes a person actually reads. Every other attribute value is


### PR DESCRIPTION
## Premise verdict: valid

On main `1527d0a`, `web/src/lib/trainer/chord-theory.js`'s `QUALITIES` and `server/fermata/trainer.py`'s `CHORD_QUALITIES` held exactly major, minor and dominant7; `theory.spec.js` covered 36 (root, quality) chords; a chord attempt with `quality=minor7` was refused with **422** (`target_quality must be one of ['major', 'minor', 'dominant7']`).

## What changed

- Added `minor7` ([0,3,7,10], suffix `m7`) and `major7` ([0,4,7,11], suffix `maj7`) to both quality tables, after `dominant7`.
- **Shapes decision**: `chord-shapes.js`'s `BARRE_TEMPLATES` keys shapes per quality (open shapes are a separate hardcoded list) - so I added one E-form and one A-form movable barre shape for each new quality (`web/src/lib/trainer/chord-shapes.js:104-136`), derived from the real open Em7/Emaj7/Am7/Amaj7 fingerings made movable. Neither quality gets an open shape (issue's own appetite: "one E-form and one A-form... is enough").
- Widened the `sevenths` family preset (`chords.js`) to `["dominant7", "minor7", "major7"]`, shape families `open` + the four new barre families - the dominant's open shapes plus the two new movable forms.
- Generalized `chordName` to spell every seventh by suffix (`Cm7`, `Cmaj7`) rather than only special-casing `dominant7`; `ChordFlashCards.svelte`'s name-to-shape prompt now uses it instead of an ad hoc ternary.
- Added `ChordFlashCards.svelte` to `practice.spec.js`'s `COMPONENTS` vocabulary guard (it was not previously listed) - this caught one pre-existing "only" in its footnote, reworded.
- New cross-side test (`server/tests/test_chord_theory.py`) parses `chord-theory.js`'s `QUALITIES` source and pins it equal to `trainer.CHORD_QUALITIES`, interval for interval - the same technique `test_settings_api.py` already uses for `SCORE_THEMES`/`WEEK_STARTS`.
- Checked the #236 preset key-quality field (`trainer.py`'s `_preset_key`/`KEY_QUALITIES`, `constraints.js`'s `KEY_QUALITIES`): it enumerates **KEY** qualities (major/minor scale), not chord qualities, and is untouched. See Hypotheses below on the Done-when item this affects.

## Done-when

- [x] Both tables list five qualities, cross-side test fails on divergence (proven by mutation)
- [x] Drill offers minor7/major7 cards, renders a shape for each root (sevenths preset; barre shapes proven against `chordTones` for all 12 roots)
- [x] `quality=minor7` attempt accepted by POST and read back (also tested with major7); unknown quality still **422**
- [x] `theory.spec.js` covers 60 chords
- [x] Browser spec answers one minor7 and one major7 card, floor file added
- [ ] "a preset saved with a seventh quality restores it" - **not implemented, likely a mismatch in the issue**: presets (#236) round-trip only strings/fret-range/key; the key's own quality field is major/minor (a scale), unrelated to chord quality, and a preset carries no chord family/quality at all. See Hypotheses.

## Mutation table

| Mutation | Expected red | Result |
|---|---|---|
| Drop `major7` from server `CHORD_QUALITIES` only | cross-side test + attempt-logging test | Both red (`test_chord_qualities_mirror_chord_theory_js_interval_for_interval`, `test_the_new_seventh_qualities_are_accepted_and_round_trip[major7-...]`), plus 3 other pre-existing tests |
| Give `minor7` dominant7's intervals in `chord-theory.js` | theory spec | Red (`known minor sevenths...`, `a minor seventh is its minor triad...`) |
| Wrong fret in a new barre shape | shape-tones test | Red (existing generic `every generated barre shape's actual sounded notes...` loop, no new test needed) |

All three reverted after confirming red; `git diff` clean before commit.

## Suite lines

- `py -3.13 -m pytest server/tests -rs -q` (PYTHONPATH pinned to this worktree's `server/`, `FERMATA_TEST_LIBRARY` unset): **1346 passed, 81 skipped, 1 warning in 134.46s** - all skips are the documented `FERMATA_TEST_LIBRARY`/`FERMATA_MUSICXML_XSD` local-only ones.
- Browser: full `npm run test:browser` **not-run locally; CI's Browser tests job stands in**. Ran the touched spec only, in the foreground, port 9147, 3x back to back after fixing a flake (see below): **12 passed** each time.
- Unit (`chord-theory`, `chord-shapes`, `chords`, `practice`): **93 passed**.

## Hypotheses

- The Done-when item "a preset saved with a seventh quality restores it" appears to conflate the preset's KEY quality (major/minor only) with CHORD quality - there is no chord-family field on a preset to restore. Confidence: high, based on reading `_preset_key`/`KEY_QUALITIES` directly.
- Found and fixed a real flake in my own new browser test during verification, not present in shipped main: a sharp root (e.g. `F#`) in the attempt-read query broke the URL (`#` starts a fragment), timing out the retry loop. Fixed with `encodeURIComponent`; reran 3x clean after.

Closes #252