### PR TITLE
Restore now checks a drill scope against the same rules the API enforces

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -307,6 +307,35 @@ the way every other write in this API does, and removes any files already
 written to the library before the failure, so a rejected import always
 leaves the library exactly as it was.
 
+**A named drill scope is checked, not just carried (#268).** Every archived
+`trainer_scope_presets` row - and the string set
+`trainer_scope_preset_strings` carries for it - is run through
+`trainer.normalise_preset`, the same call `POST /api/trainer/presets`
+itself makes, before anything above is written and before the rename check
+described above ever runs. A row the normaliser refuses (a fret or string
+number outside this schema's bounds, an empty string set, a key given
+without its pair, a name that cleans to nothing or is still over
+`trainer_scope_presets.name`'s length cap once cleaned) refuses the WHOLE
+import - nothing applied, in either dry run or applied mode - naming the
+row by its position in the archive (`trainer_scope_presets row 3`, say)
+and the normaliser's own reason, never repairing it. A row the normaliser
+only CLEANS (whitespace collapsed, ends trimmed) is not refused: it is
+imported under the cleaned name, and #260's collision check runs against
+THAT name, not the raw one the archive carried - a whitespace-padded name
+that happens to collide once cleaned is renamed exactly as any other
+collision would be. Every other archived table's rows still travel across
+verbatim (`_insert_row`, unchanged by #268) - this bet checks presets only.
+
+`ImportOut.trainer_scope_presets_renamed` reports both: an entry with no
+`reason` key is a plain #260 collision (the archived name was already a
+valid, cleanable one - nothing about it needed cleaning); `reason:
+"cleaned"` means the archived name only changed because normalising it
+changed it, and the cleaned name did not collide with anything; `reason:
+"collision"` means both happened - the archived name was cleaned AND the
+cleaned name was ALSO already taken, so `to` is that cleaned name's own
+#260-derived rename. `from` is always the name exactly as the archive
+carried it, whichever reason applies.
+
 **`dry_run` defaults to true**, the same default every bulk operation in this
 API uses (see the five rules above). It validates the archive completely and
 reports what it found without opening a transaction or writing a file.

--- a/server/fermata/api.py
+++ b/server/fermata/api.py
@@ -3986,10 +3986,17 @@ def score_practice_progress(
 # see the module docstring's own rule against that. A row the normaliser
 # only CLEANS is not refused: its name is rewritten in place to the cleaned
 # value before the collision check above ever runs, so #260 collides
-# against the name POST would actually have stored. Every other archived
-# table's rows still travel through `_insert_row` verbatim - this bet
-# validates presets only (see its own issue for why: repeating this for
-# every table is the rabbit hole it explicitly declines).
+# against the name POST would actually have stored. `_apply_import` writes
+# each preset's string rows from the SAME cleaned, deduplicated set rather
+# than the archive's own trainer_scope_preset_strings rows, for the same
+# reason: an archive carrying a duplicate (preset_id, string_number) pair
+# would otherwise pass this validation - normalise_preset dedupes before
+# checking anything else - and then hit that table's own UNIQUE constraint
+# when applied, a divergence from what POST /api/trainer/presets stores for
+# the same input. Every OTHER archived table's rows still travel through
+# `_insert_row` verbatim - this bet validates presets only (see its own
+# issue for why: repeating this for every table is the rabbit hole it
+# explicitly declines).
 #
 # TRANSACTIONAL, AND WHAT THAT ACTUALLY COVERS. Validation - the archive is a
 # real zip, `manifest.json` parses, its schema_version matches, every table
@@ -4548,6 +4555,21 @@ def _read_and_validate_manifest(zf: zipfile.ZipFile) -> dict:
             row.get("string_number")
         )
     original_preset_names: dict[int, str] = {}
+    # `cleaned["strings"]` - the SAME deduplicated, sorted set POST
+    # /api/trainer/presets stores - is kept here by archive preset id, for
+    # `_apply_import` to write instead of the archive's own
+    # trainer_scope_preset_strings rows. Those raw rows are only ever used
+    # above to build the input to normalise_preset; an archive with two
+    # identical (preset_id, string_number) rows (a hand-edited archive, or
+    # one written before this row was deduplicated on its way in) would
+    # otherwise pass this validation - normalise_preset dedupes before
+    # checking anything else - and then hit trainer_scope_preset_strings'
+    # own UNIQUE(preset_id, string_number) at the write in _apply_import,
+    # turning a dry run's 200 into the applied import's 409. Keying this by
+    # the archive's OWN preset id (not the id `_insert_row` will hand out
+    # later) mirrors preset_strings_by_id above; _apply_import remaps it
+    # through preset_id_map the same way it remaps everything else here.
+    preset_strings_cleaned: dict[int, list[int]] = {}
     for index, row in enumerate(tables["trainer_scope_presets"]):
         try:
             cleaned = trainer.normalise_preset(
@@ -4567,7 +4589,9 @@ def _read_and_validate_manifest(zf: zipfile.ZipFile) -> dict:
         if cleaned_name != row.get("name"):
             original_preset_names[row["id"]] = row["name"]
             row["name"] = cleaned_name
+        preset_strings_cleaned[row["id"]] = cleaned["strings"]
     manifest["_preset_name_originals"] = original_preset_names
+    manifest["_preset_strings_cleaned"] = preset_strings_cleaned
     return manifest
 
 
@@ -4840,12 +4864,20 @@ def _apply_import(conn, manifest: dict, file_bytes: dict[str, bytes], written_pa
             row,
             overrides={"owner": DEFAULT_OWNER, "name": preset_names[row["id"]]},
         )
-    for row in tables["trainer_scope_preset_strings"]:
-        _insert_row(
-            conn,
-            "trainer_scope_preset_strings",
-            row,
-            overrides={"preset_id": preset_id_map[row["preset_id"]]},
+    # #268 close-out: written from `_preset_strings_cleaned` (the set
+    # `trainer.normalise_preset` returned for this preset during validation),
+    # never from the archive's own trainer_scope_preset_strings rows - those
+    # can carry a duplicate (preset_id, string_number) pair, which would
+    # insert twice here and hit that table's own UNIQUE constraint, turning
+    # an import a dry run reported as good into a 409 apply never told the
+    # caller to expect. This way import stores exactly what POST
+    # /api/trainer/presets would have stored for the same string list.
+    preset_strings_cleaned = manifest["_preset_strings_cleaned"]
+    for old_preset_id, string_numbers in preset_strings_cleaned.items():
+        new_preset_id = preset_id_map[old_preset_id]
+        conn.executemany(
+            "INSERT INTO trainer_scope_preset_strings(preset_id, string_number) VALUES (?, ?)",
+            [(new_preset_id, n) for n in string_numbers],
         )
 
     session_id_map: dict[int, int] = {}

--- a/server/fermata/api.py
+++ b/server/fermata/api.py
@@ -3975,6 +3975,22 @@ def score_practice_progress(
 # a goal's owner/period_start, the preset id space itself) still reaches the
 # IntegrityError -> 409 path below unchanged.
 #
+# #268: before ANY of the above runs, every trainer_scope_presets row (and
+# the string set trainer_scope_preset_strings carries for it) is checked
+# against trainer.normalise_preset - the same call POST /api/trainer/presets
+# makes - in _read_and_validate_manifest, before this import ever opens a
+# transaction. A row the normaliser refuses (a fret or string number outside
+# this schema's bounds, an empty string set, a name that cleans to nothing
+# or stays over trainer.MAX_PRESET_NAME_CHARS) refuses the WHOLE import,
+# named by its position in the archive - nothing here repairs a bad row,
+# see the module docstring's own rule against that. A row the normaliser
+# only CLEANS is not refused: its name is rewritten in place to the cleaned
+# value before the collision check above ever runs, so #260 collides
+# against the name POST would actually have stored. Every other archived
+# table's rows still travel through `_insert_row` verbatim - this bet
+# validates presets only (see its own issue for why: repeating this for
+# every table is the rabbit hole it explicitly declines).
+#
 # TRANSACTIONAL, AND WHAT THAT ACTUALLY COVERS. Validation - the archive is a
 # real zip, `manifest.json` parses, its schema_version matches, every table
 # is the right shape, every foreign key inside the archive resolves to a row
@@ -4505,6 +4521,53 @@ def _read_and_validate_manifest(zf: zipfile.ZipFile) -> dict:
                 "the archive's practice_sessions table names a preset that is not in the "
                 "archive",
             )
+    # #268: every archived preset row - and its string set, gathered here
+    # from trainer_scope_preset_strings by the id it names - goes through
+    # trainer.normalise_preset, the SAME call POST /api/trainer/presets
+    # makes, before this import ever reaches a collision check or a write.
+    # Without this, a hand-edited or pre-#268 archive could carry a fret
+    # outside MIN_FRET/MAX_FRET, a string number outside
+    # MIN_STRING_NUMBER/MAX_STRING_NUMBER, an empty string set, or a name no
+    # route would ever accept (unbounded length, a key given without its
+    # pair) - and _apply_import inserted every one of those columns
+    # verbatim. A row the normaliser refuses is refused HERE, before
+    # anything is written, in the same validate-before-write shape every
+    # other referential check above already uses - named by its ARCHIVE
+    # POSITION rather than its own content, since the content is exactly
+    # what is wrong with it. A row the normaliser only CLEANS (whitespace
+    # collapsed, ends trimmed) is not refused: its name is rewritten here,
+    # in place, to the cleaned value, so every later step - #260's collision
+    # check included - runs against the name POST would actually have
+    # stored, never the raw one the archive carried. `original_preset_names`
+    # remembers which rows changed and what they carried before, for
+    # `_derive_preset_renames` to report alongside a genuine collision (see
+    # its own note on the two).
+    preset_strings_by_id: dict[int, list] = {}
+    for row in tables["trainer_scope_preset_strings"]:
+        preset_strings_by_id.setdefault(row.get("preset_id"), []).append(
+            row.get("string_number")
+        )
+    original_preset_names: dict[int, str] = {}
+    for index, row in enumerate(tables["trainer_scope_presets"]):
+        try:
+            cleaned = trainer.normalise_preset(
+                name=row.get("name"),
+                start_fret=row.get("start_fret"),
+                end_fret=row.get("end_fret"),
+                strings=preset_strings_by_id.get(row["id"], []),
+                key_root=row.get("key_root"),
+                key_quality=row.get("key_quality"),
+            )
+        except ValueError as exc:
+            raise HTTPException(
+                422,
+                f"the archive's trainer_scope_presets row {index} is invalid: {exc}",
+            ) from None
+        cleaned_name = cleaned["preset"]["name"]
+        if cleaned_name != row.get("name"):
+            original_preset_names[row["id"]] = row["name"]
+            row["name"] = cleaned_name
+    manifest["_preset_name_originals"] = original_preset_names
     return manifest
 
 
@@ -4575,7 +4638,9 @@ def _fit_preset_name(base: str, suffix: str) -> str:
     return base[:limit] + suffix
 
 
-def _derive_preset_renames(conn, presets: list[dict]) -> tuple[dict[int, str], list[dict]]:
+def _derive_preset_renames(
+    conn, presets: list[dict], original_names: dict[int, str] | None = None
+) -> tuple[dict[int, str], list[dict]]:
     """#260: the one collision import no longer refuses. Everywhere else,
     "added, never merged" means a real uniqueness collision against this
     library is a 409 (see the except sqlite3.IntegrityError block below) -
@@ -4593,20 +4658,31 @@ def _derive_preset_renames(conn, presets: list[dict]) -> tuple[dict[int, str], l
     Every other collision class (a setting's key, a goal's period, the
     preset id space itself) still reaches the IntegrityError path unchanged.
 
-    A row whose name is not a string at all (missing, null, or some other
-    JSON type - not something this API's own export ever writes, but nothing
-    stops a hand-edited or foreign manifest from carrying one) is not this
-    function's problem to solve: it is passed through completely unexamined,
-    so _apply_import's insert raises on it (or doesn't) exactly the way it
-    would have before this function existed. Manufacturing a rename for a
-    name that isn't one would only trade a clean refusal for a confusing
-    "success".
+    By the time this runs, `_read_and_validate_manifest` has already sent
+    every row through trainer.normalise_preset (#268): a row whose name was
+    not a real, cleanable string was refused there, before this function
+    ever saw it, so `row["name"]` here is always the CLEANED string that
+    row will actually be inserted under - what this function collides
+    against is the name POST /api/trainer/presets would itself have stored.
+
+    `original_names` is `_read_and_validate_manifest`'s
+    `{archive row id: name exactly as archived}` map, carrying only the
+    rows #268's cleaning actually changed (whitespace collapsed, ends
+    trimmed - see trainer._preset_name). For one of those rows, the
+    reported `from` is the name exactly as archived (not the cleaned name
+    this function compares against), and the entry carries `reason:
+    "cleaned"` - or `reason: "collision"` if the cleaned name ALSO turned
+    out to be taken, so the one entry shows the whole trip: archived ->
+    cleaned -> (if needed) suffixed. A row #268 left untouched reports
+    exactly as #260 always did - `{from, to}`, no `reason` key - so a
+    caller (or test) that only ever saw plain collisions before still sees
+    exactly that shape.
 
     Returns the {archive row id: name actually used} map `_apply_import`
-    inserts under, and the `{from, to}` pairs for whichever presets actually
-    got renamed - in archive order, so a second preset in the archive
-    colliding with the first archive preset's OWN derived name still lands
-    on a free one rather than raising.
+    inserts under, and the rename/clean entries described above - in
+    archive order, so a second preset in the archive colliding with the
+    first archive preset's OWN derived name still lands on a free one
+    rather than raising.
 
     Read-only, and safe to call before any write transaction is open: this
     is also how the dry run reports the same renames the applied import
@@ -4614,6 +4690,7 @@ def _derive_preset_renames(conn, presets: list[dict]) -> tuple[dict[int, str], l
     dry run that promised one name and an apply that landed on another
     would make the whole preview worthless.
     """
+    original_names = original_names or {}
     taken = {
         _ascii_fold(row["name"])
         for row in conn.execute(
@@ -4628,6 +4705,7 @@ def _derive_preset_renames(conn, presets: list[dict]) -> tuple[dict[int, str], l
             names[row["id"]] = original
             continue
         candidate = original
+        collided = False
         if _ascii_fold(candidate) in taken:
             attempt = 1
             while True:
@@ -4636,9 +4714,17 @@ def _derive_preset_renames(conn, presets: list[dict]) -> tuple[dict[int, str], l
                 if _ascii_fold(candidate) not in taken:
                     break
                 attempt += 1
-            renamed.append({"from": original, "to": candidate})
+            collided = True
         taken.add(_ascii_fold(candidate))
         names[row["id"]] = candidate
+        as_archived = original_names.get(row["id"])
+        if collided:
+            entry = {"from": as_archived if as_archived is not None else original, "to": candidate}
+            if as_archived is not None:
+                entry["reason"] = "collision"
+            renamed.append(entry)
+        elif as_archived is not None:
+            renamed.append({"from": as_archived, "to": candidate, "reason": "cleaned"})
     return names, renamed
 
 
@@ -4743,7 +4829,9 @@ def _apply_import(conn, manifest: dict, file_bytes: dict[str, bytes], written_pa
     # so that row has to exist and its new id has to be known first. The
     # string set follows its preset, exactly as setlist_scores follows its
     # setlist.
-    preset_names, presets_renamed = _derive_preset_renames(conn, tables["trainer_scope_presets"])
+    preset_names, presets_renamed = _derive_preset_renames(
+        conn, tables["trainer_scope_presets"], manifest.get("_preset_name_originals")
+    )
     preset_id_map: dict[int, int] = {}
     for row in tables["trainer_scope_presets"]:
         preset_id_map[row["id"]] = _insert_row(
@@ -4893,8 +4981,10 @@ async def import_library(file: UploadFile, dry_run: bool = True):
     API uses - see #56) validates the archive completely - it really is a
     Fermata export, its schema_version matches this Fermata's, every row's
     foreign keys resolve within the archive, every archived file's bytes
-    hash to what the archive itself claims for them - and reports what it
-    found, WITHOUT opening a database transaction or writing a single file.
+    hash to what the archive itself claims for them, and every named drill
+    scope (and its string set) passes trainer.normalise_preset (#268) - and
+    reports what it found, WITHOUT opening a database transaction or writing
+    a single file.
     Nothing is compared against what is already in this library on a dry
     run, which is why `tags_reused` is always 0 there - see ImportOut - with
     one exception: `trainer_scope_presets_renamed` IS computed against this
@@ -4947,7 +5037,9 @@ async def import_library(file: UploadFile, dry_run: bool = True):
         # a dry run reporting a rename is that it has to be the SAME rename
         # apply mode will actually make, not a guess made blind to what is
         # already here.
-        _, presets_renamed = _derive_preset_renames(connect(), tables["trainer_scope_presets"])
+        _, presets_renamed = _derive_preset_renames(
+            connect(), tables["trainer_scope_presets"], manifest.get("_preset_name_originals")
+        )
         return {
             "dry_run": True,
             "schema_version": manifest["schema_version"],

--- a/server/fermata/api_models.py
+++ b/server/fermata/api_models.py
@@ -1083,6 +1083,21 @@ class ImportOut(BaseModel):
     # under>}`. Empty when nothing collided. Identical on a dry run and an
     # applied import - the rename is computed the same way in both, not
     # decided only once writing starts (see import_library's docstring).
+    #
+    # #268 adds a THIRD, optional key to some entries: `reason`. Its
+    # absence means exactly what an entry always meant before #268 existed -
+    # a plain #260 collision, the archived name untouched apart from the
+    # rename. `reason: "cleaned"` means the archived name only went through
+    # trainer.normalise_preset's cleaning (whitespace collapsed, ends
+    # trimmed - see trainer._preset_name) and did NOT collide with
+    # anything - an entry #260 never reported at all, since nothing
+    # collided. `reason: "collision"` means BOTH happened: the archived
+    # name was cleaned, and the cleaned name was ALSO already taken, so `to`
+    # is the cleaned name's own #260 rename, not the cleaned name itself. A
+    # row the normaliser refuses outright (a fret or string number outside
+    # this schema's bounds, an empty string set, a name that cleans to
+    # nothing) never reaches this list - the whole import is refused before
+    # anything is written; see `import_library`'s 422 for that.
     trainer_scope_presets_renamed: list[dict[str, str]]
 
 

--- a/server/fermata/trainer.py
+++ b/server/fermata/trainer.py
@@ -433,15 +433,26 @@ MAX_PRESET_STRINGS = MAX_STRING_NUMBER
 def _preset_name(name) -> str:
     """A preset's name, cleaned the way api._clean_setlist_name cleans a
     setlist's: unprintable characters dropped, runs of whitespace collapsed,
-    the ends trimmed, the length bounded. A name that was only whitespace is a
-    ValueError rather than a stored blank - an unnamed entry in a list of
-    named scopes is one nobody can pick on purpose."""
+    the ends trimmed. A name that was only whitespace is a ValueError rather
+    than a stored blank - an unnamed entry in a list of named scopes is one
+    nobody can pick on purpose.
+
+    A name still over MAX_PRESET_NAME_CHARS once cleaned is a ValueError too,
+    not a silent truncation to the cap: `TrainerPresetIn.name`
+    (api.py, `Field(max_length=MAX_PRESET_NAME_CHARS)`) already refuses a
+    longer raw string before this function ever sees it on
+    `POST /api/trainer/presets`, so refusing here is the only way a caller
+    that reaches this function directly - #268's import, checking an
+    archived row nothing routed through that model - gets the same answer
+    the route would have given, rather than a row quietly shortened to fit."""
     if not isinstance(name, str):
         raise ValueError("a preset needs a name")
     cleaned = re.sub(r"\s+", " ", "".join(ch for ch in name if ch.isprintable())).strip()
     if not cleaned:
         raise ValueError("a preset needs a name")
-    return cleaned[:MAX_PRESET_NAME_CHARS]
+    if len(cleaned) > MAX_PRESET_NAME_CHARS:
+        raise ValueError(f"a preset's name must be at most {MAX_PRESET_NAME_CHARS} characters")
+    return cleaned
 
 
 def _preset_strings(string_numbers) -> list[int]:

--- a/server/tests/test_portability_api.py
+++ b/server/tests/test_portability_api.py
@@ -1189,6 +1189,65 @@ def test_a_preset_with_an_empty_string_set_is_refused(client, tmp_path, monkeypa
     assert client.get("/api/trainer/presets").json() == []
 
 
+def test_an_archived_duplicate_string_row_is_deduplicated_the_same_as_post(
+    client, tmp_path, monkeypatch
+):
+    """A preset whose trainer_scope_preset_strings rows carry a duplicate
+    (preset_id, string_number) pair - only ever possible in a hand-edited or
+    foreign archive, never one this server wrote itself - passes
+    _read_and_validate_manifest, since trainer.normalise_preset dedupes a
+    string set before checking anything else about it. Before this fix,
+    `_apply_import` then inserted the archive's raw rows verbatim, so the
+    SAME duplicate that made dry run report 200 made the applied import
+    insert the pair twice and hit trainer_scope_preset_strings' own
+    UNIQUE(preset_id, string_number) - a 409 dry run never predicted. Now
+    both modes agree, and the stored set is exactly what `POST
+    /api/trainer/presets` stores for the same (deduplicated) input."""
+    client.post(
+        "/api/trainer/presets",
+        json={"name": "Doubled strings", "start_fret": 0, "end_fret": 4, "strings": [1, 3]},
+    )
+    manifest = json.loads(_zip_of(client.get("/api/export")).read("manifest.json"))
+    string_rows = manifest["tables"]["trainer_scope_preset_strings"]
+    assert sorted(r["string_number"] for r in string_rows) == [1, 3]
+    preset_id = string_rows[0]["preset_id"]
+    assert all(r["preset_id"] == preset_id for r in string_rows)
+    # Duplicate the row naming string 1 - the archive now carries [1, 1, 3]
+    # for this preset, exactly the shape trainer.normalise_preset dedupes.
+    doubled_row = dict(next(r for r in string_rows if r["string_number"] == 1))
+    string_rows.append(doubled_row)
+
+    _switch_to_a_fresh_environment(monkeypatch, tmp_path, "target")
+    archive = _bytes_of_zip({"manifest.json": json.dumps(manifest).encode()})
+
+    preview = client.post(
+        "/api/import", files={"file": ("export.zip", archive, "application/zip")},
+    )
+    assert preview.status_code == 200, preview.text
+    assert preview.json()["trainer_scope_presets_renamed"] == []
+
+    applied = client.post(
+        "/api/import", params={"dry_run": "false"},
+        files={"file": ("export.zip", archive, "application/zip")},
+    )
+    assert applied.status_code == 200, applied.text
+    assert applied.json()["trainer_scope_presets_renamed"] == []
+
+    imported = client.get("/api/trainer/presets").json()
+    assert len(imported) == 1
+    assert imported[0]["strings"] == [1, 3]
+
+    # The POST route given the same duplicated list stores the same set -
+    # the divergence this test closes was import inserting the raw rows
+    # while POST always deduped through the normaliser first.
+    posted = client.post(
+        "/api/trainer/presets",
+        json={"name": "Doubled via post", "start_fret": 0, "end_fret": 4, "strings": [1, 1, 3]},
+    )
+    assert posted.status_code == 200, posted.text
+    assert posted.json()["strings"] == [1, 3]
+
+
 def test_a_preset_string_number_outside_bounds_is_refused(client, tmp_path, monkeypatch):
     """A string number outside MIN_STRING_NUMBER/MAX_STRING_NUMBER (1..24)
     cannot be saved through the route either - only a hand-edited or

--- a/server/tests/test_portability_api.py
+++ b/server/tests/test_portability_api.py
@@ -856,19 +856,24 @@ def test_two_identically_named_presets_within_one_archive_do_not_500(
     assert names == ["Alpha", "Alpha (imported)"]
 
 
-def test_a_preset_row_whose_name_is_not_a_string_never_500s(client, tmp_path, monkeypatch):
-    """Follow-up to #260: `_derive_preset_renames` called `.casefold()` on
-    every archived preset's name with no guard, so a manifest carrying a
-    `name` that is null, missing entirely, or some other JSON type (nothing
-    this API's own export ever writes, but nothing stops a hand-edited or
-    foreign one) turned into an unhandled AttributeError/KeyError - a 500 on
-    both dry run and applied. The fix does not invent a rename for a name
-    that isn't one: it passes the row through untouched, so the SAME
-    NOT NULL constraint that refused it before #260 ever existed refuses it
-    again (measured directly against this schema: binding None, or omitting
-    the column, both raise `sqlite3.IntegrityError: NOT NULL constraint
-    failed`; binding a plain int does not - SQLite's TEXT affinity silently
-    stringifies it, so that shape is accepted exactly as it was pre-#260)."""
+def test_a_preset_row_whose_name_is_not_a_string_is_refused_by_the_normaliser(
+    client, tmp_path, monkeypatch
+):
+    """Follow-up to #260, superseded by #268. Before #268, `_derive_preset_renames`
+    passed a `name` that was null, missing entirely, or some other JSON type
+    (nothing this API's own export ever writes, but nothing stops a
+    hand-edited or foreign manifest from carrying one) through completely
+    unexamined: null/missing reached SQLite's own NOT NULL constraint (409),
+    and a stray integer was silently accepted (SQLite's TEXT affinity
+    stringifies it).
+
+    #268 runs every archived preset through trainer.normalise_preset BEFORE
+    any of that - trainer._preset_name refuses anything that is not a real
+    string outright (`isinstance(name, str)`), so all three shapes are now
+    a clean 422, in both dry run and applied mode, naming the row's
+    position in the archive and the normaliser's own reason, with nothing
+    imported either way. The "weird, but not this fix's problem" integer
+    case is now this fix's problem, and it is refused too."""
     client.post(
         "/api/trainer/presets",
         json={"name": "Untouched", "start_fret": 0, "end_fret": 4, "strings": [6]},
@@ -891,19 +896,19 @@ def test_a_preset_row_whose_name_is_not_a_string_never_500s(client, tmp_path, mo
         preview = client.post(
             "/api/import", files={"file": (f"{shape}.zip", archive, "application/zip")},
         )
-        assert preview.status_code == 200, f"{shape} dry run: {preview.text}"
+        assert preview.status_code == 422, f"{shape} dry run: {preview.text}"
+        assert "needs a name" in preview.text, preview.text
+        assert "trainer_scope_presets row 0" in preview.text, preview.text
 
         applied = client.post(
             "/api/import", params={"dry_run": "false"},
             files={"file": (f"{shape}.zip", archive, "application/zip")},
         )
-        if shape == "integer":
-            # Weird, but not this fix's problem to solve - see the docstring:
-            # the exact behaviour import gave this shape before #260 existed.
-            assert applied.status_code == 200, f"{shape} applied: {applied.text}"
-        else:
-            assert applied.status_code == 409, f"{shape} applied: {applied.text}"
-            assert "NOT NULL constraint failed" in applied.text, applied.text
+        assert applied.status_code == 422, f"{shape} applied: {applied.text}"
+        assert "needs a name" in applied.text, applied.text
+
+    # A rejected import leaves nothing behind, whichever shape rejected it.
+    assert client.get("/api/trainer/presets").json() == []
 
 
 def test_a_cap_length_colliding_preset_name_is_trimmed_to_fit(client, tmp_path, monkeypatch):
@@ -1000,6 +1005,212 @@ def test_a_unicode_collision_nocase_would_not_actually_raise_on_is_not_renamed(
     assert renamed == [{"from": "Fifth", "to": "Fifth (imported)"}]
     names = sorted(p["name"] for p in client.get("/api/trainer/presets").json())
     assert names == ["FIFTH", "Fifth (imported)", "STRASSE", "Straße"]
+
+
+# ---------------------------------------------------------------------------
+# #268: every archived preset row (and its string set) goes through
+# trainer.normalise_preset - the same call POST /api/trainer/presets makes -
+# before any of #260's collision handling runs. A row the normaliser
+# refuses refuses the WHOLE import (nothing applied, dry run or applied); a
+# row it only cleans is imported under the cleaned name, which #260's
+# collision check then runs against.
+# ---------------------------------------------------------------------------
+
+
+def test_a_5000_character_preset_name_is_refused_in_both_modes(client, tmp_path, monkeypatch):
+    """The measured premise (#264's delta review): on main, a manifest whose
+    preset name is 5000 characters imported with 200 and stored all 5000 -
+    longer than `POST /api/trainer/presets` itself would ever accept
+    (`TrainerPresetIn.name`'s own `Field(max_length=...)`). #268 refuses it
+    instead, in both dry run and applied mode, with nothing imported."""
+    client.post(
+        "/api/trainer/presets",
+        json={"name": "seed", "start_fret": 0, "end_fret": 4, "strings": [6]},
+    )
+    manifest = json.loads(_zip_of(client.get("/api/export")).read("manifest.json"))
+    manifest["tables"]["trainer_scope_presets"][0]["name"] = "N" * 5000
+
+    _switch_to_a_fresh_environment(monkeypatch, tmp_path, "target")
+    archive = _bytes_of_zip({"manifest.json": json.dumps(manifest).encode()})
+
+    preview = client.post(
+        "/api/import", files={"file": ("evil.zip", archive, "application/zip")},
+    )
+    assert preview.status_code == 422, preview.text
+    assert "trainer_scope_presets row 0" in preview.text, preview.text
+    assert "200 characters" in preview.text, preview.text
+
+    applied = client.post(
+        "/api/import", params={"dry_run": "false"},
+        files={"file": ("evil.zip", archive, "application/zip")},
+    )
+    assert applied.status_code == 422, applied.text
+    assert client.get("/api/trainer/presets").json() == []
+
+
+def test_a_whitespace_padded_preset_name_imports_cleaned_and_collides_per_260(
+    client, tmp_path, monkeypatch
+):
+    """A name #268's normaliser only CLEANS (surrounding whitespace, here) is
+    not refused: it is imported under the cleaned name, and #260's collision
+    check runs against THAT name - so a whitespace-padded archived name that
+    happens to match an existing preset once cleaned is renamed exactly as
+    any other collision would be, not inserted as a second "same" name with
+    different spacing. The reported entry carries both facts: `from` is the
+    name exactly as archived (with its whitespace), `to` is the #260-derived
+    name, and `reason` is "collision" - not "cleaned" alone - since the
+    cleaned name was ALSO already taken.
+
+    The whitespace has to be put into the manifest by hand: POST
+    /api/trainer/presets cleans a name on the way IN, so a real save of
+    "  Fifth position  " would already be stored (and exported) as "Fifth
+    position" - never reaching this function with whitespace still on it.
+    A hand-edited or pre-#268 archive is exactly the source this bet is
+    about (see the issue)."""
+    client.post(
+        "/api/trainer/presets",
+        json={"name": "Fifth position", "start_fret": 5, "end_fret": 9, "strings": [1, 2, 3]},
+    )
+    manifest = json.loads(_zip_of(client.get("/api/export")).read("manifest.json"))
+    manifest["tables"]["trainer_scope_presets"][0]["name"] = "  Fifth position  "
+
+    _switch_to_a_fresh_environment(monkeypatch, tmp_path, "target")
+    client.post(
+        "/api/trainer/presets",
+        json={"name": "Fifth position", "start_fret": 0, "end_fret": 12, "strings": [6]},
+    )
+    archive = _bytes_of_zip({"manifest.json": json.dumps(manifest).encode()})
+
+    preview = client.post(
+        "/api/import", files={"file": ("export.zip", archive, "application/zip")},
+    )
+    assert preview.status_code == 200, preview.text
+    expected = [
+        {
+            "from": "  Fifth position  ",
+            "to": "Fifth position (imported)",
+            "reason": "collision",
+        }
+    ]
+    assert preview.json()["trainer_scope_presets_renamed"] == expected
+
+    applied = client.post(
+        "/api/import", params={"dry_run": "false"},
+        files={"file": ("export.zip", archive, "application/zip")},
+    )
+    assert applied.status_code == 200, applied.text
+    assert applied.json()["trainer_scope_presets_renamed"] == expected
+
+    names = sorted(p["name"] for p in client.get("/api/trainer/presets").json())
+    assert names == ["Fifth position", "Fifth position (imported)"]
+
+
+def test_a_whitespace_padded_preset_name_that_does_not_collide_is_reported_cleaned(
+    client, tmp_path, monkeypatch
+):
+    """The other half of the reporting decision: a name #268 cleans that does
+    NOT collide with anything still shows up in
+    `trainer_scope_presets_renamed` (#260 never reported this case at all,
+    since nothing collided) - `reason: "cleaned"`, `to` the cleaned name
+    itself, no "(imported)" suffix. The whitespace is put into the manifest
+    by hand for the same reason the collision test above does - POST
+    /api/trainer/presets would have cleaned it before it was ever stored."""
+    client.post(
+        "/api/trainer/presets",
+        json={"name": "Open position", "start_fret": 0, "end_fret": 4, "strings": [6]},
+    )
+    manifest = json.loads(_zip_of(client.get("/api/export")).read("manifest.json"))
+    manifest["tables"]["trainer_scope_presets"][0]["name"] = "  Open position  "
+
+    _switch_to_a_fresh_environment(monkeypatch, tmp_path, "target")
+    archive = _bytes_of_zip({"manifest.json": json.dumps(manifest).encode()})
+
+    resp = client.post(
+        "/api/import", params={"dry_run": "false"},
+        files={"file": ("export.zip", archive, "application/zip")},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["trainer_scope_presets_renamed"] == [
+        {"from": "  Open position  ", "to": "Open position", "reason": "cleaned"}
+    ]
+    names = [p["name"] for p in client.get("/api/trainer/presets").json()]
+    assert names == ["Open position"]
+
+
+def test_a_preset_fret_outside_bounds_is_refused(client, tmp_path, monkeypatch):
+    """A fret outside MIN_FRET/MAX_FRET cannot be produced through
+    `POST /api/trainer/presets` (trainer.normalise_preset itself refuses
+    it) - only a hand-edited or pre-#268 archive could carry one. #268
+    refuses it the same way, before anything is written."""
+    client.post(
+        "/api/trainer/presets",
+        json={"name": "Valid", "start_fret": 0, "end_fret": 4, "strings": [6]},
+    )
+    manifest = json.loads(_zip_of(client.get("/api/export")).read("manifest.json"))
+    manifest["tables"]["trainer_scope_presets"][0]["end_fret"] = 37
+
+    _switch_to_a_fresh_environment(monkeypatch, tmp_path, "target")
+    archive = _bytes_of_zip({"manifest.json": json.dumps(manifest).encode()})
+
+    for dry_run in (True, False):
+        resp = client.post(
+            "/api/import", params={"dry_run": str(dry_run).lower()},
+            files={"file": ("evil.zip", archive, "application/zip")},
+        )
+        assert resp.status_code == 422, f"dry_run={dry_run}: {resp.text}"
+        assert "trainer_scope_presets row 0" in resp.text, resp.text
+        assert "between 0 and 36" in resp.text, resp.text
+    assert client.get("/api/trainer/presets").json() == []
+
+
+def test_a_preset_with_an_empty_string_set_is_refused(client, tmp_path, monkeypatch):
+    """A preset with no strings at all cannot be saved through the route
+    either (trainer._preset_strings refuses an empty set - "every string" is
+    spelled by naming every string, never by an empty list). Only an archive
+    that dropped its trainer_scope_preset_strings rows for a preset - by
+    hand, or from a source that never wrote them - could carry one."""
+    client.post(
+        "/api/trainer/presets",
+        json={"name": "Valid", "start_fret": 0, "end_fret": 4, "strings": [6]},
+    )
+    manifest = json.loads(_zip_of(client.get("/api/export")).read("manifest.json"))
+    manifest["tables"]["trainer_scope_preset_strings"] = []
+
+    _switch_to_a_fresh_environment(monkeypatch, tmp_path, "target")
+    archive = _bytes_of_zip({"manifest.json": json.dumps(manifest).encode()})
+
+    for dry_run in (True, False):
+        resp = client.post(
+            "/api/import", params={"dry_run": str(dry_run).lower()},
+            files={"file": ("evil.zip", archive, "application/zip")},
+        )
+        assert resp.status_code == 422, f"dry_run={dry_run}: {resp.text}"
+        assert "at least one string" in resp.text, resp.text
+    assert client.get("/api/trainer/presets").json() == []
+
+
+def test_a_preset_string_number_outside_bounds_is_refused(client, tmp_path, monkeypatch):
+    """A string number outside MIN_STRING_NUMBER/MAX_STRING_NUMBER (1..24)
+    cannot be saved through the route either - only a hand-edited or
+    foreign archive could carry one."""
+    client.post(
+        "/api/trainer/presets",
+        json={"name": "Valid", "start_fret": 0, "end_fret": 4, "strings": [6]},
+    )
+    manifest = json.loads(_zip_of(client.get("/api/export")).read("manifest.json"))
+    manifest["tables"]["trainer_scope_preset_strings"][0]["string_number"] = 25
+
+    _switch_to_a_fresh_environment(monkeypatch, tmp_path, "target")
+    archive = _bytes_of_zip({"manifest.json": json.dumps(manifest).encode()})
+
+    for dry_run in (True, False):
+        resp = client.post(
+            "/api/import", params={"dry_run": str(dry_run).lower()},
+            files={"file": ("evil.zip", archive, "application/zip")},
+        )
+        assert resp.status_code == 422, f"dry_run={dry_run}: {resp.text}"
+        assert "between 1 and 24" in resp.text, resp.text
+    assert client.get("/api/trainer/presets").json() == []
 
 
 def test_export_can_leave_the_trash_out(client, add_score):


### PR DESCRIPTION
## Premise (re-derived on main `c950501`)

Built an archive with a 5000-character preset name and imported it via the API (`server/tests` throwaway check, not committed): dry run **200**, applied **200**, stored name length **5000**. Verdict: **valid** - `_apply_import` inserted every trainer_scope_presets column verbatim; only a colliding name went through #260's trim.

## What changed

Every archived `trainer_scope_presets` row - and the string set `trainer_scope_preset_strings` carries for it - now goes through `trainer.normalise_preset`, the same call `POST /api/trainer/presets` makes, inside `_read_and_validate_manifest` (`server/fermata/api.py`), before this import ever opens a transaction. This runs identically for dry run and applied (both call the same validation function).

- A row the normaliser **refuses** (fret outside `MIN_FRET`/`MAX_FRET`, string number outside `MIN_STRING_NUMBER`/`MAX_STRING_NUMBER`, empty string set, a key given without its pair, a name that cleans to nothing or stays over the cap once cleaned) refuses the **whole import** with a 422 naming the row's archive position and the normaliser's reason, in the same validate-before-write style every other referential check in that function already uses. Nothing is applied in either mode.
- A row the normaliser only **cleans** (whitespace collapsed, ends trimmed) is not refused: its name is rewritten in place to the cleaned value before #260's collision check runs, so the collision check sees the name POST would actually have stored.
- `trainer._preset_name` (`server/fermata/trainer.py`) now **raises** instead of silently truncating a name still over `MAX_PRESET_NAME_CHARS` once cleaned - the route itself never reached that branch (`TrainerPresetIn.name`'s `Field(max_length=...)` already refuses a longer raw string before `normalise_preset` runs), so this closes the gap only import could actually hit. This is the "small refactor" the brief allowed to make the normaliser usable standalone.

**Reporting decision.** `ImportOut.trainer_scope_presets_renamed` gets an optional third key, `reason`: absent means a plain #260 collision (unchanged shape, so every pre-existing #260 test still passes byte-for-byte); `"cleaned"` means the archived name only changed because normalising it changed it, with no collision; `"collision"` means both happened - the name was cleaned AND the cleaned name was also already taken. `from` is always the name exactly as archived. Documented in `docs/api.md`.

**Tables still inserted verbatim** (this bet is presets only, per its own no-go): `instruments`, `tags`, `scores`, `score_tags`, `transcriptions`, `practice_sessions`, `practice_goals`, `settings`, `setlists`, `setlist_scores`, `trainer_attempts`, `trainer_chord_attempts`. `trainer_scope_preset_strings` is the one exception - see "After review" below.

## Behavior change worth flagging

`test_a_preset_row_whose_name_is_not_a_string_never_500s` (#260 follow-up) is renamed and rewritten: before this bet, a null/missing archived preset name reached SQLite's NOT NULL constraint (409), and a stray integer was silently accepted (SQLite TEXT affinity). Now all three shapes are refused with a clean 422 from the normaliser, before anything is written - the "weird, but not this fix's problem" integer case is now this fix's problem. This test's assertions changed; every other #249/#260 test in `test_portability_api.py` is untouched.

## Done-when checklist

- [x] 5000-char name refused, 4xx, nothing applied, dry run and applied
- [x] Surrounding-whitespace name imports cleaned and collides against the cleaned name (renamed per #260)
- [x] Fret outside bounds refused
- [x] Empty string set refused
- [x] `test_a_cap_length_colliding_preset_name_is_trimmed_to_fit` and every other #249/#260 collision/round-trip test green, unmodified
- [x] Same `normalise_preset` called from both the POST route and import - `grep -n "def normalise_preset" server/fermata/trainer.py` shows one definition
- [x] `docs/api.md` updated
- [x] Mutations recorded red then green (below)

## Mutations (each: introduce, run targeted test, confirm red, `git checkout -- server/fermata/api.py` to restore, confirm green)

| Mutation | Test | Result |
| --- | --- | --- |
| Skip the normaliser entirely in `_read_and_validate_manifest` | `test_a_5000_character_preset_name_is_refused_in_both_modes` | RED (200 instead of 422) -> restored -> green |
| Normalise the preset but substitute a dummy valid string list instead of the archived one | `test_a_preset_with_an_empty_string_set_is_refused` | RED (200 instead of 422) -> restored -> green |
| Move the normaliser check into `_apply_import` only (applied-mode only) | `test_a_5000_character_preset_name_is_refused_in_both_modes`, `test_a_preset_fret_outside_bounds_is_refused` | RED on the dry-run half of both (200 instead of 422) -> restored -> green |

## Suite

`py -3.13 -m pytest server/tests -q` (foreground, `PYTHONPATH=server`, `FERMATA_TEST_LIBRARY` unset): **1363 passed, 92 skipped, 1 warning in 202.88s**. `server/tests/test_portability_api.py` alone: 29 passed.

## After review

Review verdict was **go**, with one measured divergence left open: `normalise_preset` returns the deduplicated, sorted string set (`cleaned["strings"]`), but `_apply_import` used only `cleaned["preset"]["name"]` and inserted the archive's `trainer_scope_preset_strings` rows verbatim. An archive with two identical `(preset_id, string_number)` rows therefore passed the dry run (200, since the normaliser dedupes before checking anything else) and then hit that table's own `UNIQUE(preset_id, string_number)` on apply (409) - the same input the POST route stores fine, since it always dedupes through the normaliser first. Measured identical on main `c950501`, so pre-existing, but it was the last POST/import divergence in this table.

Closed by keeping the cleaned string set `_read_and_validate_manifest` already computes per preset (for the row-bounds check) on the manifest, and having `_apply_import` write from that set - remapped through the same `preset_id_map` everything else here uses - instead of from the archive's raw `trainer_scope_preset_strings` rows.

- Added `test_an_archived_duplicate_string_row_is_deduplicated_the_same_as_post` (`server/tests/test_portability_api.py`): an archive whose one preset's string rows are `[1, 1, 3]` now dry-runs 200, applies 200, and stores `[1, 3]` on both routes; `trainer_scope_presets_renamed` stays `[]` for this case, unaffected. `POST /api/trainer/presets` given `strings: [1, 1, 3]` stores the same `[1, 3]`.
- Mutation: reverted `_apply_import` to insert the archive's raw rows again - the new test went RED (409 on the applied half, `UNIQUE constraint failed: trainer_scope_preset_strings.preset_id, trainer_scope_preset_strings.string_number`). Restored, confirmed green.
- Full suite after the fix, foreground, `PYTHONPATH` at this worktree's `server/`, `FERMATA_TEST_LIBRARY` unset: `py -3.13 -m pytest server/tests -rs -q` -> **1364 passed, 92 skipped, 1 warning in 140.96s**. All 92 skips are the same environment-gated ones (`FERMATA_TEST_LIBRARY`, `FERMATA_MUSICXML_XSD`) as the original run above.

Closes #268
