### PR TITLE
State how many sessions kept their time when a saved scope is deleted (#277)

### DIFF
--- a/web/src/lib/trainer/ScopePresets.svelte
+++ b/web/src/lib/trainer/ScopePresets.svelte
@@ -43,6 +43,10 @@
   let name = $state("");
   let saving = $state(false);
   let problem = $state("");
+  // What removing a preset just told us, so the sessions it covered are not
+  // left an open question - see remove() and TrainerPresetDeleteOut's own
+  // docstring for why the count is the whole point of the response.
+  let notice = $state("");
 
   async function load() {
     try {
@@ -64,6 +68,7 @@
     if (!typed || saving || disabled) return;
     saving = true;
     problem = "";
+    notice = "";
     try {
       const saved = await api.createTrainerPreset(presetFromScope(typed, strings, scope));
       presets = [saved, ...presets];
@@ -87,10 +92,19 @@
   async function remove(preset) {
     if (disabled) return;
     problem = "";
+    notice = "";
     try {
-      await api.deleteTrainerPreset(preset.id);
+      const result = await api.deleteTrainerPreset(preset.id);
       presets = presets.filter((p) => p.id !== preset.id);
       if (selectedId === preset.id) onSelect(null, null);
+      // sessions_kept: the whole reason TrainerPresetDeleteOut carries it -
+      // a session logged under a scope that is now gone keeps its day, its
+      // length and its activity, and this says so plainly rather than
+      // leaving that unstated.
+      const kept = result?.sessions_kept ?? 0;
+      notice =
+        `${preset.name} is gone. ${kept} session${kept === 1 ? "" : "s"} logged under it ` +
+        `kept their time.`;
     } catch (e) {
       problem = e?.message || "That scope could not be removed.";
     }
@@ -162,6 +176,10 @@
       No scope has been saved yet. Set the strings, the frets and the key you want, give it a
       name, and it will be here in this drill and in the other one.
     </p>
+  {/if}
+
+  {#if notice}
+    <p class="notice preset-notice">{notice}</p>
   {/if}
 
   {#if problem}

--- a/web/tests/browser/scope-presets.spec.js
+++ b/web/tests/browser/scope-presets.spec.js
@@ -258,6 +258,45 @@ test("removing a saved scope leaves the practice logged under it, without the re
   expect(after.preset_id).toBeNull();
 });
 
+test("removing a saved scope states how many sessions kept their time, and it drops out of the other drill's picker (#277)", async ({
+  page,
+  request,
+}) => {
+  await page.goto("/#/fretboard");
+  await expect(drill(page)).toBeVisible();
+  await narrowScope(page, NARROW);
+  await saveScopeAs(page, "Top two, fifth position");
+
+  // One session logged under it, so the count in the sentence below is
+  // asserted against something real rather than a hardcoded zero.
+  await page.locator(".start-drill").click();
+  const note = await drill(page).getAttribute("data-question-note");
+  await page.locator(`.choice[data-note="${note}"]`).click();
+  await page.locator(".stop-drill").click();
+  await expect(page.locator(".logged")).toBeVisible();
+  expect(
+    (await (await request.get("/api/practice/sessions?limit=1000")).json()).sessions.length,
+  ).toBe(1);
+
+  await page.locator(".delete-preset").click();
+  await expect(presets(page)).toHaveAttribute("data-preset-count", "0");
+  const notice = page.locator(".preset-notice");
+  await expect(notice).toBeVisible();
+  const noticeText = await notice.textContent();
+  expect(noticeText).toContain("1 session");
+  expect(noticeText).toMatch(/kept their time/);
+  expect(forbiddenWord(noticeText), noticeText).toBeNull();
+
+  // Gone from the OTHER drill's picker too - one row, one table, no
+  // per-drill copy of it left behind to disagree.
+  await page.goto("/#/chords");
+  await expect(drill(page)).toBeVisible();
+  await expect(presets(page)).toHaveAttribute("data-preset-count", "0");
+  await expect(
+    page.locator('.preset-choice[data-preset-name="Top two, fifth position"]'),
+  ).toHaveCount(0);
+});
+
 test("a name already in use is refused in words rather than by making a second entry of it", async ({
   page,
 }) => {

--- a/web/tests/spec-floors/browser-scope-presets-277.json
+++ b/web/tests/spec-floors/browser-scope-presets-277.json
@@ -1,0 +1,5 @@
+{
+  "file": "tests/browser/scope-presets.spec.js",
+  "count": 1,
+  "reason": "issue #277: deleting a saved scope states how many sessions logged under it kept their time, using sessions_kept from the route's response, and the removed scope drops out of the other drill's picker too."
+}


### PR DESCRIPTION
## Premise: invalid (in part)

The issue's central claim - "the wrapper is called from no component" / "the picker offers save and select only, no delete" - is false as of `aa0ac44`. Issue #249 (merged before #277 was filed) already added a `remove()` handler, a `.delete-preset` button, and wiring so the deleted preset drops from the list and the selection falls back to the drill's current unsaved scope. `git log --follow -- web/src/lib/trainer/ScopePresets.svelte` shows the delete control landing in commit `1527d0a` (#249), an ancestor of the base commit the issue was filed against.

What was genuinely missing, matching the issue's "Expected" section: the `sessions_kept` count from `DELETE /api/trainer/presets/{id}` was never surfaced. A player who deleted a preset had no confirmation that the sessions logged under it kept their time.

## Change

`web/src/lib/trainer/ScopePresets.svelte`: `remove()` now reads `sessions_kept` off the delete response and sets a notice sentence, rendered in a new `.preset-notice` line below the picker:

> `{name} is gone. {N} session{s} logged under it kept their time.`

Checked against `FORBIDDEN_WORDS` in `web/tests/unit/practice.spec.js` - `ScopePresets.svelte` is already in that file's `COMPONENTS` list, so the existing vocabulary guard covers the new text; ran it directly to confirm.

No confirmation dialog - the delete control already followed the project's no-modal-dialog rule (single click, same pattern as the setlists/library delete controls), and the new sentence is a post-hoc notice, not a prompt.

## Spec

Extended `web/tests/browser/scope-presets.spec.js` with a new test (raises the file's floor: `web/tests/spec-floors/browser-scope-presets-277.json`, +1): saves a preset in the fretboard drill, logs one session under it, deletes it, asserts the exact sentence text (with the count and no forbidden word), then navigates to the chord drill and asserts the preset is absent from its picker too.

Mutation testing (recorded, then reverted, rebuilt green):
- Made delete skip the route call (returned a fake `{sessions_kept: 0}` locally) - test went red on the sentence's session count.
- Dropped the `notice` assignment entirely - test went red on `.preset-notice` never becoming visible.

## Runs

- `tests/unit/practice.spec.js`: 41/41 passed.
- `tests/browser/scope-presets.spec.js`, `tests/browser/fretboard-trainer.spec.js`, `tests/browser/chord-flashcards.spec.js` together on `FERMATA_TEST_PORT=9233`: 36/36 passed.
- pytest: not run (no server-side change).

Closes #277
