### PR TITLE
An export taken before an upgrade restores after it

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -301,7 +301,7 @@ that ties them together.
 | `POST /api/import` | Restores an archive `GET /api/export` produced. **Dry run by default.** |
 
 **The archive.** A zip with `manifest.json` at its root - a JSON object naming
-the exact `schema_version` (`fermata/db.py`'s `SCHEMA_VERSION`, not the
+the `schema_version` (`fermata/db.py`'s `SCHEMA_VERSION`, not the
 application's own release number) the rest of it was written against, and
 carrying every table's rows verbatim under `tables` (drill history included
 since #243, named drill scopes since #236). Score files themselves
@@ -350,10 +350,35 @@ having found `(imported)` already taken by the first); the library to import
 into is an empty one - a fresh install, or one just scanned onto an empty
 database.
 
+**An archive from an older Fermata still imports (#275).** `schema_version`
+does not have to match the running one. An archive written at schema version
+3 or later imports into any Fermata from that version onwards: rows are
+inserted with the columns the archive actually carries, so a column added
+after it was written fills from the schema instead of being demanded of it
+(a version 4 archive restores its practice sessions with `preset_id` empty,
+which is what "practised under no named scope" already means). Two things
+are still refused, both with a message that says which and change nothing:
+
+- An archive from a **newer** Fermata than the one reading it. Its rows may
+  carry columns and meanings this version knows nothing about, so the answer
+  is to upgrade first and import again.
+- An archive carrying a **table or column this Fermata no longer has** -
+  renamed or dropped since it was written. The message names the table, or
+  the table and the columns.
+
+Version 3 is the floor because everything below it is on the far side of a
+schema change that had to repair practice rows as it went, and import cannot
+make that repair on an archive. Restore such an archive with a Fermata that
+reads it, let that one bring the database up to date, and export again.
+
+The import response says both numbers: `schema_version_read` is the version
+the archive was written at, and `schema_version` is the one its rows now live
+under (always the running Fermata's). They are equal for an archive written
+by the version reading it.
+
 **Validated completely before anything is written.** The archive is a real
-zip, its manifest parses, its `schema_version` matches this Fermata's exactly
-(cross-version migration is not implemented yet - restore an old archive with
-the Fermata version that wrote it), every foreign key inside the archive
+zip, its manifest parses, its `schema_version` is one this Fermata can read
+(see above), every foreign key inside the archive
 resolves to a row also in the archive, and every archived file's bytes hash
 to what the archive itself records for them. A malformed or
 incompatible archive is rejected with a clear message and changes nothing -

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -669,6 +669,15 @@ the better choice for a quick local snapshot before an upgrade. See [the API
 guide](api.md#getting-everything-in-and-out-issue-58) for the archive's shape
 and what restoring it (`POST /api/import`) does and does not do.
 
+**An export survives an upgrade.** An archive is imported by any Fermata from
+the version that wrote it onwards, back as far as schema version 3 — so an
+archive you take today is still restorable after Fermata's database schema
+changes, which is what makes it a backup rather than a snapshot with a
+shelf life. Columns that did not exist when the archive was written simply
+fill in as empty on the way back in. What is *not* supported is the other
+direction: an archive from a **newer** Fermata than the one reading it is
+refused, with a message saying to upgrade first.
+
 Restoring an archive into a library that is not empty **adds** rather than
 replaces or refuses outright — the one collision it does not stop the whole
 restore over is a named drill scope (a "preset") whose name the target
@@ -726,6 +735,14 @@ docker compose up --build -d
 
 If something looks wrong after an upgrade, restoring that backup and going
 back to the previous `git` commit gets you back to where you started.
+
+Copy `config/` even though an export now survives an upgrade (see
+[Backups](#backups)). The two are for different jobs: an export restores
+*forwards*, into the new version, and a copy of `config/` is the only thing
+that puts you *back* on the old one — the old version refuses to open a
+database the new one has written, and an archive from the new version is
+refused by the old one for the same reason. So the pre-upgrade `config/`
+copy stays the recommended step regardless.
 
 Going back without restoring the backup is a different matter, and this is why
 the backup is worth taking. Once a version has started, its schema changes have

--- a/server/fermata/api.py
+++ b/server/fermata/api.py
@@ -4224,6 +4224,54 @@ LEGACY_OPTIONAL_TABLES = (
     "trainer_scope_preset_strings",
 )
 
+# The oldest db.SCHEMA_VERSION an archive may be stamped with and still be
+# imported (issue #275). Import used to demand the running SCHEMA_VERSION
+# exactly, which made an archive worthless the moment the schema moved - the
+# opposite of what docs/deployment.md recommends `GET /api/export` for.
+#
+# WHY 3, AND NOT LOWER. An archive is a dump of a database that had already
+# been brought up to the version it is stamped with, so an archive stamped N
+# has had every db.MIGRATIONS step up to N applied to it. Two of those steps
+# REWRITE ROWS rather than only reshaping a table, and this path cannot
+# reproduce either one:
+#
+#   Step 3 (_repair_dangling_practice_references) points a practice row at
+#   nothing when the score it names is gone. A database stamped 2 has NOT had
+#   that repair, so an archive stamped 2 may still carry such a row - and
+#   validation below refuses an archive whose practice row names a score the
+#   archive does not carry, rather than nulling it. So a pre-3 archive that a
+#   real upgrade would have quietly repaired would instead be refused here,
+#   with a message about a missing score that says nothing about why. Growing a
+#   second, divergent repair path just for archives - one that silently detaches
+#   somebody's practice from a piece, which this feature never does elsewhere -
+#   is worse than saying plainly that the archive is too old.
+#
+#   Step 2 rebuilt practice_sessions from `score_id INTEGER NOT NULL`. Its own
+#   rewrite (activity = 'piece', owner = DEFAULT_OWNER) IS reproduced here for
+#   free - the column defaults and _apply_import's owner override land on the
+#   same values - so step 2 alone would not have set the floor. Step 3 does.
+#
+# EVERY COLUMN ADDED SINCE 3 IS NULLABLE OR DEFAULTED, which is what makes the
+# range above the floor safe to insert into: db.COLUMN_ADDITIONS holds
+# scores.deleted_at, scores.deleted_from (the 4 -> 5 step), scores.key,
+# scores.tempo, scores.difficulty and practice_sessions.preset_id, and not one
+# of them is NOT NULL. A future NOT-NULL-without-default column cannot arrive
+# through that mechanism at all (see db.COLUMN_ADDITIONS' own comment); one
+# arriving through a MIGRATIONS step would have to raise this floor, and the
+# refusal message below is what would then name it.
+#
+# WHAT THIS DOES NOT CLAIM. No released Fermata has ever WRITTEN an archive
+# below 5: export landed three days after SCHEMA_VERSION last moved, so 5 is
+# the only stamp any real manifest carries today. The range exists for the NEXT
+# bump, when every archive anybody already holds becomes an old one.
+OLDEST_IMPORTABLE_SCHEMA_VERSION = 3
+
+# Keys a manifest row carries that are NOT columns of the table it belongs to,
+# and so are exempt from the column-existence check below. `file_included` is
+# export's own bookkeeping - whether the archive bundled that score's bytes -
+# and _apply_import already excludes it from the INSERT.
+MANIFEST_NON_COLUMN_KEYS = {"scores": frozenset({"file_included"})}
+
 
 def _dump_table(conn, sql: str, params=()) -> list[dict]:
     """Every row a query returns, as plain dicts - the shape both the
@@ -4470,11 +4518,26 @@ def _validate_import_score_path(path) -> None:
     _safe_filename(parts[-1])
 
 
-def _read_and_validate_manifest(zf: zipfile.ZipFile) -> dict:
+def _live_columns(conn, table: str) -> set[str]:
+    """The columns this database actually has on `table`, read back rather
+    than assumed. PRAGMA table_info is the only honest source here: the
+    column set an upgraded install ends up with is SCHEMA plus whatever
+    db.COLUMN_ADDITIONS added on the way, and restating either one in this
+    file is how the two quietly stop matching."""
+    return {row["name"] for row in conn.execute(f"PRAGMA table_info({table})")}
+
+
+def _read_and_validate_manifest(zf: zipfile.ZipFile, conn) -> dict:
     """Everything about the archive that can be checked without writing
     anything - see the module comment on why this runs to completion, naming
     every problem it can find that matters, before import touches the
     database or the library at all.
+
+    `conn` is READ FROM AND NEVER WRITTEN TO: the only thing it is for is
+    PRAGMA table_info, which is what makes the column check below a statement
+    about the database this import would actually land in rather than about a
+    list kept in this file. No transaction is opened here, so a rejected
+    archive still leaves nothing changed - see import_library's docstring.
     """
     try:
         raw = zf.read(EXPORT_MANIFEST_NAME)
@@ -4498,14 +4561,27 @@ def _read_and_validate_manifest(zf: zipfile.ZipFile) -> dict:
     version = manifest.get("schema_version")
     if not isinstance(version, int) or isinstance(version, bool):
         raise HTTPException(422, "the archive's schema_version is missing or not a whole number")
-    if version != SCHEMA_VERSION:
+    # #275: an archive OLDER than this Fermata is the ordinary case after an
+    # upgrade, and is accepted - see OLDEST_IMPORTABLE_SCHEMA_VERSION for the
+    # floor and why it sits where it does. What is refused is an archive from
+    # the FUTURE, whose rows may carry columns and meanings this code knows
+    # nothing about, and an archive from before the floor.
+    if version > SCHEMA_VERSION:
         raise HTTPException(
             422,
             f"this archive is at schema version {version}, but this Fermata understands "
-            f"{SCHEMA_VERSION}. Import only accepts an archive written by the exact version "
-            "of Fermata that is running now - restore it with that version, or export again "
-            "once this one has produced a database at the version it understands. Nothing "
-            "has been changed.",
+            f"{SCHEMA_VERSION} - this archive was written by a newer Fermata; upgrade first, "
+            "then import it again. Nothing has been changed.",
+        )
+    if version < OLDEST_IMPORTABLE_SCHEMA_VERSION:
+        raise HTTPException(
+            422,
+            f"this archive is at schema version {version}, and this Fermata can only read "
+            f"archives from version {OLDEST_IMPORTABLE_SCHEMA_VERSION} onwards. Versions "
+            "below that are the far side of a change that had to repair practice rows as it "
+            "went, and import cannot make that repair on an archive - restore it with a "
+            "Fermata that reads it, let that one bring the database up to date, and export "
+            "again. Nothing has been changed.",
         )
     tables = manifest.get("tables")
     # A key this Fermata does not know at all, or a REQUIRED key missing
@@ -4524,7 +4600,20 @@ def _read_and_validate_manifest(zf: zipfile.ZipFile) -> dict:
         )
     provided = set(tables)
     required = set(EXPORT_TABLE_NAMES) - set(LEGACY_OPTIONAL_TABLES)
-    if provided - set(EXPORT_TABLE_NAMES) or not required <= provided:
+    # #275: a table this Fermata no longer has is NAMED, rather than reported
+    # as the same "not exactly the tables export writes" the missing-key case
+    # gets. Now that an older archive is accepted at all, this is the message
+    # somebody actually meets when a table was renamed or dropped between the
+    # version that wrote the archive and this one, and "which table" is the
+    # whole of what they need to know.
+    gone = sorted(provided - set(EXPORT_TABLE_NAMES))
+    if gone:
+        raise HTTPException(
+            422,
+            f"the archive carries a table this Fermata no longer has ({', '.join(gone)}), so "
+            "it cannot be imported here. Nothing has been changed.",
+        )
+    if not required <= provided:
         raise HTTPException(
             422,
             "the archive's manifest does not carry exactly the tables Fermata's export "
@@ -4535,6 +4624,36 @@ def _read_and_validate_manifest(zf: zipfile.ZipFile) -> dict:
     for name in EXPORT_TABLE_NAMES:
         if not isinstance(tables[name], list) or not all(isinstance(r, dict) for r in tables[name]):
             raise HTTPException(422, f"the archive's {name!r} table is not a list of objects")
+
+    # #275, the other half of accepting an older archive: every column a row
+    # carries has to still BE a column here, because _insert_row names the
+    # archive's own keys in its INSERT and an unknown one is an OperationalError
+    # in the middle of write_tx() rather than a message anybody can act on. The
+    # reverse direction needs no check at all - a column this schema has and the
+    # archive does not is simply not named in the INSERT, so it takes its
+    # default (NULL for every addition since the floor; see
+    # OLDEST_IMPORTABLE_SCHEMA_VERSION).
+    #
+    # Read from the live database rather than from any list in this file, and
+    # checked per table over the union of the keys its rows actually carry - so
+    # a hand-edited archive with one stray key in one row is caught as surely as
+    # a whole table written by a version that named its columns differently.
+    for name in EXPORT_TABLE_NAMES:
+        rows = tables[name]
+        if not rows:
+            continue
+        here = _live_columns(conn, name) | MANIFEST_NON_COLUMN_KEYS.get(name, frozenset())
+        carried: set[str] = set()
+        for row in rows:
+            carried |= set(row)
+        unknown = sorted(carried - here)
+        if unknown:
+            raise HTTPException(
+                422,
+                f"the archive's {name!r} table carries {len(unknown)} column(s) this Fermata "
+                f"no longer has ({', '.join(unknown)}), so it cannot be imported here. "
+                "Nothing has been changed.",
+            )
 
     # Every row this import will ever index by `["id"]` (never `.get`, once
     # apply actually runs) has to have one, and has to have it as a real
@@ -4567,7 +4686,11 @@ def _read_and_validate_manifest(zf: zipfile.ZipFile) -> dict:
     tag_ids = {row["id"] for row in tables["tags"]}
     score_ids = {_require_id(row, "scores") for row in tables["scores"]}
     for row in tables["scores"]:
-        if "deleted_at" not in row:
+        # `deleted_at` arrived with schema 5 (#56), so an archive stamped 4 or
+        # lower legitimately has no such key and no trash to describe - #275.
+        # From 5 on, an export always writes it, and its absence means a
+        # hand-edited manifest rather than an old one.
+        if version >= 5 and "deleted_at" not in row:
             raise HTTPException(
                 422, f"score {row.get('path')!r} in the archive is missing 'deleted_at'"
             )
@@ -4926,7 +5049,9 @@ def _apply_import(conn, manifest: dict, file_bytes: dict[str, bytes], written_pa
             },
         )
         score_id_map[row["id"]] = new_id
-        if row["deleted_at"] is not None:
+        # `.get`, not `[...]`: an archive from before schema 5 has no
+        # `deleted_at` key at all and nothing in the trash to count (#275).
+        if row.get("deleted_at") is not None:
             scores_trashed += 1
         data = file_bytes.get(row["hash"]) if row.get("file_included") else None
         if data is None:
@@ -5099,7 +5224,8 @@ def _apply_import(conn, manifest: dict, file_bytes: dict[str, bytes], written_pa
     scanner.record_deliberate_shrink(conn)
 
     return {
-        "schema_version": manifest["schema_version"],
+        "schema_version": SCHEMA_VERSION,
+        "schema_version_read": manifest["schema_version"],
         "exported_at": manifest["exported_at"],
         "fermata_version": manifest.get("fermata_version") or "unknown",
         "scores_imported": len(tables["scores"]),
@@ -5161,7 +5287,7 @@ async def import_library(file: UploadFile, dry_run: bool = True):
         zf = zipfile.ZipFile(file.file)
     except zipfile.BadZipFile:
         raise HTTPException(422, "that is not a valid zip archive") from None
-    manifest = _read_and_validate_manifest(zf)
+    manifest = _read_and_validate_manifest(zf, connect())
 
     file_bytes: dict[str, bytes] = {}
     for file_hash, suffix in _referenced_files(manifest):
@@ -5199,7 +5325,8 @@ async def import_library(file: UploadFile, dry_run: bool = True):
         )
         return {
             "dry_run": True,
-            "schema_version": manifest["schema_version"],
+            "schema_version": SCHEMA_VERSION,
+            "schema_version_read": manifest["schema_version"],
             "exported_at": manifest["exported_at"],
             "fermata_version": manifest.get("fermata_version") or "unknown",
             "scores_imported": len(tables["scores"]),

--- a/server/fermata/api_models.py
+++ b/server/fermata/api_models.py
@@ -1035,7 +1035,18 @@ class ImportOut(BaseModel):
     also a count of what is new since this call."""
 
     dry_run: bool
+    # The schema the imported rows now live under - always this Fermata's own
+    # `db.SCHEMA_VERSION`, since that is the database they were written into.
     schema_version: int
+    # #275: the version the ARCHIVE itself was stamped with, which since that
+    # issue may be older than the field above. Equal to it for an archive
+    # written by the running version, which is what every archive was before
+    # import accepted an older one at all - so this pair says exactly what was
+    # read and what it was read into, rather than leaving one number to mean
+    # both. An archive from a NEWER Fermata is refused outright and never
+    # reaches this response; so is one older than
+    # `api.OLDEST_IMPORTABLE_SCHEMA_VERSION`.
+    schema_version_read: int
     exported_at: str
     fermata_version: str
     scores_imported: int

--- a/server/tests/test_portability_api.py
+++ b/server/tests/test_portability_api.py
@@ -1465,3 +1465,224 @@ def test_import_is_transactional_on_a_collision_in_the_target_library(
     # committed) before the goal collision was hit.
     assert len(client.get("/api/scores").json()) == 1
     assert len(client.get("/api/practice/goals").json()["goals"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# #275: an archive from an OLDER schema imports into this one, so the backup
+# route docs/deployment.md recommends survives a schema bump. The exact-match
+# check that used to sit here made every archive worthless the moment
+# db.SCHEMA_VERSION moved.
+#
+# EVERY OLDER ARCHIVE IN THIS SECTION IS SYNTHETIC, AND HAS TO BE. Export
+# landed on 2026-08-31, three days AFTER db.SCHEMA_VERSION last moved (to 5),
+# so no released Fermata has ever written a manifest stamped 4 or lower and
+# there is no real one to copy - see `_as_written_by_schema`, which derives
+# one from a real export by removing exactly the columns that arrived after
+# the version being simulated, rather than hand-copying rows.
+# ---------------------------------------------------------------------------
+
+
+# Which db.COLUMN_ADDITIONS entries had NOT arrived yet at a given schema
+# version - and so which keys a manifest written at that version could not
+# have carried. Read off db.py's own history: instrument_id came with 1,
+# missing_since with 4, deleted_at/deleted_from with the 4 -> 5 step (#56),
+# and key/tempo/difficulty (#8) plus practice_sessions.preset_id (#236) came
+# after 5 was already stamped, so no pre-5 archive can hold any of them.
+_ABSENT_BELOW_5 = {
+    "scores": ("deleted_at", "deleted_from", "key", "tempo", "difficulty"),
+    "practice_sessions": ("preset_id",),
+}
+_ABSENT_BELOW_4 = {"scores": ("missing_since",)}
+
+
+def _as_written_by_schema(manifest: dict, version: int) -> dict:
+    """A real export's manifest, reduced to what a Fermata at `version` could
+    have written: the stamp changed, every column that arrived later removed
+    from every row, and the tables that arrived later dropped outright (which
+    is exactly what api.LEGACY_OPTIONAL_TABLES already tolerates). Derived
+    from the live export rather than typed out, so a column added tomorrow
+    travels through here the same way it travels through _dump_table."""
+    out = json.loads(json.dumps(manifest))
+    out["schema_version"] = version
+    absent = dict(_ABSENT_BELOW_5)
+    if version < 4:
+        for table, columns in _ABSENT_BELOW_4.items():
+            absent[table] = absent.get(table, ()) + columns
+    if version < 5:
+        for table, columns in absent.items():
+            for row in out["tables"][table]:
+                for column in columns:
+                    row.pop(column, None)
+        for table in api.LEGACY_OPTIONAL_TABLES:
+            out["tables"].pop(table, None)
+    return out
+
+
+def _archive_of(manifest: dict) -> bytes:
+    return _bytes_of_zip({"manifest.json": json.dumps(manifest).encode()})
+
+
+def _exported_manifest(client) -> dict:
+    return json.loads(
+        _zip_of(client.get("/api/export?include_files=false")).read("manifest.json")
+    )
+
+
+def test_an_archive_from_the_schema_before_this_one_imports(client, add_score):
+    """The headline of #275. A manifest stamped 4 - no `deleted_at`, no
+    `deleted_from`, no `preset_id` on a session, and none of the four tables
+    that arrived after 5 - lands in a version 5 database, with the columns it
+    does not carry taking their schema defaults rather than being demanded of
+    it. `schema_version_read` is what says which version was actually read;
+    `schema_version` is the one the rows now live under."""
+    add_score("Prelude.pdf", title="Prelude")
+    client.post("/api/practice/sessions", json={"seconds": 300, "activity": "fretboard"})
+    older = _as_written_by_schema(_exported_manifest(client), 4)
+    assert "deleted_at" not in older["tables"]["scores"][0]
+    assert "preset_id" not in older["tables"]["practice_sessions"][0]
+
+    resp = client.post(
+        "/api/import", params={"dry_run": "false"},
+        files={"file": ("v4.zip", _archive_of(older), "application/zip")},
+    )
+    assert resp.status_code == 200, resp.text
+    summary = resp.json()
+    assert summary["schema_version_read"] == 4
+    assert summary["schema_version"] == db.SCHEMA_VERSION
+    assert summary["scores_imported"] == 1
+    assert summary["scores_trashed_imported"] == 0
+    assert summary["practice_sessions_imported"] == 1
+    assert summary["trainer_presets_imported"] == 0
+
+    # Import ADDS, so the source rows and the restored ones are both here.
+    titles = sorted(s["title"] for s in client.get("/api/scores").json())
+    assert titles == ["Prelude", "Prelude"]
+    restored = client.get("/api/practice/sessions").json()["sessions"]
+    assert [s["seconds"] for s in restored] == [300, 300]
+    # The column the archive could not carry filled from the schema, not from
+    # a guess - NULL is what "practised under no named scope" already means.
+    assert [s["preset_id"] for s in restored] == [None, None]
+
+
+def test_a_dry_run_of_an_older_archive_reports_the_version_it_read(client, add_score):
+    """The dry run has to say the same thing the applied import does, or the
+    preview is worthless - `schema_version_read` included."""
+    add_score("Prelude.pdf", title="Prelude")
+    older = _as_written_by_schema(_exported_manifest(client), 4)
+
+    resp = client.post(
+        "/api/import", params={"dry_run": "true"},
+        files={"file": ("v4.zip", _archive_of(older), "application/zip")},
+    )
+    assert resp.status_code == 200, resp.text
+    summary = resp.json()
+    assert summary["dry_run"] is True
+    assert summary["schema_version_read"] == 4
+    assert summary["schema_version"] == db.SCHEMA_VERSION
+    # A dry run writes nothing, so the library still holds only the fixture's
+    # own score.
+    assert len(client.get("/api/scores").json()) == 1
+
+
+def test_the_oldest_accepted_schema_version_still_imports(client, add_score):
+    """api.OLDEST_IMPORTABLE_SCHEMA_VERSION is an accepted version, not the
+    first refused one - the boundary is checked from both sides here and in
+    the test below it."""
+    add_score("Prelude.pdf", title="Prelude")
+    oldest = api.OLDEST_IMPORTABLE_SCHEMA_VERSION
+    older = _as_written_by_schema(_exported_manifest(client), oldest)
+    assert "missing_since" not in older["tables"]["scores"][0]
+
+    resp = client.post(
+        "/api/import", params={"dry_run": "false"},
+        files={"file": ("oldest.zip", _archive_of(older), "application/zip")},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["schema_version_read"] == oldest
+    assert len(client.get("/api/scores").json()) == 2
+
+
+def test_an_archive_from_before_the_practice_repair_is_refused_and_changes_nothing(
+    client, add_score
+):
+    """One below the floor. A database stamped 2 has not been through
+    db.MIGRATIONS' step 3, so an archive taken from one may carry a practice
+    row naming a score that is gone - which that step repairs and this import
+    path cannot. Refused with a message that says so, rather than accepted
+    and then rejected downstream for a missing score."""
+    add_score("Prelude.pdf", title="Prelude")
+    too_old = _as_written_by_schema(
+        _exported_manifest(client), api.OLDEST_IMPORTABLE_SCHEMA_VERSION - 1
+    )
+
+    resp = client.post(
+        "/api/import", params={"dry_run": "false"},
+        files={"file": ("too-old.zip", _archive_of(too_old), "application/zip")},
+    )
+    assert resp.status_code == 422, resp.text
+    detail = resp.json()["detail"]
+    assert str(api.OLDEST_IMPORTABLE_SCHEMA_VERSION) in detail
+    assert "practice" in detail
+    assert len(client.get("/api/scores").json()) == 1
+
+
+def test_an_archive_from_a_newer_fermata_is_refused_and_says_to_upgrade(client, add_score):
+    """The direction that stays refused, and the one the old exact-match
+    check was actually right about: a newer archive's rows may carry columns
+    and meanings this code knows nothing about."""
+    add_score("Prelude.pdf", title="Prelude")
+    manifest = _exported_manifest(client)
+    manifest["schema_version"] = db.SCHEMA_VERSION + 1
+
+    resp = client.post(
+        "/api/import", params={"dry_run": "false"},
+        files={"file": ("newer.zip", _archive_of(manifest), "application/zip")},
+    )
+    assert resp.status_code == 422, resp.text
+    detail = resp.json()["detail"]
+    assert "newer Fermata" in detail
+    assert "upgrade first" in detail
+    assert len(client.get("/api/scores").json()) == 1
+
+
+def test_an_archive_carrying_a_column_this_fermata_no_longer_has_is_refused_by_name(
+    client, add_score
+):
+    """The other half of accepting an older archive: a column that has since
+    been renamed or dropped cannot be inserted, and _insert_row names the
+    archive's own keys - so an unknown one would be an OperationalError in
+    the middle of write_tx() rather than a message anybody can act on. Named
+    here, before anything is written. Engineered by adding a column no
+    schema has ever had to an otherwise-importable version 4 manifest."""
+    add_score("Prelude.pdf", title="Prelude")
+    older = _as_written_by_schema(_exported_manifest(client), 4)
+    older["tables"]["scores"][0]["binding_colour"] = "green"
+
+    resp = client.post(
+        "/api/import", params={"dry_run": "false"},
+        files={"file": ("stray-column.zip", _archive_of(older), "application/zip")},
+    )
+    assert resp.status_code == 422, resp.text
+    detail = resp.json()["detail"]
+    assert "binding_colour" in detail
+    assert "scores" in detail
+    assert len(client.get("/api/scores").json()) == 1
+
+
+def test_an_archive_carrying_a_table_this_fermata_no_longer_has_is_refused_by_name(
+    client, add_score
+):
+    """The table-level form of the same rule. A key under `tables` that this
+    Fermata has no table for is refused, and the message NAMES it - which is
+    the whole of what somebody restoring an old archive needs to know."""
+    add_score("Prelude.pdf", title="Prelude")
+    older = _as_written_by_schema(_exported_manifest(client), 4)
+    older["tables"]["practice_diaries"] = []
+
+    resp = client.post(
+        "/api/import", params={"dry_run": "false"},
+        files={"file": ("stray-table.zip", _archive_of(older), "application/zip")},
+    )
+    assert resp.status_code == 422, resp.text
+    assert "practice_diaries" in resp.json()["detail"]
+    assert len(client.get("/api/scores").json()) == 1


### PR DESCRIPTION
Closes #275.

## Premise verdict: invalid as reported, real as a mechanism

The mechanism is exactly as described: `_read_and_validate_manifest` demanded `schema_version == SCHEMA_VERSION`, so any mismatch is a 422.

The reported instance is not reachable. The live instance's image `16a33dd` (2026-08-27, schema 4) **has no export endpoint at all** — `EXPORT_TABLE_NAMES` and `/api/export` first appear in `82a6356` (#58, 2026-08-31), and `SCHEMA_VERSION` had already moved to 5 in `c374e1e` (#56, 2026-08-30). So 5 is the only stamp any released Fermata has ever written into a manifest, no schema-4 archive can exist, and "an archive taken from the live instance today" cannot be taken. The brief's instruction to read v4's `EXPORT_TABLE_NAMES` at `16a33dd` has no answer for the same reason.

The fix is still worth having, prospectively: the *next* bump turns every archive anybody holds into an unimportable one. Every older archive in the new tests is therefore synthetic, and says so.

## Oldest accepted version: 3

An archive stamped N is a dump of a database that had already had every `MIGRATIONS` step up to N applied. Step 3 (`_repair_dangling_practice_references`) nulls a practice row whose score is gone; a database stamped 2 has not had it, and import *refuses* an archive whose practice row names a score it does not carry rather than nulling one. Rather than grow a second repair path that silently detaches somebody's practice from a piece, 2 and below are refused with a message saying why. Step 2's own rewrite (`activity='piece'`, owner) **is** reproduced for free by the column default and `_apply_import`'s owner override, so it does not set the floor. Every `COLUMN_ADDITIONS` entry since 3 is nullable — checked one by one.

## Done when

- Older archive imports; rows inserted with the archive's columns only.
- Newer archive → 422, "newer Fermata … upgrade first".
- Table or column this version no longer has → 422 naming it (columns read via `PRAGMA table_info`, not a list in `api.py`).
- `ImportOut.schema_version_read` = the archive's; `schema_version` = the schema the rows now live under. Equal for every archive accepted before this change, so no existing response value moves.
- `docs/api.md` import section and `docs/deployment.md` backup + upgrade paragraphs rewritten.

## Mutations (commit `801f66c`, restored after)

| Mutation | Red |
| --- | --- |
| Column-existence check disabled | 1 — the stray-column test, as `OperationalError: table scores has no column named binding_colour` mid-write |
| Newer versions accepted | 2 — new newer-archive test + the pre-existing wrong-version test |
| Exact-match reinstated | 6 — v4, v4 dry run, floor, below-floor, stray column, stray table |

`py -3.13 -m pytest server/tests -rs -q` → **1384 passed, 92 skipped** (`FERMATA_TEST_LIBRARY` unset).

## Conflict with #281

PR #281 is still open and rewrites the same `deployment.md` paragraph to say an export does *not* survive a bump until this lands. This branch is on `origin/main` `aa0ac44` with #281 unmerged, so whichever lands second needs that paragraph reconciled.
