### PR TITLE
Download a rendered score's MIDI, out of the browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ them.
   reads that format natively; a browser spec carries an original Guitar Pro 7
   fixture through that whole path (see the format table below). The built-in
   synthesizer also drives practice tools: drag-select a passage on the score
-  to loop it, plus a count-in. The
+  to loop it, plus a count-in. A "Download MIDI" control takes the rendered
+  score's playback out of the browser as a standard MIDI file. The
   staff is themed to match the interface, lays itself out differently on a
   phone, a tablet on a stand and a desktop, and can be drawn dark for
   practising in the dark — see [how scores are rendered](docs/rendering.md) for

--- a/web/src/lib/TabViewer.svelte
+++ b/web/src/lib/TabViewer.svelte
@@ -1474,6 +1474,37 @@
     view?.setCountIn(countIn);
   }
 
+  // The characters a filesystem (or a zip entry, or a URL) would read as a
+  // path separator or a reserved shell character - stripped rather than
+  // escaped, because a download's filename has no way to carry an escape.
+  // "Untitled" matches the fallback Library.svelte already shows for a score
+  // with no title (issue #58's export path), so a MIDI pulled from either
+  // place reads the same way.
+  function sanitizeFilename(name) {
+    return name.replace(/[/\\:*?"<>|]/g, "").trim();
+  }
+
+  // Download the current score's MIDI (issue #270) - the same bytes the
+  // renderer plays from, handed over exactly the way DataPortability.svelte's
+  // library export already does: a Blob, an object URL, and a throwaway <a
+  // download> clicked once and torn back down. No server round trip - the
+  // bytes never leave the browser that rendered them.
+  function downloadMidi() {
+    const exported = view?.exportMidi();
+    if (!exported) return;
+    const cleaned = sanitizeFilename(exported.title ?? "");
+    const filename = `${cleaned || "Untitled"}.mid`;
+    const blob = new Blob([exported.bytes], { type: "audio/midi" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = filename;
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    URL.revokeObjectURL(url);
+  }
+
   function clamp(n, lo, hi) {
     if (Number.isNaN(n)) return lo;
     return Math.min(hi, Math.max(lo, n));
@@ -1830,6 +1861,18 @@
           {editMode ? "Done editing" : "Edit notes"}
         </button>
       {/if}
+      <!-- Disabled together with the "nothing drawable" notice below
+      (profileOptions null before a score has loaded, or empty once one has
+      loaded with nothing to draw) - the same render-ok signal that notice
+      already reads, not a second one. A render that throws for some other
+      reason surfaces through loadError, which disables this too. -->
+      <button
+        disabled={!profileOptions?.length || !!loadError}
+        onclick={downloadMidi}
+        title="Download this score's MIDI, as the renderer plays it — bends approximated as pitch-bend events; not a re-engraving of the score"
+      >
+        Download MIDI
+      </button>
       <div class="player">
         <button class="primary" disabled={!playerReady} onclick={() => view?.playPause()}>
           {playing ? "❚❚ Pause ((Space))" : "▶ Play ((Space))"}

--- a/web/src/lib/TabViewer.svelte
+++ b/web/src/lib/TabViewer.svelte
@@ -2,6 +2,7 @@
   import { untrack } from "svelte";
   import { api } from "./api.js";
   import { createScoreView, UNRENDERABLE_MESSAGE, tabWithheldMessage } from "./score-render.js";
+  import { midiFilename } from "./filename.js";
   import { getSettings, setSetting, STAFF_THEMES, STAFF_THEME_LABELS } from "./settings.svelte.js";
   import Metronome from "./Metronome.svelte";
   import { createDocument, DURATION_TYPES } from "./editor/document.js";
@@ -1474,26 +1475,19 @@
     view?.setCountIn(countIn);
   }
 
-  // The characters a filesystem (or a zip entry, or a URL) would read as a
-  // path separator or a reserved shell character - stripped rather than
-  // escaped, because a download's filename has no way to carry an escape.
-  // "Untitled" matches the fallback Library.svelte already shows for a score
-  // with no title (issue #58's export path), so a MIDI pulled from either
-  // place reads the same way.
-  function sanitizeFilename(name) {
-    return name.replace(/[/\\:*?"<>|]/g, "").trim();
-  }
-
   // Download the current score's MIDI (issue #270) - the same bytes the
   // renderer plays from, handed over exactly the way DataPortability.svelte's
   // library export already does: a Blob, an object URL, and a throwaway <a
   // download> clicked once and torn back down. No server round trip - the
   // bytes never leave the browser that rendered them.
+  //
+  // Filename sanitising lives in filename.js, not here - see that file for
+  // the length bound, control-character stripping and leading/trailing-dot
+  // handling the review on this issue asked for.
   function downloadMidi() {
     const exported = view?.exportMidi();
     if (!exported) return;
-    const cleaned = sanitizeFilename(exported.title ?? "");
-    const filename = `${cleaned || "Untitled"}.mid`;
+    const filename = midiFilename(exported.title ?? "");
     const blob = new Blob([exported.bytes], { type: "audio/midi" });
     const url = URL.createObjectURL(blob);
     const a = document.createElement("a");

--- a/web/src/lib/filename.js
+++ b/web/src/lib/filename.js
@@ -1,0 +1,70 @@
+// Turns an arbitrary score title into a filesystem-safe download name
+// (issue #270's review nit, on top of #270 itself).
+//
+// TabViewer.svelte's original inline sanitizeFilename() only stripped the
+// characters a filesystem or a shell would read as a path separator or a
+// reserved character. The reviewer measured three gaps that left, none of
+// them hypothetical:
+//   - no length bound: a 300-character title produced a 304-character
+//     ".mid" file, past Windows' 255-character path-COMPONENT limit (not the
+//     full-path limit - a single segment).
+//   - control characters (codepoints 0-31, plus DEL/127) passed through
+//     untouched.
+//   - a title of only bad characters could sanitise down to something that
+//     READS as a relative path once ".mid" is appended: "." + ".." became
+//     "...mid", which Chrome's own <a download> rewrote to "mid.mid" -
+//     silently, on the browser's own initiative, not this code's.
+//
+// STEM_MAX_LENGTH is 120, not something closer to 255: 255 is Windows' limit
+// for the whole component INCLUDING the ".mid" suffix, and a browser is free
+// to append its own disambiguating suffix to a downloaded file that collides
+// with one already on disk (Chrome's own pattern is " (1)", " (2)", ...) -
+// that suffix lands after this function returns, so headroom for it has to
+// come out of the stem this function controls. 120 leaves well over 100
+// characters of slack under 255 for ".mid" plus anything a browser tacks on,
+// on any platform, without needing to special-case the extension's length.
+export const STEM_MAX_LENGTH = 120;
+
+// Same fallback Library.svelte already shows for a score with no title
+// (issue #58's export path) - a MIDI pulled from either place reads the same
+// way.
+const FALLBACK_STEM = "Untitled";
+
+// The characters a filesystem (or a zip entry, or a URL) would read as a
+// path separator or a reserved shell character - checked one at a time
+// against this string rather than folded into a regex character class,
+// because the control-character check right beside it is written the same
+// per-codepoint way and putting one in a regex literal while the other
+// walks codepoints would be two different techniques doing one job.
+const RESERVED_CHARS = "/\\:*?\"<>|";
+
+/**
+ * Sanitises a score title into a filesystem-safe filename stem (no
+ * extension). Strips path/shell-reserved characters and every C0 control
+ * codepoint plus DEL (0-31, 127), collapses any run of whitespace left
+ * behind into a single space, trims the result, strips leading/trailing
+ * dots (so an all-dots title can never read as "." or ".." once an
+ * extension is appended), bounds it to STEM_MAX_LENGTH characters, and
+ * falls back to "Untitled" when nothing survives.
+ */
+export function sanitizeFilename(name) {
+  const source = name ?? "";
+  let kept = "";
+  for (const ch of source) {
+    const code = ch.codePointAt(0);
+    if (code <= 0x1f || code === 0x7f) continue; // control characters
+    if (RESERVED_CHARS.includes(ch)) continue; // path/shell-reserved
+    kept += ch;
+  }
+  const stripped = kept
+    .replace(/\s+/g, " ")
+    .trim()
+    .replace(/^\.+|\.+$/g, "");
+  if (!stripped) return FALLBACK_STEM;
+  return stripped.slice(0, STEM_MAX_LENGTH);
+}
+
+/** sanitizeFilename(name) with ".mid" appended - the full download name. */
+export function midiFilename(name) {
+  return `${sanitizeFilename(name)}.mid`;
+}

--- a/web/src/lib/score-render.js
+++ b/web/src/lib/score-render.js
@@ -3366,6 +3366,76 @@ export function createScoreView(host, opts = {}) {
       return lastRenderMs;
     },
 
+    /**
+     * The current score's MIDI bytes (issue #270) - built fresh from the
+     * renderer's OWN generator (MidiFileGenerator, the exact class that
+     * produces the midi alphaTab plays from - see the note on
+     * loadMidiForScore below), not a re-engraving and not a recording of
+     * whatever the synthesiser happened to play. Returns
+     * `{ bytes: Uint8Array, trackCount, title }` or **null**.
+     *
+     * null covers every state that leaves nothing honest to export: no
+     * score has loaded yet (`api.score` unset), the loaded score has
+     * nothing drawable under any profile (`unrenderable` - see
+     * supportedProfiles), or the most recent render attempt failed outright
+     * (`renderOk` false - set in the api.error handler below). A caller
+     * that built bytes from a half-drawn or nonexistent model would be
+     * handing over something that does not describe what is, or isn't, on
+     * screen.
+     *
+     * `format` is deliberately MidiFileFormat.MultiTrack (SMF Type 1) and
+     * NOT the SingleTrackMultiChannel default api.downloadMidi() itself
+     * uses: MidiFileGenerator writes one event stream per SCORE track
+     * (`_generateTrack` is called once per `score.tracks` entry, keyed on
+     * that track's own `.index`), and MidiFile.addEvent only ever opens a
+     * new track chunk for an event's own `.track` index when the format is
+     * MultiTrack - Type 0 collapses every channel onto tracks[0]
+     * regardless of how many the score has. MultiTrack is therefore what
+     * makes `trackCount` (== `midiFile.tracks.length`, which is also the
+     * exact number the SMF header's own track-count field gets written
+     * with - see MidiFile.writeTo) equal `api.tracks.length`/
+     * `host.dataset.scoreTracks`, the same count the scoreLoaded handler
+     * above already reports - measured against alphaTab.core.mjs's own
+     * MidiFile/AlphaSynthMidiFileHandler source, not assumed from the
+     * typings alone.
+     *
+     * The handler is built with smf1Mode=true, exactly like
+     * api.downloadMidi()'s own construction - not a shortcut taken only
+     * here. That is what turns a per-note bend into a single, channel-wide
+     * PitchBendEvent instead of the newer MIDI 2.0-flavoured per-note bend
+     * message (see AlphaSynthMidiFileHandler.addNoteBend); this is the
+     * "bends approximated as pitch-bend events" half of the control's own
+     * tooltip caveat, and it is true of every export this method produces.
+     *
+     * A caveat of its own: this is a snapshot of the score exactly as
+     * MidiFileGenerator sees it right now, generated synchronously on
+     * demand rather than cached - a second call after an edit or a profile
+     * change regenerates rather than replaying a stale buffer, at the cost
+     * of repeating the generation work on every call. No caller here needs
+     * more than one call per click, so that cost was never measured against
+     * an alternative.
+     */
+    exportMidi() {
+      if (destroyed || unrenderable || !renderOk) return null;
+      const score = api.score;
+      if (!score) return null;
+      try {
+        const { MidiFile, MidiFileFormat, AlphaSynthMidiFileHandler, MidiFileGenerator } = alphaTab.midi;
+        const midiFile = new MidiFile();
+        midiFile.format = MidiFileFormat.MultiTrack;
+        const handler = new AlphaSynthMidiFileHandler(midiFile, true);
+        new MidiFileGenerator(score, api.settings, handler).generate();
+        return {
+          bytes: midiFile.toBinary(),
+          trackCount: midiFile.tracks.length,
+          title: score.title ?? "",
+        };
+      } catch (e) {
+        console.warn("score-render: exportMidi() failed to generate a MIDI file.", e);
+        return null;
+      }
+    },
+
     setProfile(next) {
       // Keyed on appliedProfile, not profile: profile is set eagerly, right
       // below, the moment a switch is requested, whether or not it ever

--- a/web/test-fixtures/midi-export-fixture.musicxml
+++ b/web/test-fixtures/midi-export-fixture.musicxml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.musicxml.org/xsd/musicxml.xsd">
+  <!-- Issue #270's own fixture: two parts (so the exported MIDI's header
+       carries a track count worth checking against data-score-tracks,
+       rather than the trivially-true "1" a single-part fixture would give),
+       and a work-title containing a path-separator character ("/") on
+       purpose - download-midi.spec.js uploads this to prove the Download
+       MIDI control's filename sanitiser actually strips it rather than
+       merely never being asked to. -->
+  <work>
+    <work-title>Fermata MIDI export/fixture</work-title>
+  </work>
+  <identification>
+    <encoding>
+      <software>Fermata test fixture</software>
+      <encoding-date>2026-09-06</encoding-date>
+    </encoding>
+  </identification>
+  <part-list>
+    <score-part id="P1">
+      <part-name>Upper Part</part-name>
+    </score-part>
+    <score-part id="P2">
+      <part-name>Lower Part</part-name>
+    </score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>1</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <note><pitch><step>C</step><octave>5</octave></pitch><duration>1</duration><voice>1</voice><type>quarter</type></note>
+      <note><pitch><step>D</step><octave>5</octave></pitch><duration>1</duration><voice>1</voice><type>quarter</type></note>
+      <note><pitch><step>E</step><octave>5</octave></pitch><duration>1</duration><voice>1</voice><type>quarter</type></note>
+      <note><pitch><step>F</step><octave>5</octave></pitch><duration>1</duration><voice>1</voice><type>quarter</type></note>
+    </measure>
+    <measure number="2">
+      <note><pitch><step>G</step><octave>5</octave></pitch><duration>4</duration><voice>1</voice><type>whole</type></note>
+    </measure>
+  </part>
+  <part id="P2">
+    <measure number="1">
+      <attributes>
+        <divisions>1</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>F</sign><line>4</line></clef>
+      </attributes>
+      <note><pitch><step>C</step><octave>3</octave></pitch><duration>1</duration><voice>1</voice><type>quarter</type></note>
+      <note><pitch><step>B</step><octave>2</octave></pitch><duration>1</duration><voice>1</voice><type>quarter</type></note>
+      <note><pitch><step>A</step><octave>2</octave></pitch><duration>1</duration><voice>1</voice><type>quarter</type></note>
+      <note><pitch><step>G</step><octave>2</octave></pitch><duration>1</duration><voice>1</voice><type>quarter</type></note>
+    </measure>
+    <measure number="2">
+      <note><pitch><step>C</step><octave>3</octave></pitch><duration>4</duration><voice>1</voice><type>whole</type></note>
+    </measure>
+  </part>
+</score-partwise>

--- a/web/tests/browser/download-midi.spec.js
+++ b/web/tests/browser/download-midi.spec.js
@@ -1,0 +1,181 @@
+// Issue #270: the tab viewer plays a score through the renderer's own
+// synthesiser but never offered a way to take that performance out of the
+// browser. score-render.js's createScoreView() now exposes exportMidi() -
+// the renderer's own MidiFileGenerator, not a re-implementation - and
+// TabViewer.svelte wires a "Download MIDI" toolbar button to it. This spec
+// drives that whole path with a real upload: a real MIDI file lands on
+// disk, its header says what MidiFileGenerator actually produced, and the
+// filename is what the sanitiser actually did to the score's own title -
+// not what the code is merely supposed to do.
+//
+// THE FIXTURE. web/test-fixtures/midi-export-fixture.musicxml is original,
+// two parts (so the exported file's track count is a real check rather than
+// the trivially-true "1" a single-part fixture gives - see its own header),
+// with a work-title carrying a "/" on purpose: "Fermata MIDI export/fixture"
+// sanitises to "Fermata MIDI exportfixture" (the slash removed outright, no
+// space substituted - see TabViewer.svelte's sanitizeFilename), so the
+// suggested filename is a direct, hand-computed assertion, not a guess at
+// what "some path character got removed" might look like.
+//
+// WHY THE HEADER IS READ BYTE-FOR-BYTE. A standard MIDI file opens with the
+// four-byte tag "MThd", a 32-bit big-endian chunk length (always 6), a
+// 16-bit format (1 == MidiFileFormat.MultiTrack, what exportMidi() asks
+// for), and a 16-bit track count - see the Standard MIDI File spec and
+// score-render.js's own exportMidi() comment for why MultiTrack (not the
+// SingleTrackMultiChannel default alphaTab's own api.downloadMidi() uses)
+// is what makes that count equal the score's own track count rather than
+// always reading 1.
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { expect, test } from "@playwright/test";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const FIXTURE = path.join(here, "..", "..", "test-fixtures", "midi-export-fixture.musicxml");
+const SCORE_NAME = "midi-export-fixture.musicxml";
+const UNRENDERABLE_FIXTURE = path.join(here, "..", "..", "test-fixtures", "unrenderable.musicxml");
+const UNRENDERABLE_NAME = "unrenderable-for-midi-export.musicxml";
+
+const EXPECTED_TRACKS = "2";
+// sanitizeFilename removes only /\:*?"<>| - the slash in the fixture's own
+// title is the one character this proves gets stripped, not substituted.
+const EXPECTED_FILENAME = "Fermata MIDI exportfixture.mid";
+
+const OWN_PATHS = [`Uploads/${SCORE_NAME}`, `Uploads/${UNRENDERABLE_NAME}`];
+
+const host = (page) => page.locator(".at-host");
+const playButton = (page) => page.locator(".player button.primary");
+const downloadButton = (page) => page.getByRole("button", { name: "Download MIDI", exact: true });
+
+async function waitForScore(request, name) {
+  // The scan runs in a background thread - see guitar-pro-import.spec.js's
+  // own copy of this wait for the same reason.
+  for (let attempt = 0; attempt < 60; attempt += 1) {
+    const scores = await (await request.get("/api/scores")).json();
+    const found = scores.find((s) => s.path.endsWith(name));
+    if (found) return found;
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+  throw new Error(`the uploaded score ${name} never appeared in the library`);
+}
+
+async function uploadFixture(request, fixturePath, name) {
+  const res = await request.post("/api/upload?folder=Uploads", {
+    multipart: {
+      file: { name, mimeType: "application/octet-stream", buffer: fs.readFileSync(fixturePath) },
+    },
+  });
+  expect(res.ok(), await res.text()).toBe(true);
+  return waitForScore(request, name);
+}
+
+async function openScore(page, id) {
+  await page.goto(`/#/score/${id}`);
+  await expect(playButton(page)).toBeEnabled({ timeout: 30_000 });
+  await expect(host(page)).toHaveAttribute("data-score-render-ok", "true", { timeout: 30_000 });
+}
+
+// Same convention as guitar-pro-import.spec.js's emptyTheLibrary: a single
+// DELETE moves a score to the trash, so the trash also has to be purged or
+// the score would still show up (as a trashed row) to a later spec's "the
+// library is empty" check.
+async function emptyTheLibrary(request) {
+  for (const score of await (await request.get("/api/scores")).json()) {
+    await request.delete(`/api/scores/${score.id}`);
+  }
+  for (const score of await (await request.get("/api/trash")).json()) {
+    await request.delete(`/api/trash/${score.id}`);
+  }
+}
+
+test.describe("Download MIDI", () => {
+  test.beforeEach(async ({ request }) => {
+    // The same refusal guitar-pro-import.spec.js makes: this suite must not
+    // be pointed at a real library that already has scores in it.
+    const existing = await (await request.get("/api/scores")).json();
+    expect(
+      existing.filter((s) => !OWN_PATHS.includes(s.path)),
+      "refusing to run: this backend has scores in its library this spec did not put " +
+        "there, so it is not the throwaway instance the suite creates",
+    ).toEqual([]);
+  });
+
+  test.afterEach(async ({ request }) => {
+    await emptyTheLibrary(request);
+  });
+
+  test("downloads a real MIDI file whose header and track count match the render, with a sanitised filename", async ({
+    page,
+    request,
+  }) => {
+    const consoleErrors = [];
+    page.on("console", (m) => {
+      if (m.type() === "error") consoleErrors.push(m.text());
+    });
+    page.on("pageerror", (e) => consoleErrors.push(String(e)));
+
+    const score = await uploadFixture(request, FIXTURE, SCORE_NAME);
+    await openScore(page, score.id);
+
+    // score-render.js's own account of the loaded score's track count - the
+    // number exportMidi()'s SMF header is checked against below, not a
+    // number this test invents on its own.
+    await expect(host(page)).toHaveAttribute("data-score-tracks", EXPECTED_TRACKS);
+
+    const button = downloadButton(page);
+    await expect(button).toBeEnabled({ timeout: 10_000 });
+
+    const downloadPromise = page.waitForEvent("download");
+    await button.click();
+    const download = await downloadPromise;
+
+    // Chromium's own download dialog renders the suggested filename with
+    // U+00A0 (no-break space) in place of every ordinary ASCII space -
+    // confirmed by hand (charCodeAt on the raw value) against this exact
+    // fixture, not assumed - which is a property of the browser's download
+    // plumbing, not of TabViewer's sanitizeFilename(): the <a download> the
+    // page sets carries an ordinary space (also confirmed - the same value
+    // survives unmangled into the actually-saved file's own path below).
+    // Normalised back before comparing so this assertion is about the
+    // filename this app chose, not about that browser quirk.
+    expect(download.suggestedFilename().replace(/\u00a0/g, " ")).toBe(EXPECTED_FILENAME);
+
+    const savedPath = path.join(
+      fs.mkdtempSync(path.join(os.tmpdir(), "fermata-midi-export-")),
+      "downloaded.mid",
+    );
+    await download.saveAs(savedPath);
+    const bytes = fs.readFileSync(savedPath);
+
+    expect(bytes.length, "the downloaded file is suspiciously small").toBeGreaterThan(100);
+    expect(bytes.subarray(0, 4).toString("ascii"), "missing the MThd header").toBe("MThd");
+    // Bytes 8-9: the SMF format (big-endian uint16) - 1 == MidiFileFormat.MultiTrack.
+    const format = bytes.readUInt16BE(8);
+    expect(format, "expected MidiFileFormat.MultiTrack (1), not the Type-0 default").toBe(1);
+    // Bytes 10-11: the header's own track-count field - has to equal the
+    // score's track count as the renderer reports it (data-score-tracks
+    // above), not just be present.
+    const headerTrackCount = bytes.readUInt16BE(10);
+    expect(headerTrackCount, "the SMF header's track count").toBe(Number(EXPECTED_TRACKS));
+
+    expect(consoleErrors).toEqual([]);
+  });
+
+  test("the control is disabled for a score that fails to render", async ({ page, request }) => {
+    const score = await uploadFixture(request, UNRENDERABLE_FIXTURE, UNRENDERABLE_NAME);
+    // Not openScore(): this score is genuinely unrenderable (every staff
+    // fails every profile's check - see score-render.js's supportedProfiles),
+    // so data-score-render-ok never becomes "true" and the play button's own
+    // readiness is a different question from the one this test asks.
+    // publish() still writes data-score-profiles as soon as scoreLoaded runs
+    // though - "" once profiles is known to be empty - so waiting on that
+    // value is the correct sync point for "this score's degraded state has
+    // settled".
+    await page.goto(`/#/score/${score.id}`);
+    await expect(host(page)).toHaveAttribute("data-score-profiles", "", { timeout: 30_000 });
+
+    await expect(downloadButton(page)).toBeDisabled();
+  });
+});

--- a/web/tests/spec-floors/download-midi-270.json
+++ b/web/tests/spec-floors/download-midi-270.json
@@ -1,0 +1,5 @@
+{
+  "file": "tests/browser/download-midi.spec.js",
+  "count": 2,
+  "reason": "issue #270: TabViewer had no way to take a rendered score's MIDI out of the browser. This spec uploads a real two-part MusicXML fixture, clicks the new Download MIDI toolbar control, and reads the downloaded file byte-for-byte (MThd header, MultiTrack format, track count matching data-score-tracks, filename sanitised from the score's own title). A second test proves the control is disabled for a score that fails to render."
+}

--- a/web/tests/spec-floors/unit-filename-270-review.json
+++ b/web/tests/spec-floors/unit-filename-270-review.json
@@ -1,0 +1,5 @@
+{
+  "file": "tests/unit/filename.spec.js",
+  "count": 7,
+  "reason": "issue #270 review nit: sanitizeFilename() moved to its own module with a length bound, control-character stripping and leading/trailing-dot stripping - the reviewer's torture cases (a 300-char title, an all-reserved-character title, \"..\", a tab/NUL) plus the ordinary-title and mixed-character paths."
+}

--- a/web/tests/unit/filename.spec.js
+++ b/web/tests/unit/filename.spec.js
@@ -1,0 +1,50 @@
+// sanitizeFilename()/midiFilename() called directly - no browser, no
+// backend. filename.js has no runes and no imports precisely so this can
+// import it, the same reason pitch.spec.js gives for pitch.js.
+//
+// These are the torture cases the review on issue #270 measured against the
+// ORIGINAL inline sanitizeFilename() in TabViewer.svelte: a 300-character
+// title produced a 304-character ".mid" name (over Windows' 255-character
+// path-component limit), control characters passed through untouched, and a
+// ".." title sanitised down to "..mid" - which Chrome's own <a download>
+// rewrote to "mid.mid" on its own initiative, not visible from this file's
+// return value at all. Every case below is one of those, or the ordinary
+// path the original already handled correctly.
+import { expect, test } from "@playwright/test";
+
+import { STEM_MAX_LENGTH, midiFilename, sanitizeFilename } from "../../src/lib/filename.js";
+
+test("strips path separators and shell-reserved characters, keeping ordinary letters", () => {
+  expect(midiFilename('a/b\\c:d*e?f"g<h>i|j')).toBe("abcdefghij.mid");
+});
+
+test("a title made of nothing but reserved characters falls back to Untitled", () => {
+  expect(midiFilename('/\\:*?"<>|')).toBe("Untitled.mid");
+});
+
+test("an empty title falls back to Untitled", () => {
+  expect(midiFilename("")).toBe("Untitled.mid");
+});
+
+test("a 300-character title is bounded to a 120-character stem before the extension", () => {
+  const title = "L".repeat(300);
+  const got = midiFilename(title);
+  expect(got).toBe("L".repeat(STEM_MAX_LENGTH) + ".mid");
+  // The bound is on the RETURNED stem, not just true of this one input -
+  // guards against a fix that special-cases "L" or this exact length.
+  expect(sanitizeFilename(title).length).toBe(STEM_MAX_LENGTH);
+});
+
+test('".." sanitises to Untitled, not to a name a browser could rewrite as a bare extension', () => {
+  expect(midiFilename("..")).toBe("Untitled.mid");
+});
+
+test("a tab and a NUL are both stripped as control characters", () => {
+  const tab = String.fromCharCode(9);
+  const nul = String.fromCharCode(0);
+  expect(midiFilename(`a${tab}b${nul}c`)).toBe("abc.mid");
+});
+
+test("an ordinary title is unaffected", () => {
+  expect(midiFilename("My Score")).toBe("My Score.mid");
+});


### PR DESCRIPTION
## Premise (issue #270)

Re-derived on main c950501: `git grep -n -i midi web/src/lib/TabViewer.svelte web/src/lib/api.js server/fermata/api.py` finds only the note editor's pitch fields (`selMidi`, `v.midi`, `d.midi`) - no export, no download control. **valid**.

## What changed

- `web/src/lib/score-render.js`: `createScoreView()`'s returned view now exposes `exportMidi()` - builds the current score's MIDI with the renderer's own `alphaTab.midi.MidiFileGenerator` (via `AlphaSynthMidiFileHandler(midiFile, true)`, `MidiFileFormat.MultiTrack`), returning `{ bytes, trackCount, title }` or **null** when no score has loaded, the score is unrenderable, or the last render attempt failed (`unrenderable`/`renderOk`, already tracked). `MultiTrack` (not the `SingleTrackMultiChannel` default `api.downloadMidi()` itself uses) is what makes the SMF header's own track-count field equal the score's track count - measured against alphaTab 1.8.4's own `alphaTab.core.mjs` source (`MidiFileGenerator._generateTrack` calls once per score track, keyed on `track.index`; `MidiFile.writeTo` writes `this.tracks.length` as the header's `ntrks`). `smf1Mode: true` matches `api.downloadMidi()`'s own construction - a note bend becomes a channel-wide pitch-bend event, the "bends approximated" half of the caveat below.
- `web/src/lib/TabViewer.svelte`: a "Download MIDI" toolbar button, disabled by the same `profileOptions`/`loadError` signal the existing "nothing drawable" notice already reads (no new render-ok tracking added). On click it builds a `Blob` (`audio/midi`) and triggers a download the same way `DataPortability.svelte`'s library export already does (an `<a download>`, an object URL, clicked once and torn down) - filename sanitised via `filename.js` (see the review-nit section below) and falling back to `"Untitled"` when the title is empty. Tooltip: "Download this score's MIDI, as the renderer plays it — bends approximated as pitch-bend events; not a re-engraving of the score." Checked by hand against `FORBIDDEN_WORDS` in `web/tests/unit/practice.spec.js` - none present; `TabViewer.svelte` is outside that guard's own component list, so this check was necessarily manual.
- `README.md`: one clause on the existing "Notation / tab / both" bullet naming the control.
- Confirmed NOT shown for a PDF score: `ScoreCompare.svelte` only mounts `TabViewer` inside its `{:else if transcriptionState === "ready"}` branch - a PDF with no transcription never reaches it.

## Done-when checklist

- [x] Control appears for a rendered score, not for a failed render or a PDF (unrenderable case tested; PDF confirmed by mount-path reading above)
- [x] Clicking yields a file starting `MThd`, matching track count
- [x] Browser spec captures the download, checks header + nonzero size, asserts sanitised filename
- [x] Control text passes the vocabulary check by hand
- [x] Mutation (empty buffer) recorded red then green

## Mutation table

| Mutation | Result |
|---|---|
| `bytes: new Uint8Array(0)` instead of `midiFile.toBinary()` | red - size (`toBeGreaterThan(100)`) and header (`MThd`) assertions both failed |
| Skip `sanitizeFilename()` on the title | red - filename assertion failed (`Fermata MIDI export_fixture.mid` - Chrome's own `<a download>` substitutes `_` for `/` on its own, which is exactly why the app can't rely on that and sanitises itself) |
| Restored | green |

## Specs run

`FERMATA_TEST_PORT=9217 PLAYWRIGHT_ALLOW_PARTIAL=1`, foreground, never the full suite:
- `web/tests/browser/download-midi.spec.js` (new, 2 tests) - green
- `web/tests/browser/toolbar-responsive.spec.js` (20 tests, toolbar/gig-HUD clipping + reachability at every width) - green, no regression from the new button
- `web/tests/browser/guitar-pro-import.spec.js` (1 test, exercises the play button/profile toolbar through a real import) - green

pytest: not-run (no server-side change). `gh pr checks --watch`: not-run.

## Follow-up: review nit (filename hardening)

The review found `sanitizeFilename()` (inline in `TabViewer.svelte`) had no length bound (a 300-character title produced a 304-character name, over Windows' 255-character path-component limit), did not strip control characters, and turned a `".."` title into `"...mid"`, which Chrome rewrote to `mid.mid`.

- Moved into `web/src/lib/filename.js` (`sanitizeFilename()`/`midiFilename()`), with no browser dependency (same reason `pitch.js`/`disclosures.js` are plain modules) so it can be unit-tested directly. `TabViewer.svelte` now imports `midiFilename()` from there; ordinary titles are unaffected.
- Now strips path/shell-reserved characters (`/ \ : * ? " < > |`) and every control codepoint (0-31, plus DEL/127), collapses whitespace, trims, strips leading/trailing dots (so an all-dots title can't read as `.`/`..` once `.mid` is appended), and bounds the stem to 120 characters before the extension - 120 leaves well over 100 characters of headroom under Windows' 255-character component limit for `.mid` plus any suffix a browser appends on a name collision (Chrome's own `" (1)"` pattern).
- `web/tests/unit/filename.spec.js` (new, 7 tests, floor added under `web/tests/spec-floors/`): the reviewer's torture cases (a 300-character title, a title of only reserved characters, `".."`, a tab plus a NUL) plus the ordinary and mixed-character paths.

Mutation, unit tests (`web/tests/unit/filename.spec.js`):
| Mutation | Result |
|---|---|
| Remove the 120-character length bound | red - the 300-character-title test failed |
| Remove control-character stripping | red - the tab/NUL test failed |
| Restored | green (all 7) |

Specs run for this follow-up, `FERMATA_TEST_PORT=9227 PLAYWRIGHT_ALLOW_PARTIAL=1`, foreground:
- `web/tests/unit/filename.spec.js` (7 tests) - green
- `web/tests/browser/download-midi.spec.js` (2 tests, rebuilt first) - unchanged, green

Closes #270.
