### PR TITLE
Drain and reset scanner state between tests, closing #278's leaked-scan race

### DIFF
--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -841,15 +841,25 @@ def _drain_and_reset_scanner(timeout: float = 5.0) -> None:
     """
     from fermata import scanner
 
+    # The reset lives in a `finally` so a timeout still leaves the NEXT test
+    # a clean state: raising alone would blame the test that left the scan
+    # and then hand its leftovers on anyway, so the following tests would
+    # fail too and be named in error.
     deadline = time.monotonic() + timeout
-    while scanner.scan_status()["scanning"]:
-        if time.monotonic() > deadline:
-            raise AssertionError(
-                f"{_current_test_id()} left a library scan running "
-                "and it did not finish in time - the next test would have "
-                "inherited it"
-            )
-        time.sleep(0.02)
+    try:
+        while scanner.scan_status()["scanning"]:
+            if time.monotonic() > deadline:
+                raise AssertionError(
+                    f"{_current_test_id()} left a library scan running "
+                    "and it did not finish in time - the next test would have "
+                    "inherited it"
+                )
+            time.sleep(0.02)
+    finally:
+        _reset_scanner_state(scanner)
+
+
+def _reset_scanner_state(scanner) -> None:
     with scanner._state_lock:
         scanner._state.update(
             scanning=False,
@@ -881,8 +891,8 @@ def _current_test_id() -> str:
 
     Read from the environment variable pytest itself sets for exactly this
     (`PYTEST_CURRENT_TEST`) rather than threaded through as a fixture
-    argument, so `_drain_and_reset_scanner` can be called from `app_env`'s
-    plain teardown without also taking `request`.
+    argument, so `_drain_and_reset_scanner` can be called from an
+    argument-free autouse fixture without also taking `request`.
     """
     current = os.environ.get("PYTEST_CURRENT_TEST", "")
     return current.split(" ", 1)[0] if current else "a test"

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -791,13 +791,39 @@ def app_env(tmp_path, monkeypatch):
     db.init_db()
     yield
     db._local.conn = None
+
+
+@pytest.fixture(autouse=True)
+def _scanner_idle_between_tests():
+    """Wait out any scan a test left running, then reset scanner._state to
+    idle - the counterpart, for `scanner._state`, to `app_env`'s own reset of
+    `db._local.conn` (#278).
+
+    Deliberately its OWN autouse fixture, taking no fixture arguments of its
+    own - in particular not `monkeypatch`, even though `app_env` uses it and
+    this could have lived in app_env's own teardown instead. Some tests fake
+    a running scan with `monkeypatch.setitem(scanner._state, "scanning",
+    True)` rather than starting a real one (see
+    test_a_move_is_refused_while_a_scan_is_running) - a plain dict write, so
+    nothing here can distinguish it from a real scan, and it stays True until
+    `monkeypatch`'s OWN finalizer undoes it. A fixture that itself depends on
+    `monkeypatch` (as `app_env` does) tears down BEFORE `monkeypatch`'s own
+    finalizer runs (pytest tears down in the reverse of setup order, and
+    `app_env` cannot be set up before the `monkeypatch` it requires) - so
+    from inside app_env's teardown this would see that fake `True` as if it
+    were a real, permanently-stuck scan and time out. Taking no arguments
+    keeps this fixture out of that dependency chain entirely, so pytest sets
+    it up independently of `monkeypatch` and tears it down after
+    `monkeypatch` has already put the faked value back.
+    """
+    yield
     _drain_and_reset_scanner()
 
 
 def _drain_and_reset_scanner(timeout: float = 5.0) -> None:
     """Wait out any scan this test left running, then reset scanner._state to
     idle - the counterpart, for `scanner._state`, to the `db._local.conn`
-    reset just above (#278).
+    reset in `app_env` (#278).
 
     `scanner._state` is a bare module global, not per-test state, so a test
     that starts a follow-up scan (directly, or via `hold_library_still`'s own

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -21,6 +21,7 @@ of the extraction suite is exactly how this gap went unnoticed.
 """
 
 import os
+import time
 from pathlib import Path
 
 import pytest
@@ -790,6 +791,75 @@ def app_env(tmp_path, monkeypatch):
     db.init_db()
     yield
     db._local.conn = None
+    _drain_and_reset_scanner()
+
+
+def _drain_and_reset_scanner(timeout: float = 5.0) -> None:
+    """Wait out any scan this test left running, then reset scanner._state to
+    idle - the counterpart, for `scanner._state`, to the `db._local.conn`
+    reset just above (#278).
+
+    `scanner._state` is a bare module global, not per-test state, so a test
+    that starts a follow-up scan (directly, or via `hold_library_still`'s own
+    finally) and does not drain it with the module's `_wait_for_scan` leaves
+    it running for whichever test happens to run next. That test then gets
+    the CURRENT scan's answer to a question it never asked - most visibly a
+    409 (scanner.LibraryBusy, api._busy) from a route that holds the library
+    for its own change and has no idea a previous test is why one is running.
+
+    Waits on `scan_status()["scanning"]` - the same real completion signal
+    every `_wait_for_scan` helper in this test suite already polls - rather
+    than a sleep. Bounded, and loud on a timeout: a scan that has not
+    finished in five seconds against an empty throwaway library did not hang
+    by accident, and the test that left it running is worth naming.
+    """
+    from fermata import scanner
+
+    deadline = time.monotonic() + timeout
+    while scanner.scan_status()["scanning"]:
+        if time.monotonic() > deadline:
+            raise AssertionError(
+                f"{_current_test_id()} left a library scan running "
+                "and it did not finish in time - the next test would have "
+                "inherited it"
+            )
+        time.sleep(0.02)
+    with scanner._state_lock:
+        scanner._state.update(
+            scanning=False,
+            total=0,
+            processed=0,
+            added=0,
+            updated=0,
+            missing=0,
+            restored=0,
+            unmatched_moves=0,
+            refused=False,
+            refused_reason=None,
+            unmatched_paths=[],
+            unmatched_count=0,
+            acknowledge_token=None,
+            errors=0,
+            last_error=None,
+            started_at=None,
+            finished_at=None,
+            transcribe_batch_started=None,
+            transcribe_batch_note=None,
+        )
+    scanner._mutating = False
+    scanner._rescan_pending = False
+
+
+def _current_test_id() -> str:
+    """The nodeid pytest is currently running, for the timeout message above.
+
+    Read from the environment variable pytest itself sets for exactly this
+    (`PYTEST_CURRENT_TEST`) rather than threaded through as a fixture
+    argument, so `_drain_and_reset_scanner` can be called from `app_env`'s
+    plain teardown without also taking `request`.
+    """
+    current = os.environ.get("PYTEST_CURRENT_TEST", "")
+    return current.split(" ", 1)[0] if current else "a test"
 
 
 @pytest.fixture

--- a/server/tests/test_library_management_api.py
+++ b/server/tests/test_library_management_api.py
@@ -1657,7 +1657,8 @@ def test_restore_after_a_leaked_scan_still_gets_a_404_not_a_409(client, add_scor
     above (pytest runs a module's tests in file order), so it inherits
     whatever the previous test left scanner._state holding.
 
-    Without app_env draining and resetting that state between tests, the
+    Without the autouse scanner fixture draining and resetting that state
+    between tests, the
     scan the previous test left running answers this restore with 409
     (LibraryBusy) before ever reaching the not-in-trash check; with it, this
     is indistinguishable from calling restore in a clean process and reads

--- a/server/tests/test_library_management_api.py
+++ b/server/tests/test_library_management_api.py
@@ -28,6 +28,7 @@ library shows it.
 """
 
 import errno
+import threading
 import time
 from pathlib import Path
 
@@ -1599,6 +1600,11 @@ def test_an_upload_is_not_held_against_a_change_and_the_scan_it_starts_is(
         assert scanner.scan_status()["scanning"] is False
 
     assert (library / "Uploads/new.pdf").is_file()
+    # Leaving the library held queues exactly one follow-up scan (see
+    # hold_library_still's own finally) - drained here, like every sibling
+    # test that triggers one, so it does not still be running when the next
+    # test's request lands (#278).
+    _wait_for_scan()
 
 
 def test_a_score_that_is_not_in_the_trash_cannot_be_restored_or_destroyed(
@@ -1611,6 +1617,54 @@ def test_a_score_that_is_not_in_the_trash_cannot_be_restored_or_destroyed(
     # is what makes destroying a score always the second of two steps.
     assert client.delete(f"/api/trash/{score_id}").status_code == 404
     assert client.get(f"/api/scores/{score_id}").json()["deleted_at"] is None
+
+
+def test_a_scan_left_running_by_one_test_does_not_leak_into_the_next(
+    client, monkeypatch
+):
+    """Issue #278's deterministic pin, half one: start a follow-up scan the
+    same way the upload-during-a-hold test above does, but make it slow
+    enough on purpose that it is still running when this test function
+    returns - and, unlike that test, deliberately do not drain it.
+
+    `threading.Event` rather than a sleep to know the swapped-in `_scan` has
+    actually been entered (past monkeypatch's lookup of the name) before this
+    test ends and monkeypatch reverts the attribute - reverting the module
+    attribute does not touch the frame already executing inside it.
+    """
+    entered = threading.Event()
+
+    def slow_scan(acknowledge=None):
+        entered.set()
+        time.sleep(1.0)
+
+    monkeypatch.setattr(scanner, "_scan", slow_scan)
+    with scanner.hold_library_still():
+        res = client.post(
+            "/api/upload?folder=Uploads",
+            files={"file": ("leaked.pdf", b"%PDF-1.4 leaked follow-up scan", "application/pdf")},
+        )
+        assert res.status_code == 200, res.text
+    if not entered.wait(timeout=5.0):
+        raise AssertionError("the follow-up scan this upload queued never started")
+    assert scanner.scan_status()["scanning"] is True
+    # No _wait_for_scan() here - on purpose. This is the leak #278 is about,
+    # reproduced deterministically rather than waited out.
+
+
+def test_restore_after_a_leaked_scan_still_gets_a_404_not_a_409(client, add_score):
+    """Issue #278's deterministic pin, half two - ordered right after the one
+    above (pytest runs a module's tests in file order), so it inherits
+    whatever the previous test left scanner._state holding.
+
+    Without app_env draining and resetting that state between tests, the
+    scan the previous test left running answers this restore with 409
+    (LibraryBusy) before ever reaching the not-in-trash check; with it, this
+    is indistinguishable from calling restore in a clean process and reads
+    404.
+    """
+    score_id = add_score("Inbox/Study.pdf")
+    assert client.post(f"/api/trash/{score_id}/restore").status_code == 404
 
 
 def test_a_score_in_the_trash_cannot_be_moved_back_out_by_a_move(client, library, add_score):


### PR DESCRIPTION
## Premise, re-derived

Ran the pair named in #278 (`test_an_upload_is_not_held_against_a_change_and_the_scan_it_starts_is` + `test_a_score_that_is_not_in_the_trash_cannot_be_restored_or_destroyed`) 20 times before touching anything: 0/20 failures locally this session (the issue reports 2/20; CI reports 0/20) - a rare, timing-dependent race is expected to come back 0 some of the time, so this alone neither confirms nor refutes it.

Read the mechanism instead of only re-running it, and it holds up exactly as measured:

- `scanner._state` (`server/fermata/scanner.py:21`) is a bare module global. `app_env`'s teardown (`server/tests/conftest.py`, pre-fix) reset `db._local.conn` but never touched it.
- `test_an_upload_is_not_held_against_a_change_and_the_scan_it_starts_is` uploads inside `scanner.hold_library_still()`. The upload's own `start_scan()` is declined while held and recorded via `_rescan_pending`; leaving the `with` block calls `_run_pending_rescan()`, which starts a real scan on a background thread (`scanner.py:873`, `:953`). Unlike its siblings, this test never calls `_wait_for_scan()` to drain it.
- `restore_score` (`api.py:3806`) opens with `scanner.hold_library_still()`, which raises `LibraryBusy` whenever `_state["scanning"]` is true - before ever reaching the not-in-trash lookup. `_busy()` (`api.py:3323`) turns that into 409.
- So when the leaked scan is still running as the next test's request lands, `restore_score` answers 409 instead of the 404 the not-in-trash check would give.

**Verdict: valid.** Confirmed by code reading and by a deterministic reproduction built for this PR (see below); the flakiness the issue reports is exactly this race, just rarely timed to land.

## Fix

1. `server/tests/conftest.py`: a new autouse fixture (`_scanner_idle_between_tests`) drains any scan left running after every test (bounded 5s wait on `scanner.scan_status()["scanning"]` - the same real signal every `_wait_for_scan` helper already polls, not a sleep; fails loudly, naming the test, on timeout) and resets `scanner._state` to idle.
   It is deliberately its own fixture, taking no fixture arguments - in particular not `monkeypatch`. Some tests fake a running scan with `monkeypatch.setitem(scanner._state, "scanning", True)` rather than starting a real one; a fixture that itself depends on `monkeypatch` (as `app_env` does) tears down *before* `monkeypatch`'s own finalizer undoes that, so it would see the faked `True` as a permanently stuck scan and time out. A dependency-free fixture sits outside that chain and tears down after `monkeypatch` has already reverted it. (Measured: folding this into `app_env`'s teardown made `test_a_move_is_refused_while_a_scan_is_running` and `test_deleting_is_refused_while_a_scan_is_running` time out every run; moving it out fixed both.)
2. The predecessor test now calls `_wait_for_scan()` after its `with` block, draining its own follow-up scan like its siblings - the fixture is a safety net, not the only guard.
3. A deterministic pin, added and committed *before* the fix to record it red: one test starts a slowed scan the same way (upload inside `hold_library_still`, monkeypatched `scanner._scan` that signals entry via a `threading.Event` then sleeps) and deliberately does not drain it; the next test (file order) calls restore on a live, untrashed score expecting 404.
   - Without the fixture: 409 (red) - reproduced.
   - With the fixture: 404 (green) - reproduced.
   Both tests stay in the suite as the pin.
4. No production code changed. `scan_status()` already existed and already gave tests everything needed to wait on the real signal, so no new accessor was needed.

## Verification

- Original pair, 20/20 runs, 0 failures (post-fix).
- `server/tests/test_library_management_api.py`, 10/10 runs, 81 passed each, 0 failures.
- Full suite (`server/tests`, `FERMATA_TEST_LIBRARY` unset), 3 runs:
  - `1379 passed, 92 skipped, 1 warning in 124.95s`
  - `1379 passed, 92 skipped, 1 warning in 143.54s`
  - `1379 passed, 92 skipped, 1 warning in 101.87s`
  Skip count identical across all three runs (92 - all `FERMATA_TEST_LIBRARY`/musicxml-xsd/web-node_modules gated, none new).

Closes #278.
