### PR TITLE
Pin practice-data enumerations to the server, and let the auto-transcribe spec stand on its own

### DIFF
--- a/server/tests/test_practice_data_doc.py
+++ b/server/tests/test_practice_data_doc.py
@@ -1,0 +1,213 @@
+"""Pins docs/practice-data.md's hand-written enumerations and column lists to
+the server they describe (issue #259).
+
+#254's review found the chord-quality row three qualities stale after the API
+had grown to accept five, and it passed CI because nothing read the doc - the
+same gap test_api_docs.py closed for docs/api.md's routes, never opened here.
+This module is that guard for practice-data.md: it parses the doc's own
+markdown tables (locating each row by its backticked COLUMN NAME, never by
+line number, so a paragraph inserted above a table cannot silently point this
+at the wrong row) and asserts the values it documents equal the tuples and
+dict keys `server/fermata/trainer.py` actually enforces, and that each
+table's documented column list matches the real column list `server/fermata/
+db.py`'s schema creates - the same "read the real thing back, do not trust a
+parallel description of it" discipline test_export_table_names_matches_
+every_table_the_schema_creates (test_portability_api.py) already applies to
+the export catalog.
+
+Deliberately does NOT check every table this doc describes - practice_goals
+and its prose are out of scope for #259 (see that issue's no-gos), and adding
+a table here later is a decision for whoever adds it, not something this
+guard should invent an opinion about by omission.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+from fermata import trainer
+
+DOC_PATH = Path(__file__).resolve().parents[2] / "docs" / "practice-data.md"
+
+_BACKTICK = re.compile(r"`([^`]+)`")
+
+
+@pytest.fixture(scope="module")
+def doc_text():
+    return DOC_PATH.read_text(encoding="utf-8")
+
+
+def _table_rows(doc_text: str, anchor: str) -> list[tuple[str, str]]:
+    """Every data row of the markdown table that follows `anchor` in the doc -
+    `anchor` is a piece of literal text (a heading like "## Trainer attempts",
+    or an inline table title like "`trainer_scope_presets`:") that appears
+    exactly once before the table this function is meant to read, so locating
+    the table is finding the next "| Column | Meaning |" header after that
+    text rather than counting lines to it.
+
+    Returns (first_cell, second_cell) pairs - a combined row like
+    "`from_bar`, `to_bar`" | "The bars worked." comes back as one pair, the
+    same row a person reading the doc sees, so a caller that wants either
+    column's name checks the first cell for its own backticked name rather
+    than assuming one row names exactly one column.
+    """
+    start = doc_text.index(anchor)
+    header = "| Column | Meaning |"
+    header_at = doc_text.index(header, start)
+    lines = doc_text[header_at:].splitlines()
+    rows = []
+    # lines[0] is the header itself, lines[1] the "| --- | --- |" separator -
+    # both skipped; the table ends at the first line that is not a table row,
+    # exactly where the blank line after every table in this doc falls.
+    for line in lines[2:]:
+        stripped = line.strip()
+        if not stripped.startswith("|"):
+            break
+        cells = [c.strip() for c in stripped.strip("|").split("|")]
+        rows.append((cells[0], cells[1] if len(cells) > 1 else ""))
+    return rows
+
+
+def _row_for(rows: list[tuple[str, str]], column_name: str) -> str:
+    """The Meaning cell of the row naming `column_name` - found by searching
+    every row's first cell for that exact backticked name, so a row that
+    documents two columns together (`"`key_root`, `key_quality`"`) is found
+    by either name."""
+    needle = f"`{column_name}`"
+    for first_cell, meaning in rows:
+        if needle in first_cell:
+            return meaning
+    raise AssertionError(
+        f"no row documents a `{column_name}` column under this table - renamed, "
+        "or the table this test reads from changed shape?"
+    )
+
+
+def _documented_column_names(rows: list[tuple[str, str]]) -> set[str]:
+    """Every column name a table's rows document - a row's first cell may
+    name more than one column (a combined row like "`from_bar`, `to_bar`"),
+    so this is every backticked token in every first cell, not one per row."""
+    names: set[str] = set()
+    for first_cell, _ in rows:
+        names.update(_BACKTICK.findall(first_cell))
+    return names
+
+
+def _enum_values(meaning_cell: str) -> set[str]:
+    """The enumeration values a Meaning cell names, out of every backticked
+    token in it - filtering out the two shapes of backticked token that
+    appear in these cells but never name a stored value:
+
+    - a file reference (`` `chord-theory.js` ``, `` `trainer.py` ``) - always
+      contains a '.', which no enumeration value here ever does;
+    - the SQL `NULL` literal, used throughout this doc to mean "unset", never
+      as a stored enum value.
+
+    A value quoted as `` `'fret_to_note'` `` (single quotes inside the
+    backticks, matching how db.py's own DEFAULT/comparison literals read) has
+    those quotes stripped, so it compares equal to trainer.py's own bare
+    string.
+    """
+    values = set()
+    for token in _BACKTICK.findall(meaning_cell):
+        if "." in token or token == "NULL":
+            continue
+        values.add(token.strip("'"))
+    return values
+
+
+# ---------------------------------------------------------------------------
+# Enumerations: docs/practice-data.md's prose values against trainer.py's
+# real tuples and dict keys.
+# ---------------------------------------------------------------------------
+
+
+def test_trainer_attempts_drill_enumeration_matches_trainer_py(doc_text):
+    rows = _table_rows(doc_text, "## Trainer attempts")
+    documented = _enum_values(_row_for(rows, "drill"))
+    assert documented == set(trainer.DRILLS)
+
+
+def test_trainer_attempts_direction_enumeration_matches_trainer_py(doc_text):
+    rows = _table_rows(doc_text, "## Trainer attempts")
+    documented = _enum_values(_row_for(rows, "direction"))
+    assert documented == set(trainer.DIRECTIONS)
+
+
+def test_trainer_chord_attempts_drill_enumeration_matches_trainer_py(doc_text):
+    rows = _table_rows(doc_text, "## Trainer chord attempts")
+    documented = _enum_values(_row_for(rows, "drill"))
+    assert documented == set(trainer.CHORD_DRILLS)
+
+
+def test_trainer_chord_attempts_direction_enumeration_matches_trainer_py(doc_text):
+    rows = _table_rows(doc_text, "## Trainer chord attempts")
+    documented = _enum_values(_row_for(rows, "direction"))
+    assert documented == set(trainer.CHORD_DIRECTIONS)
+
+
+def test_chord_quality_enumeration_matches_trainer_py(doc_text):
+    """target_root/target_quality's own row names the five qualities in a
+    parenthetical list alongside two FILE references (`chord-theory.js`,
+    `trainer.py`) that _enum_values must not mistake for a sixth and seventh
+    quality - see that helper's own docstring for the '.' filter this row is
+    exactly why."""
+    rows = _table_rows(doc_text, "## Trainer chord attempts")
+    documented = _enum_values(_row_for(rows, "target_quality"))
+    assert documented == set(trainer.CHORD_QUALITIES)
+
+
+def test_key_quality_enumeration_matches_trainer_py(doc_text):
+    rows = _table_rows(doc_text, "`trainer_scope_presets`:")
+    documented = _enum_values(_row_for(rows, "key_quality"))
+    assert documented == set(trainer.KEY_QUALITIES)
+
+
+# ---------------------------------------------------------------------------
+# Column lists: docs/practice-data.md's tables against db.py's real schema -
+# read back from a freshly initialised database, the same way
+# test_export_table_names_matches_every_table_the_schema_creates
+# (test_portability_api.py) reads the export catalog against sqlite_master
+# rather than against db.py's CREATE TABLE text, so a column added by a
+# migration rather than by the CREATE TABLE statement itself still counts.
+# ---------------------------------------------------------------------------
+
+_TABLE_ANCHORS = {
+    "practice_sessions": "## Sessions",
+    "trainer_attempts": "## Trainer attempts",
+    "trainer_chord_attempts": "## Trainer chord attempts",
+    "trainer_scope_presets": "`trainer_scope_presets`:",
+    "trainer_scope_preset_strings": "`trainer_scope_preset_strings`, one row per string:",
+}
+
+
+@pytest.mark.parametrize("table_name", sorted(_TABLE_ANCHORS))
+def test_documented_columns_match_the_real_table(doc_text, table_name, app_env):
+    from fermata import db
+
+    rows = _table_rows(doc_text, _TABLE_ANCHORS[table_name])
+    documented = _documented_column_names(rows)
+
+    conn = db.connect()
+    try:
+        actual = {row[1] for row in conn.execute(f"PRAGMA table_info({table_name})")}
+    finally:
+        conn.close()
+    # Sanity floor on the read itself - PRAGMA table_info silently returns
+    # zero rows for a table name that does not exist (a typo in
+    # _TABLE_ANCHORS's key, say), which would otherwise pass this test for
+    # the wrong reason: an empty `actual` trivially equal to an empty
+    # `missing_from_doc`.
+    assert actual, f"{table_name}: PRAGMA table_info returned no columns - does this table exist?"
+
+    missing_from_doc = actual - documented
+    extra_in_doc = documented - actual
+    assert not missing_from_doc, (
+        f"{table_name}: column(s) {sorted(missing_from_doc)} exist in db.py's schema but are "
+        "not documented in docs/practice-data.md"
+    )
+    assert not extra_in_doc, (
+        f"{table_name}: docs/practice-data.md documents column(s) {sorted(extra_in_doc)} that "
+        f"{table_name} does not have"
+    )

--- a/web/tests/browser/zzzz-library-auto-transcribe.spec.js
+++ b/web/tests/browser/zzzz-library-auto-transcribe.spec.js
@@ -18,13 +18,20 @@
 //      set, and its complement to exactly the untranscribed one.
 //
 // WHY IT IS NAMED TO SORT AMONG THE OTHER zzzz-library-* SPECS: it uploads
-// and deletes scores the same way they do, and carries the same refusal-
-// unless-throwaway-instance guard zzz-library-organise.spec.js's own header
-// explains. Fully emptying the library after EVERY test - rather than
-// tracking its own small "OWN" list, the way zz-library-missing does - is
-// deliberate here: this file's whole subject is what a FRESH scan does, so
-// starting one from a library that already has a transcribed score in it
-// would silently defeat its own premise.
+// and deletes scores the same way they do. Fully emptying the library after
+// EVERY test - rather than tracking its own small "OWN" list, the way
+// zz-library-missing does - is deliberate here: this file's whole subject is
+// what a FRESH scan does, so starting one from a library that already has a
+// transcribed score in it would silently defeat its own premise.
+//
+// THIS FILE ESTABLISHES ITS OWN EMPTY LIBRARY (issue #259) - it used to rely
+// on zz-library-organise.spec.js's own afterAll having already emptied
+// everything, which held only while that spec actually ran before this one.
+// Skip it (or run this file alone) and zz-library-missing.spec.js's own
+// missing-flagged rows - left behind on purpose, see that file's header -
+// are still sitting here when this file's first test starts, failing this
+// file's own guard for a reason that has nothing to do with what this file
+// tests. See the beforeAll below.
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -149,20 +156,35 @@ async function emptyTheLibrary(request) {
   }
 }
 
-test.beforeEach(async ({ request }) => {
+// Establishes this file's own precondition instead of inheriting one - the
+// same ordering problem #250 retired for zz-library-missing's own refusal
+// test (see that file's header). Checked, not assumed, before anything is
+// destroyed: "Uploads" is the only folder this file's own uploads ever use
+// (see uploadAndSettle/uploadRowOnly above), so a score outside it - and not
+// already missing-flagged, which is an ordinary inert leftover from
+// zz-library-missing.spec.js, never this file's own doing - means this is
+// not the throwaway instance the suite creates, and nothing below may run.
+// Only once that has passed does this call emptyTheLibrary - through the
+// same GET/DELETE /api/scores and /api/trash routes
+// zz-library-organise.spec.js's own afterAll uses - so the first test below
+// starts from a library that is empty because THIS file made it so, not
+// because some other spec happened to run first.
+test.beforeAll(async ({ request }) => {
   const existing = await (await request.get("/api/scores")).json();
+  const foreign = existing.filter(
+    (s) => !s.missing_since && s.path.split("/")[0] !== "Uploads",
+  );
   expect(
-    existing,
-    "refusing to run: this backend already has scores in its library, so it is not the " +
-      "throwaway instance the suite creates - and this file's whole subject is what a FRESH " +
-      "scan does",
+    foreign,
+    "refusing to run: this backend has scores in folders this suite never creates, so it is " +
+      "not the throwaway instance the suite creates - and this file empties the library",
   ).toEqual([]);
+  await emptyTheLibrary(request);
 });
 
 // After EVERY test, not only at the end - each test in this file starts from
-// a library that reads as genuinely fresh (see beforeEach above), which a
-// later test in the same file could not claim if an earlier one's uploads
-// were still sitting in it.
+// a library that reads as genuinely fresh, which a later test in the same
+// file could not claim if an earlier one's uploads were still sitting in it.
 test.afterEach(async ({ request }) => {
   await emptyTheLibrary(request);
 });


### PR DESCRIPTION
## Premises re-derived on main 939a8b3

1. **No test reads docs/practice-data.md's enumerations** - `valid`. `grep -rn "practice-data" server/tests web/tests` finds only comments referencing the doc (test_score_progress_api.py, ear-training.spec.js, fret-weak-spots.spec.js, position-counts.spec.js) - nothing parses its tables or compares them to `trainer.py`/`db.py`.
2. **The auto-transcribe spec fails its own guard when the organise spec is skipped** - `valid`. Measured: `FERMATA_TEST_PORT=9181 PLAYWRIGHT_ALLOW_PARTIAL=1 npx playwright test tests/browser/zz-library-missing.spec.js tests/browser/zzzz-library-auto-transcribe.spec.js` (organise excluded) on the pre-fix spec - 1 failed (the "refusing to run" guard, tripped by `zz-library-missing.spec.js`'s own missing-flagged leftover rows), 8 passed.

Doc content itself needed no corrections - #254 had already brought the enumerations and column lists into agreement with `trainer.py`/`db.py`; the gap was only that nothing checked it.

## Changes

- `server/tests/test_practice_data_doc.py` (new): parses docs/practice-data.md's own markdown tables - each row found by its backticked column name, never by line number - and asserts `drill`/`direction`/chord-quality/key-quality enumerations equal `trainer.py`'s `DRILLS`, `CHORD_DRILLS`, `DIRECTIONS`, `CHORD_DIRECTIONS`, `CHORD_QUALITIES`, `KEY_QUALITIES`, plus a parametrized check that each documented table's column list (practice_sessions, trainer_attempts, trainer_chord_attempts, trainer_scope_presets, trainer_scope_preset_strings) matches the real columns a freshly initialised database has (`PRAGMA table_info`, the same "read the real schema back" discipline `test_export_table_names_matches_every_table_the_schema_creates` uses for the export catalog).
- `web/tests/browser/zzzz-library-auto-transcribe.spec.js`: establishes its own empty-library precondition in a `beforeAll` - checked (foreign, non-missing-flagged scores outside "Uploads" refuse the run) then emptied through the same `GET`/`DELETE /api/scores` and `/api/trash` routes `zzz-library-organise.spec.js`'s own `afterAll` uses - instead of depending on that spec having emptied things first. The old per-test `beforeEach` guard is now dead (the new `beforeAll` plus the existing per-test `afterEach` already guarantee the precondition for every test in the file) and was removed.

## Mutations (each committed, run, reverted)

| # | Mutation | Result |
| --- | --- | --- |
| a | `"probe_drill"` added to `trainer.DRILLS` | RED - `test_trainer_attempts_drill_enumeration_matches_trainer_py` fails (1 failed, 10 passed) |
| b | a column added to `practice_sessions`' CREATE TABLE | RED - `test_documented_columns_match_the_real_table[practice_sessions]` fails, naming the extra column (1 failed, 10 passed) |
| c | a temporary spec (`zzzz-a-probe-leftover.spec.js`, sorted before the auto-transcribe spec, uploads 3 files to Uploads/ and never cleans up) run before the auto-transcribe spec | with the OLD spec: RED (1 failed, 6 passed - the "refusing to run" guard); with the NEW spec: GREEN (7 passed). Temporary spec removed afterward. |

## Suite runs

- `py -3.13 -m pytest server/tests -rs -q` (FERMATA_TEST_LIBRARY unset): **1358 passed, 81 skipped** (all skips are `FERMATA_TEST_LIBRARY`/`FERMATA_MUSICXML_XSD` not set - expected, no library fixture configured here).
- `FERMATA_TEST_PORT=9181 PLAYWRIGHT_ALLOW_PARTIAL=1 npx playwright test tests/browser/zzz-library-organise.spec.js tests/browser/zzzz-library-auto-transcribe.spec.js`: **12 passed** (organise's normal ordering still works).
- Same two specs with organise excluded, `zz-library-missing.spec.js` substituted in as the leftover-producing predecessor: **9 passed** (see premise 2 above for the pre-fix baseline of that same run).

## Done-when checklist

- [x] The contract test fails when a value is added to `DRILLS` (or any pinned tuple) without the doc changing - mutation (a).
- [x] Green on main - 11/11 in `test_practice_data_doc.py`.
- [x] The auto-transcribe spec passes when run alone after another spec has left rows behind - proven with mutation (c)'s temporary leftover spec.
- [x] Floors updated - not needed: the auto-transcribe spec's test count (6) is unchanged; only a hook moved from `beforeEach` to `beforeAll` and no test was added or removed.
- [x] Every mutation recorded red then green in the PR - see table above.

Closes #259.
