### PR TITLE
Chord flash cards now offer Em7, Emaj7, Am7 and Amaj7 in open position

### DIFF
--- a/web/src/lib/trainer/chord-shapes.js
+++ b/web/src/lib/trainer/chord-shapes.js
@@ -108,7 +108,7 @@ const BARRE_TEMPLATES = {
     offsets: [[6, 0], [5, 2], [4, 2], [3, 0], [2, 0], [1, 0]],
   },
   // The E-shape's minor-seventh and major-seventh forms (issue #252) - the
-  // open Em7 (022030-style: 0 2 0 0 0 0) and Emaj7 (0 2 1 1 0 0) fingerings,
+  // open Em7 (0 2 0 0 0 0) and Emaj7 (0 2 1 1 0 0) fingerings,
   // made movable the same way barre-e-major/minor already are: every fret
   // relative to a base that slides up the neck. shape-tones.spec.js checks
   // every instance this produces against chord-theory.js's own chordTones,

--- a/web/src/lib/trainer/chord-shapes.js
+++ b/web/src/lib/trainer/chord-shapes.js
@@ -75,6 +75,19 @@ const OPEN_SHAPE_TEMPLATES = [
   { root: "G", quality: "dominant7", frets: [[6, 3], [5, 2], [4, 0], [3, 0], [2, 0], [1, 1]] },
   { root: "C", quality: "major", frets: [[5, 3], [4, 2], [3, 0], [2, 1], [1, 0]] },
   { root: "B", quality: "dominant7", frets: [[5, 2], [4, 1], [3, 2], [2, 0], [1, 2]] },
+  // The open minor-seventh and major-seventh chords (issue #261) - exactly
+  // the E-form and A-form BARRE_TEMPLATES' own offsets below, at base fret
+  // 0, the same relationship the E/A major and minor open shapes above
+  // already have to their own barre templates (compare, e.g., "E" "major"
+  // above to BARRE_TEMPLATES["barre-e-major"].offsets: identical numbers).
+  // barreShapesFor defaults minBaseFret to 1, so these two qualities never
+  // otherwise reach base fret 0 - the open Em7/Emaj7/Am7/Amaj7 fingerings a
+  // player actually learns first were missing entirely until this shape was
+  // added here, hardcoded the same way every other open shape is.
+  { root: "E", quality: "minor7", frets: [[6, 0], [5, 2], [4, 0], [3, 0], [2, 0], [1, 0]] },
+  { root: "E", quality: "major7", frets: [[6, 0], [5, 2], [4, 1], [3, 1], [2, 0], [1, 0]] },
+  { root: "A", quality: "minor7", frets: [[5, 0], [4, 2], [3, 0], [2, 1], [1, 0]] },
+  { root: "A", quality: "major7", frets: [[5, 0], [4, 2], [3, 1], [2, 2], [1, 0]] },
 ];
 
 // The two moveable barre forms, as offsets from a base fret on the form's

--- a/web/src/lib/trainer/chords.js
+++ b/web/src/lib/trainer/chords.js
@@ -58,11 +58,11 @@ export const FAMILIES = {
   },
   sevenths: {
     label: "Sevenths",
-    // Dominant, minor and major sevenths together (issue #252) - the
-    // dominant's open shapes plus the minor and major's movable E/A-form
-    // barre shapes (chord-shapes.js has no OPEN shape for either new
-    // quality, only "one E-form and one A-form movable shape" as the
-    // issue's own appetite asks for).
+    // Dominant, minor and major sevenths together (issue #252, open
+    // minor/major-seventh shapes added by #261) - the dominant's, minor's
+    // and major's open shapes (Em7, Emaj7, Am7, Amaj7 alongside the
+    // existing open E7, A7, D7, G7, B7) plus the minor and major's movable
+    // E/A-form barre shapes for every other root.
     qualities: ["dominant7", "minor7", "major7"],
     shapeFamilies: ["open", "barre-e-minor7", "barre-a-minor7", "barre-e-major7", "barre-a-major7"],
   },

--- a/web/tests/browser/chord-flashcards.spec.js
+++ b/web/tests/browser/chord-flashcards.spec.js
@@ -402,6 +402,49 @@ test("sevenths: a minor7 and a major7 card are each offered, answered, and logge
   }
 });
 
+// ---------------------------------------------------------------------------
+// Open-position sevenths (issue #261): Em7, Emaj7, Am7 and Amaj7 are real
+// open shapes now, not only reachable as a barre form. Narrowed to frets
+// 0-2, no barre shape fits at all - its lowest base fret is 1 and its
+// smallest template still needs two frets past that, so this scope's
+// sevenths pool is open shapes only, and any minor7/major7 card drawn here
+// is necessarily the open one.
+// ---------------------------------------------------------------------------
+
+test("sevenths, open position only: a minor7 or major7 card is offered at base fret 0 with an open string", async ({
+  page,
+}) => {
+  await page.locator(".family-choice", { hasText: "Sevenths" }).click();
+  await page.selectOption(".scope-end-fret", "2");
+  await startButton(page).click();
+
+  let openSeventh = null;
+  for (let i = 0; i < 20 && !openSeventh; i++) {
+    const q = await question(page);
+    if (q.quality === "minor7" || q.quality === "major7") {
+      openSeventh = q;
+      break;
+    }
+    await page.locator(`.choice[data-root="${q.root}"][data-quality="${q.quality}"]`).click();
+    await page.locator(".next-question").click();
+  }
+
+  expect(
+    openSeventh,
+    "a minor7 or major7 card was drawn within 20 questions, frets 0-2 only",
+  ).toBeTruthy();
+  expect(["E", "A"]).toContain(openSeventh.root);
+
+  // Confirmed off the neck's own rendered markers, not merely inferred from
+  // the scope: the shown shape really does include an open string, which no
+  // barre instance in this range could ever show.
+  const targetFrets = await page
+    .locator('g.position[data-marker="target"]')
+    .evaluateAll((els) => els.map((el) => Number(el.dataset.fret)));
+  expect(targetFrets.length).toBeGreaterThan(0);
+  expect(targetFrets).toContain(0);
+});
+
 test("leaving the page mid-drill still logs the practice", async ({ page, request }) => {
   await startButton(page).click();
   const q = await question(page);

--- a/web/tests/spec-floors/browser-chord-flashcards-261.json
+++ b/web/tests/spec-floors/browser-chord-flashcards-261.json
@@ -1,0 +1,5 @@
+{
+  "file": "tests/browser/chord-flashcards.spec.js",
+  "count": 1,
+  "reason": "issue #261: against the real backend and the real build, the sevenths preset narrowed to open position (frets 0-2, where no barre shape fits) offers a minor7 or major7 card that is the open Em7/Emaj7/Am7/Amaj7 shape - confirmed off the neck's own rendered target markers, base fret 0 with an open string."
+}

--- a/web/tests/spec-floors/unit-chord-shapes-261.json
+++ b/web/tests/spec-floors/unit-chord-shapes-261.json
@@ -1,0 +1,5 @@
+{
+  "file": "tests/unit/chord-shapes.spec.js",
+  "count": 1,
+  "reason": "issue #261: Em7, Emaj7, Am7 and Amaj7 are all offered as open shapes - base fret 0 with an open string, each checked against chord-theory.js's own chordTones (via the existing exhaustive open-shape loop, unchanged) and, on top of that, read exactly as a guitarist would write the frets (022000, 021100, x02010, x02120)."
+}

--- a/web/tests/spec-floors/unit-chord-shapes-261.json
+++ b/web/tests/spec-floors/unit-chord-shapes-261.json
@@ -1,5 +1,5 @@
 {
   "file": "tests/unit/chord-shapes.spec.js",
   "count": 1,
-  "reason": "issue #261: Em7, Emaj7, Am7 and Amaj7 are all offered as open shapes - base fret 0 with an open string, each checked against chord-theory.js's own chordTones (via the existing exhaustive open-shape loop, unchanged) and, on top of that, read exactly as a guitarist would write the frets (022000, 021100, x02010, x02120)."
+  "reason": "issue #261: Em7, Emaj7, Am7 and Amaj7 are all offered as open shapes - base fret 0 with an open string, each checked against chord-theory.js's own chordTones (via the existing exhaustive open-shape loop, unchanged) and, on top of that, read exactly as a guitarist would write the frets (020000, 021100, x02010, x02120)."
 }

--- a/web/tests/spec-floors/unit-chords-252.json
+++ b/web/tests/spec-floors/unit-chords-252.json
@@ -1,5 +1,5 @@
 {
   "file": "tests/unit/chords.spec.js",
   "count": 1,
-  "reason": "issue #252: the sevenths family preset, widened to all three seventh qualities, actually offers minor7 and major7 chords in its pool - drawn entirely from the new movable barre shapes, since neither new quality has an open shape."
+  "reason": "issue #252: the sevenths family preset, widened to all three seventh qualities, actually offers minor7 and major7 chords in its pool - drawn from the movable barre shapes plus, since #261, the open Em7, Emaj7, Am7 and Amaj7 shapes."
 }

--- a/web/tests/unit/chord-shapes.spec.js
+++ b/web/tests/unit/chord-shapes.spec.js
@@ -72,7 +72,7 @@ test("Em7, Emaj7, Am7 and Amaj7 are all offered as open shapes, base fret 0 with
     expect(shape.frets.some((f) => f.fret === 0), `${shape.id} has an open string`).toBe(true);
     expect(shape.frets.every((f) => f.fret >= 0), `${shape.id} never frets below the nut`).toBe(true);
   }
-  // Read exactly as a guitarist would write them - Em7 022000, Emaj7 021100,
+  // Read exactly as a guitarist would write them - Em7 020000, Emaj7 021100,
   // Am7 x02010, Amaj7 x02120 (see chord-shapes.js's own comment on why these
   // are the barre templates' own offsets at base fret 0).
   expect(Object.fromEntries(em7.frets.map((f) => [f.string, f.fret]))).toEqual({

--- a/web/tests/unit/chord-shapes.spec.js
+++ b/web/tests/unit/chord-shapes.spec.js
@@ -59,6 +59,36 @@ test("a known open shape's frets read exactly as a guitarist would write them - 
   expect(byString[6]).toBeUndefined(); // muted, same as chord notation's "x"
 });
 
+// -------------------------------------------------- open minor7/major7 shapes (issue #261)
+
+test("Em7, Emaj7, Am7 and Amaj7 are all offered as open shapes, base fret 0 with an open string", () => {
+  const shapes = openShapesFor(strings);
+  const em7 = shapes.find((s) => s.id === "open:E:minor7");
+  const emaj7 = shapes.find((s) => s.id === "open:E:major7");
+  const am7 = shapes.find((s) => s.id === "open:A:minor7");
+  const amaj7 = shapes.find((s) => s.id === "open:A:major7");
+  for (const shape of [em7, emaj7, am7, amaj7]) {
+    expect(shape, `${shape?.id ?? "shape"} is present`).toBeTruthy();
+    expect(shape.frets.some((f) => f.fret === 0), `${shape.id} has an open string`).toBe(true);
+    expect(shape.frets.every((f) => f.fret >= 0), `${shape.id} never frets below the nut`).toBe(true);
+  }
+  // Read exactly as a guitarist would write them - Em7 022000, Emaj7 021100,
+  // Am7 x02010, Amaj7 x02120 (see chord-shapes.js's own comment on why these
+  // are the barre templates' own offsets at base fret 0).
+  expect(Object.fromEntries(em7.frets.map((f) => [f.string, f.fret]))).toEqual({
+    6: 0, 5: 2, 4: 0, 3: 0, 2: 0, 1: 0,
+  });
+  expect(Object.fromEntries(emaj7.frets.map((f) => [f.string, f.fret]))).toEqual({
+    6: 0, 5: 2, 4: 1, 3: 1, 2: 0, 1: 0,
+  });
+  const am7ByString = Object.fromEntries(am7.frets.map((f) => [f.string, f.fret]));
+  expect(am7ByString).toEqual({ 5: 0, 4: 2, 3: 0, 2: 1, 1: 0 });
+  expect(am7ByString[6]).toBeUndefined(); // muted, like the open A shapes above it
+  const amaj7ByString = Object.fromEntries(amaj7.frets.map((f) => [f.string, f.fret]));
+  expect(amaj7ByString).toEqual({ 5: 0, 4: 2, 3: 1, 2: 2, 1: 0 });
+  expect(amaj7ByString[6]).toBeUndefined();
+});
+
 // ---------------------------------------------------------------- barre shapes, generated
 
 test("barre shapes are generated across a fret range, root read off the neck at each one", () => {

--- a/web/tests/unit/chords.spec.js
+++ b/web/tests/unit/chords.spec.js
@@ -36,9 +36,9 @@ const fullScope = { startFret: 0, endFret: 12 };
 test("the three family presets say what issue #28 asks for, in order", () => {
   expect(FAMILY_LIST).toEqual(["major_minor", "sevenths", "barre"]);
   expect(FAMILIES.major_minor.qualities).toEqual(["major", "minor"]);
-  // Sevenths widened by issue #252 to all three seventh qualities - the
-  // dominant's open shapes plus the new minor/major sevenths' movable
-  // barre forms.
+  // Sevenths widened by issue #252 to all three seventh qualities: the
+  // dominant's open shapes, the minor/major sevenths' movable barre forms,
+  // and (since #261) the open Em7, Emaj7, Am7 and Amaj7 shapes.
   expect(FAMILIES.sevenths.qualities).toEqual(["dominant7", "minor7", "major7"]);
   expect(FAMILIES.barre.qualities).toEqual(["major", "minor"]);
   expect(FAMILIES.major_minor.shapeFamilies).toEqual(["open"]);

--- a/web/tests/unit/chords.spec.js
+++ b/web/tests/unit/chords.spec.js
@@ -66,17 +66,25 @@ test("the sevenths pool contains only the three seventh qualities, and the barre
   expect(barre.every((s) => s.family.startsWith("barre"))).toBe(true);
 });
 
-test("the sevenths pool also offers minor and major sevenths, drawn from the new barre shapes", () => {
+test("the sevenths pool also offers minor and major sevenths, both open and barre", () => {
   const sevenths = chordPool(strings, fullScope, "sevenths");
   const minor7 = sevenths.filter((s) => s.quality === "minor7");
   const major7 = sevenths.filter((s) => s.quality === "major7");
   expect(minor7.length).toBeGreaterThan(0);
   expect(major7.length).toBeGreaterThan(0);
-  // Neither new quality has an open shape (chord-shapes.js only builds one
-  // for major, minor and dominant7) - every instance is one of the two new
-  // movable barre families.
-  expect(minor7.every((s) => s.family.startsWith("barre"))).toBe(true);
-  expect(major7.every((s) => s.family.startsWith("barre"))).toBe(true);
+  // Every instance is either the open Em7/Am7 (or Emaj7/Amaj7) shape
+  // (issue #261) or one of the two movable barre families - never anything
+  // else.
+  expect(minor7.every((s) => s.family === "open" || s.family.startsWith("barre"))).toBe(true);
+  expect(major7.every((s) => s.family === "open" || s.family.startsWith("barre"))).toBe(true);
+  // The open shape itself really is in the pool, at base fret 0 with at
+  // least one open string - the whole point of issue #261.
+  const openEm7 = minor7.find((s) => s.family === "open" && s.root === "E");
+  expect(openEm7).toBeTruthy();
+  expect(openEm7.frets.some((f) => f.fret === 0)).toBe(true);
+  const openAmaj7 = major7.find((s) => s.family === "open" && s.root === "A");
+  expect(openAmaj7).toBeTruthy();
+  expect(openAmaj7.frets.some((f) => f.fret === 0)).toBe(true);
 });
 
 test("narrowing the fret range to open position drops a shape that needs a higher fret", () => {


### PR DESCRIPTION
## Premise verdict: valid

On main `939a8b3`, `chord-shapes.js`'s `OPEN_SHAPE_TEMPLATES` had entries for major, minor and dominant7 only. `barreShapesFor`'s `minBaseFret` defaults to 1, and `chords.js`'s `sevenths` preset draws minor7/major7 only from the movable E-form/A-form barre families - no open shape existed for either quality, so a player drilling sevenths never saw Em7, Emaj7, Am7 or Amaj7, only their barre forms starting at fret 1 (matching the issue's own measured account, and PR #254's body, which states outright: "Neither quality gets an open shape").

## The four shapes, as shipped

Each is the corresponding E-form/A-form `BARRE_TEMPLATES` entry's own offsets at base fret 0 - the same relationship the existing open E/A major and minor shapes already have to their own barre templates.

| Shape | Frets (6→1) | Chord tones wanted | Sounded (verified via `chordTones`) |
|---|---|---|---|
| Em7 | 0 2 0 0 0 0 | E, G, B, D | E, G, B, D ✓ |
| Emaj7 | 0 2 1 1 0 0 | E, Ab, B, Eb | E, Ab, B, Eb ✓ |
| Am7 | x 0 2 0 1 0 | A, C, E, G | A, C, E, G ✓ |
| Amaj7 | x 0 2 1 2 0 | A, Ab, C#, E | A, Ab, C#, E ✓ |

Verified with a standalone script calling the real `chordTones`/`noteAt`/`pitchClass` before committing to the fingerings (all four matched on the first try - they are literally the barre templates' own numbers).

The `sevenths` family preset's `shapeFamilies` already included `"open"` (added by #254 for the dominant7 opens), so no change to `chords.js`'s selection path was needed - the new shapes enter automatically. Updated two stale comments (`chords.js`, `chords.spec.js`) that said "neither new quality has an open shape."

## Done-when

- [x] Shape-tones test covers the new shapes automatically - the existing exhaustive `openShapesFor` loop iterates all shapes, plus a new dedicated test naming all four and their exact frets.
- [x] Count moved: no floor or doc stated an exact shape count (only `toBeGreaterThan(N)` assertions, which still hold); grepped for a stated number, found none.
- [x] Drill actually offers an open seventh shape - new browser test narrows the scope to frets 0-2, where no barre shape fits (its lowest base fret is 1 and its smallest template still needs 2 frets past that), so the sevenths pool there is open shapes only; any minor7/major7 card drawn is the open one, confirmed off the neck's own rendered `data-marker="target"` frets (contains `0`).
- [x] Mutations recorded red then green (table below).

## Mutation table

| Mutation | Rebuild | Expected red | Result |
|---|---|---|---|
| Em7's D string (string 4) fret changed 0→1 | n/a (unit) | shape-tones test | Red: 2 failed (`every open shape's actual sounded notes...`, and the new dedicated Em7/Emaj7/Am7/Amaj7 test) |
| Removed all 4 new entries from `OPEN_SHAPE_TEMPLATES` | `npm run build` | new browser spec | Red: `sevenths, open position only: ...` failed - `openSeventh` stayed `null` after 20 draws |

Both reverted, rebuilt, reran green; `git diff` clean before push.

## Runs

- Unit (`chord-shapes`, `chords`, `chord-theory`, `practice`): `npx playwright test tests/unit/chord-shapes.spec.js tests/unit/chords.spec.js tests/unit/chord-theory.spec.js tests/unit/practice.spec.js` (with `PLAYWRIGHT_ALLOW_PARTIAL=1`) - **94 passed**.
- Browser (`chord-flashcards`), `FERMATA_TEST_PORT=9185`, `PLAYWRIGHT_ALLOW_PARTIAL=1`: **13 passed**, including the new open-position test re-run 4x back to back with no flake.
- Full browser suite: not-run (partial run only, per instructions).
- pytest: not-run (no `server/` files touched).
- `gh pr checks --watch`: not-run.

Closes #261