### PR TITLE
Restore renames a colliding drill-scope preset instead of refusing the whole archive

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -262,14 +262,28 @@ someone moving the library folder across by other means and wanting the
 archive to carry only the part that is not already portable that way.
 
 **What import does, exactly: it ADDS.** Every row from a validated archive is
-inserted as a new row with a fresh id - the only exception is a tag whose
+inserted as a new row with a fresh id - the only exceptions are a tag whose
 NAME already matches one already in the target library, which is reused
-rather than duplicated. Import never replaces, and never merges by guessing
-which of two similarly-shaped rows is "the same one" - a wrong guess risks
-silently discarding practice history, which this feature's one absolute rule
-is that it never does. Importing the same archive twice therefore creates two
-copies of everything; the library to import into is an empty one - a fresh
-install, or one just scanned onto an empty database.
+rather than duplicated, and a named drill scope (a "preset") whose NAME
+collides with one already in the target library (or with another preset
+earlier in the same archive), which is **renamed**, not reused and not
+refused: it is inserted under `<name> (imported)` (then `(imported 2)`,
+`(imported 3)`, ... - the first free name, compared the same
+case-insensitive way the preset's own uniqueness rule is), with its string
+set intact and its id remapped so the archive's own sessions still point at
+the imported copy. `ImportOut.trainer_scope_presets_renamed` lists every
+`{from, to}` pair this produced - empty when nothing collided - identically
+on a dry run and an applied import, so a preview never promises a name the
+real restore would not actually use. Import never replaces, and never merges
+by guessing which of two similarly-shaped rows is "the same one" - a wrong
+guess risks silently discarding practice history, which this feature's one
+absolute rule is that it never does; renaming a preset is not that guess,
+since both the existing preset and the archive's own copy survive under
+their own names. Importing the same archive twice therefore creates two
+copies of everything (a second import's preset lands under `(imported 2)`,
+having found `(imported)` already taken by the first); the library to import
+into is an empty one - a fresh install, or one just scanned onto an empty
+database.
 
 **Validated completely before anything is written.** The archive is a real
 zip, its manifest parses, its `schema_version` matches this Fermata's exactly

--- a/docs/api.md
+++ b/docs/api.md
@@ -269,12 +269,20 @@ collides with one already in the target library (or with another preset
 earlier in the same archive), which is **renamed**, not reused and not
 refused: it is inserted under `<name> (imported)` (then `(imported 2)`,
 `(imported 3)`, ... - the first free name, compared the same
-case-insensitive way the preset's own uniqueness rule is), with its string
-set intact and its id remapped so the archive's own sessions still point at
-the imported copy. `ImportOut.trainer_scope_presets_renamed` lists every
-`{from, to}` pair this produced - empty when nothing collided - identically
-on a dry run and an applied import, so a preview never promises a name the
-real restore would not actually use. Import never replaces, and never merges
+case-insensitive way the preset's own uniqueness rule is, and folded
+ASCII-only the way SQLite's own `COLLATE NOCASE` is - not Python's broader
+`casefold()`, which would flag a collision (e.g. `Straße` against
+`STRASSE`) that the unique index itself would never raise on), with its
+string set intact and its id remapped so the archive's own sessions still
+point at the imported copy. A base name at or near
+`trainer_scope_presets.name`'s own length cap is trimmed to make room for the
+suffix, so the derived name always satisfies the same cap
+`POST /api/trainer/presets` enforces on every name it accepts - never a row
+longer than any name the API would otherwise let anyone create.
+`ImportOut.trainer_scope_presets_renamed` lists every `{from, to}` pair this
+produced - empty when nothing collided - identically on a dry run and an
+applied import, so a preview never promises a name the real restore would
+not actually use. Import never replaces, and never merges
 by guessing which of two similarly-shaped rows is "the same one" - a wrong
 guess risks silently discarding practice history, which this feature's one
 absolute rule is that it never does; renaming a preset is not that guess,

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -669,6 +669,14 @@ the better choice for a quick local snapshot before an upgrade. See [the API
 guide](api.md#getting-everything-in-and-out-issue-58) for the archive's shape
 and what restoring it (`POST /api/import`) does and does not do.
 
+Restoring an archive into a library that is not empty **adds** rather than
+replaces or refuses outright — the one collision it does not stop the whole
+restore over is a named drill scope (a "preset") whose name the target
+library already has: that preset is imported anyway, under a name like
+`<name> (imported)`, rather than dropped or refused. Every other collision
+(two goals for the same week, say) still refuses the whole archive with
+nothing changed, so restoring twice by mistake is safe.
+
 ### Restoring a backup
 
 Stop the container, replace the live `config/` folder with the backed-up one,

--- a/server/fermata/api.py
+++ b/server/fermata/api.py
@@ -3959,6 +3959,22 @@ def score_practice_progress(
 # fresh install, or one just scanned onto an empty database - and every test
 # of this feature below imports into exactly that.
 #
+# THE ONE OTHER EXCEPTION (#260): a trainer_scope_presets row whose NAME
+# collides with one already in this library - or with an earlier preset from
+# the SAME archive - is not reused the way a tag is (a preset is a whole
+# arrangement, not just a name; the two rows are not "the same scope" merely
+# for sharing a label) and is not refused the way every other collision is
+# either. It is still INSERTED as a new row with a fresh id, same as always,
+# just under a derived name (`<name> (imported)`, `(imported 2)`, ...) rather
+# than the one it carried - see `_derive_preset_renames`. This is still
+# "added, never merged": nothing about the existing preset changes, the
+# archive's own copy exists standalone under its new name, and the archive's
+# sessions are remapped to point at THAT copy so the restored history still
+# names something real. `ImportOut.trainer_scope_presets_renamed` says which
+# names moved. Every other uniqueness rule in this library (a setting's key,
+# a goal's owner/period_start, the preset id space itself) still reaches the
+# IntegrityError -> 409 path below unchanged.
+#
 # TRANSACTIONAL, AND WHAT THAT ACTUALLY COVERS. Validation - the archive is a
 # real zip, `manifest.json` parses, its schema_version matches, every table
 # is the right shape, every foreign key inside the archive resolves to a row
@@ -4538,6 +4554,62 @@ def _insert_row(
     return cur.lastrowid
 
 
+def _derive_preset_renames(conn, presets: list[dict]) -> tuple[dict[int, str], list[dict]]:
+    """#260: the one collision import no longer refuses. Everywhere else,
+    "added, never merged" means a real uniqueness collision against this
+    library is a 409 (see the except sqlite3.IntegrityError block below) -
+    but a same-named drill-scope preset is exactly the shape of collision a
+    restore runs into constantly (a backup taken after a preset got renamed,
+    or after this library made one with the same name by hand), and the only
+    workaround available today is renaming presets BEFORE restoring, by
+    hand, in the archive nobody wants to edit. So a preset whose name is
+    already taken - by a row already in this library, or by an earlier
+    preset from this SAME import, compared exactly the way the unique index
+    does it (COLLATE NOCASE) - is imported anyway, under
+    "<name> (imported)", then "<name> (imported 2)", "<name> (imported 3)"
+    and so on, until one is free. Every other collision class (a setting's
+    key, a goal's period, the preset id space itself) still reaches the
+    IntegrityError path unchanged.
+
+    Returns the {archive row id: name actually used} map `_apply_import`
+    inserts under, and the `{from, to}` pairs for whichever presets actually
+    got renamed - in archive order, so a second preset in the archive
+    colliding with the first archive preset's OWN derived name still lands
+    on a free one rather than raising.
+
+    Read-only, and safe to call before any write transaction is open: this
+    is also how the dry run reports the same renames the applied import
+    will make, without writing anything - the two have to agree, since a
+    dry run that promised one name and an apply that landed on another
+    would make the whole preview worthless.
+    """
+    taken = {
+        (row["name"] or "").casefold()
+        for row in conn.execute(
+            "SELECT name FROM trainer_scope_presets WHERE owner = ?", (DEFAULT_OWNER,)
+        )
+    }
+    names: dict[int, str] = {}
+    renamed: list[dict] = []
+    for row in presets:
+        original = row["name"]
+        candidate = original
+        if candidate.casefold() in taken:
+            attempt = 1
+            while True:
+                candidate = (
+                    f"{original} (imported)" if attempt == 1
+                    else f"{original} (imported {attempt})"
+                )
+                if candidate.casefold() not in taken:
+                    break
+                attempt += 1
+            renamed.append({"from": original, "to": candidate})
+        taken.add(candidate.casefold())
+        names[row["id"]] = candidate
+    return names, renamed
+
+
 def _apply_import(conn, manifest: dict, file_bytes: dict[str, bytes], written_paths: list) -> dict:
     """Write a validated archive's rows and files into this library. Runs
     entirely inside the caller's write_tx(), so a failure partway through -
@@ -4639,10 +4711,14 @@ def _apply_import(conn, manifest: dict, file_bytes: dict[str, bytes], written_pa
     # so that row has to exist and its new id has to be known first. The
     # string set follows its preset, exactly as setlist_scores follows its
     # setlist.
+    preset_names, presets_renamed = _derive_preset_renames(conn, tables["trainer_scope_presets"])
     preset_id_map: dict[int, int] = {}
     for row in tables["trainer_scope_presets"]:
         preset_id_map[row["id"]] = _insert_row(
-            conn, "trainer_scope_presets", row, overrides={"owner": DEFAULT_OWNER}
+            conn,
+            "trainer_scope_presets",
+            row,
+            overrides={"owner": DEFAULT_OWNER, "name": preset_names[row["id"]]},
         )
     for row in tables["trainer_scope_preset_strings"]:
         _insert_row(
@@ -4766,6 +4842,7 @@ def _apply_import(conn, manifest: dict, file_bytes: dict[str, bytes], written_pa
         "trainer_chord_attempts_imported": len(tables["trainer_chord_attempts"]),
         "trainer_presets_imported": len(tables["trainer_scope_presets"]),
         "trainer_preset_strings_imported": len(tables["trainer_scope_preset_strings"]),
+        "trainer_scope_presets_renamed": presets_renamed,
     }
 
 
@@ -4787,7 +4864,11 @@ async def import_library(file: UploadFile, dry_run: bool = True):
     hash to what the archive itself claims for them - and reports what it
     found, WITHOUT opening a database transaction or writing a single file.
     Nothing is compared against what is already in this library on a dry
-    run, which is why `tags_reused` is always 0 there - see ImportOut.
+    run, which is why `tags_reused` is always 0 there - see ImportOut - with
+    one exception: `trainer_scope_presets_renamed` IS computed against this
+    library on a dry run too (a read, not a write - see
+    `_derive_preset_renames`), so the rename it reports is the one apply
+    mode will actually make, not a guess.
 
     A REJECTED IMPORT LEAVES NOTHING CHANGED, whether it was rejected by
     validation (a malformed archive, the wrong schema version - nothing was
@@ -4828,6 +4909,13 @@ async def import_library(file: UploadFile, dry_run: bool = True):
 
     tables = manifest["tables"]
     if dry_run:
+        # #260: the one thing dry run DOES compare against this library, the
+        # exception to the paragraph above - because _derive_preset_renames is
+        # a read (a SELECT, no BEGIN, nothing written), and the whole point of
+        # a dry run reporting a rename is that it has to be the SAME rename
+        # apply mode will actually make, not a guess made blind to what is
+        # already here.
+        _, presets_renamed = _derive_preset_renames(connect(), tables["trainer_scope_presets"])
         return {
             "dry_run": True,
             "schema_version": manifest["schema_version"],
@@ -4852,6 +4940,7 @@ async def import_library(file: UploadFile, dry_run: bool = True):
             "trainer_chord_attempts_imported": len(tables["trainer_chord_attempts"]),
             "trainer_presets_imported": len(tables["trainer_scope_presets"]),
             "trainer_preset_strings_imported": len(tables["trainer_scope_preset_strings"]),
+            "trainer_scope_presets_renamed": presets_renamed,
         }
 
     _require_library()

--- a/server/fermata/api.py
+++ b/server/fermata/api.py
@@ -4554,6 +4554,27 @@ def _insert_row(
     return cur.lastrowid
 
 
+def _ascii_fold(name: str) -> str:
+    """Fold the way `(owner, name COLLATE NOCASE)` does - ASCII A-Z only, not
+    Python's str.casefold(), which also folds characters NOCASE does not (the
+    German eszett 'ß' casefolds to 'ss', so 'Straße' and 'STRASSE' would look
+    like a collision here even though the unique index would never raise on
+    them side by side). Comparing this way is what keeps
+    _derive_preset_renames's predictions equal to what the insert itself
+    would - or would not - collide on."""
+    return "".join(chr(ord(ch) + 32) if "A" <= ch <= "Z" else ch for ch in name)
+
+
+def _fit_preset_name(base: str, suffix: str) -> str:
+    """Trim `base` so `base + suffix` still satisfies
+    trainer.MAX_PRESET_NAME_CHARS (#249) - a collision's derived name has to
+    be a name the API's own POST /api/trainer/presets would accept, not just
+    one the unique index would. A base already short enough is returned
+    unchanged."""
+    limit = max(trainer.MAX_PRESET_NAME_CHARS - len(suffix), 0)
+    return base[:limit] + suffix
+
+
 def _derive_preset_renames(conn, presets: list[dict]) -> tuple[dict[int, str], list[dict]]:
     """#260: the one collision import no longer refuses. Everywhere else,
     "added, never merged" means a real uniqueness collision against this
@@ -4565,11 +4586,21 @@ def _derive_preset_renames(conn, presets: list[dict]) -> tuple[dict[int, str], l
     hand, in the archive nobody wants to edit. So a preset whose name is
     already taken - by a row already in this library, or by an earlier
     preset from this SAME import, compared exactly the way the unique index
-    does it (COLLATE NOCASE) - is imported anyway, under
-    "<name> (imported)", then "<name> (imported 2)", "<name> (imported 3)"
-    and so on, until one is free. Every other collision class (a setting's
-    key, a goal's period, the preset id space itself) still reaches the
-    IntegrityError path unchanged.
+    does it (COLLATE NOCASE, folded ASCII-only - see _ascii_fold) - is
+    imported anyway, under "<name> (imported)", then "<name> (imported 2)",
+    "<name> (imported 3)" and so on, trimmed to fit
+    trainer.MAX_PRESET_NAME_CHARS (see _fit_preset_name) until one is free.
+    Every other collision class (a setting's key, a goal's period, the
+    preset id space itself) still reaches the IntegrityError path unchanged.
+
+    A row whose name is not a string at all (missing, null, or some other
+    JSON type - not something this API's own export ever writes, but nothing
+    stops a hand-edited or foreign manifest from carrying one) is not this
+    function's problem to solve: it is passed through completely unexamined,
+    so _apply_import's insert raises on it (or doesn't) exactly the way it
+    would have before this function existed. Manufacturing a rename for a
+    name that isn't one would only trade a clean refusal for a confusing
+    "success".
 
     Returns the {archive row id: name actually used} map `_apply_import`
     inserts under, and the `{from, to}` pairs for whichever presets actually
@@ -4584,7 +4615,7 @@ def _derive_preset_renames(conn, presets: list[dict]) -> tuple[dict[int, str], l
     would make the whole preview worthless.
     """
     taken = {
-        (row["name"] or "").casefold()
+        _ascii_fold(row["name"])
         for row in conn.execute(
             "SELECT name FROM trainer_scope_presets WHERE owner = ?", (DEFAULT_OWNER,)
         )
@@ -4592,20 +4623,21 @@ def _derive_preset_renames(conn, presets: list[dict]) -> tuple[dict[int, str], l
     names: dict[int, str] = {}
     renamed: list[dict] = []
     for row in presets:
-        original = row["name"]
+        original = row.get("name")
+        if not isinstance(original, str):
+            names[row["id"]] = original
+            continue
         candidate = original
-        if candidate.casefold() in taken:
+        if _ascii_fold(candidate) in taken:
             attempt = 1
             while True:
-                candidate = (
-                    f"{original} (imported)" if attempt == 1
-                    else f"{original} (imported {attempt})"
-                )
-                if candidate.casefold() not in taken:
+                suffix = " (imported)" if attempt == 1 else f" (imported {attempt})"
+                candidate = _fit_preset_name(original, suffix)
+                if _ascii_fold(candidate) not in taken:
                     break
                 attempt += 1
             renamed.append({"from": original, "to": candidate})
-        taken.add(candidate.casefold())
+        taken.add(_ascii_fold(candidate))
         names[row["id"]] = candidate
     return names, renamed
 

--- a/server/fermata/api_models.py
+++ b/server/fermata/api_models.py
@@ -1074,6 +1074,16 @@ class ImportOut(BaseModel):
     # before drill history travelled.
     trainer_presets_imported: int
     trainer_preset_strings_imported: int
+    # #260: which of those presets landed under a name other than the one
+    # the archive carried, because that name was already taken - by a
+    # preset already in this library, or by an earlier preset from this same
+    # archive - and the collision was resolved by renaming rather than by
+    # refusing the whole import (see api._derive_preset_renames). Each entry
+    # is `{"from": <archived name>, "to": <name it was actually inserted
+    # under>}`. Empty when nothing collided. Identical on a dry run and an
+    # applied import - the rename is computed the same way in both, not
+    # decided only once writing starts (see import_library's docstring).
+    trainer_scope_presets_renamed: list[dict[str, str]]
 
 
 # ---------------------------------------------------------------------------

--- a/server/tests/test_portability_api.py
+++ b/server/tests/test_portability_api.py
@@ -29,6 +29,7 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from fermata import api, db, scanner
+from fermata import trainer as trainer_module
 
 FIXTURE = b"<score-file-bytes-standing-in-for-a-pdf>"
 OTHER_FIXTURE = b"<a-second-score-entirely>"
@@ -853,6 +854,152 @@ def test_two_identically_named_presets_within_one_archive_do_not_500(
     ]
     names = sorted(p["name"] for p in client.get("/api/trainer/presets").json())
     assert names == ["Alpha", "Alpha (imported)"]
+
+
+def test_a_preset_row_whose_name_is_not_a_string_never_500s(client, tmp_path, monkeypatch):
+    """Follow-up to #260: `_derive_preset_renames` called `.casefold()` on
+    every archived preset's name with no guard, so a manifest carrying a
+    `name` that is null, missing entirely, or some other JSON type (nothing
+    this API's own export ever writes, but nothing stops a hand-edited or
+    foreign one) turned into an unhandled AttributeError/KeyError - a 500 on
+    both dry run and applied. The fix does not invent a rename for a name
+    that isn't one: it passes the row through untouched, so the SAME
+    NOT NULL constraint that refused it before #260 ever existed refuses it
+    again (measured directly against this schema: binding None, or omitting
+    the column, both raise `sqlite3.IntegrityError: NOT NULL constraint
+    failed`; binding a plain int does not - SQLite's TEXT affinity silently
+    stringifies it, so that shape is accepted exactly as it was pre-#260)."""
+    client.post(
+        "/api/trainer/presets",
+        json={"name": "Untouched", "start_fret": 0, "end_fret": 4, "strings": [6]},
+    )
+    manifest = json.loads(_zip_of(client.get("/api/export")).read("manifest.json"))
+    template = manifest["tables"]["trainer_scope_presets"][0]
+
+    _switch_to_a_fresh_environment(monkeypatch, tmp_path, "target")
+
+    shapes = {
+        "null": {**template, "name": None},
+        "missing": {k: v for k, v in template.items() if k != "name"},
+        "integer": {**template, "name": 42},
+    }
+    for shape, bad_row in shapes.items():
+        bad_manifest = json.loads(json.dumps(manifest))  # deep copy - each shape is independent
+        bad_manifest["tables"]["trainer_scope_presets"] = [bad_row]
+        archive = _bytes_of_zip({"manifest.json": json.dumps(bad_manifest).encode()})
+
+        preview = client.post(
+            "/api/import", files={"file": (f"{shape}.zip", archive, "application/zip")},
+        )
+        assert preview.status_code == 200, f"{shape} dry run: {preview.text}"
+
+        applied = client.post(
+            "/api/import", params={"dry_run": "false"},
+            files={"file": (f"{shape}.zip", archive, "application/zip")},
+        )
+        if shape == "integer":
+            # Weird, but not this fix's problem to solve - see the docstring:
+            # the exact behaviour import gave this shape before #260 existed.
+            assert applied.status_code == 200, f"{shape} applied: {applied.text}"
+        else:
+            assert applied.status_code == 409, f"{shape} applied: {applied.text}"
+            assert "NOT NULL constraint failed" in applied.text, applied.text
+
+
+def test_a_cap_length_colliding_preset_name_is_trimmed_to_fit(client, tmp_path, monkeypatch):
+    """#249's cap on a preset's own name (trainer.MAX_PRESET_NAME_CHARS) is an
+    invariant `POST /api/trainer/presets` enforces on every name it accepts -
+    a collision's derived name has to satisfy it too, or import would hand
+    back a row `preset_dict` reports as 211 characters when this same
+    library's own POST would refuse anything over 200. The base is trimmed
+    so `<base> (imported)` still fits, and a second import of the very same
+    archive still finds a free (still-fitting) name."""
+    long_name = "A" * trainer_module.MAX_PRESET_NAME_CHARS
+    assert len(long_name) == 200
+    client.post(
+        "/api/trainer/presets",
+        json={"name": long_name, "start_fret": 5, "end_fret": 9, "strings": [1, 2, 3]},
+    )
+    archive = client.get("/api/export").content
+
+    _switch_to_a_fresh_environment(monkeypatch, tmp_path, "target")
+    client.post(
+        "/api/trainer/presets",
+        json={"name": long_name, "start_fret": 0, "end_fret": 12, "strings": [6]},
+    )
+
+    first = client.post(
+        "/api/import", params={"dry_run": "false"},
+        files={"file": ("long.zip", archive, "application/zip")},
+    )
+    assert first.status_code == 200, first.text
+    renamed = first.json()["trainer_scope_presets_renamed"]
+    assert len(renamed) == 1
+    assert renamed[0]["from"] == long_name
+    assert len(renamed[0]["to"]) <= trainer_module.MAX_PRESET_NAME_CHARS
+    assert renamed[0]["to"].endswith("(imported)")
+
+    names = {p["name"] for p in client.get("/api/trainer/presets").json()}
+    assert long_name in names
+    assert renamed[0]["to"] in names
+    assert all(len(n) <= trainer_module.MAX_PRESET_NAME_CHARS for n in names)
+
+    second = client.post(
+        "/api/import", params={"dry_run": "false"},
+        files={"file": ("long.zip", archive, "application/zip")},
+    )
+    assert second.status_code == 200, second.text
+    second_renamed = second.json()["trainer_scope_presets_renamed"]
+    assert len(second_renamed) == 1
+    assert second_renamed[0]["from"] == long_name
+    assert second_renamed[0]["to"] != renamed[0]["to"]
+    assert len(second_renamed[0]["to"]) <= trainer_module.MAX_PRESET_NAME_CHARS
+    names_after = {p["name"] for p in client.get("/api/trainer/presets").json()}
+    assert len(names_after) == 3
+    assert all(len(n) <= trainer_module.MAX_PRESET_NAME_CHARS for n in names_after)
+
+
+def test_a_unicode_collision_nocase_would_not_actually_raise_on_is_not_renamed(
+    client, tmp_path, monkeypatch
+):
+    """`(owner, name COLLATE NOCASE)` is SQLite's own NOCASE - ASCII A-Z only
+    - not Python's str.casefold(), which also folds characters NOCASE does
+    not: 'ß'.casefold() == 'ss', so a library preset named 'Straße' and an
+    archived one named 'STRASSE' looked identical to casefold() even though
+    the unique index those two would actually hit never collides on them.
+    Renaming one anyway would be exactly backwards - a rename this feature
+    exists to AVOID, on an archive the real insert would have accepted
+    unchanged. 'Fifth'/'FIFTH' - plain ASCII case only - still has to
+    collide, or the fix has gone too far the other way."""
+    client.post(
+        "/api/trainer/presets",
+        json={"name": "STRASSE", "start_fret": 5, "end_fret": 9, "strings": [1, 2, 3]},
+    )
+    client.post(
+        "/api/trainer/presets",
+        json={"name": "Fifth", "start_fret": 0, "end_fret": 4, "strings": [1]},
+    )
+    archive = client.get("/api/export").content
+
+    _switch_to_a_fresh_environment(monkeypatch, tmp_path, "target")
+    client.post(
+        "/api/trainer/presets",
+        json={"name": "Straße", "start_fret": 0, "end_fret": 12, "strings": [6]},
+    )
+    client.post(
+        "/api/trainer/presets",
+        json={"name": "FIFTH", "start_fret": 0, "end_fret": 4, "strings": [2]},
+    )
+
+    resp = client.post(
+        "/api/import", params={"dry_run": "false"},
+        files={"file": ("export.zip", archive, "application/zip")},
+    )
+    assert resp.status_code == 200, resp.text
+    renamed = resp.json()["trainer_scope_presets_renamed"]
+    assert renamed == [{"from": "Fifth", "to": "Fifth (imported)"}]
+    names = sorted(p["name"] for p in client.get("/api/trainer/presets").json())
+    assert names == ["FIFTH", "Fifth (imported)", "STRASSE", "Straße"]
 
 
 def test_export_can_leave_the_trash_out(client, add_score):

--- a/server/tests/test_portability_api.py
+++ b/server/tests/test_portability_api.py
@@ -671,6 +671,190 @@ def test_an_archive_naming_a_preset_it_does_not_carry_is_refused_before_anything
     assert "preset" in resp.json()["detail"]
 
 
+# ---------------------------------------------------------------------------
+# #260: a same-named preset is renamed rather than refusing the whole
+# archive. See the module comment above EXPORT_TABLE_NAMES ("THE ONE OTHER
+# EXCEPTION") for why this, and only this, collision class gets this
+# treatment - everything else still reaches the IntegrityError -> 409 path,
+# covered below by test_import_is_transactional_on_a_collision_in_the_target_library
+# (practice_goals' own UNIQUE(owner, period_start), the one other uniqueness
+# rule this feature can trip that is NOT a preset).
+# ---------------------------------------------------------------------------
+
+
+def test_import_renames_a_preset_that_collides_with_one_already_in_the_target_library(
+    client, tmp_path, monkeypatch
+):
+    """The headline claim: import keeps "added, never merged" even here. The
+    colliding preset is imported anyway, under a derived name, with its
+    string set intact, and the archive's own session is remapped to point at
+    the IMPORTED copy - not at the pre-existing preset of the same name.
+    Dry run has to report the identical rename apply mode actually makes.
+    """
+    real = client.post(
+        "/api/trainer/presets",
+        json={"name": "Fifth position", "start_fret": 5, "end_fret": 9, "strings": [1, 2, 3]},
+    ).json()
+    client.post(
+        "/api/practice/sessions",
+        json={"seconds": 120, "activity": "fretboard", "preset_id": real["id"]},
+    )
+    archive = client.get("/api/export").content
+
+    _switch_to_a_fresh_environment(monkeypatch, tmp_path, "target")
+    preexisting = client.post(
+        "/api/trainer/presets",
+        json={"name": "Fifth position", "start_fret": 0, "end_fret": 12, "strings": [6]},
+    ).json()
+
+    expected_rename = [{"from": "Fifth position", "to": "Fifth position (imported)"}]
+
+    preview = client.post(
+        "/api/import", files={"file": ("export.zip", archive, "application/zip")}
+    )
+    assert preview.status_code == 200, preview.text
+    preview_body = preview.json()
+    assert preview_body["dry_run"] is True
+    assert preview_body["trainer_scope_presets_renamed"] == expected_rename
+
+    applied = client.post(
+        "/api/import", params={"dry_run": "false"},
+        files={"file": ("export.zip", archive, "application/zip")},
+    )
+    assert applied.status_code == 200, applied.text
+    applied_body = applied.json()
+    assert applied_body["dry_run"] is False
+    assert applied_body["trainer_scope_presets_renamed"] == expected_rename
+
+    by_name = {p["name"]: p for p in client.get("/api/trainer/presets").json()}
+    assert set(by_name) == {"Fifth position", "Fifth position (imported)"}
+    imported = by_name["Fifth position (imported)"]
+    assert imported["strings"] == [1, 2, 3]
+    assert imported["start_fret"] == 5
+    assert imported["end_fret"] == 9
+    # The pre-existing preset of the same name is untouched.
+    assert by_name["Fifth position"]["id"] == preexisting["id"]
+    assert by_name["Fifth position"]["strings"] == [6]
+
+    imported_session = next(
+        s for s in client.get("/api/practice/sessions").json()["sessions"]
+        if s["seconds"] == 120
+    )
+    assert imported_session["preset_id"] == imported["id"]
+    assert imported_session["preset_id"] != preexisting["id"]
+
+
+def test_a_second_import_of_the_same_archive_derives_imported_2(client, tmp_path, monkeypatch):
+    """`_derive_preset_renames` re-reads the library each call, so importing
+    the SAME archive a second time (a person restoring the same backup
+    twice, say) sees its own first import's "(imported)" copy already sitting
+    there and has to skip past it too."""
+    client.post(
+        "/api/trainer/presets",
+        json={"name": "Fifth position", "start_fret": 5, "end_fret": 9, "strings": [1, 2, 3]},
+    )
+    archive = client.get("/api/export").content
+
+    _switch_to_a_fresh_environment(monkeypatch, tmp_path, "target")
+    client.post(
+        "/api/trainer/presets",
+        json={"name": "Fifth position", "start_fret": 0, "end_fret": 12, "strings": [6]},
+    )
+
+    first = client.post(
+        "/api/import", params={"dry_run": "false"},
+        files={"file": ("export.zip", archive, "application/zip")},
+    )
+    assert first.status_code == 200, first.text
+    assert first.json()["trainer_scope_presets_renamed"] == [
+        {"from": "Fifth position", "to": "Fifth position (imported)"}
+    ]
+
+    second = client.post(
+        "/api/import", params={"dry_run": "false"},
+        files={"file": ("export.zip", archive, "application/zip")},
+    )
+    assert second.status_code == 200, second.text
+    assert second.json()["trainer_scope_presets_renamed"] == [
+        {"from": "Fifth position", "to": "Fifth position (imported 2)"}
+    ]
+    names = {p["name"] for p in client.get("/api/trainer/presets").json()}
+    assert names == {
+        "Fifth position", "Fifth position (imported)", "Fifth position (imported 2)",
+    }
+
+
+def test_a_collision_differing_only_in_case_is_renamed(client, tmp_path, monkeypatch):
+    """The unique index this whole feature exists to get past is
+    `(owner, name COLLATE NOCASE)` - a rename decision that compared names
+    case-sensitively would miss exactly this collision and let _apply_import
+    crash into the IntegrityError -> 409 path instead of renaming."""
+    client.post(
+        "/api/trainer/presets",
+        json={"name": "fifth position", "start_fret": 5, "end_fret": 9, "strings": [1, 2, 3]},
+    )
+    archive = client.get("/api/export").content
+
+    _switch_to_a_fresh_environment(monkeypatch, tmp_path, "target")
+    client.post(
+        "/api/trainer/presets",
+        json={"name": "FIFTH POSITION", "start_fret": 0, "end_fret": 12, "strings": [6]},
+    )
+
+    resp = client.post(
+        "/api/import", params={"dry_run": "false"},
+        files={"file": ("export.zip", archive, "application/zip")},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["trainer_scope_presets_renamed"] == [
+        {"from": "fifth position", "to": "fifth position (imported)"}
+    ]
+    names = sorted(p["name"] for p in client.get("/api/trainer/presets").json())
+    assert names == ["FIFTH POSITION", "fifth position (imported)"]
+
+
+def test_two_identically_named_presets_within_one_archive_do_not_500(
+    client, tmp_path, monkeypatch
+):
+    """Two presets sharing a name INSIDE THE SAME ARCHIVE - not constructible
+    through this API (the (owner, name COLLATE NOCASE) index refuses it
+    there) but nothing stops a hand-edited manifest, or a merge of two
+    exports, from naming two. `_derive_preset_renames` tracks every name it
+    has already handed out THIS import (not only what the library already
+    held), so the second one still lands on a free name instead of raising
+    an IntegrityError _apply_import has no except clause for."""
+    client.post(
+        "/api/trainer/presets",
+        json={"name": "Alpha", "start_fret": 0, "end_fret": 4, "strings": [6, 5]},
+    )
+    manifest = json.loads(_zip_of(client.get("/api/export")).read("manifest.json"))
+    presets = manifest["tables"]["trainer_scope_presets"]
+    strings = manifest["tables"]["trainer_scope_preset_strings"]
+    assert len(presets) == 1
+    original_id = presets[0]["id"]
+    dup = dict(presets[0])
+    dup["id"] = original_id + 1000
+    presets.append(dup)
+    for row in list(strings):
+        if row["preset_id"] == original_id:
+            strings.append({**row, "preset_id": dup["id"]})
+    archive = _bytes_of_zip({"manifest.json": json.dumps(manifest).encode()})
+
+    _switch_to_a_fresh_environment(monkeypatch, tmp_path, "target")
+    resp = client.post(
+        "/api/import", params={"dry_run": "false"},
+        files={"file": ("dup-name.zip", archive, "application/zip")},
+    )
+    assert resp.status_code == 200, resp.text
+    summary = resp.json()
+    assert summary["trainer_presets_imported"] == 2
+    assert summary["trainer_scope_presets_renamed"] == [
+        {"from": "Alpha", "to": "Alpha (imported)"}
+    ]
+    names = sorted(p["name"] for p in client.get("/api/trainer/presets").json())
+    assert names == ["Alpha", "Alpha (imported)"]
+
+
 def test_export_can_leave_the_trash_out(client, add_score):
     live_id = add_score("Keeper.pdf", title="Keeper")
     trashed_id = add_score("Doomed.pdf", title="Doomed")
@@ -832,6 +1016,12 @@ def test_import_is_transactional_on_a_collision_in_the_target_library(
     through (after its scores and tags have already been inserted, since
     goals are applied last) and the whole thing has to roll back rather than
     leave a second copy of the scores behind.
+
+    Also the (d) case #260 asks for: a collision that is NOT a preset still
+    has to reach the plain 409, with nothing applied - #260 only carves out
+    an exception for trainer_scope_presets' own uniqueness rule, and this
+    goal collision is the other uniqueness rule this feature can actually
+    trip.
     """
     score_id = add_score("Prelude.pdf", title="Prelude")
     client.post(
@@ -852,7 +1042,7 @@ def test_import_is_transactional_on_a_collision_in_the_target_library(
         "/api/import", params={"dry_run": "false"},
         files={"file": ("export.zip", archive, "application/zip")},
     )
-    assert second.status_code != 200
+    assert second.status_code == 409, second.text
     # ROLLED BACK, NOT HALF-APPLIED: the second import's scores must not be
     # sitting in the library even though its own insert ran (and would have
     # committed) before the goal collision was hit.

--- a/web/src/lib/DataPortability.svelte
+++ b/web/src/lib/DataPortability.svelte
@@ -143,6 +143,13 @@
           Importing adds this to your library - it never replaces or overwrites what is already
           there. Import into an empty library to restore a backup exactly.
         </p>
+        {#if preview.trainer_scope_presets_renamed?.length}
+          <p class="hint" data-testid="import-renames">
+            Renamed on import: {preview.trainer_scope_presets_renamed
+              .map((r) => `${r.from} → ${r.to}`)
+              .join(", ")}
+          </p>
+        {/if}
         <div class="row">
           <button onclick={confirmImport} disabled={applying} data-testid="import-confirm">
             {applying ? "Importing…" : "Import"}
@@ -159,6 +166,13 @@
         Imported {applied.scores_imported} score(s), {applied.practice_sessions_imported} practice
         session(s) and {applied.practice_goals_imported} goal(s).
       </p>
+      {#if applied.trainer_scope_presets_renamed?.length}
+        <p class="hint" data-testid="import-renames">
+          Renamed on import: {applied.trainer_scope_presets_renamed
+            .map((r) => `${r.from} → ${r.to}`)
+            .join(", ")}
+        </p>
+      {/if}
     {/if}
   </div>
 </section>

--- a/web/tests/browser/data-portability.spec.js
+++ b/web/tests/browser/data-portability.spec.js
@@ -34,6 +34,7 @@ const exportButton = (page) => page.getByTestId("export-button");
 const fileInput = (page) => page.getByTestId("import-file-input");
 const importError = (page) => page.getByTestId("import-error");
 const importPreview = (page) => page.getByTestId("import-preview");
+const importRenames = (page) => page.getByTestId("import-renames");
 
 test("exporting the library downloads a real archive", async ({ page }) => {
   await page.goto("/#/settings");
@@ -82,4 +83,44 @@ test("choosing a real exported archive shows what it actually holds", async ({ p
   // applicable preview rather than an error rendered under a different
   // testid - but is never clicked; see the module comment on why.
   await expect(page.getByTestId("import-confirm")).toBeVisible();
+});
+
+test("previewing an archive that collides with a preset already here shows the rename", async ({
+  page,
+  request,
+}) => {
+  // #260's rename is reported on a dry run too (server/fermata/api.py's
+  // _derive_preset_renames), which is exactly what keeps this test inside
+  // the module comment's own rule above: the archive is only ever
+  // PREVIEWED, never confirmed, so this never adds a second copy of
+  // anything to the shared library. A preset made here, still present when
+  // the same library's own export is re-uploaded, collides with itself -
+  // deleted again in `finally` regardless of how the assertions come out,
+  // so this spec leaves the shared library exactly as it found it.
+  const created = await (
+    await request.post("/api/trainer/presets", {
+      data: {
+        name: "Data portability rename check",
+        start_fret: 0,
+        end_fret: 4,
+        strings: [6],
+      },
+    })
+  ).json();
+  try {
+    await page.goto("/#/settings");
+    const downloadPromise = page.waitForEvent("download");
+    await exportButton(page).click();
+    const download = await downloadPromise;
+    const archivePath = await download.path();
+
+    await fileInput(page).setInputFiles(archivePath);
+    await expect(importPreview(page)).toBeVisible();
+    await expect(importRenames(page)).toBeVisible();
+    await expect(importRenames(page)).toContainText(
+      "Data portability rename check → Data portability rename check (imported)",
+    );
+  } finally {
+    await request.delete(`/api/trainer/presets/${created.id}`);
+  }
 });

--- a/web/tests/spec-floors/browser-data-portability-58.json
+++ b/web/tests/spec-floors/browser-data-portability-58.json
@@ -1,5 +1,5 @@
 {
   "file": "tests/browser/data-portability.spec.js",
-  "count": 3,
-  "reason": "issue #58: exporting the library downloads a real archive, a non-archive file is refused with a clear message, and a real exported archive previews what it actually holds through the same upload path."
+  "count": 4,
+  "reason": "issue #58: exporting the library downloads a real archive, a non-archive file is refused with a clear message, a real exported archive previews what it actually holds through the same upload path, and a preview colliding with a preset already in the library shows the rename it would make (#260 follow-up)."
 }


### PR DESCRIPTION
## Premise (re-derived on main 939a8b3)

Built an archive with a `trainer_scope_presets` row named like one already in
the target library and `POST /api/import`ed it (dry_run=false):

- status: `409`
- body: `the archive could not be applied - it collides with something already in this library (UNIQUE constraint failed: trainer_scope_presets.owner, trainer_scope_presets.name). Nothing has been imported.`

**Verdict: valid.** Matches the issue exactly.

## Changes

- `server/fermata/api.py`: new `_derive_preset_renames(conn, presets)` -
  read-only, checks each archived preset's name against what's already in
  the target library AND against presets already handed a name earlier in
  the same import (both compared `COLLATE NOCASE`, matching the unique
  index). A collision gets `<name> (imported)`, then `(imported 2)`,
  `(imported 3)`, ... until free. `_apply_import` inserts each preset under
  its derived name and remaps its id exactly as before, so a session naming
  it still points at the imported copy. The dry-run branch calls the same
  function (a plain `SELECT`, no transaction) so a preview reports the exact
  rename apply mode will make. Every other collision (e.g. two goals for the
  same week) still reaches the existing `IntegrityError` -> 409 path,
  unchanged.
- `server/fermata/api_models.py`: `ImportOut` gains
  `trainer_scope_presets_renamed: list[dict[str, str]]` - `{from, to}` pairs,
  empty when nothing collided, identical in dry run and applied mode. (Not
  in the touch-list handed to me, but this is where `ImportOut` actually
  lives - the field couldn't be added without it.)
- `docs/api.md`: import section documents the rename rule and the new field.
- `docs/deployment.md`: restore notes say a colliding preset is renamed, not
  refused.
- `server/tests/test_portability_api.py`: 5 new tests - same-name collision
  renames with strings intact and the session's `preset_id` following the
  renamed copy (dry run == applied); a second import of the same archive
  derives `(imported 2)`; a case-only collision is still caught; two
  identically-named presets inside one archive resolve without a 500. Also
  tightened the existing goal-collision test's assertion to `== 409` and
  noted it as the (d) non-preset-collision case (practice_goals'
  `UNIQUE(owner, period_start)` is the only other uniqueness rule import can
  trip; no second one was needed).

## Done-when checklist

- [x] Same-name collision imports 200, preset under derived name, strings intact - `test_import_renames_a_preset_that_collides_with_one_already_in_the_target_library`
- [x] Imported session's `preset_id` points at the renamed copy - same test
- [x] Response lists the rename, dry run and applied identical - same test
- [x] Second import of the same archive -> `(imported 2)` - `test_a_second_import_of_the_same_archive_derives_imported_2`
- [x] Case-only collision renamed - `test_a_collision_differing_only_in_case_is_renamed`
- [x] Old 409 still fires for a non-preset collision - `test_import_is_transactional_on_a_collision_in_the_target_library` (practice_goals collision, tightened to assert `== 409`)
- [x] Docs updated - `docs/api.md`, `docs/deployment.md`
- [x] Mutations recorded red then green (below)
- [x] Two presets colliding within one archive handled without a 500 (not asked for by Done-when but asked for in the build steps) - `test_two_identically_named_presets_within_one_archive_do_not_500`

## Mutations

| Mutation | Test | Result |
| --- | --- | --- |
| Drop the rename override on insert | `test_import_renames_a_preset_that_collides_...` | red: `409 == 200` fails (archive collides again) |
| Reuse the existing colliding preset's id instead of inserting + remapping to the renamed copy | same test | red: the renamed preset never exists (`by_name` set assertion fails) |
| Compare names case-sensitively (drop `.casefold()`) | `test_a_collision_differing_only_in_case_is_renamed` | red: `409 == 200` fails (case-only collision not caught) |

All three restored (`git checkout -- server/fermata/api.py`) and reverified green.

## Suite

`py -3.13 -m pytest server/tests -rs -q` (FERMATA_TEST_LIBRARY unset): **1340 passed, 92 skipped** - identical before and after the mutation round-trip.

## After review

A bounded follow-up (`c8abf2c`, `d3e19e7`, `026b902`) fixing four findings the
review of this PR measured:

1. **500 on a malformed manifest.** `_derive_preset_renames` called
   `.casefold()` on an archived preset's `name` with no guard - null,
   missing, or a non-string `name` raised (AttributeError/KeyError/whatever
   the type lacked), turning both dry run and applied into a 500. Fixed by
   passing a non-`str` name straight through, unexamined, so the same
   `sqlite3.IntegrityError` path (NOT NULL, since `trainer_scope_presets.name`
   has no default) catches it exactly as it did before #260 ever existed.
   Measured directly against the schema: binding `None`, or omitting the
   column, both raise `NOT NULL constraint failed`; binding a plain `int`
   does not (SQLite's TEXT affinity silently stringifies it), so that one
   shape is accepted - unchanged from pre-#260 behaviour, and explicitly not
   this fix's problem to solve. Test:
   `test_a_preset_row_whose_name_is_not_a_string_never_500s` (all three
   shapes, dry run and applied).
2. **Name cap.** `trainer.MAX_PRESET_NAME_CHARS` is 200, enforced by
   `POST /api/trainer/presets` (`trainer._preset_name`) but not by import's
   raw insert - so a 200-character colliding name became a 211-character row
   the API's own POST would refuse. **Decision: trim the base.** A new
   `_fit_preset_name(base, suffix)` shortens `base` so `base + suffix` still
   fits the cap, re-derived per rename attempt (`(imported)`,
   `(imported 2)`, ...) so a longer suffix still fits and the trimmed base is
   re-checked against the taken set before it is accepted. Test:
   `test_a_cap_length_colliding_preset_name_is_trimmed_to_fit` (a 200-char
   collision imports within the cap; a second import of the same archive
   still finds a free, still-fitting name).
3. **Reader-facing half.** `trainer_scope_presets_renamed` was in `ImportOut`
   but `DataPortability.svelte` never showed it - a restore through the UI
   renamed a preset silently. Added a line to both the dry-run preview and
   the applied result: `Renamed on import: <from> → <to>` (comma-joined),
   shown only when the list is non-empty. `DataPortability.svelte` is **not**
   in `practice.spec.js`'s `COMPONENTS` vocabulary-guard list - checked by
   hand instead: the new string uses none of `FORBIDDEN_WORDS`. Covered by a
   new browser test,
   `previewing an archive that collides with a preset already here shows the
   rename` (`web/tests/browser/data-portability.spec.js`), which - matching
   this spec file's own rule of never confirming an import against the
   shared library - creates a preset via the API, previews (dry run only)
   the library's own fresh export against itself so the preset collides with
   its own name, asserts the rename line, and deletes the preset again in
   `finally` regardless of outcome. Spec floor
   (`browser-data-portability-58.json`) bumped 3 -> 4.
4. **Case folding.** The collision check used Python's `.casefold()`, which
   folds beyond ASCII (e.g. `'ß'.casefold() == 'ss'`), while
   `trainer_scope_presets`' own unique index is `COLLATE NOCASE` - ASCII
   A-Z only. Measured: a library preset `Straße` and an archived
   `STRASSE` looked identical to `casefold()` though the index would never
   actually collide on them. Fixed with a new `_ascii_fold` helper (folds
   only `A`-`Z`) used everywhere `_derive_preset_renames` compares names.
   Test: `test_a_unicode_collision_nocase_would_not_actually_raise_on_is_not_renamed`
   (`Straße`/`STRASSE` import without a rename; `Fifth`/`FIFTH` still
   renames).

**Mutations** (each: commit clean before, mutate, run the one test, confirm
red, revert by hand, confirm the file diffs clean):

| Mutation | Test | Result |
| --- | --- | --- |
| Drop the non-`str`-name guard (`row["name"]` unguarded again) | `test_a_preset_row_whose_name_is_not_a_string_never_500s` | red: `TypeError: 'NoneType' object is not iterable` inside `_ascii_fold` (the original 500, reproduced) |
| Drop `_fit_preset_name` (plain `f"{original} (imported)"`, no trim) | `test_a_cap_length_colliding_preset_name_is_trimmed_to_fit` | red: `assert 211 <= 200` |
| `_ascii_fold` body replaced with `name.casefold()` | `test_a_unicode_collision_nocase_would_not_actually_raise_on_is_not_renamed` | red: `Straße`/`STRASSE` renamed when they should not have been |
| Hide the rename line (`{#if false}` in `DataPortability.svelte`) | browser: `previewing an archive that collides with a preset already here shows the rename` | red: `getByTestId('import-renames')` - element not found |

**Suite after this follow-up:**
`py -3.13 -m pytest server/tests -rs -q` (`FERMATA_TEST_LIBRARY` unset):
**1354 passed, 81 skipped**. (Environment note: the skip count differs from
this PR's own 92 - unrelated to this change; both runs had
`FERMATA_TEST_LIBRARY`/`FERMATA_MUSICXML_XSD` unset, and no skip reason
touching import/presets changed.)

Closes #260
