### PR TITLE
Draw the drill neck with real fret spacing

### DIFF
--- a/web/src/lib/trainer/Neck.svelte
+++ b/web/src/lib/trainer/Neck.svelte
@@ -44,6 +44,7 @@
   // how that stays legible and touch-target-sized down to tablet width
   // without a break-point, which issue #25 asks for directly.
   import { DEFAULT_FRET_COUNT, inlayDots, noteAt, pitchClass, posKey } from "./neck.js";
+  import { fretMarkerX, fretX } from "./neck-geometry.js";
 
   let {
     strings = [],
@@ -60,25 +61,35 @@
 
   // ---- geometry, in SVG user units -----------------------------------------
   const NUT_GAP = 44; // space left of the nut wire, for open-string markers
+  // A per-fret pixel unit used ONLY to size the board's TOTAL width for a
+  // given fret count - never to place an individual fret, which real fret
+  // spacing (neck-geometry.js's fretX) narrows toward the body. Keeping the
+  // total the same as the old linear layout is what keeps this component's
+  // outer size and every consumer's existing layout unchanged (issue #287).
   const FRET_WIDTH = 62;
   const STRING_GAP = 34;
   const MARGIN = 22;
   const DOT_R = 5;
   const MARKER_R = 14;
 
-  const width = $derived(NUT_GAP + Math.max(1, fretCount) * FRET_WIDTH + MARGIN);
+  const boardWidth = $derived(Math.max(1, fretCount) * FRET_WIDTH);
+  const width = $derived(NUT_GAP + boardWidth + MARGIN);
   const height = $derived(MARGIN * 2 + Math.max(0, sorted.length - 1) * STRING_GAP);
 
   function stringY(index) {
     return MARGIN + index * STRING_GAP;
   }
 
+  // Every fret wire and marker on this neck reads its x-position from here -
+  // the one function (neck-geometry.js's fretX) that knows real fret
+  // spacing, so a fret line, its inlay dot and its tap target can never
+  // disagree about where the fret is.
   function fretWireX(fret) {
-    return NUT_GAP + fret * FRET_WIDTH;
+    return NUT_GAP + fretX(fret, fretCount, boardWidth);
   }
 
   function positionX(fret) {
-    return fret === 0 ? NUT_GAP / 2 : NUT_GAP + (fret - 0.5) * FRET_WIDTH;
+    return fret === 0 ? NUT_GAP / 2 : NUT_GAP + fretMarkerX(fret, fretCount, boardWidth);
   }
 
   const fretWires = $derived(
@@ -136,7 +147,7 @@
       class="board"
       x={NUT_GAP}
       y={MARGIN - STRING_GAP / 2}
-      width={Math.max(1, fretCount) * FRET_WIDTH}
+      width={boardWidth}
       height={Math.max(0, sorted.length - 1) * STRING_GAP + STRING_GAP}
     />
 
@@ -166,6 +177,7 @@
       <line
         class="wire"
         class:nut={fret === 0}
+        data-fret={fret}
         x1={fretWireX(fret)}
         x2={fretWireX(fret)}
         y1={MARGIN - STRING_GAP / 2}

--- a/web/src/lib/trainer/Neck.svelte
+++ b/web/src/lib/trainer/Neck.svelte
@@ -44,7 +44,7 @@
   // how that stays legible and touch-target-sized down to tablet width
   // without a break-point, which issue #25 asks for directly.
   import { DEFAULT_FRET_COUNT, inlayDots, noteAt, pitchClass, posKey } from "./neck.js";
-  import { fretMarkerX, fretX } from "./neck-geometry.js";
+  import { fretMarkerX, fretX, hitRadius } from "./neck-geometry.js";
 
   let {
     strings = [],
@@ -90,6 +90,17 @@
 
   function positionX(fret) {
     return fret === 0 ? NUT_GAP / 2 : NUT_GAP + fretMarkerX(fret, fretCount, boardWidth);
+  }
+
+  // The invisible tap target's radius - fixed at the open string (fret 0
+  // sits in NUT_GAP, off the fretted board that narrows), clamped per fret
+  // everywhere else so real fret spacing (issue #287) can never let two
+  // neighbouring hit circles overlap and steal a tap for the wrong fret
+  // (found in review of #287 - see neck-geometry.js's hitRadius). The DRAWN
+  // marker (the visible ".mark" circle) keeps its fixed MARKER_R regardless;
+  // only the larger, invisible touch target is ever clamped.
+  function positionHitR(fret) {
+    return fret === 0 ? MARKER_R + 8 : hitRadius(fret, fretCount, boardWidth);
   }
 
   const fretWires = $derived(
@@ -233,7 +244,7 @@
             <!-- a large, invisible hit area - the touch target is bigger
                  than what is drawn, per this app's tablet-at-a-music-stand
                  sizing (issue #25's "big touch targets"). -->
-            <circle class="hit" cx={positionX(fret)} cy={stringY(i)} r={MARKER_R + 8} />
+            <circle class="hit" cx={positionX(fret)} cy={stringY(i)} r={positionHitR(fret)} />
             {#if kind}
               <circle class="mark {kind}" cx={positionX(fret)} cy={stringY(i)} r={MARKER_R} />
             {/if}

--- a/web/src/lib/trainer/neck-geometry.js
+++ b/web/src/lib/trainer/neck-geometry.js
@@ -1,0 +1,49 @@
+// Real fret spacing (issue #287) - the one place a fret's x-position on the
+// drawn neck is computed, so Neck.svelte's fret wires, inlay dots, tap
+// targets and note labels can never disagree with each other about where a
+// fret actually is.
+//
+// A real neck's frets shrink by the twelfth root of two per fret - the
+// twelfth fret sits at half the (theoretical, unfretted) scale length, the
+// 24th at a quarter, and so on. Unscaled (scale length = 1), fret n sits at
+//
+//   u(n) = 1 - 2^(-n/12)
+//
+// which climbs toward 1 as n grows but never reaches it - there is no fret
+// at "the end of the string". Neck.svelte only ever draws a fixed number of
+// frets (fretCount), and its layout - the component's outer width, the
+// board rect, the margins - is unchanged by this issue: the LAST drawn fret
+// must still land exactly where it always did, at the given pixel `width`.
+// So u(n) is rescaled by whatever factor puts u(fretCount) at `width`:
+//
+//   x(n) = width * u(n) / u(fretCount)
+//        = width * (1 - 2^(-n/12)) / (1 - 2^(-fretCount/12))
+//
+// x(0) = 0 and x(fretCount) = width exactly (up to floating point), so the
+// nut and the last fret wire are pinned at the same places the old linear
+// layout put them; every fret between narrows on the way there. `width` is
+// the TOTAL board width for the given fret count, not a per-fret constant -
+// Neck.svelte derives it once (fretCount * a fixed pixel-per-fret unit) and
+// passes it in here, rather than multiplying a per-fret width by a fret
+// number the way the old linear layout did.
+
+/** A drawn fret's x-position, in the same units as `width`, with the nut at
+ * 0 and `fretCount`'s own wire landing exactly at `width`. `fret` may be
+ * fractional (used for marker centres, which sit midway between two fret
+ * wires) and is not required to be an integer or in range; `fretCount` is
+ * floored at 1 so a neck asked to draw zero frets still has a well-defined
+ * (if degenerate) scale. */
+export function fretX(fret, fretCount, width) {
+  const count = Math.max(1, fretCount);
+  if (fret <= 0) return 0;
+  const unscaled = 1 - Math.pow(2, -fret / 12);
+  const unscaledTotal = 1 - Math.pow(2, -count / 12);
+  return (width * unscaled) / unscaledTotal;
+}
+
+/** The centre of the fret-N marker (the fingered position between wire N-1
+ * and wire N) - the open string (fret 0) is not "between" anything and is
+ * handled by the caller instead, exactly as it was under linear spacing. */
+export function fretMarkerX(fret, fretCount, width) {
+  return (fretX(fret - 1, fretCount, width) + fretX(fret, fretCount, width)) / 2;
+}

--- a/web/src/lib/trainer/neck-geometry.js
+++ b/web/src/lib/trainer/neck-geometry.js
@@ -47,3 +47,37 @@ export function fretX(fret, fretCount, width) {
 export function fretMarkerX(fret, fretCount, width) {
   return (fretX(fret - 1, fretCount, width) + fretX(fret, fretCount, width)) / 2;
 }
+
+// Neck.svelte's touch-target sizing, duplicated here (not imported) because
+// this module has no dependency on the component - see the module comment
+// on why fretX/fretMarkerX are the one place x-position lives. These two
+// numbers MUST match Neck.svelte's own MARKER_R and its hit-circle padding
+// (`MARKER_R + 8`) or the clamp below stops describing what is actually
+// drawn.
+const MARKER_R = 14;
+const MAX_HIT_R = MARKER_R + 8;
+
+/** The radius of a fret-N marker's invisible tap target, clamped so that
+ * adjacent hit circles never overlap.
+ *
+ * Under real (non-linear) fret spacing, marker-centre spacing shrinks toward
+ * the body - by fret 22 on a 24-fret neck it is well under the fixed
+ * MAX_HIT_R * 2 the old linear layout could always afford, so a fixed radius
+ * makes neighbouring hit circles overlap and steals taps for the wrong fret
+ * (issue #287's regression, found in review). This clamps fret N's own
+ * radius to just under half of fret N's own cell width - the distance
+ * between the two fret wires the marker sits between - minus a 1-unit
+ * safety margin. Because that cell's far wire is shared with the NEXT
+ * fret's own cell, and that neighbour is clamped by the exact same rule
+ * against the same shared wire, no two adjacent markers can ever be given
+ * enough radius to reach each other: each one stops at least 1 unit short
+ * of the wire between them, leaving a real (if small) gap rather than a
+ * point of tangency.
+ *
+ * Not meant to be called for fret 0 (the open string marker, drawn off the
+ * fretted board entirely in NUT_GAP space) - callers keep that position's
+ * fixed radius, the same way positionX() special-cases it. */
+export function hitRadius(fret, fretCount, width) {
+  const cellWidth = fretX(fret, fretCount, width) - fretX(fret - 1, fretCount, width);
+  return Math.min(MAX_HIT_R, cellWidth / 2 - 1);
+}

--- a/web/tests/browser/fretboard-trainer.spec.js
+++ b/web/tests/browser/fretboard-trainer.spec.js
@@ -147,6 +147,29 @@ test("string count and fret count are published on the neck, matching the standa
   await expect(neck).toHaveAttribute("data-fret-count", "12");
 });
 
+// Real fret spacing (issue #287): the rendered neck narrows toward the
+// body, not the evenly-spaced diagram it used to draw. Read directly off
+// the fret wires' own x1 attributes (neck-geometry.js's fretX, via
+// Neck.svelte's fretWireX) rather than any tap helper's assumption about
+// where a fret sits - every drill spec above locates a tap target by its
+// data-string/data-fret attributes, never by computed coordinates, so this
+// is the one place geometry itself needs checking.
+test("frets narrow toward the body: the gap between frets 1 and 2 is wider than between 11 and 12", async ({
+  page,
+}) => {
+  await startButton(page).click();
+  await expect(page.locator(".neck")).toHaveAttribute("data-fret-count", "12");
+
+  async function wireX(fret) {
+    const x = await page.locator(`.wire[data-fret="${fret}"]`).getAttribute("x1");
+    return Number(x);
+  }
+
+  const gapFirst = (await wireX(2)) - (await wireX(1));
+  const gapLast = (await wireX(12)) - (await wireX(11));
+  expect(gapFirst).toBeGreaterThan(gapLast);
+});
+
 test("a saved instrument's own tuning drives the neck, not a hardcoded six strings", async ({
   page,
   request,

--- a/web/tests/browser/fretboard-trainer.spec.js
+++ b/web/tests/browser/fretboard-trainer.spec.js
@@ -188,6 +188,53 @@ test("a saved instrument's own tuning drives the neck, not a hardcoded six strin
   ).toHaveAttribute("data-note", "B");
 });
 
+// Regression found in review of #287: real fret spacing narrows toward the
+// body, but Neck.svelte's invisible tap target used to have a FIXED radius
+// sized for the old, evenly-spaced layout. On a 24-fret neck the high frets
+// sit close enough together that two neighbouring fixed-radius hit circles
+// overlapped, so a tap near the shared edge resolved to the WRONG fret's
+// target (measured in the built app: fret 22's right edge hit fret 23's
+// target, and fret 23's hit fret 24's). This reads the actual rendered
+// geometry - getBoundingClientRect of the hit circle Neck.svelte draws, not
+// any assumption about where a fret "should" be - and asks the browser's own
+// hit-testing (document.elementFromPoint), the same call a real tap goes
+// through, exactly where the earlier regression was found: one pixel inside
+// the drawn circle's right edge.
+test("a tap at any fret's hit-circle edge resolves to that fret, not its narrowing neighbour", async ({
+  page,
+  request,
+}) => {
+  await addInstrument(request, SEVEN_STRING);
+  await page.reload();
+  await expect(drill(page)).toBeVisible();
+
+  await page.selectOption(".scope-source", { label: "Seven-string guitar" });
+  await startButton(page).click();
+  await expect(page.locator(".neck")).toHaveAttribute("data-fret-count", "24");
+
+  const stringNumber = "1";
+  for (let fret = 1; fret <= 24; fret++) {
+    const resolvedFret = await page.evaluate(
+      ({ stringNumber, fret }) => {
+        const pos = document.querySelector(
+          `g.position[data-string="${stringNumber}"][data-fret="${fret}"]`,
+        );
+        const hit = pos.querySelector("circle.hit");
+        const rect = hit.getBoundingClientRect();
+        // One pixel inside the drawn hit circle's own right edge, in CSS
+        // pixels - the same point the regression this test guards against
+        // was measured at.
+        const x = rect.x + rect.width - 1;
+        const y = rect.y + rect.height / 2;
+        const resolved = document.elementFromPoint(x, y)?.closest(".position");
+        return resolved ? resolved.dataset.fret : null;
+      },
+      { stringNumber, fret },
+    );
+    expect(resolvedFret, `fret ${fret}'s own hit-circle edge`).toBe(String(fret));
+  }
+});
+
 // ---------------------------------------------------------------------------
 // A tap highlights/identifies (#25's interaction contract).
 // ---------------------------------------------------------------------------

--- a/web/tests/spec-floors/browser-fretboard-trainer-287.json
+++ b/web/tests/spec-floors/browser-fretboard-trainer-287.json
@@ -1,0 +1,5 @@
+{
+  "file": "tests/browser/fretboard-trainer.spec.js",
+  "count": 1,
+  "reason": "issue #287: the rendered neck's fret spacing narrows toward the body - the gap between frets 1 and 2 is wider than between frets 11 and 12, read off the fret wires' own x1 attributes."
+}

--- a/web/tests/spec-floors/browser-fretboard-trainer-hitradius-288.json
+++ b/web/tests/spec-floors/browser-fretboard-trainer-hitradius-288.json
@@ -1,0 +1,5 @@
+{
+  "file": "tests/browser/fretboard-trainer.spec.js",
+  "count": 1,
+  "reason": "review follow-up to #287: on a 24-fret instrument, a tap at each fret's own drawn hit-circle edge (document.elementFromPoint, the real hit-testing path) resolves to that fret rather than a narrowing neighbour - the overlapping-hit-circle regression this follow-up fixes."
+}

--- a/web/tests/spec-floors/unit-neck-geometry-287.json
+++ b/web/tests/spec-floors/unit-neck-geometry-287.json
@@ -1,0 +1,5 @@
+{
+  "file": "tests/unit/neck-geometry.spec.js",
+  "count": 5,
+  "reason": "issue #287: real fret spacing strictly decreases toward the body, the twelfth fret sits at half the open-string (unfretted scale) length, the last drawn fret lands exactly at the board's total width with the nut pinned at the origin, a marker centre sits midway between its two fret wires, and a linear (constant-spacing) layout is shown to fail the two geometry claims - the mutation this issue's Done-when asks to see red."
+}

--- a/web/tests/spec-floors/unit-neck-geometry-hitradius-288.json
+++ b/web/tests/spec-floors/unit-neck-geometry-hitradius-288.json
@@ -1,0 +1,5 @@
+{
+  "file": "tests/unit/neck-geometry.spec.js",
+  "count": 4,
+  "reason": "review follow-up to #287: adjacent hit circles never overlap at 12/22/24 frets, a 12-fret board leaves the hit radius unclamped, 22- and 24-fret boards DO clamp it below the unclamped 22, and a fixed (unclamped) radius is shown to fail the disjointness claim at 22/24 frets - the overlapping-hit-circle regression this follow-up fixes."
+}

--- a/web/tests/unit/neck-geometry.spec.js
+++ b/web/tests/unit/neck-geometry.spec.js
@@ -1,0 +1,76 @@
+// Real fret spacing (issue #287) - pins neck-geometry.js's fretX against the
+// three falsifiable claims a real fretboard makes that a linear layout
+// cannot: spacing shrinks fret over fret, the twelfth fret sits at half the
+// (unfretted) scale length, and the last drawn fret still lands exactly at
+// the board's total width - so the on-screen board doesn't get wider or
+// narrower than the old linear layout drew it.
+import { expect, test } from "@playwright/test";
+
+import { fretMarkerX, fretX } from "../../src/lib/trainer/neck-geometry.js";
+
+const WIDTH = 1200;
+
+test("fret spacing strictly decreases toward the body - a real neck, not a diagram", () => {
+  const count = 24;
+  const gaps = [];
+  for (let n = 1; n <= count; n++) {
+    gaps.push(fretX(n, count, WIDTH) - fretX(n - 1, count, WIDTH));
+  }
+  for (let i = 1; i < gaps.length; i++) {
+    expect(gaps[i], `gap at fret ${i + 1} vs fret ${i}`).toBeLessThan(gaps[i - 1]);
+  }
+  // The sharpest, most legible case a reviewer would sanity-check by eye:
+  // fret 1 is markedly wider than fret 12.
+  expect(gaps[0]).toBeGreaterThan(gaps[11]);
+});
+
+test("the twelfth fret sits at half the open-string (unfretted scale) length when 24 frets are drawn", () => {
+  const count = 24;
+  // The theoretical, never-drawn scale length this board's spacing implies:
+  // fret n's unscaled position is 1 - 2^(-n/12), so the scale length itself
+  // (n -> infinity) is the pixel value that same formula converges to,
+  // i.e. WIDTH's own scale factor: WIDTH / (1 - 2^(-count/12)).
+  const scaleLength = WIDTH / (1 - Math.pow(2, -count / 12));
+  expect(Math.abs(fretX(12, count, WIDTH) - scaleLength / 2)).toBeLessThan(1);
+});
+
+test("the last drawn fret lands exactly at the total width, whatever the fret count", () => {
+  for (const count of [1, 12, 22, 24]) {
+    expect(Math.abs(fretX(count, count, WIDTH) - WIDTH)).toBeLessThan(1e-9);
+  }
+  // The nut (fret 0) is unmoved - still the origin.
+  expect(fretX(0, 24, WIDTH)).toBe(0);
+});
+
+test("a marker centre sits midway between the two fret wires it lies between", () => {
+  const count = 24;
+  for (const fret of [1, 5, 12, 24]) {
+    const expected = (fretX(fret - 1, count, WIDTH) + fretX(fret, count, WIDTH)) / 2;
+    expect(fretMarkerX(fret, count, WIDTH)).toBeCloseTo(expected, 9);
+  }
+});
+
+// ---------------------------------------------------------------- mutation guard
+//
+// A constant-spacing layout (the bug this issue fixes) is a valid function
+// too - it just isn't a fretboard. This proves the two geometry assertions
+// above actually distinguish the two: swap in the old linear formula and
+// watch them fail, so a future edit that quietly reverts to linear spacing
+// cannot pass this file by accident.
+function linearFretX(fret, fretCount, width) {
+  const count = Math.max(1, fretCount);
+  return (width * fret) / count;
+}
+
+test("a linear (constant-spacing) layout fails both the decreasing-gap and the twelfth-fret claims", () => {
+  const count = 24;
+  const gaps = [];
+  for (let n = 1; n <= count; n++) {
+    gaps.push(linearFretX(n, count, WIDTH) - linearFretX(n - 1, count, WIDTH));
+  }
+  const strictlyDecreasing = gaps.every((g, i) => i === 0 || g < gaps[i - 1]);
+  expect(strictlyDecreasing).toBe(false);
+
+  const scaleLength = WIDTH / (1 - Math.pow(2, -count / 12));
+  expect(Math.abs(linearFretX(12, count, WIDTH) - scaleLength / 2)).toBeGreaterThan(1);
+});

--- a/web/tests/unit/neck-geometry.spec.js
+++ b/web/tests/unit/neck-geometry.spec.js
@@ -6,9 +6,18 @@
 // narrower than the old linear layout drew it.
 import { expect, test } from "@playwright/test";
 
-import { fretMarkerX, fretX } from "../../src/lib/trainer/neck-geometry.js";
+import { fretMarkerX, fretX, hitRadius } from "../../src/lib/trainer/neck-geometry.js";
 
 const WIDTH = 1200;
+
+// Neck.svelte's own per-fret pixel unit (FRET_WIDTH), used to derive the
+// board's total width for a given fret count exactly as the component does -
+// see neck-geometry.js's module comment on why that per-fret constant sizes
+// the board ONCE rather than placing an individual fret. hitRadius's clamp
+// is only interesting at the board width a real neck actually draws, not at
+// an arbitrary WIDTH like the tests above use for the pure spacing claims.
+const FRET_WIDTH = 62;
+const boardWidth = (fretCount) => fretCount * FRET_WIDTH;
 
 test("fret spacing strictly decreases toward the body - a real neck, not a diagram", () => {
   const count = 24;
@@ -47,6 +56,76 @@ test("a marker centre sits midway between the two fret wires it lies between", (
   for (const fret of [1, 5, 12, 24]) {
     const expected = (fretX(fret - 1, count, WIDTH) + fretX(fret, count, WIDTH)) / 2;
     expect(fretMarkerX(fret, count, WIDTH)).toBeCloseTo(expected, 9);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Hit-radius clamping (regression found in review of #287): real fret
+// spacing shrinks marker-centre spacing toward the body, but Neck.svelte's
+// invisible tap target used to have a FIXED radius sized for the old, even
+// linear layout - on a 22- or 24-fret neck the high frets are close enough
+// together that two neighbouring fixed-radius hit circles overlap, and a tap
+// near the shared edge resolves to the wrong fret's target.
+// ---------------------------------------------------------------------------
+
+test("adjacent hit circles never overlap, at every fret count real instruments ship", () => {
+  for (const count of [12, 22, 24]) {
+    const width = boardWidth(count);
+    for (let n = 1; n < count; n++) {
+      const xHere = fretMarkerX(n, count, width);
+      const xNext = fretMarkerX(n + 1, count, width);
+      const rHere = hitRadius(n, count, width);
+      const rNext = hitRadius(n + 1, count, width);
+      expect(
+        xNext - xHere,
+        `frets ${n} and ${n + 1} of ${count}: centre gap ${xNext - xHere} vs radii ${rHere} + ${rNext}`,
+      ).toBeGreaterThan(rHere + rNext);
+    }
+  }
+});
+
+test("at 12 frets, spacing is generous enough that the hit radius is not clamped", () => {
+  const count = 12;
+  const width = boardWidth(count);
+  // Every fret except the very last: at fret 12 itself the cell is the
+  // narrowest on this board (as it is on every board - see "fret spacing
+  // strictly decreases toward the body" above) and sits right at the
+  // boundary of needing a clamp, which is exactly the point of the other
+  // tests in this section - this one is about the ordinary case, where the
+  // clamp does nothing because a 12-fret board is wide enough not to need
+  // it.
+  for (let n = 1; n < count; n++) {
+    expect(hitRadius(n, count, width), `fret ${n} of ${count}`).toBe(22);
+  }
+});
+
+test("at 22 and 24 frets, the high frets DO get clamped below the unclamped 22", () => {
+  for (const count of [22, 24]) {
+    const width = boardWidth(count);
+    expect(hitRadius(count, count, width)).toBeLessThan(22);
+  }
+});
+
+// A fixed radius (the bug this section fixes) is exactly the shape of the
+// old code: prove the disjointness test above actually distinguishes the
+// two by swapping in the old constant and watching it fail at 22 and 24
+// frets, so a future edit that quietly reverts to a fixed hit radius cannot
+// pass this file by accident.
+function fixedHitRadius() {
+  return 22;
+}
+
+test("a fixed (unclamped) hit radius fails the disjointness claim at 22 and 24 frets", () => {
+  for (const count of [22, 24]) {
+    const width = boardWidth(count);
+    let sawOverlap = false;
+    for (let n = 1; n < count; n++) {
+      const xHere = fretMarkerX(n, count, width);
+      const xNext = fretMarkerX(n + 1, count, width);
+      const gap = xNext - xHere;
+      if (gap <= fixedHitRadius() + fixedHitRadius()) sawOverlap = true;
+    }
+    expect(sawOverlap, `fret count ${count}`).toBe(true);
   }
 });
 


### PR DESCRIPTION
## Premise, re-derived

Confirmed on `main` `0279b50`: `web/src/lib/trainer/Neck.svelte` had `const FRET_WIDTH = 62` (line 63), and `fretWireX`/`positionX` (lines 77/81) both placed frets linearly as `NUT_GAP + fret * FRET_WIDTH`. The board rect's width (line 139) used the same linear product. Every fret was drawn the same width - a diagram, not a neck. Confirmed no other file in `web/src` reads `FRET_WIDTH` or computes a fret's x-position - `ChordFlashCards.svelte` and `PositionCounts.svelte` both consume `Neck.svelte` through its props (`markers`, `data-string`/`data-fret`) and never touch pixel geometry themselves. Premise held.

## The formula, and why the total width is unchanged

New module `web/src/lib/trainer/neck-geometry.js` exports `fretX(fret, fretCount, width)`:

```
x(n) = width * (1 - 2^(-n/12)) / (1 - 2^(-fretCount/12))
```

Unscaled (scale length 1), fret `n` sits at `1 - 2^(-n/12)` - climbing toward 1 but never reaching it, since there is no fret at "the end of the string". Rescaling by `width / (1 - 2^(-fretCount/12))` pins `x(0) = 0` and `x(fretCount) = width` exactly, so the nut and the last drawn fret land at the same pixels the old linear layout put them at - the component's outer size, the board rect, and every consumer's layout are unchanged. Every fret in between narrows on the way there, which is the actual point.

`Neck.svelte` keeps its per-fret pixel constant (`FRET_WIDTH = 62`) but now uses it **once**, to derive `boardWidth = fretCount * FRET_WIDTH` (the total board width for a given fret count, exactly as before) - never to place an individual fret. `fretWireX` and `positionX` (marker centres, via the new `fretMarkerX`, which sits midway between two fret wires) both read `fretX`/`fretMarkerX` off `boardWidth`. The nut/open-string marker and all margins are untouched. No other component in `web/src` computes fret x-positions on its own (grepped `FRET_WIDTH` and `fretWireX`/`positionX` across `web/src`), so nothing needed rerouting.

## Done-when

- [x] Frets narrow toward the body in both drills - both render through the same `Neck.svelte`/`fretX`, so one fix covers both. (Corrected after review: the weak-spots panel does not render through `Neck.svelte` at all - `PositionCounts.svelte` never imports it and shows a list of positions, not a fretboard - so this claim only ever covered the two drills.)
- [x] The unit test pins the geometry and goes red under a constant-spacing mutation.
- [x] The drill tap tests stay green (they locate positions by `data-string`/`data-fret`/`data-note`, never by computed coordinates - no tap helper needed touching).
- [x] Mutations recorded red then green (below).

## Mutations

| Mutation | Unit (`neck-geometry.spec.js`) | Browser (`fretboard-trainer.spec.js`) |
|---|---|---|
| `fretX` reverted to `(width * fret) / count` (constant spacing) | "fret spacing strictly decreases..." → **red**; "the twelfth fret sits at half the open-string..." → **red**; other 3 tests unaffected/still pass | "frets narrow toward the body: the gap between frets 1 and 2 is wider than between 11 and 12" → **red** (`Expected: > 62, Received: 62`) |
| reverted | all 5 green | green |

Applied on top of the committed fix, rebuilt (`npm run build`) before each run, restored, rebuilt, reconfirmed green.

## Specs run

- `npx playwright test tests/unit/neck-geometry.spec.js tests/unit/practice.spec.js tests/unit/neck.spec.js` - 61 passed
- `FERMATA_TEST_PORT=9257 PLAYWRIGHT_ALLOW_PARTIAL=1 npx playwright test tests/browser/fretboard-trainer.spec.js tests/browser/chord-flashcards.spec.js tests/browser/fret-weak-spots.spec.js tests/browser/scope-presets.spec.js` - 40 passed
- Full suite and `gh pr checks --watch` intentionally not run; pytest not run (no server-side change).

New spec floors added additively: `unit-neck-geometry-287.json` (5), `browser-fretboard-trainer-287.json` (+1, the new gap assertion).

## After review

Review measured a regression in the built app: `Neck.svelte`'s invisible tap target (the `.hit` circle) kept a fixed radius, `MARKER_R + 8` (22 units, 44 units across), sized for the old evenly-spaced layout. Real fret spacing shrinks marker-centre spacing toward the body - by the high frets on a 22- or 24-fret instrument (`server/fermata/instruments.py` ships both; the browser suite's `SEVEN_STRING` is 24 frets) that spacing drops well under 44, so neighbouring hit circles overlapped and `document.elementFromPoint` at the edge of one fret's drawn circle resolved to the next fret's target instead.

**The clamp.** `neck-geometry.js` now exports `hitRadius(fret, fretCount, width)`, which clamps a fret's own hit radius to just under half its local cell width (the gap between the two fret wires its marker sits between), minus a 1-unit margin: `min(MARKER_R + 8, (fretX(fret) - fretX(fret - 1)) / 2 - 1)`. Because that cell's far wire is shared with the next fret's own cell, and the neighbour is clamped by the identical rule against the same shared wire, no two adjacent hit circles can ever be given enough radius to reach each other. `Neck.svelte` uses this for every fretted position; the open-string marker (drawn off the fretted board, in the fixed-width `NUT_GAP` area) keeps its fixed radius, matching how `positionX` already special-cases it. The visible, drawn `.mark` circle is untouched - only the larger, invisible touch target is ever clamped.

**Unit test** (`neck-geometry.spec.js`, +4 tests, tracked in a new additive floor file rather than editing the existing #287 one): at 12, 22 and 24 frets, every pair of adjacent hit circles is proven disjoint (`x(n+1) - x(n) > r(n) + r(n+1)`); at 12 frets the radius is shown unclamped (the full 22) everywhere except the very last fret, where the cell is narrowest on any board; at 22 and 24 frets the last fret's radius is shown clamped below 22. Mutation: reverting `hitRadius` to the old fixed `22` turns the disjointness test red (and the "DOES get clamped" test red too); restored, green.

**Browser test** (`fretboard-trainer.spec.js`, +1 test, also its own new floor file): on the 24-fret `SEVEN_STRING` instrument, for frets 1 through 24 on one string, a point one CSS pixel inside the drawn `.hit` circle's own right edge (via `getBoundingClientRect`) is resolved with `document.elementFromPoint` - the real hit-testing path a tap goes through - and must land on that same fret's `.position` group. Mutation: reverting `Neck.svelte`'s hit circle to the fixed `MARKER_R + 8` radius turns this red - measured failing first at fret 18 (marker-centre spacing already drops below the fixed circles' combined 44 units there), earlier than the fret 22/23 the review's rough estimate named, so the test's net is if anything stronger than asked. Restored, green.

Both specs rerun clean together with the rest of their files: `tests/unit/neck-geometry.spec.js tests/unit/neck.spec.js tests/unit/practice.spec.js` (65 passed), and `FERMATA_TEST_PORT=9263 PLAYWRIGHT_ALLOW_PARTIAL=1` against `tests/browser/fretboard-trainer.spec.js tests/browser/chord-flashcards.spec.js tests/browser/fret-weak-spots.spec.js tests/browser/scope-presets.spec.js` (41 passed). Full suite intentionally not run.

Closes #287

