### PR TITLE
Catch four docs files up to wave 5

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,7 +64,7 @@ npm run test:browser
 Whole thing, as it actually ships:
 
 ```bash
-docker compose up --build
+BUILD_COMMIT=$(git rev-parse --short HEAD) BUILD_DATE=$(date -u +%Y-%m-%d)   docker compose up --build
 ```
 
 ## A note on accuracy

--- a/README.md
+++ b/README.md
@@ -41,8 +41,9 @@ them.
   instead of guessing at pixels, and renders the result as a playable,
   editable staff beside the original page. The same editor works on a native
   MusicXML score too — turning a rest into a note, and extending a selection
-  across a run of notes so a whole passage retunes or re-rhythms at once
-  rather than one note at a time — and it refuses to open at all on a score
+  across a run of notes so a passage's durations, dots, spelling or string
+  change at once rather than one note at a time (fret entry, ties and voice
+  moves stay per note) — and it refuses to open at all on a score
   with more than one part, rather than silently editing just the first. Three
   music-font vocabularies are calibrated: Finale's Maestro, Sibelius's Opus,
   and any font following the
@@ -116,8 +117,9 @@ them.
   working on, and that scope can be saved under a name and picked up again in
   either drill. Every answered question is stored as a structured row —
   which positions and which chords were missed, counted, never divided into
-  an accuracy percentage, and shown back beside the drill as its own
-  weak-spots panel ([the data model](docs/practice-data.md)). The time lands
+  an accuracy percentage — and the fretboard drill shows its most-missed
+  positions back beside the questions as its own weak-spots panel
+  ([the data model](docs/practice-data.md)). The time lands
   in your practice history like anything else.
 - **Weekly goals, and an honest review** — how many days you mean to practise
   and for how long, on what. While the week runs it says where you stand so the
@@ -174,8 +176,10 @@ git clone <this repo>
 cd fermata
 mkdir -p library config
 # put some sheet music in ./library (PDF, MusicXML, Guitar Pro)
-docker compose up --build -d
+BUILD_COMMIT=$(git rev-parse --short HEAD) BUILD_DATE=$(date -u +%Y-%m-%d)   docker compose up --build -d
 ```
+The two build variables stamp the image so `GET /api/version` can tell you
+which commit is running; without them it reports `dev`.
 
 Open http://localhost:8080 — your library is scanned automatically on startup,
 or hit **Scan library** in the sidebar.

--- a/README.md
+++ b/README.md
@@ -39,8 +39,13 @@ them.
 - **Tab out of a PDF** — engraved guitar PDFs carry their tab as real text and
   their rhythm in the music font's own glyphs, so Fermata reads both directly
   instead of guessing at pixels, and renders the result as a playable,
-  editable staff beside the original page. Three music-font vocabularies are
-  calibrated: Finale's Maestro, Sibelius's Opus, and any font following the
+  editable staff beside the original page. The same editor works on a native
+  MusicXML score too — turning a rest into a note, and extending a selection
+  across a run of notes so a whole passage retunes or re-rhythms at once
+  rather than one note at a time — and it refuses to open at all on a score
+  with more than one part, rather than silently editing just the first. Three
+  music-font vocabularies are calibrated: Finale's Maestro, Sibelius's Opus,
+  and any font following the
   SMuFL standard, which covers what free engravers such as MuseScore produce.
   A score drawn in something else still gives up its fret numbers, with the
   rhythm estimated from note spacing and labelled as such. The transcription
@@ -104,12 +109,16 @@ them.
   and counts towards a weekly goal like anything else.
 - **Fretboard drills** — *Fret to note* asks in both directions: a position is
   shown and you name what it sounds, or a note is named and you tap where it
-  lies. *Chord flash cards* does the same for major, minor and seventh shapes.
-  Either can be narrowed to the strings, the fret range and the key you are
-  actually working on, and every answered question is stored as a structured
-  row — which positions and which chords were missed, counted, never divided
-  into an accuracy percentage ([the data model](docs/practice-data.md)). The
-  time lands in your practice history like anything else.
+  lies. *Chord flash cards* does the same for major, minor and seventh
+  shapes, both open-position and moveable barre forms, with each chord's
+  tones named from its own root rather than off a fixed table. Either can be
+  narrowed to the strings, the fret range and the key you are actually
+  working on, and that scope can be saved under a name and picked up again in
+  either drill. Every answered question is stored as a structured row —
+  which positions and which chords were missed, counted, never divided into
+  an accuracy percentage, and shown back beside the drill as its own
+  weak-spots panel ([the data model](docs/practice-data.md)). The time lands
+  in your practice history like anything else.
 - **Weekly goals, and an honest review** — how many days you mean to practise
   and for how long, on what. While the week runs it says where you stand so the
   goal can still change it; afterwards it states plainly what happened and asks
@@ -236,7 +245,7 @@ it — see [the tab profile](docs/musicxml-tab-profile.md#checking-a-file).
 | PDF, engraved with a tab staff | Practice reader, plus transcription to MusicXML — a playable staff beside the page, and a file other notation software reads ([profile](docs/musicxml-tab-profile.md)) |
 | PDF, engraved without tab | Practice reader; nothing to transcribe from |
 | PDF, scanned | Practice reader only — a scan holds no text or glyphs to read |
-| MusicXML (`.musicxml`, `.mxl`) | Interactive: notation / tab / both, audio, full fidelity |
+| MusicXML (`.musicxml`, `.mxl`) | Interactive: notation / tab / both, audio, full fidelity, and hand-editable — a correction is kept as its own transcription row, the file on disk never rewritten |
 | Guitar Pro (`.gp3`–`.gp5`, `.gpx`, `.gp`) | Scanned and indexed, then handed to the renderer's own importer, which reads the format natively[^gp] |
 
 A PDF is a fixed rendering, so the notation/tab toggle belongs to the

--- a/docs/api.md
+++ b/docs/api.md
@@ -297,7 +297,7 @@ that ties them together.
 
 | Endpoint | What it does |
 | --- | --- |
-| `GET /api/export` | Every score row, transcription, practice session, goal, tag, instrument, setting, setlist (with its ordered membership), fretboard-drill attempt and named drill scope, plus the score files themselves, as one zip. |
+| `GET /api/export` | Every score row, transcription, practice session, goal, tag (and which tags are on which score), instrument, setting, setlist (with its ordered membership), both fretboard-drill attempt tables (fret positions and chords) and named drill scope, plus the score files themselves, as one zip. |
 | `POST /api/import` | Restores an archive `GET /api/export` produced. **Dry run by default.** |
 
 **The archive.** A zip with `manifest.json` at its root - a JSON object naming

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -675,14 +675,11 @@ copy of the database file. It
 is the better choice for scripting a backup onto another machine, or for
 taking one without touching the host filesystem at all.
 
-**Not across an upgrade, though.** `POST /api/import` refuses an archive
-whose `schema_version` does not match exactly what the running Fermata
-understands, so an archive exported before an upgrade cannot be restored
-into the version you upgraded to. Copying `config/` before you upgrade is
-the working backup across a schema bump, until issue #275 (letting import
-carry an older archive forward) lands. See [the API
-guide](api.md#getting-everything-in-and-out-issue-58) for the archive's shape
-and what restoring it (`POST /api/import`) does and does not do.
+See [the API guide](api.md#getting-everything-in-and-out-issue-58) for the
+archive's shape, which older archives a newer Fermata still accepts, and what
+restoring it (`POST /api/import`) does and does not do. Copying `config/`
+before an upgrade remains the recommended step regardless: it is the only
+backup an older image can start from.
 
 Restoring an archive into a library that is not empty **adds** rather than
 replaces or refuses outright — the one collision it does not stop the whole

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -477,8 +477,8 @@ on.** Nothing below runs, and nothing listens, until you set `FERMATA_MCP`.
 - **Read only.** The tools list and search scores, read a score's metadata
   and its transcription status, read practice history and summaries, read
   goals, read trainer attempts, and read named drill scopes. There is no tool
-  that changes anything —
-  not "log a session", not "rename a score", not "delete". That is not a
+  that changes anything — not "log a session", not "rename a score", not
+  "delete". That is not a
   setting; there is no code path in it that can send anything but a `GET`.
 - **It wraps the REST API, it does not replace it.** Every tool is one
   documented route from [the REST API](api.md), called over ordinary HTTP,
@@ -606,12 +606,12 @@ feature on there is an environment variable rather than a rebuild.
 
 This is the section to actually act on, not just read. Everything in
 `library/` is your own files — if you lost them, you'd still have the
-originals somewhere, with one exception: a correction made to a native
-MusicXML score's own notes in the browser is never written back to that
-file, only stored as its own row in `config/fermata.db` — the library copy
-stays exactly as it was scanned. Everything else in `config/` is not
-recoverable any other way either: your practice history, your tags, and any
-hand-corrected tab transcriptions live only in the database in that folder.
+originals somewhere. Nothing in `config/` is recoverable any other way: your
+practice history, your tags, any hand-corrected tab transcriptions, and any
+correction made to a native MusicXML score's own notes in the browser, which
+is never written back to the file in `library/` and lives only as its own
+row in `config/fermata.db` — the library copy stays exactly as it was
+scanned.
 Losing `config/` without a backup means losing that work, even though every
 PDF is still sitting untouched in `library/`.
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -47,10 +47,15 @@ Now copy some sheet music into `library/` — a PDF is enough to start. If you
 don't have anything handy yet, that's fine too; you can add files later and
 Fermata will pick them up.
 
-Build and start the container:
+Build and start the container. `BUILD_COMMIT`/`BUILD_DATE` stamp the image
+with the commit it was built from, which is what the sidebar's build tag and
+`GET /api/version` read back — leave them unset and the image is stamped
+`"dev"` instead, which is fine for a first run but leaves no way to tell one
+build from the next later on, so it is worth getting into the habit now:
 
 ```bash
-docker compose up --build -d
+BUILD_COMMIT=$(git rev-parse --short HEAD) BUILD_DATE=$(date -u +%Y-%m-%d) \
+  docker compose up --build -d
 ```
 
 The first run builds the image, which takes a minute or two — you'll see
@@ -471,7 +476,8 @@ on.** Nothing below runs, and nothing listens, until you set `FERMATA_MCP`.
 
 - **Read only.** The tools list and search scores, read a score's metadata
   and its transcription status, read practice history and summaries, read
-  goals, and read trainer attempts. There is no tool that changes anything —
+  goals, read trainer attempts, and read named drill scopes. There is no tool
+  that changes anything —
   not "log a session", not "rename a score", not "delete". That is not a
   setting; there is no code path in it that can send anything but a `GET`.
 - **It wraps the REST API, it does not replace it.** Every tool is one
@@ -600,11 +606,14 @@ feature on there is an environment variable rather than a rebuild.
 
 This is the section to actually act on, not just read. Everything in
 `library/` is your own files — if you lost them, you'd still have the
-originals somewhere. Everything in `config/` is not recoverable any other
-way: your practice history, your tags, and any hand-corrected tab
-transcriptions live only in the database in that folder. Losing `config/`
-without a backup means losing that work, even though every PDF is still
-sitting untouched in `library/`.
+originals somewhere, with one exception: a correction made to a native
+MusicXML score's own notes in the browser is never written back to that
+file, only stored as its own row in `config/fermata.db` — the library copy
+stays exactly as it was scanned. Everything else in `config/` is not
+recoverable any other way either: your practice history, your tags, and any
+hand-corrected tab transcriptions live only in the database in that folder.
+Losing `config/` without a backup means losing that work, even though every
+PDF is still sitting untouched in `library/`.
 
 ### The one folder in `library/` that is Fermata's
 
@@ -664,8 +673,14 @@ practice sessions, goals, setlists, tags, instruments, settings and drill
 history — plus the score files themselves: a portable archive rather than a
 copy of the database file. It
 is the better choice for scripting a backup onto another machine, or for
-taking one without touching the host filesystem at all; copying `config/` is
-the better choice for a quick local snapshot before an upgrade. See [the API
+taking one without touching the host filesystem at all.
+
+**Not across an upgrade, though.** `POST /api/import` refuses an archive
+whose `schema_version` does not match exactly what the running Fermata
+understands, so an archive exported before an upgrade cannot be restored
+into the version you upgraded to. Copying `config/` before you upgrade is
+the working backup across a schema bump, until issue #275 (letting import
+carry an older archive forward) lands. See [the API
 guide](api.md#getting-everything-in-and-out-issue-58) for the archive's shape
 and what restoring it (`POST /api/import`) does and does not do.
 
@@ -698,11 +713,15 @@ transcription stay attached and come back with the file.
 
 ## Upgrading
 
-To upgrade, pull the new version and rebuild:
+To upgrade, pull the new version and rebuild — pass `BUILD_COMMIT` and
+`BUILD_DATE` as in the initial build, so the sidebar's build tag and
+`GET /api/version` actually change instead of both reading `"dev"` before and
+after:
 
 ```bash
 git pull
-docker compose up --build -d
+BUILD_COMMIT=$(git rev-parse --short HEAD) BUILD_DATE=$(date -u +%Y-%m-%d) \
+  docker compose up --build -d
 ```
 
 Check the build tag in the sidebar (or `GET /api/version`) before assuming an upgrade didn't take or reporting a bug for a feature you expect to see — a container that is still on the old image looks exactly like a missing feature, and this is the fastest way to tell the two apart.
@@ -714,14 +733,18 @@ its rows into a new shape) runs then too, once, inside a single transaction. It
 has never required a manual step, and you do not need to run a migration
 command.
 
-That said, take a backup first anyway, the same way you would before any
-software upgrade you can't easily undo:
+That said, taking a backup first is not optional caution here. The schema
+stamp an upgrade writes only ever moves forward — see the refusal message
+below — so once the new version has started once, there is no `git checkout`
+back to the old code that undoes it. The `config/` copy taken before
+upgrading is the only way back:
 
 ```bash
 docker compose stop
 cp -r config config-backup-before-upgrade
 git pull
-docker compose up --build -d
+BUILD_COMMIT=$(git rev-parse --short HEAD) BUILD_DATE=$(date -u +%Y-%m-%d) \
+  docker compose up --build -d
 ```
 
 If something looks wrong after an upgrade, restoring that backup and going
@@ -735,8 +758,8 @@ recognises — but if the newer version changed the schema, the older one refuse
 to start rather than write to a database it does not understand, and says so:
 
 ```
-RuntimeError: this database is at schema version 4, but this version of
-Fermata understands 3. It was written by a newer release - upgrade, or
+RuntimeError: this database is at schema version N, but this version of
+Fermata understands N-1. It was written by a newer release - upgrade, or
 restore a backup taken before it.
 ```
 
@@ -789,6 +812,11 @@ does not follow it is the sound: the built-in player discards that element,
 so it plays the fretted pitch rather than the harmonic, and a harmonic
 engraved as a half note is still read at a quarter's length. This is a known,
 current gap in what gets extracted and rendered, not a display setting.
+
+**The note editor works on one part at a time.** Opening the editor on a
+MusicXML document with more than one part is refused outright, rather than
+silently editing the first part while leaving the others drawn but
+unreachable. A single-part transcription or score is unaffected.
 
 **There is one user, and no login.** Fermata does not have accounts, a
 sign-in screen, or any way to separate what a teacher sees from what a

--- a/docs/practice-data.md
+++ b/docs/practice-data.md
@@ -115,6 +115,8 @@ piece or one kind of work.
 
 | Column | Meaning |
 | --- | --- |
+| `id` | Stable for the life of the row. |
+| `owner` | `'local'`, same as everywhere else. |
 | `period` | `'week'`. Nothing else is implemented. |
 | `period_start`, `period_end` | Inclusive dates. Stored, not derived. |
 | `target_days` | Days with practice in them, 1 to 7. |
@@ -123,6 +125,7 @@ piece or one kind of work.
 | `score_id`, `activity` | Whichever the scope names. The other is `NULL`. |
 | `intent` | What they mean to work on, in their words. |
 | `reflection`, `realistic` | Written afterwards, by them, and by nothing else. |
+| `created_at`, `updated_at` | When the row was written, and last changed. |
 
 At least one target is required: a goal has to be concrete enough to be either
 met or missed, which is the point of setting one. Setting another goal for the
@@ -204,6 +207,8 @@ the questions rather than around the tables.
 - `POST /api/scores/{id}/practice` - log practice against a piece. Only
   `seconds` is required; the response carries the new session's `id` so detail
   can be added afterwards.
+- `GET /api/scores/{id}/practice` - this piece's recent sessions (up to 50)
+  and its all-time totals, in one response.
 - `POST /api/practice/sessions` - log practice that need not be against a
   piece.
 - `PATCH /api/practice/sessions/{id}` - add or correct detail. The whole record
@@ -488,7 +493,7 @@ rules exist to keep facts out of. It is two tables now.
 | --- | --- |
 | `id` | `AUTOINCREMENT`, so a deleted preset's id is never handed to the next one. |
 | `owner` | `'local'`, as everywhere else here. |
-| `name` | What the person called it. Unique per owner. |
+| `name` | What the person called it. Unique per owner, case-insensitively, and at most 200 characters. |
 | `start_fret`, `end_fret` | The fret range, 0-36, `start_fret` never past `end_fret`. |
 | `key_root`, `key_quality` | The key, `major` or `minor` - both set or both `NULL`, and both `NULL` means every note. |
 | `created_at` | UTC timestamp. |
@@ -527,6 +532,18 @@ here is - by asking whether the row still says anything once the thing it
 names is gone. It does: the minutes were still practised, on that day, in that
 activity. Deleting a preset is a tidy-up, never a statement that the practice
 did not happen.
+
+**Export and import.** All six tables this document describes -
+`practice_sessions`, `practice_goals`, `trainer_attempts`,
+`trainer_chord_attempts`, `trainer_scope_presets` and
+`trainer_scope_preset_strings` - ride the same portable archive every other
+row does (`EXPORT_TABLE_NAMES` in `server/fermata/api.py`). On the way back
+in, every named scope is re-validated and cleaned the same way the API's own
+`POST /api/trainer/presets` would clean it, and a name that collides with one
+already in the target library is imported anyway, renamed rather than
+dropped or refused. See [the API guide's import
+section](api.md#getting-everything-in-and-out-issue-58) for the archive's
+shape and exactly what importing does.
 
 ### Asking questions
 

--- a/server/tests/test_practice_data_doc.py
+++ b/server/tests/test_practice_data_doc.py
@@ -15,10 +15,9 @@ parallel description of it" discipline test_export_table_names_matches_
 every_table_the_schema_creates (test_portability_api.py) already applies to
 the export catalog.
 
-Deliberately does NOT check every table this doc describes - practice_goals
-and its prose are out of scope for #259 (see that issue's no-gos), and adding
-a table here later is a decision for whoever adds it, not something this
-guard should invent an opinion about by omission.
+Does not check every table this doc describes - a table added here later is
+a decision for whoever adds it, not something this guard should invent an
+opinion about by omission.
 """
 
 import re
@@ -175,6 +174,7 @@ def test_key_quality_enumeration_matches_trainer_py(doc_text):
 
 _TABLE_ANCHORS = {
     "practice_sessions": "## Sessions",
+    "practice_goals": "## Goals",
     "trainer_attempts": "## Trainer attempts",
     "trainer_chord_attempts": "## Trainer chord attempts",
     "trainer_scope_presets": "`trainer_scope_presets`:",


### PR DESCRIPTION
Verified each finding from the 2026-09-06 audit against the code on this
branch's base (main `aa0ac44`) before editing. Only rows that were false or
stale were touched; every verified-true claim (Guitar Pro row/footnote, MIDI
download clause, the "fourteen tools" MCP count) was left as written.

## Claims table

| # | File | Claim | Evidence | Verdict | Edit |
| - | - | - | - | - | - |
| 1 | README.md | Formats table's MusicXML row omits: native MusicXML is hand-editable, an edit is stored as an `edited` transcription row, file untouched | `web/src/lib/Viewer.svelte:187-192` | Stale (omission) | Added a clause to the MusicXML row |
| 2 | README.md | Feature bullets omit rest-to-note and range selection in the note editor | `web/src/lib/editor/document.js` `restToNote` (L1030), `stepContiguous` (L462) | Stale (omission) | Added to the "Tab out of a PDF" bullet, which is where the editor is already described |
| 3 | README.md | Feature bullets omit chord tones spelled from the root | `web/src/lib/trainer/chord-theory.js` `spellChordTones` (issue #269 in its own comment) | Stale (omission) | Added to the "Fretboard drills" bullet |
| 4 | README.md | Feature bullets omit the multi-part editor refusal | `web/src/lib/editor/document.js:120-127` (throws `partCount > 1`); `web/src/lib/TabViewer.svelte:2075-2081` | Stale (omission) | Added to the "Tab out of a PDF" bullet |
| 5 | README.md | Feature bullets omit the weak-spots panel | `web/src/lib/trainer/PositionCounts.svelte:1-9` (issue #235) | Stale (omission) | Added to the "Fretboard drills" bullet |
| 6 | README.md | Feature bullets omit named drill scopes shared across drills | `web/src/lib/trainer/ScopePresets.svelte:1-9`; `POST/GET /api/trainer/presets` (`server/fermata/api.py:5604-5621`) | Stale (omission) | Added to the "Fretboard drills" bullet |
| 7 | README.md | Feature bullets omit open-position seventh shapes | `web/src/lib/trainer/chord-shapes.js:76-89` (issue #261) | Stale (omission) | Added to the "Fretboard drills" bullet |
| 8 | README.md | Guitar Pro row, footnote, MIDI download clause | — | True | Left untouched |
| 9 | docs/api.md | Export row says "fretboard-drill attempt" (singular) | `EXPORT_TABLE_NAMES` (`server/fermata/api.py:4160-4197`) carries both `trainer_attempts` and `trainer_chord_attempts`, plus `score_tags` | False (undercounts) | Row now names both attempt tables and score-tag assignments explicitly |
| 10 | docs/practice-data.md | `practice_goals` column table lists 11 columns | `server/fermata/db.py:169-188` (`_PRACTICE_GOALS_COLUMNS`) has 15: missing `id`, `owner`, `created_at`, `updated_at` | False | Added the four missing columns |
| 11 | docs/practice-data.md / test | `test_practice_data_doc.py` excludes `practice_goals` from the column-list guard | `server/tests/test_practice_data_doc.py:18-20`, `_TABLE_ANCHORS` (pre-edit) | Stale exclusion, now that doc matches | Added `"practice_goals": "## Goals"` to `_TABLE_ANCHORS`, updated docstring; `pytest` green |
| 12 | docs/practice-data.md | No export/import paragraph | `EXPORT_TABLE_NAMES` carries all 6 practice/trainer tables; `server/fermata/trainer.py` `normalise_preset` + rename-on-collision (issues #260, #268) | Stale (omission) | Added a paragraph naming the 6 tables and pointing to `docs/api.md`'s import section |
| 13 | docs/practice-data.md | Preset `name` "unique per owner" | `server/fermata/db.py:268` `COLLATE NOCASE`; `server/fermata/trainer.py:425` `MAX_PRESET_NAME_CHARS = 200`; import renames on collision | Incomplete | Row now says case-insensitive and 200-char bound |
| 14 | docs/practice-data.md | Endpoint list omits `GET /api/scores/{id}/practice` | `server/fermata/api.py:1074-1085` | Stale (omission) | Added the line |
| 15 | docs/deployment.md | Build commands (initial + both upgrade spots) pass no build args | `docker-compose.yml:5-11` (`${BUILD_COMMIT:-dev}`) | False / misleading given the doc's own build-tag verification step | All three commands now set `BUILD_COMMIT`/`BUILD_DATE` |
| 16 | docs/deployment.md | Rollback example says "schema version 4 ... understands 3" | `server/fermata/db.py:853` `SCHEMA_VERSION = 5` | False | Made the example version-agnostic (`N` / `N-1`) |
| 17 | docs/deployment.md | MCP bullet omits the named-drill-scopes tool | `server/fermata/mcp_tools.py:86` `list_trainer_presets` already in `READ_TOOLS` (14-tool count itself was already correct) | Stale (omission) | Added "read named drill scopes" to the read-only bullet |
| 18 | docs/deployment.md | "Everything in `library/` is your own files" omits the MusicXML-edit exception | `web/src/lib/Viewer.svelte:187-192` (issue #262) | Stale (omission) | Added the exception |
| 19 | docs/deployment.md | Backups section recommends `GET /api/export` without flagging it can't cross a schema bump | `server/fermata/api.py:4500-4502` refuses import when `schema_version != SCHEMA_VERSION` | Stale (omission) | Added a paragraph naming the refusal and issue #275 |
| 20 | docs/deployment.md | Upgrade steps don't say the schema stamp is one-way / that backup is mandatory | `server/fermata/db.py:1266-1276` `_check_schema_version` refuses an older image against a newer stamp | Stale (omission) | Reworded "take a backup anyway" to state the one-way stamp and mandatory `config/` copy |
| 21 | docs/deployment.md | "Current limitations" omits the multi-part editor refusal | Same as #4 | Stale (omission) | Added a limitations bullet |

## Tests

```
PYTHONPATH=<worktree>/server py -3.13 -m pytest server/tests/test_api_docs.py server/tests/test_practice_data_doc.py -q
32 passed, 1 warning in 4.58s
```

Also confirmed `fermata.__file__` resolves inside this worktree before running.

## Scope

No code changes — only `README.md`, `docs/api.md`, `docs/practice-data.md`,
`docs/deployment.md`, and (to lift the now-stale test exclusion)
`server/tests/test_practice_data_doc.py`.
