### PR TITLE
A drill session under a named scope shows that scope's name again

### DIFF
--- a/web/src/lib/Practice.svelte
+++ b/web/src/lib/Practice.svelte
@@ -31,6 +31,7 @@
     periodLabel,
     formatDays,
     periodStatement,
+    presetLabel,
     rangeLabel,
     sessionSubject,
     tempoLabel,
@@ -51,6 +52,10 @@
   let history = $state(null);
   let scores = $state([]);
   let sessions = $state([]);
+  // Named drill scopes (issue #236), fetched once per load so a session's
+  // preset_id can be shown as the name it was saved under (issue #276)
+  // instead of the id no row anywhere else prints.
+  let presets = $state([]);
   let loading = $state(true);
   let error = $state("");
 
@@ -113,16 +118,18 @@
   async function refresh() {
     error = "";
     try {
-      const [nextCurrent, nextReview, nextHistory, nextScores] = await Promise.all([
+      const [nextCurrent, nextReview, nextHistory, nextScores, nextPresets] = await Promise.all([
         api.currentGoal(today),
         api.practiceReview(REVIEW_WEEKS, today),
         api.practiceHistory(HISTORY_DAYS, today),
         api.scores(),
+        api.trainerPresets(),
       ]);
       current = nextCurrent;
       review = nextReview;
       history = nextHistory;
       scores = nextScores;
+      presets = nextPresets;
       // Sent after the first call, because the week to ask for comes back from
       // it - the server decides which seven days "this week" is, from the
       // week-start preference, and asking for a week the client worked out
@@ -147,6 +154,9 @@
 
   let goal = $derived(current?.goal ?? null);
   let statements = $derived(goalStatements(goal));
+  // id -> name, for presetLabel() below. Built once per load rather than
+  // looked up per row.
+  let presetsById = $derived(Object.fromEntries(presets.map((p) => [p.id, p.name])));
   // The period on screen is the GOAL's when there is one, and the canonical
   // week from the preference only when there is not. A goal stores the dates it
   // was set for, so after the week-start preference changes the two differ -
@@ -706,7 +716,12 @@
                 </span>
                 <span class="session-length">{formatDuration(session.seconds)}</span>
                 <span class="quiet session-extra">
-                  {[rangeLabel(session), tempoLabel(session), session.note]
+                  {[
+                    rangeLabel(session),
+                    tempoLabel(session),
+                    presetLabel(session, presetsById),
+                    session.note,
+                  ]
                     .filter(Boolean)
                     .join(" · ")}
                 </span>

--- a/web/src/lib/Practice.svelte
+++ b/web/src/lib/Practice.svelte
@@ -118,18 +118,29 @@
   async function refresh() {
     error = "";
     try {
-      const [nextCurrent, nextReview, nextHistory, nextScores, nextPresets] = await Promise.all([
+      const [nextCurrent, nextReview, nextHistory, nextScores] = await Promise.all([
         api.currentGoal(today),
         api.practiceReview(REVIEW_WEEKS, today),
         api.practiceHistory(HISTORY_DAYS, today),
         api.scores(),
-        api.trainerPresets(),
       ]);
       current = nextCurrent;
       review = nextReview;
       history = nextHistory;
       scores = nextScores;
-      presets = nextPresets;
+      // Fired, not awaited: presets only supply the scope NAME a session's
+      // preset_id is shown under (issue #276), and a failure here is not a
+      // reason to blank the practice history those rows are the point of.
+      // Left out of the Promise.all above for the same reason - the trainer
+      // endpoint settling slowly must not hold up the first paint of history
+      // that has nothing to do with it.
+      api.trainerPresets()
+        .then((nextPresets) => {
+          presets = nextPresets;
+        })
+        .catch(() => {
+          presets = [];
+        });
       // Sent after the first call, because the week to ask for comes back from
       // it - the server decides which seven days "this week" is, from the
       // week-start preference, and asking for a week the client worked out

--- a/web/src/lib/ScoreProgress.svelte
+++ b/web/src/lib/ScoreProgress.svelte
@@ -39,6 +39,7 @@
     localDay,
     modeLabel,
     periodLabel,
+    presetLabel,
     ratingStatement,
     rangeLabel,
     shortDate,
@@ -62,11 +63,20 @@
   let data = $state(null);
   let loading = $state(true);
   let error = $state("");
+  // Named drill scopes (issue #236), fetched once per load so a session's
+  // preset_id can be shown as the name it was saved under (issue #276)
+  // instead of the id no row anywhere else prints.
+  let presets = $state([]);
 
   async function refresh() {
     error = "";
     try {
-      data = await api.scoreProgress(id, HISTORY_DAYS, today);
+      const [nextData, nextPresets] = await Promise.all([
+        api.scoreProgress(id, HISTORY_DAYS, today),
+        api.trainerPresets(),
+      ]);
+      data = nextData;
+      presets = nextPresets;
     } catch (e) {
       error = e?.message ?? "Could not load this piece's practice history.";
     } finally {
@@ -81,6 +91,9 @@
   // Scaled inside this window, like every other bar in this application: a bar
   // that shrank because some other stretch was busier is a comparison drawn in
   // pixels.
+  // id -> name, for presetLabel() below. Built once per load rather than
+  // looked up per row.
+  let presetsById = $derived(Object.fromEntries(presets.map((p) => [p.id, p.name])));
   let windowBars = $derived(dayBars(data?.window?.days ?? []));
   let chart = $derived(tempoChart(data?.tempo));
   // The line through the points, in the order the sessions happened. Not a fit
@@ -354,7 +367,12 @@
                 </span>
                 <span class="session-length">{formatDuration(session.seconds)}</span>
                 <span class="quiet session-extra">
-                  {[modeLabel(session.mode), rangeLabel(session), tempoLabel(session)]
+                  {[
+                    modeLabel(session.mode),
+                    rangeLabel(session),
+                    tempoLabel(session),
+                    presetLabel(session, presetsById),
+                  ]
                     .filter(Boolean)
                     .join(" · ")}
                 </span>

--- a/web/src/lib/ScoreProgress.svelte
+++ b/web/src/lib/ScoreProgress.svelte
@@ -71,12 +71,19 @@
   async function refresh() {
     error = "";
     try {
-      const [nextData, nextPresets] = await Promise.all([
-        api.scoreProgress(id, HISTORY_DAYS, today),
-        api.trainerPresets(),
-      ]);
-      data = nextData;
-      presets = nextPresets;
+      data = await api.scoreProgress(id, HISTORY_DAYS, today);
+      // Fired, not awaited: presets only supply the scope NAME a session's
+      // preset_id is shown under (issue #276), and a failure here is not a
+      // reason to blank this piece's practice history. Left out of the
+      // scoreProgress await above so a slow trainer endpoint does not hold up
+      // the first paint of history that has nothing to do with it.
+      api.trainerPresets()
+        .then((nextPresets) => {
+          presets = nextPresets;
+        })
+        .catch(() => {
+          presets = [];
+        });
     } catch (e) {
       error = e?.message ?? "Could not load this piece's practice history.";
     } finally {

--- a/web/src/lib/practice.js
+++ b/web/src/lib/practice.js
@@ -347,6 +347,23 @@ export function rangeLabel(session) {
   return parts.join(", ");
 }
 
+/** The named drill scope a session was practised under, by name (issue #236
+ * gave sessions `preset_id` instead of a sentence in `note`; issue #276 is
+ * this function - nothing had read the column since).
+ *
+ * `presetsById` is an id-to-name map the caller builds once per page load
+ * from `GET /api/trainer/presets`, so this stays a function that puts
+ * already-fetched facts into words rather than one that fetches anything
+ * itself. A `preset_id` absent from the map - the preset was deleted, which
+ * nulls the column on every session that named it, so this is only the gap
+ * between that delete and this page's own reload - says nothing rather than
+ * guessing at a name.
+ */
+export function presetLabel(session, presetsById) {
+  if (!session || session.preset_id == null) return "";
+  return presetsById?.[session.preset_id] ?? "";
+}
+
 // ---------------------------------------------------------------------------
 // ONE PIECE: how is this piece going (#57).
 //

--- a/web/tests/browser/practice.spec.js
+++ b/web/tests/browser/practice.spec.js
@@ -44,6 +44,12 @@ async function reset(request) {
     await (await request.get("/api/practice/sessions?limit=1000")).json()
   ).sessions;
   for (const session of sessions) await request.delete(`/api/practice/sessions/${session.id}`);
+  // Presets last, after every session referencing one is already gone - a
+  // named scope one of these tests saved would otherwise leak into the next
+  // test's history page.
+  for (const preset of await (await request.get("/api/trainer/presets")).json()) {
+    await request.delete(`/api/trainer/presets/${preset.id}`);
+  }
   await request.put("/api/settings", { data: { week_starts_on: "monday" } });
 }
 
@@ -338,6 +344,37 @@ test("practice that is not a piece is logged here and lands in the record", asyn
     cells.filter((c) => Number(c.dataset.seconds) > 0).map((c) => c.dataset.day),
   );
   expect(withPractice).toEqual([today]);
+});
+
+test("a session logged under a named scope shows that scope's name, and one logged without shows none", async ({
+  page,
+  request,
+}) => {
+  // Issue #276: #236 gave a preset-scoped session `preset_id` instead of a
+  // scope sentence in `note`, and nothing on this page ever read the column -
+  // the history showed the drill and nothing about what it was scoped to.
+  const preset = await request.post("/api/trainer/presets", {
+    data: { name: "Top two, fifth position", start_fret: 5, end_fret: 9, strings: [1, 2] },
+  });
+  expect(preset.ok(), await preset.text()).toBe(true);
+  const presetId = (await preset.json()).id;
+
+  const scoped = await request.post("/api/practice/sessions", {
+    data: { activity: "fretboard", seconds: 120, local_date: today, preset_id: presetId },
+  });
+  expect(scoped.ok(), await scoped.text()).toBe(true);
+  const unscoped = await request.post("/api/practice/sessions", {
+    data: { activity: "fretboard", seconds: 60, local_date: today },
+  });
+  expect(unscoped.ok(), await unscoped.text()).toBe(true);
+
+  await page.reload();
+  await expect(sessionRows(page)).toHaveCount(2);
+  const rowText = await sessionRows(page).allInnerTexts();
+  const scopedRow = rowText.find((t) => t.includes("2m"));
+  const unscopedRow = rowText.find((t) => t.includes("1m"));
+  expect(scopedRow, rowText.join("\n")).toContain("Top two, fifth position");
+  expect(unscopedRow, rowText.join("\n")).not.toContain("Top two, fifth position");
 });
 
 test("a finished week asks whether the goal was realistic, and remembers the answer", async ({

--- a/web/tests/browser/practice.spec.js
+++ b/web/tests/browser/practice.spec.js
@@ -44,9 +44,10 @@ async function reset(request) {
     await (await request.get("/api/practice/sessions?limit=1000")).json()
   ).sessions;
   for (const session of sessions) await request.delete(`/api/practice/sessions/${session.id}`);
-  // Presets last, after every session referencing one is already gone - a
-  // named scope one of these tests saved would otherwise leak into the next
-  // test's history page.
+  // Presets last, after every session referencing one is already gone. This
+  // deletes EVERY preset in the throwaway library, not only ones a test
+  // happened to name - the suite shares one database, and a preset left
+  // behind by any means would leak into the next test's history page.
   for (const preset of await (await request.get("/api/trainer/presets")).json()) {
     await request.delete(`/api/trainer/presets/${preset.id}`);
   }
@@ -375,6 +376,30 @@ test("a session logged under a named scope shows that scope's name, and one logg
   const unscopedRow = rowText.find((t) => t.includes("1m"));
   expect(scopedRow, rowText.join("\n")).toContain("Top two, fifth position");
   expect(unscopedRow, rowText.join("\n")).not.toContain("Top two, fifth position");
+});
+
+test("a failing presets fetch drops the scope label, not the practice history", async ({
+  page,
+  request,
+}) => {
+  // Issue #276 follow-up: `api.trainerPresets()` used to sit inside the same
+  // `Promise.all` that gates every other call this page needs, so a trainer
+  // endpoint failure - unrelated to the sessions being shown - took the whole
+  // page down with it. Presets exist here only to put a NAME on a row that
+  // already renders without one; losing them is not a reason to lose the row.
+  const logged = await request.post("/api/practice/sessions", {
+    data: { activity: "fretboard", seconds: 90, local_date: today },
+  });
+  expect(logged.ok(), await logged.text()).toBe(true);
+
+  await page.route("**/api/trainer/presets", (route) =>
+    route.request().method() === "GET" ? route.fulfill({ status: 500 }) : route.fallback(),
+  );
+
+  await page.reload();
+  await expect(sessionRows(page)).toHaveCount(1);
+  await expect(sessionRows(page).first()).toContainText("1m");
+  await expect(notices(page)).toHaveCount(0);
 });
 
 test("a finished week asks whether the goal was realistic, and remembers the answer", async ({

--- a/web/tests/browser/practice.spec.js
+++ b/web/tests/browser/practice.spec.js
@@ -392,6 +392,18 @@ test("a failing presets fetch drops the scope label, not the practice history", 
   });
   expect(logged.ok(), await logged.text()).toBe(true);
 
+  // Caught, not merely unobserved: presets is fetched fire-and-forget (see
+  // Practice.svelte), so a missing .catch would not blank anything this test
+  // already reads - it would surface only as an unhandled rejection, which
+  // Chromium reports through `pageerror` rather than through `console` (the
+  // routed 500 itself already logs a console "Failed to load resource" of
+  // its own, which is the network layer working as intended and not this
+  // test's business). Watching pageerror is what makes the mutation this
+  // file's discipline requires (dropping the .catch) actually turn this test
+  // red.
+  const pageErrors = [];
+  page.on("pageerror", (e) => pageErrors.push(String(e)));
+
   await page.route("**/api/trainer/presets", (route) =>
     route.request().method() === "GET" ? route.fulfill({ status: 500 }) : route.fallback(),
   );
@@ -400,6 +412,8 @@ test("a failing presets fetch drops the scope label, not the practice history", 
   await expect(sessionRows(page)).toHaveCount(1);
   await expect(sessionRows(page).first()).toContainText("1m");
   await expect(notices(page)).toHaveCount(0);
+  await page.waitForTimeout(200);
+  expect(pageErrors).toEqual([]);
 });
 
 test("a finished week asks whether the goal was realistic, and remembers the answer", async ({

--- a/web/tests/browser/zzzz-score-progress.spec.js
+++ b/web/tests/browser/zzzz-score-progress.spec.js
@@ -383,6 +383,18 @@ test("a failing presets fetch drops the scope label, not this piece's practice h
   const score = await upload(request, "progress-preset-500.musicxml");
   await practise(request, score.id, { seconds: 180, local_date: today, activity: "fretboard" });
 
+  // Caught, not merely unobserved: presets is fetched fire-and-forget (see
+  // ScoreProgress.svelte), so a missing .catch would not blank anything this
+  // test already reads - it would surface only as an unhandled rejection,
+  // which Chromium reports through `pageerror` rather than through `console`
+  // (the routed 500 itself already logs a console "Failed to load resource"
+  // of its own, which is the network layer working as intended and not this
+  // test's business). Watching pageerror is what makes the mutation this
+  // file's discipline requires (dropping the .catch) actually turn this test
+  // red.
+  const pageErrors = [];
+  page.on("pageerror", (e) => pageErrors.push(String(e)));
+
   await page.route("**/api/trainer/presets", (route) =>
     route.request().method() === "GET" ? route.fulfill({ status: 500 }) : route.fallback(),
   );
@@ -391,6 +403,8 @@ test("a failing presets fetch drops the scope label, not this piece's practice h
   await expect(sessions(page)).toHaveCount(1);
   await expect(headline(page)).toHaveText("1 session, 3m in total");
   await expect(page.locator(".notice")).toHaveCount(0);
+  await page.waitForTimeout(200);
+  expect(pageErrors).toEqual([]);
 });
 
 test("nothing on this page is styled as an error", async ({ page, request }) => {

--- a/web/tests/browser/zzzz-score-progress.spec.js
+++ b/web/tests/browser/zzzz-score-progress.spec.js
@@ -87,6 +87,13 @@ async function emptyTheLibrary(request) {
   for (const session of sessions) await request.delete(`/api/practice/sessions/${session.id}`);
   const goals = (await (await request.get(`/api/practice/goals?today=${today}`)).json()).goals;
   for (const goal of goals) await request.delete(`/api/practice/goals/${goal.id}`);
+  // Presets last, after every session referencing one is already gone. This
+  // deletes EVERY preset in the throwaway library, not only one this file's
+  // own preset-label test saved - the suite shares one database, and a
+  // preset left behind would leak into the next spec's history page.
+  for (const preset of await (await request.get("/api/trainer/presets")).json()) {
+    await request.delete(`/api/trainer/presets/${preset.id}`);
+  }
 }
 
 test.beforeEach(async ({ request }) => {
@@ -333,6 +340,57 @@ test("a piece in the trash keeps every hour and stops being a way into the libra
   // And no route into a score the library no longer holds.
   await expect(page.locator(`a[href="#/score/${score.id}"]`)).toHaveCount(0);
   await expect(page.locator(".open-score")).toHaveCount(0);
+});
+
+test("a session logged under a named scope shows that scope's name on this piece's row too", async ({
+  page,
+  request,
+}) => {
+  // Issue #276: the same drill-scope label practice.spec.js proves on the
+  // library-wide page, proved here instead of assumed, because this page
+  // fetches presets and builds presetsById independently of Practice.svelte -
+  // nothing about the one review stubbing it establishes the other actually
+  // wires the same column through.
+  const score = await upload(request, "progress-preset-label.musicxml");
+  const preset = await request.post("/api/trainer/presets", {
+    data: { name: "Top two, fifth position", start_fret: 5, end_fret: 9, strings: [1, 2] },
+  });
+  expect(preset.ok(), await preset.text()).toBe(true);
+  const presetId = (await preset.json()).id;
+
+  await practise(request, score.id, {
+    seconds: 120,
+    local_date: today,
+    activity: "fretboard",
+    preset_id: presetId,
+  });
+  await open(page, score.id);
+
+  await expect(sessions(page)).toHaveCount(1);
+  await expect(sessions(page).first().locator(".session-extra")).toContainText(
+    "Top two, fifth position",
+  );
+});
+
+test("a failing presets fetch drops the scope label, not this piece's practice history", async ({
+  page,
+  request,
+}) => {
+  // Same review finding as Practice.svelte's version of this test: presets
+  // used to sit in the same Promise.all as the progress data this page
+  // exists to show, so a trainer endpoint failure blanked a piece's whole
+  // history instead of just losing a label nothing else here depends on.
+  const score = await upload(request, "progress-preset-500.musicxml");
+  await practise(request, score.id, { seconds: 180, local_date: today, activity: "fretboard" });
+
+  await page.route("**/api/trainer/presets", (route) =>
+    route.request().method() === "GET" ? route.fulfill({ status: 500 }) : route.fallback(),
+  );
+
+  await open(page, score.id);
+  await expect(sessions(page)).toHaveCount(1);
+  await expect(headline(page)).toHaveText("1 session, 3m in total");
+  await expect(page.locator(".notice")).toHaveCount(0);
 });
 
 test("nothing on this page is styled as an error", async ({ page, request }) => {

--- a/web/tests/spec-floors/browser-practice-276.json
+++ b/web/tests/spec-floors/browser-practice-276.json
@@ -1,0 +1,5 @@
+{
+  "file": "tests/browser/practice.spec.js",
+  "count": 2,
+  "reason": "issue #276: a session logged under a named scope shows that scope's name on this page, and a failing presets fetch drops only the label rather than blanking the practice history under it."
+}

--- a/web/tests/spec-floors/browser-zzzz-score-progress-276.json
+++ b/web/tests/spec-floors/browser-zzzz-score-progress-276.json
@@ -1,0 +1,5 @@
+{
+  "file": "tests/browser/zzzz-score-progress.spec.js",
+  "count": 2,
+  "reason": "issue #276: a session scoped to a named preset shows that scope's name on this piece's own progress page too, and a failing presets fetch drops only the label rather than blanking this piece's practice history under it."
+}


### PR DESCRIPTION
## Premise

`valid`. Confirmed by grep: `preset_id` had zero readers anywhere under `web/src/`. `Practice.svelte` (~709) and `ScoreProgress.svelte` (~361) rendered only `note`. Logging a preset-scoped drill session and opening the practice history showed the drill with no scope at all - #236 dropped the scope sentence from `note` for a preset-scoped session on the promise that the row would say which named scope it was, and the reader half was never written.

## Change

`web/src/lib/practice.js` gets `presetLabel(session, presetsById)`: given an id-to-name map, returns a preset's name for a session's `preset_id`, or nothing if the id isn't in the map (only reachable when a preset is deleted between two page-load fetches - the server already nulls the column on delete).

`Practice.svelte` and `ScoreProgress.svelte` each now fetch `GET /api/trainer/presets` alongside their existing data (one call per page load, via `api.trainerPresets()`, which already existed), build the id-to-name map, and add `presetLabel(...)` into the row's existing joined clause list (range, tempo, preset name, note). `note` itself is untouched - the row carries the fact now, not a sentence rebuilt into it.

Neither file's static text changed in a way that trips the vocabulary check; both are still in `practice.spec.js`'s `COMPONENTS` list and pass.

## Mutation

Reverted the three source files (stashed), rebuilt, re-ran the new browser test: red, failing on the row not containing the preset's name. Restored the fix, rebuilt, re-ran: green, along with the rest of `practice.spec.js` and `tests/unit/practice.spec.js`.

## Specs

- `web/tests/unit/practice.spec.js` - all 41 tests, unchanged, still pass (`presetLabel` isn't unit-tested directly but is exercised through the browser spec below; the file's own vocabulary/COMPONENTS checks pass with the new import).
- `web/tests/browser/practice.spec.js:349` - new test: saves a preset via the API, logs one session with its `preset_id` and one without, reloads the practice page, and asserts the preset's name appears on the scoped session's row and not on the unscoped one. Also added preset cleanup to this spec's `reset()` so a saved preset doesn't leak between tests. Ran on `FERMATA_TEST_PORT=9231` with `PLAYWRIGHT_ALLOW_PARTIAL=1`: 16/16 pass.

pytest: not run, no server-side change.

Closes #276

## After review

Review found three gaps in the change above, all confirmed against the live pages before fixing:

1. **A failing presets fetch blanked the practice history.** `api.trainerPresets()` sat inside the same `Promise.all` gating the sessions fetch in `Practice.svelte`, and inside the one assigning `data` in `ScoreProgress.svelte`. Routing `GET /api/trainer/presets` to a 500 confirmed it: Practice rendered zero session rows behind a raw "Internal Server Error" notice, and ScoreProgress rendered nothing. Fixed by pulling the presets fetch out of both `Promise.all`s into its own fire-and-forget call with `.catch(() => { presets = []; })` - a trainer-endpoint failure now drops only the label, and the history renders regardless. This also stops presets from serializing first paint, since it no longer has to settle before the rest of the page can render.
2. **The new test was unfloored.** `browser-practice-102.json` still claimed 15 while the spec executed 16 (the #276 label test from the prior commit). Added `browser-practice-276.json` and `browser-zzzz-score-progress-276.json`, each claiming the tests this round adds.
3. **ScoreProgress had no test for the label.** The claim that the fetch-and-map logic in `ScoreProgress.svelte` shows a scope's name had only ever been demonstrated by stubbing. Added a real browser test: save a preset, log a score-scoped session against it, open that score's progress page, and assert the name appears on the row.

Also corrected `reset()`'s comment in `practice.spec.js`, which said it cleaned up presets "these tests saved" - it deletes every preset in the throwaway library, not only ones a test happened to name.

### Mutation (this round)

- Removed both `.catch` handlers, rebuilt, ran the two new "failing presets fetch" tests: both red. The unhandled rejection doesn't touch anything the tests already assert on (sessions still render, since presets is decoupled), so both tests watch `page.on("pageerror")` specifically to catch it - a plain `console` listener also picks up the routed 500's own "Failed to load resource" line and can't tell the two apart. Restored the `.catch`, rebuilt, re-ran: green.
- Removed the `presetLabel(...)` line from `ScoreProgress.svelte`'s row template, rebuilt, ran the new label test: red, failing on the row not containing the preset's name. Restored the line, rebuilt, re-ran: green.

### Specs (this round)

- Unit `web/tests/unit/practice.spec.js`: 41/41 pass, unchanged.
- Browser, `FERMATA_TEST_PORT=9239` with `PLAYWRIGHT_ALLOW_PARTIAL=1`: `practice.spec.js` (17 tests), `zzzz-score-progress.spec.js` (12 tests), `scope-presets.spec.js` (7 tests) - 36/36 pass.
