### PR TITLE
Chord tones are now named A, C#, E, G#, not the table's A, C#, E, Ab

### DIFF
--- a/web/src/lib/trainer/chord-theory.js
+++ b/web/src/lib/trainer/chord-theory.js
@@ -68,6 +68,64 @@ export function chordName(root, quality) {
   return `${root}${q.suffix}`;
 }
 
+// The seven letter names, in alphabetical (staff-step) order - not pitch-
+// class order, since spelling a chord is about how far a tone sits from the
+// root on the STAFF (a letter apart), never about semitone distance. Used
+// only by spellChordTones; chordTones and chordsMatch never touch a letter.
+const LETTERS = ["A", "B", "C", "D", "E", "F", "G"];
+
+// Each natural letter's own pitch class, as a semitone (C=0 .. B=11) - the
+// zero-accidental reference spellChordTones measures every accidental
+// against. Independent of PITCH_CLASSES's own sharp-or-flat choices.
+const NATURAL_SEMITONES = { C: 0, D: 2, E: 4, F: 5, G: 7, A: 9, B: 11 };
+
+// How many letters a tone sits above the root, by its position in
+// QUALITIES' interval list - a third is two letters up (skip one), a fifth
+// four, a seventh six. Triads only use the first three; a tetrad's fourth
+// tone (the seventh) is index 3, hence offset 6. The root itself (index 0,
+// offset 0) is never computed this way - see spellChordTones below.
+const LETTER_OFFSETS = [0, 2, 4, 6];
+
+/** How a chord's tones are named to the player, root by root - unlike
+ * chordTones (identity, one fixed spelling per pitch class, used for
+ * grading), this spells each tone by LETTER from the root, choosing
+ * whichever accidental makes that letter's pitch class agree with
+ * chordTones' answer. "A major 7" is A, C#, E, G# this way (G, not chordTones'
+ * own Ab, is the seventh's letter four letters plus a fifth above... two
+ * letters past the fifth, i.e. offset 6 from A: A-B-C-D-E-F-G lands on G,
+ * sharped to reach the same pitch class Ab already names) - see the module
+ * docstring and issue #269 for why a fixed twelve-name table is right for
+ * identity but wrong for what a learner reads.
+ *
+ * The ROOT keeps the table's own name (Eb, Ab, Bb, C#, F# spelled as the
+ * table spells them - these are ids, not chord-specific spellings, same
+ * rule chordTones already follows). Every other tone is spelled fresh: null
+ * for an unknown root or quality, matching chordTones.
+ *
+ * Checked (unit test) to need at most a single sharp or flat across all 60
+ * (root, quality) chords this module builds - no double accidental. If a
+ * future quality or root ever did need one, the fix belongs here (extend
+ * the accidental to "##"/"bb"), not in a special-cased table lookup. */
+export function spellChordTones(root, quality) {
+  const tones = chordTones(root, quality);
+  if (!tones) return null;
+  const rootLetterIndex = LETTERS.indexOf(root[0]);
+  return tones.map((tone, degree) => {
+    if (degree === 0) return root;
+    const letter = LETTERS[(rootLetterIndex + LETTER_OFFSETS[degree]) % 7];
+    const natural = NATURAL_SEMITONES[letter];
+    const actual = PITCH_CLASSES.indexOf(tone);
+    let accidentalSteps = ((actual - natural) % 12 + 12) % 12;
+    if (accidentalSteps > 6) accidentalSteps -= 12;
+    const accidental = accidentalSteps === 0
+      ? ""
+      : accidentalSteps > 0
+        ? "#".repeat(accidentalSteps)
+        : "b".repeat(-accidentalSteps);
+    return `${letter}${accidental}`;
+  });
+}
+
 /** Whether two chords - each a (root, quality) pair - are the SAME chord,
  * meaning the same set of pitch classes. Compares the tone sets rather than
  * the root/quality strings directly, which is the honest version of "is

--- a/web/src/lib/trainer/chord-theory.js
+++ b/web/src/lib/trainer/chord-theory.js
@@ -88,14 +88,15 @@ const LETTER_OFFSETS = [0, 2, 4, 6];
 
 /** How a chord's tones are named to the player, root by root - unlike
  * chordTones (identity, one fixed spelling per pitch class, used for
- * grading), this spells each tone by LETTER from the root, choosing
- * whichever accidental makes that letter's pitch class agree with
- * chordTones' answer. "A major 7" is A, C#, E, G# this way (G, not chordTones'
- * own Ab, is the seventh's letter four letters plus a fifth above... two
- * letters past the fifth, i.e. offset 6 from A: A-B-C-D-E-F-G lands on G,
- * sharped to reach the same pitch class Ab already names) - see the module
- * docstring and issue #269 for why a fixed twelve-name table is right for
- * identity but wrong for what a learner reads.
+ * grading), this spells each tone by LETTER from the root: letters ascend
+ * one staff-step per degree from the root's own letter, and each letter
+ * takes whatever accidental makes its pitch class agree with chordTones'
+ * answer. "A major 7" is A, C#, E, G# this way - the seventh's letter sits
+ * two staff-steps past the fifth (offset 6 from A: A-B-C-D-E-F-G lands on
+ * G), sharped to reach the same pitch class chordTones' own Ab already
+ * names - see the module docstring and issue #269 for why a fixed
+ * twelve-name table is right for identity but wrong for what a learner
+ * reads.
  *
  * The ROOT keeps the table's own name (Eb, Ab, Bb, C#, F# spelled as the
  * table spells them - these are ids, not chord-specific spellings, same

--- a/web/src/lib/trainer/chords.js
+++ b/web/src/lib/trainer/chords.js
@@ -243,20 +243,29 @@ export function attemptPayload({ sessionId = null, question, given, responseMs =
  *
  * The tones read out here are SPELLED (chord-theory.js's spellChordTones -
  * issue #269), not chordTones' own fixed twelve-name table: "A major 7" is
- * read as A, C#, E, G#, not A, C#, E, Ab. Grading above (checkNameAnswer,
- * checkShapeAnswer) stays on chordTones' pitch-class identity, unchanged -
- * only what the player is TOLD changes here. */
+ * read as A, C#, E, G#, not A, C#, E, Ab. What was actually TAPPED gets the
+ * same treatment: a tapped pitch class that is one of the chord's own tones
+ * is read out with that chord's spelling too, so a wrong answer never says
+ * "sounded G#" in one clause and "sounded Ab" in the next for the same
+ * pitch. A tapped pitch class that ISN'T one of the chord's tones has no
+ * root-relative spelling to borrow - it keeps chordTones' table name.
+ * Grading above (checkNameAnswer, checkShapeAnswer) stays on chordTones'
+ * pitch-class identity, unchanged - only what the player is TOLD changes
+ * here. */
 export function answerStatement(question, given, correct) {
   const name = chordName(question.root, question.quality);
   if (question.direction === SHAPE_TO_NAME) {
     const givenName = chordName(given.root, given.quality);
     return correct ? `That shape is ${name}.` : `That shape is ${name}. You named ${givenName ?? "nothing"}.`;
   }
-  const spelled = spellChordTones(question.root, question.quality).join(", ");
+  const tones = chordTones(question.root, question.quality);
+  const spelledTones = spellChordTones(question.root, question.quality);
+  const spelled = spelledTones.join(", ");
   if (!given.notes?.length) return `${name} is ${spelled}.`;
-  return correct
-    ? `${name} is ${spelled} - that's what sounded.`
-    : `${name} is ${spelled}. What was tapped sounded ${given.notes.join(", ")}.`;
+  if (correct) return `${name} is ${spelled} - that's what sounded.`;
+  const spellingByPitchClass = new Map(tones.map((tone, i) => [tone, spelledTones[i]]));
+  const tapped = given.notes.map((note) => spellingByPitchClass.get(note) ?? note).join(", ");
+  return `${name} is ${spelled}. What was tapped sounded ${tapped}.`;
 }
 
 /** How the drill has gone so far. Two counts, nothing else - no percentage,

--- a/web/src/lib/trainer/chords.js
+++ b/web/src/lib/trainer/chords.js
@@ -35,7 +35,7 @@
 // drill committed to, and db.py's comment on the new table for the honest
 // alternative: a sibling table shaped for what a chord attempt actually is.
 import { countOrNone, formatDuration } from "../practice.js";
-import { chordName, chordTones, chordsMatch } from "./chord-theory.js";
+import { chordName, chordTones, chordsMatch, spellChordTones } from "./chord-theory.js";
 import { allShapes, shapeMatchesChord, shapeNotes } from "./chord-shapes.js";
 import { groupInScope, keyNotes, scopeLabel as regionLabel } from "./constraints.js";
 import { DEFAULT_FRET_COUNT, noteAt, pitchClass } from "./neck.js";
@@ -239,17 +239,24 @@ export function attemptPayload({ sessionId = null, question, given, responseMs =
 /** What to say about the answer just given - the chord's name either way,
  * and what was actually played when a shape was tapped. No verdict word:
  * the fact stated is what teaches, same rule as fret-to-note's
- * answerStatement. */
+ * answerStatement.
+ *
+ * The tones read out here are SPELLED (chord-theory.js's spellChordTones -
+ * issue #269), not chordTones' own fixed twelve-name table: "A major 7" is
+ * read as A, C#, E, G#, not A, C#, E, Ab. Grading above (checkNameAnswer,
+ * checkShapeAnswer) stays on chordTones' pitch-class identity, unchanged -
+ * only what the player is TOLD changes here. */
 export function answerStatement(question, given, correct) {
   const name = chordName(question.root, question.quality);
   if (question.direction === SHAPE_TO_NAME) {
     const givenName = chordName(given.root, given.quality);
     return correct ? `That shape is ${name}.` : `That shape is ${name}. You named ${givenName ?? "nothing"}.`;
   }
-  if (!given.notes?.length) return `${name} is ${chordTones(question.root, question.quality).join(", ")}.`;
+  const spelled = spellChordTones(question.root, question.quality).join(", ");
+  if (!given.notes?.length) return `${name} is ${spelled}.`;
   return correct
-    ? `${name} is ${chordTones(question.root, question.quality).join(", ")} - that's what sounded.`
-    : `${name} is ${chordTones(question.root, question.quality).join(", ")}. What was tapped sounded ${given.notes.join(", ")}.`;
+    ? `${name} is ${spelled} - that's what sounded.`
+    : `${name} is ${spelled}. What was tapped sounded ${given.notes.join(", ")}.`;
 }
 
 /** How the drill has gone so far. Two counts, nothing else - no percentage,

--- a/web/tests/browser/chord-flashcards.spec.js
+++ b/web/tests/browser/chord-flashcards.spec.js
@@ -44,6 +44,33 @@ function chordName(root, quality) {
   return `${root}${SEVENTH_SUFFIX[quality]}`;
 }
 
+// An independent copy of the tone-SPELLING formula too (issue #269), same
+// discipline as chordTones above: a letter run from the root (third +2
+// letters, fifth +4, seventh +6), sharped or flatted to agree with
+// chordTones' own pitch class - not imported from chord-theory.js, so a
+// drift in the app's spelling would fail here rather than only restate it.
+const LETTERS = ["A", "B", "C", "D", "E", "F", "G"];
+const NATURAL_SEMITONES = { C: 0, D: 2, E: 4, F: 5, G: 7, A: 9, B: 11 };
+const LETTER_OFFSETS = [0, 2, 4, 6];
+function spellChordTones(root, quality) {
+  const tones = chordTones(root, quality);
+  const rootLetterIndex = LETTERS.indexOf(root[0]);
+  return tones.map((tone, degree) => {
+    if (degree === 0) return root;
+    const letter = LETTERS[(rootLetterIndex + LETTER_OFFSETS[degree]) % 7];
+    const natural = NATURAL_SEMITONES[letter];
+    const actual = PITCH_CLASSES.indexOf(tone);
+    let accidentalSteps = (((actual - natural) % 12) + 12) % 12;
+    if (accidentalSteps > 6) accidentalSteps -= 12;
+    const accidental = accidentalSteps === 0
+      ? ""
+      : accidentalSteps > 0
+        ? "#".repeat(accidentalSteps)
+        : "b".repeat(-accidentalSteps);
+    return `${letter}${accidental}`;
+  });
+}
+
 async function reset(request) {
   const existing = await (await request.get("/api/instruments")).json();
   for (const instrument of existing) await request.delete(`/api/instruments/${instrument.id}`);
@@ -165,7 +192,9 @@ test("name_to_shape: tapping every required tone and only those grades correct",
 
   await expect(drill(page)).toHaveAttribute("data-asked", "1");
   await expect(drill(page)).toHaveAttribute("data-correct", "1");
-  await expect(answerStatement(page)).toContainText(tones.join(", "));
+  // The statement reads the SPELLED tones (issue #269), not chordTones' own
+  // fixed table - E major's third is G#, never Ab.
+  await expect(answerStatement(page)).toContainText(spellChordTones(q.root, q.quality).join(", "));
   const text = await answerStatement(page).textContent();
   expect(forbiddenWord(text), text).toBeNull();
 });
@@ -184,7 +213,7 @@ test("name_to_shape: tapping too few tones grades incorrect and names the full c
 
   await expect(drill(page)).toHaveAttribute("data-asked", "1");
   await expect(drill(page)).toHaveAttribute("data-correct", "0");
-  await expect(answerStatement(page)).toContainText(tones.join(", "));
+  await expect(answerStatement(page)).toContainText(spellChordTones(q.root, q.quality).join(", "));
   const text = await answerStatement(page).textContent();
   expect(forbiddenWord(text), text).toBeNull();
 });
@@ -443,6 +472,44 @@ test("sevenths, open position only: a minor7 or major7 card is offered at base f
     .evaluateAll((els) => els.map((el) => Number(el.dataset.fret)));
   expect(targetFrets.length).toBeGreaterThan(0);
   expect(targetFrets).toContain(0);
+});
+
+// ---------------------------------------------------------------------------
+// Spelled tones (issue #269): the statement reads a chord's tones by LETTER
+// from the root, not off chordTones' own fixed twelve-name table - so A
+// major 7 reads its seventh as G#, never the table's Ab.
+// ---------------------------------------------------------------------------
+
+test("name_to_shape: A major 7's statement spells the seventh G#, not the table's Ab", async ({
+  page,
+}) => {
+  await page.locator(".direction-choice").nth(1).click();
+  await page.locator(".family-choice", { hasText: "Sevenths" }).click();
+  await page.selectOption(".scope-end-fret", "2");
+  await startButton(page).click();
+
+  let target = null;
+  for (let i = 0; i < 40 && !target; i++) {
+    const q = await question(page);
+    if (q.root === "A" && q.quality === "major7") {
+      target = q;
+      break;
+    }
+    const tones = chordTones(q.root, q.quality);
+    await tapChord(page, tones);
+    await page.locator(".check-shape").click();
+    await page.locator(".next-question").click();
+  }
+  expect(target, "an A major7 card was drawn within 40 questions").toBeTruthy();
+
+  const spelled = spellChordTones("A", "major7");
+  expect(spelled).toEqual(["A", "C#", "E", "G#"]);
+  await tapChord(page, chordTones("A", "major7"));
+  await page.locator(".check-shape").click();
+
+  await expect(answerStatement(page)).toContainText(`${chordName("A", "major7")} is ${spelled.join(", ")}`);
+  const text = await answerStatement(page).textContent();
+  expect(forbiddenWord(text), text).toBeNull();
 });
 
 test("leaving the page mid-drill still logs the practice", async ({ page, request }) => {

--- a/web/tests/spec-floors/browser-chord-flashcards-269.json
+++ b/web/tests/spec-floors/browser-chord-flashcards-269.json
@@ -1,0 +1,5 @@
+{
+  "file": "tests/browser/chord-flashcards.spec.js",
+  "count": 1,
+  "reason": "issue #269: against the real backend and the real build, name_to_shape's A major 7 answer statement is confirmed to read its seventh as G#, not chordTones' own Ab table entry - checked against an independently reimplemented letter-spelling formula in this suite, the same discipline its chordTones copy already follows."
+}

--- a/web/tests/spec-floors/unit-chord-theory-269.json
+++ b/web/tests/spec-floors/unit-chord-theory-269.json
@@ -1,0 +1,5 @@
+{
+  "file": "tests/unit/chord-theory.spec.js",
+  "count": 6,
+  "reason": "issue #269: spellChordTones' letter-based spelling checked against chord-theory.spec.js's own known-chord cases (A major 7 spells G#, B major spells D#), a hand-written table for major triads/sevenths across all twelve roots, every one of the 60 (root, quality) chords reducing to chordTones' own pitch classes, every spelled tone's letter ascending from the root by its interval degree, no chord among the 60 needing a double accidental, and an unknown root or quality spelling nothing."
+}

--- a/web/tests/spec-floors/unit-chords-269.json
+++ b/web/tests/spec-floors/unit-chords-269.json
@@ -1,0 +1,5 @@
+{
+  "file": "tests/unit/chords.spec.js",
+  "count": 1,
+  "reason": "issue #269: answerStatement's name_to_shape wording now reads spellChordTones' spelled tones, not chordTones' own fixed table - A major 7 states its seventh as G#, in all three given.notes branches (no tap, correct, and incorrect)."
+}

--- a/web/tests/unit/chord-theory.spec.js
+++ b/web/tests/unit/chord-theory.spec.js
@@ -12,7 +12,9 @@ import {
   chordName,
   chordTones,
   chordsMatch,
+  spellChordTones,
 } from "../../src/lib/trainer/chord-theory.js";
+import { PITCH_CLASSES } from "../../src/lib/trainer/neck.js";
 
 // ---------------------------------------------------------------- known chords, by hand
 
@@ -136,6 +138,97 @@ test("an unknown root or quality names no chord at all", () => {
   expect(chordTones("C", "augmented")).toBeNull();
   expect(chordName("H", "major")).toBeNull();
   expect(chordName("C", "augmented")).toBeNull();
+});
+
+// ---------------------------------------------------------------- spelled tones (issue #269)
+
+// The seven letters, each letter's own natural pitch class as a semitone,
+// and a reducer that turns a spelled tone ("G#", "Bb", "E") back into the
+// pitch class chordTones would name for the same semitone - independent of
+// spellChordTones' own implementation, so this test would catch the
+// function computing the wrong semitone, not merely restate its own math.
+const LETTER_NATURAL_SEMITONE = { C: 0, D: 2, E: 4, F: 5, G: 7, A: 9, B: 11 };
+function pitchClassOf(spelledTone) {
+  const letter = spelledTone[0];
+  const accidental = spelledTone.slice(1);
+  let semitone = LETTER_NATURAL_SEMITONE[letter];
+  for (const ch of accidental) semitone += ch === "#" ? 1 : -1;
+  semitone = ((semitone % 12) + 12) % 12;
+  return PITCH_CLASSES[semitone];
+}
+
+const LETTERS = ["A", "B", "C", "D", "E", "F", "G"];
+const LETTER_OFFSETS = [0, 2, 4, 6];
+
+test("A major 7 spells G#, not the table's Ab; B major spells D#, not Eb", () => {
+  // The two strings #263's review measured directly off main, and #269's
+  // whole reason to exist - see this repo's issue #269.
+  expect(spellChordTones("A", "major7")).toEqual(["A", "C#", "E", "G#"]);
+  expect(spellChordTones("B", "major")).toEqual(["B", "D#", "F#"]);
+});
+
+// A hand-written table for one quality (major) across all twelve roots -
+// the twelve results a reviewer can check by eye against a staff, not only
+// against this module's own reduction logic below. The four roots the
+// twelve-name table already spells with a sharp (C#, F#) read their thirds
+// and sevenths as sharps too (E#, A#, B#) rather than switching to a flat
+// spelling mid-chord - the same "roots stay as the table names them" rule
+// issue #269 states, applied consistently within a chord.
+test("major triads/sevenths, all twelve roots: a hand-written spelling table", () => {
+  expect(spellChordTones("C", "major")).toEqual(["C", "E", "G"]);
+  expect(spellChordTones("C#", "major")).toEqual(["C#", "E#", "G#"]);
+  expect(spellChordTones("D", "major")).toEqual(["D", "F#", "A"]);
+  expect(spellChordTones("Eb", "major")).toEqual(["Eb", "G", "Bb"]);
+  expect(spellChordTones("E", "major")).toEqual(["E", "G#", "B"]);
+  expect(spellChordTones("F", "major")).toEqual(["F", "A", "C"]);
+  expect(spellChordTones("F#", "major")).toEqual(["F#", "A#", "C#"]);
+  expect(spellChordTones("G", "major")).toEqual(["G", "B", "D"]);
+  expect(spellChordTones("Ab", "major")).toEqual(["Ab", "C", "Eb"]);
+  expect(spellChordTones("A", "major")).toEqual(["A", "C#", "E"]);
+  expect(spellChordTones("Bb", "major")).toEqual(["Bb", "D", "F"]);
+  expect(spellChordTones("B", "major")).toEqual(["B", "D#", "F#"]);
+});
+
+test("every one of the 60 spelled chords reduces to chordTones' own pitch classes", () => {
+  for (const root of ROOTS) {
+    for (const quality of QUALITY_LIST) {
+      const tones = chordTones(root, quality);
+      const spelled = spellChordTones(root, quality);
+      expect(spelled, `${root} ${quality}`).toHaveLength(tones.length);
+      expect(spelled[0], `${root} ${quality} root keeps the table's own name`).toBe(root);
+      for (let i = 0; i < tones.length; i++) {
+        expect(pitchClassOf(spelled[i]), `${root} ${quality} tone ${i}: ${spelled[i]}`).toBe(tones[i]);
+      }
+    }
+  }
+});
+
+test("every spelled tone's letter ascends from the root by its interval degree", () => {
+  for (const root of ROOTS) {
+    for (const quality of QUALITY_LIST) {
+      const spelled = spellChordTones(root, quality);
+      const rootLetterIndex = LETTERS.indexOf(root[0]);
+      for (let degree = 1; degree < spelled.length; degree++) {
+        const expectedLetter = LETTERS[(rootLetterIndex + LETTER_OFFSETS[degree]) % 7];
+        expect(spelled[degree][0], `${root} ${quality} tone ${degree}`).toBe(expectedLetter);
+      }
+    }
+  }
+});
+
+test("no chord among the 60 needs a double accidental", () => {
+  for (const root of ROOTS) {
+    for (const quality of QUALITY_LIST) {
+      for (const tone of spellChordTones(root, quality)) {
+        expect(tone.slice(1).length, `${root} ${quality}: ${tone}`).toBeLessThanOrEqual(1);
+      }
+    }
+  }
+});
+
+test("an unknown root or quality spells no chord at all", () => {
+  expect(spellChordTones("H", "major")).toBeNull();
+  expect(spellChordTones("C", "augmented")).toBeNull();
 });
 
 // ---------------------------------------------------------------- chord equality

--- a/web/tests/unit/chords.spec.js
+++ b/web/tests/unit/chords.spec.js
@@ -3,7 +3,7 @@
 // see this module's own docstring.
 import { expect, test } from "@playwright/test";
 
-import { chordTones } from "../../src/lib/trainer/chord-theory.js";
+import { chordTones, spellChordTones } from "../../src/lib/trainer/chord-theory.js";
 import {
   DRILL,
   FAMILIES,
@@ -291,6 +291,24 @@ test("answerStatement names the chord honestly either way, with no verdict word"
   ]) {
     expect(forbiddenWord(text), text).toBeNull();
   }
+});
+
+// issue #269: name_to_shape's statement reads the SPELLED tones
+// (chord-theory.js's spellChordTones), not chordTones' own fixed table -
+// "A major 7" is A, C#, E, G#, never the table's Ab, and this is the one
+// place in this module where that distinction is visible in a string.
+test("answerStatement spells A major 7's tones G#, not chordTones' own Ab", () => {
+  const question = { direction: NAME_TO_SHAPE, root: "A", quality: "major7" };
+  expect(chordTones("A", "major7")).toEqual(["A", "C#", "E", "Ab"]);
+  const spelled = spellChordTones("A", "major7").join(", ");
+  expect(spelled).toBe("A, C#, E, G#");
+  expect(answerStatement(question, { notes: [] }, false)).toBe(`Amaj7 is ${spelled}.`);
+  expect(answerStatement(question, { notes: ["A", "C#", "E", "G#"] }, true)).toBe(
+    `Amaj7 is ${spelled} - that's what sounded.`,
+  );
+  expect(answerStatement(question, { notes: ["A", "C#", "E"] }, false)).toBe(
+    `Amaj7 is ${spelled}. What was tapped sounded A, C#, E.`,
+  );
 });
 
 test("every phrase this module produces avoids the forbidden words and never a percentage", () => {

--- a/web/tests/unit/chords.spec.js
+++ b/web/tests/unit/chords.spec.js
@@ -311,6 +311,19 @@ test("answerStatement spells A major 7's tones G#, not chordTones' own Ab", () =
   );
 });
 
+// issue #271 nit: the TAPPED clause used to read out chordTones' raw
+// PITCH_CLASSES names, so one sentence could say "G#" for the spelled
+// chord tone and "Ab" for the very same tapped pitch class. A tapped tone
+// that belongs to the chord must be read out with the chord's own
+// spelling; a tapped tone that ISN'T one of the chord's tones has no
+// root-relative spelling to borrow, so it keeps chordTones' table name.
+test("answerStatement spells a tapped chord tone by the chord, but keeps a non-chord tone's table name", () => {
+  const question = { direction: NAME_TO_SHAPE, root: "A", quality: "major7" };
+  const text = answerStatement(question, { notes: ["A", "C#", "E", "Ab", "Bb"] }, false);
+  expect(text).toBe("Amaj7 is A, C#, E, G#. What was tapped sounded A, C#, E, G#, Bb.");
+  expect(text).not.toContain("Ab");
+});
+
 test("every phrase this module produces avoids the forbidden words and never a percentage", () => {
   const samples = [
     progressStatement({ asked: 5, correct: 2 }),


### PR DESCRIPTION
## Premise (re-derived on main c950501)

**Valid.** On main, `node -e` against `chord-theory.js`'s `chordTones` reproduced the exact strings the issue measured:
- `chordTones("A","major7")` → `["A","C#","E","Ab"]`
- `chordTones("B","major")` → `["B","Eb","F#"]`

## What changed

`answerStatement` (`chords.js`) now reads a chord's tones through a new `spellChordTones(root, quality)` (`chord-theory.js`), not `chordTones`' own fixed twelve-name identity table. Grading (`chordsMatch`, `checkNameAnswer`, `checkShapeAnswer`) is untouched - still `chordTones`' pitch-class comparison. Server untouched.

**Spelling rule:** the root keeps the table's own name (Eb, Ab, Bb, C#, F# spelled exactly as `PITCH_CLASSES` names them - ids, not chord-specific choices). Every other tone is spelled by LETTER, ascending from the root's own letter: third = +2 letters, fifth = +4, seventh = +6 (mod 7 over A-G). Each letter gets whichever accidental (`#`, `b`, or none) makes its pitch class agree with `chordTones`' answer for that same tone. Checked exhaustively (unit test) that no chord among the 60 needs more than a single accidental - none do, so no double-accidental fallback was needed.

**Twelve-root table, major quality** (hand-written, in the test):

| root | spelled |
|---|---|
| C | C, E, G |
| C# | C#, E#, G# |
| D | D, F#, A |
| Eb | Eb, G, Bb |
| E | E, G#, B |
| F | F, A, C |
| F# | F#, A#, C# |
| G | G, B, D |
| Ab | Ab, C, Eb |
| A | A, C#, E |
| Bb | Bb, D, F |
| B | B, D#, F# |

(C#'s E# and F#'s A# are single sharps on a natural note - conventional, not a special case: a root already spelled sharp in the table reads its whole chord in sharps.)

## Done-when checklist

- [x] A major 7 reads A, C#, E, G# — `chords.spec.js`, `chord-theory.spec.js`, browser spec
- [x] B major reads B, D#, F# — `chord-theory.spec.js`
- [x] Unit test covers all 60 chords for pitch-class agreement and letter order — `chord-theory.spec.js`
- [x] Hand-written table for one quality (major, all 12 roots) — `chord-theory.spec.js`
- [x] Browser spec answers one card and asserts the spelled statement — `chord-flashcards.spec.js`
- [x] Vocabulary guard passes — `practice.spec.js` (ChordFlashCards is in COMPONENTS)
- [x] Mutation recorded red then green (below)

## Mutations

| mutation | result |
|---|---|
| revert `answerStatement` to `chordTones` instead of `spellChordTones` | red: `chords.spec.js:300` (new spelling test), then rebuilt + red: `chord-flashcards.spec.js:483` (browser) |
| letter step wrong (third = +3 letters instead of +2) | red: 4 tests in `chord-theory.spec.js` including the letter-ascent test and the hand-written table |
| revert both | green |

## Runs

- `PLAYWRIGHT_ALLOW_PARTIAL=1 npx playwright test tests/unit/chord-theory.spec.js tests/unit/chords.spec.js tests/unit/chord-shapes.spec.js tests/unit/practice.spec.js` → 101 passed
- `FERMATA_TEST_PORT=9215 PLAYWRIGHT_ALLOW_PARTIAL=1 npx playwright test tests/browser/chord-flashcards.spec.js` → 14 passed
- Full suite: not-run (per instructions). `gh pr checks --watch`: not-run. pytest: not-run (no server change).

## Files

- `web/src/lib/trainer/chord-theory.js` - `spellChordTones`
- `web/src/lib/trainer/chords.js` - `answerStatement` uses it
- `web/tests/unit/chord-theory.spec.js`, `web/tests/unit/chords.spec.js` - new tests
- `web/tests/browser/chord-flashcards.spec.js` - independent spelling reimplementation, new/updated assertions
- `web/tests/spec-floors/{unit-chord-theory,unit-chords,browser-chord-flashcards}-269.json` - new floor entries

Closes #269

## After review

Review verdict on the code was sound; two nits fixed:

1. `chord-theory.js`'s `spellChordTones` docstring had a garbled mid-clause sentence explaining the letter/offset rule. Rewritten as one clear sentence: letters ascend one staff-step per degree from the root's own letter, and each letter takes whatever accidental makes its pitch class agree with `chordTones`' answer; the root keeps the table's own name.
2. `answerStatement`'s "What was tapped sounded ..." clause still printed raw `chordTones`/`PITCH_CLASSES` names, so a wrong answer could read `G#` for the spelled chord tone and `Ab` for the same tapped pitch class in the next clause. Fixed: a tapped pitch class that is one of the chord's own tones is now read out with that chord's spelling (`spellChordTones`'s entry for that tone); a tapped pitch class outside the chord keeps `chordTones`' table name, since it has no root-relative spelling to borrow. New unit test (`chords.spec.js`) covers A major7 with a tapped G#/Ab-pitch-class tone and a tapped non-chord tone; reverting the fix to raw names was recorded red before the fix was restored green.
