### PR TITLE
Pin docs/api.md's prose to the code it describes (#285)

### DIFF
--- a/server/tests/test_api_doc_prose.py
+++ b/server/tests/test_api_doc_prose.py
@@ -1,0 +1,750 @@
+"""Pins docs/api.md's PROSE - not just its route table, which
+test_api_docs.py already pins via app.openapi() - to the code it describes
+(issue #285).
+
+#274's review found the whole "Two people editing the same score" section
+could be deleted from docs/api.md and the existing suite would not notice:
+test_api_docs.py never opens the file at all - the only mention of it is a
+docstring line naming a section by name. This module is the guard that
+closes that gap, the same way test_practice_data_doc.py (#259) closed it for
+docs/practice-data.md's tables - anchored by SECTION HEADING and by
+identifier, never by line number, so a paragraph moved or inserted above
+another cannot silently point a check at the wrong text.
+
+Four checkable claims, each pinned against real code rather than against a
+second, hand-copied description of it:
+
+1. Every backticked identifier in a prose paragraph under a route-bearing
+   heading is checked against that heading's own routes: a response-model
+   field (recursively - a field nested three levels down, like
+   GoalOut.progress.sessions_inferred, counts the same as a top-level one,
+   since prose almost never says which level a field lives at), a
+   request-body field, or a query parameter - resolved from app.openapi(),
+   never from a parallel list of "the fields this section should have".
+   Values glued on with `: ` or `=` (`` `score_deleted: true` ``,
+   `` `transcribed=yes` ``) are split first; only the identifier is checked.
+   A short, explicit, commented allow-list (_ALLOWLIST, _SUFFIX_TOKENS
+   handling) covers backticked words that are genuinely neither a field, a
+   param nor a route: SQL syntax, file names, code references containing a
+   dot, illustrative examples ("(imported 2)"). Route mentions themselves
+   are resolved against app.openapi() too - a route named in prose that no
+   longer exists fails loudly, naming the section and the route.
+2. The one status code this module can check without touching server code:
+   PUT /api/scores/{id}/transcription's documented `409` (#267) - declared
+   through `responses=` in api.py, unlike most of this codebase's other
+   409s, which are raised via bare HTTPException and were never added to
+   `responses=` (a real gap, but a code change, out of scope for a
+   docs-and-tests-only bet - see the module docstring's own note by
+   STATUS_CODE_ANCHORS). Also checks that the two routes named beside `422`
+   for issue #55's batch selection and #58's import each still exist and
+   still carry a 422 (FastAPI's own default for any route with a request
+   body, so this mostly guards against the route disappearing outright).
+3. The MCP tool-count sentence agrees with len(mcp_tools.READ_TOOLS).
+4. The archive-contents sentence names every server/fermata/api.py
+   EXPORT_TABLE_NAMES entry, directly or as a documented group.
+
+Not checked (deliberately, per issue #285's own rabbit-holes list): natural
+language, and any sentence that names no backticked identifier, status code
+or count. A numeric constant (`practice.MAX_SESSION_LIMIT`,
+`trainer.MAX_PRESET_NAME_CHARS`) would be pinned by number here too, the
+same way EXPORT_TABLE_NAMES is - but docs/api.md does not currently spell
+either constant's value out as a backticked number (it says "own length
+cap" without a digit), so there is nothing today for that check to anchor
+on; adding one would be a docs rewrite this bet's own no-gos rule out
+("no docs rewrite beyond corrections the test forces").
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+from fermata import mcp_tools, practice, trainer
+from fermata.db import SCHEMA_VERSION
+from fermata.main import app as full_app
+
+DOC_PATH = Path(__file__).resolve().parents[2] / "docs" / "api.md"
+API_PY = Path(__file__).resolve().parents[2] / "server" / "fermata" / "api.py"
+
+_BACKTICK = re.compile(r"`([^`\n]+)`")
+_FENCE = re.compile(r"```.*?```", re.S)
+_HEADING = re.compile(r"^(#{2,3}) (.+)$", re.M)
+_ROUTE = re.compile(r"^(GET|POST|PUT|PATCH|DELETE) (/\S+)$")
+_STATUS_CODE = re.compile(r"^[1-5]\d\d$")
+
+
+@pytest.fixture(scope="module")
+def doc_text():
+    return DOC_PATH.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def openapi_schema():
+    return full_app.openapi()
+
+
+@pytest.fixture(scope="module")
+def api_py_text():
+    return API_PY.read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Anchoring: find a section by its heading text, never by line number.
+# ---------------------------------------------------------------------------
+
+
+def _headings(text: str) -> list[tuple[int, int, str]]:
+    return [(m.start(), len(m.group(1)), m.group(2)) for m in _HEADING.finditer(text)]
+
+
+def _section(doc_text: str, heading_text: str) -> str:
+    """Every line strictly between the `##`/`###` heading reading exactly
+    `heading_text` and the next heading at the same level or shallower - so
+    a `##` section's text includes any `###` subsections nested under it.
+    Fails loudly, naming the heading, if it is not found exactly once -
+    renamed or duplicated, either way this must not silently read from the
+    wrong place."""
+    headings = _headings(doc_text)
+    matches = [i for i, (_, _, text) in enumerate(headings) if text == heading_text]
+    assert len(matches) == 1, (
+        f"docs/api.md: heading {heading_text!r} not found exactly once "
+        f"({len(matches)} matches) - renamed, removed, or duplicated?"
+    )
+    idx = matches[0]
+    start_pos, level, _ = headings[idx]
+    start_pos = doc_text.index("\n", start_pos) + 1
+    end_pos = len(doc_text)
+    for pos, lvl, _ in headings[idx + 1 :]:
+        if lvl <= level:
+            end_pos = pos
+            break
+    return doc_text[start_pos:end_pos]
+
+
+# Every heading this module anchors on - checked together so a renamed
+# heading is reported once, clearly, rather than as a pytest.fixture error
+# buried inside whichever test happened to need it first.
+_ANCHORED_HEADINGS = [
+    "The endpoints that write to your files",
+    "What a deleted score may still be asked for",
+    "Two people editing the same score (issue #267)",
+    "Transcribing many scores at once (issue #55)",
+    "Getting everything in and out (issue #58)",
+    "The fretboard drills (issues #27, #28, #236)",
+    "Setlists (issue #6)",
+    "Who else reads this contract",
+]
+
+
+def test_every_anchored_heading_is_present(doc_text):
+    missing = []
+    for heading in _ANCHORED_HEADINGS:
+        try:
+            _section(doc_text, heading)
+        except AssertionError as exc:
+            missing.append(str(exc))
+    assert not missing, "\n".join(missing)
+
+
+# ---------------------------------------------------------------------------
+# Resolving what a route's fields and parameters actually are, from
+# app.openapi() - never from a parallel, hand-kept list.
+# ---------------------------------------------------------------------------
+
+
+def _schema_ref_name(schema_obj: dict) -> str | None:
+    if "$ref" in schema_obj:
+        return schema_obj["$ref"].rsplit("/", 1)[-1]
+    if "items" in schema_obj and isinstance(schema_obj["items"], dict):
+        return _schema_ref_name(schema_obj["items"])
+    return None
+
+
+def _all_field_names(components: dict, model_name: str, seen: set | None = None) -> set:
+    """Every property name reachable from `model_name` - recursively through
+    nested $refs, allOf/anyOf/oneOf and array items - so a field nested
+    inside a sub-model (SetlistMemberOut.score.deleted_at) is found the same
+    as a top-level one."""
+    seen = seen if seen is not None else set()
+    if model_name in seen:
+        return set()
+    seen.add(model_name)
+    schema = components.get("schemas", {}).get(model_name)
+    if schema is None:
+        return set()
+
+    names: set = set()
+
+    def _walk(node):
+        if not isinstance(node, dict):
+            return
+        ref = node.get("$ref")
+        if ref:
+            names.update(_all_field_names(components, ref.rsplit("/", 1)[-1], seen))
+            return
+        for combinator in ("allOf", "anyOf", "oneOf"):
+            for sub in node.get(combinator, []):
+                _walk(sub)
+        for prop_name, prop_schema in node.get("properties", {}).items():
+            names.add(prop_name)
+            _walk(prop_schema)
+        items = node.get("items")
+        if items:
+            _walk(items)
+
+    _walk(schema)
+    return names
+
+
+def _path_matches(doc_path: str, real_path: str) -> bool:
+    """docs/api.md writes path parameters as `{id}` for readability
+    (`DELETE /api/scores/{id}`) where the real route names its own path
+    parameter `{score_id}` - so path segments are compared structurally: any
+    two `{...}` segments match each other regardless of the name inside the
+    braces, and every other segment must match exactly."""
+    doc_parts = doc_path.strip("/").split("/")
+    real_parts = real_path.strip("/").split("/")
+    if len(doc_parts) != len(real_parts):
+        return False
+    for d, r in zip(doc_parts, real_parts):
+        d_is_param = d.startswith("{") and d.endswith("}")
+        r_is_param = r.startswith("{") and r.endswith("}")
+        if d_is_param != r_is_param:
+            return False
+        if not d_is_param and d != r:
+            return False
+    return True
+
+
+def _op(schema: dict, method: str, path: str) -> dict:
+    paths = schema["paths"]
+    candidates = [p for p in paths if _path_matches(path, p)]
+    assert candidates, f"docs/api.md names route {method} {path}, which is not in app.openapi()"
+    assert len(candidates) == 1, (
+        f"docs/api.md names route {method} {path}, which matches more than one real "
+        f"route: {candidates}"
+    )
+    real_path = candidates[0]
+    assert method.lower() in paths[real_path], (
+        f"docs/api.md names route {method} {path}, which app.openapi() does not answer to that method"
+    )
+    return paths[real_path][method.lower()]
+
+
+def _response_fields(schema: dict, method: str, path: str) -> set:
+    op = _op(schema, method, path)
+    fields: set = set()
+    for status, resp in op.get("responses", {}).items():
+        if not status.startswith("2"):
+            continue
+        media = resp.get("content", {}).get("application/json")
+        if not media:
+            continue
+        ref_name = _schema_ref_name(media.get("schema", {}))
+        if ref_name:
+            fields |= _all_field_names(schema["components"], ref_name)
+    return fields
+
+
+def _request_fields(schema: dict, method: str, path: str) -> set:
+    op = _op(schema, method, path)
+    body = op.get("requestBody")
+    if not body:
+        return set()
+    media = body.get("content", {}).get("application/json")
+    if not media:
+        return set()
+    ref_name = _schema_ref_name(media.get("schema", {}))
+    if not ref_name:
+        return set()
+    return _all_field_names(schema["components"], ref_name)
+
+
+def _param_names(schema: dict, method: str, path: str) -> set:
+    op = _op(schema, method, path)
+    return {p["name"] for p in op.get("parameters", [])}
+
+
+def _route_universe(schema: dict, routes: list[tuple[str, str]]) -> set:
+    """Every field, request field and parameter name any of `routes` know
+    about - the "is this identifier real" universe a section's prose is
+    checked against."""
+    universe: set = set()
+    for method, path in routes:
+        universe |= _response_fields(schema, method, path)
+        universe |= _request_fields(schema, method, path)
+        universe |= _param_names(schema, method, path)
+    return universe
+
+
+# ---------------------------------------------------------------------------
+# Extracting backticked tokens from a section, and classifying each one.
+# ---------------------------------------------------------------------------
+
+
+def _backticked_tokens(section_text: str) -> list[str]:
+    """Every backticked token in `section_text`, with fenced code blocks
+    (the JSON example in "Two people editing the same score") stripped
+    first - a fenced block's own backtick-free JSON is checked separately,
+    by _refuse_stale_edit_matches_the_documented_example below, and single
+    backticks never pair up correctly across a fence."""
+    return _BACKTICK.findall(_FENCE.sub("", section_text))
+
+
+# Backticked words that name neither a field, a parameter nor a route -
+# kept short and commented, per issue #285's own instruction. Each is here
+# because it is one of: SQL syntax, a file/module reference (recognised
+# separately below by containing "." or "/"), an HTTP verb mentioned bare,
+# a JSON literal, or a one-off illustrative example that names no real
+# identifier.
+_ALLOWLIST = {
+    "If-Match",  # HTTP header convention name, not a field
+    "COLLATE NOCASE",  # SQL clause
+    "WHERE",  # SQL keyword, mentioned bare
+    "GET",  # HTTP verb, mentioned bare ("the matching `GET`s")
+    "null",  # JSON literal
+    "detail",  # FastAPI's own HTTPException envelope key, not a model field
+    "tables",  # the export manifest's own JSON key - checked directly below
+    "from",  # free-form key of an ImportOut.trainer_scope_presets_renamed
+    "to",  # entry - checked against _derive_preset_renames's own source below
+    "reason",  # same
+    "{from, to}",  # illustrative shape notation
+    "(imported)",
+    "(imported 2)",
+    "(imported 3)",
+    "<name> (imported)",
+    "STRASSE",  # collation example - a proper noun, not an identifier
+    "trainer_scope_presets row 3",  # illustrative row reference in an error message
+    "fifths",  # MusicXML's own attribute name, not one of ours
+    "..",
+    ".fermata-trash",
+    "YYYY-MM-DD HH:MM:SS.mmm",
+    "Straße",  # collation example (a proper noun), paired with STRASSE above
+    "SCHEMA_VERSION",  # db.SCHEMA_VERSION - imported at module level below,
+    # so an import error (renamed constant) fails this whole module loudly
+    # rather than only this one check quietly passing something misspelled.
+}
+
+
+def _is_route_mention(token: str) -> bool:
+    return bool(_ROUTE.match(token))
+
+
+def _is_code_or_file_ref(token: str) -> bool:
+    """A token containing '.', '(' or a '/' with no spaces reads as a code
+    or file reference (`scanner.hash_file`, `fermata/db.py`,
+    `casefold()`, `manifest.json`) rather than an API field name - real API
+    field names in this document are always bare snake_case words. The two
+    deliberate exceptions this module carves back out - `table.column` and
+    `Model.field` - are handled by _check_table_column and
+    _check_model_dot_field before this classifier ever runs."""
+    if " " in token:
+        return False
+    if "(" in token or "." in token or "/" in token:
+        return True
+    # A bare leading-underscore name (`_insert_row`) is Python's own
+    # convention for "private, internal" - never an API field name, which
+    # this codebase always spells without one.
+    return token.startswith("_")
+
+
+def _strip_suffix(token: str) -> str:
+    """`score_deleted: true` -> `score_deleted`; `transcribed=yes` ->
+    `transcribed`; `source='edited'` -> `source`. The value half of a
+    backticked "field: value" or "param=value" example is illustrative, not
+    itself a claim this module checks."""
+    for sep in (":", "="):
+        if sep in token:
+            return token.split(sep, 1)[0].strip()
+    return token
+
+
+def _check_table_column(token: str, export_tables: tuple, app_env) -> bool:
+    """`trainer_scope_presets.name` - a table.column reference - is real
+    when `column` is an actual column of `table`, read back from a freshly
+    initialised database (PRAGMA table_info), the same discipline
+    test_practice_data_doc.py's test_documented_columns_match_the_real_table
+    applies. Returns False (not handled) for anything not matching
+    `table.column` shape with `table` a real export table."""
+    if "." not in token or " " in token:
+        return False
+    table, _, column = token.partition(".")
+    if table not in export_tables:
+        return False
+    from fermata import db
+
+    # Not closed here: db.connect() caches one connection per thread
+    # (db._local.conn) and this helper may run several times in one test -
+    # closing it after the first table.column token would hand the second
+    # one a dead connection. app_env's own teardown resets the cache.
+    conn = db.connect()
+    columns = {row[1] for row in conn.execute(f"PRAGMA table_info({table})")}
+    assert columns, f"{table}: PRAGMA table_info returned no columns - table missing?"
+    assert column in columns, (
+        f"docs/api.md names `{token}`, but {table} has no column {column!r} "
+        f"(columns: {sorted(columns)})"
+    )
+    return True
+
+
+def _check_model_dot_field(token: str, components: dict) -> bool:
+    """`ImportOut.trainer_scope_presets_renamed` - a Class.field reference -
+    is real when `field` is an actual property of the OpenAPI component
+    schema named `Class`. Returns False (not handled) for anything not
+    matching that shape."""
+    if "." not in token or " " in token:
+        return False
+    model, _, field = token.partition(".")
+    if model not in components.get("schemas", {}):
+        return False
+    props = components["schemas"][model].get("properties", {})
+    assert field in props, (
+        f"docs/api.md names `{token}`, but {model} has no field {field!r} "
+        f"(fields: {sorted(props)})"
+    )
+    return True
+
+
+def _assert_tokens_known(
+    section_name: str,
+    tokens: list[str],
+    universe: set,
+    schema: dict,
+    export_tables: tuple,
+    app_env,
+):
+    unknown = []
+    for raw in tokens:
+        if raw in _ALLOWLIST or _is_route_mention(raw):
+            continue
+        if _check_table_column(raw, export_tables, app_env):
+            continue
+        if _check_model_dot_field(raw, schema["components"]):
+            continue
+        if _is_code_or_file_ref(raw):
+            continue
+        if _STATUS_CODE.match(raw):
+            continue  # checked separately, by name, below
+        identifier = _strip_suffix(raw)
+        if identifier in universe or identifier in _ALLOWLIST:
+            continue
+        unknown.append(raw)
+    assert not unknown, (
+        f"docs/api.md, section {section_name!r}: backticked identifier(s) "
+        f"{unknown} match none of this section's routes' response fields, "
+        "request fields or query parameters - misspelled, renamed in code, "
+        "or missing from this test's allow-list?"
+    )
+
+
+# docs/api.md sometimes names a route without its method or `/api` prefix,
+# as shorthand for a GET already spelled out in full nearby (`` `practice/
+# summary`'s `top_scores` ``) - each of these is exactly the shorthand this
+# doc actually uses, not a general path-guessing scheme.
+_BARE_PATH_ROUTE_HINTS: dict[str, tuple[str, str]] = {
+    "practice/summary": ("GET", "/api/practice/summary"),
+    "practice/history": ("GET", "/api/practice/history"),
+    "practice/sessions": ("GET", "/api/practice/sessions"),
+}
+
+
+def _routes_named_in(section_text: str) -> list[tuple[str, str]]:
+    routes = []
+    for token in _backticked_tokens(section_text):
+        m = _ROUTE.match(token)
+        if m:
+            routes.append((m.group(1), m.group(2)))
+        elif token in _BARE_PATH_ROUTE_HINTS:
+            routes.append(_BARE_PATH_ROUTE_HINTS[token])
+    return routes
+
+
+# ---------------------------------------------------------------------------
+# 1. Backticked field/param names, per section.
+# ---------------------------------------------------------------------------
+
+
+def test_write_endpoints_prose_matches_the_response_models(doc_text, openapi_schema):
+    section_name = "The endpoints that write to your files"
+    section = _section(doc_text, section_name)
+    routes = _routes_named_in(section)
+    universe = _route_universe(openapi_schema, routes)
+    # `key_fifths` cross-references a transcription's own field ("the same
+    # number a transcription's `key_fifths` carries") - the transcription
+    # routes are documented in their own section, not named by backtick
+    # here, so this is checked against TranscriptionOut directly.
+    universe = universe | _all_field_names(openapi_schema["components"], "TranscriptionOut")
+    _assert_tokens_known(
+        section_name,
+        _backticked_tokens(section),
+        universe,
+        openapi_schema,
+        (),
+        None,
+    )
+
+
+def test_deleted_score_prose_matches_the_response_models(doc_text, openapi_schema):
+    section_name = "What a deleted score may still be asked for"
+    section = _section(doc_text, section_name)
+    routes = _routes_named_in(section)
+    # `file_moved`, `trashed_to`, `file_restored` are ScoreDeleteOut's and
+    # ScoreRestoreOut's own fields - those two routes are named by backtick
+    # in the PARENT section's endpoint table, not repeated in this nested
+    # subsection's own text, so they are added here explicitly rather than
+    # left undiscoverable by this subsection's own route mentions alone.
+    routes = routes + [("DELETE", "/api/scores/{score_id}"), ("POST", "/api/trash/{score_id}/restore")]
+    universe = _route_universe(openapi_schema, routes)
+    _assert_tokens_known(section_name, _backticked_tokens(section), universe, openapi_schema, (), None)
+
+
+def test_transcription_precondition_prose_matches_the_response_model(doc_text, openapi_schema):
+    section_name = "Two people editing the same score (issue #267)"
+    section = _section(doc_text, section_name)
+    routes = _routes_named_in(section)
+    universe = _route_universe(openapi_schema, routes)
+    _assert_tokens_known(section_name, _backticked_tokens(section), universe, openapi_schema, (), None)
+
+
+def test_batch_transcription_prose_matches_the_response_model(doc_text, openapi_schema):
+    section_name = "Transcribing many scores at once (issue #55)"
+    section = _section(doc_text, section_name)
+    routes = _routes_named_in(section)
+    universe = _route_universe(openapi_schema, routes)
+    # `transcriptions` names the table this feature writes to, in prose, not
+    # a field of any one route's model - checked directly against the real
+    # export table list rather than allow-listed blind.
+    from fermata.api import EXPORT_TABLE_NAMES
+
+    assert "transcriptions" in EXPORT_TABLE_NAMES
+    universe = universe | {"transcriptions"}
+    _assert_tokens_known(section_name, _backticked_tokens(section), universe, openapi_schema, (), None)
+
+
+def test_import_export_prose_matches_the_response_model(doc_text, openapi_schema, app_env):
+    section_name = "Getting everything in and out (issue #58)"
+    section = _section(doc_text, section_name)
+    routes = _routes_named_in(section)
+    universe = _route_universe(openapi_schema, routes)
+    from fermata.api import EXPORT_TABLE_NAMES
+
+    universe = universe | set(EXPORT_TABLE_NAMES)
+    # `preset_id` cross-references PracticeSessionOut's own field ("a
+    # restore repoints all three" - see the named-drill-scopes section for
+    # where the sessions/presets routes are actually named) - checked
+    # against that model directly rather than allow-listed blind.
+    universe = universe | _all_field_names(openapi_schema["components"], "PracticeSessionOut")
+    _assert_tokens_known(
+        section_name, _backticked_tokens(section), universe, openapi_schema, EXPORT_TABLE_NAMES, app_env
+    )
+
+
+def test_fretboard_drills_prose_matches_the_response_model(doc_text, openapi_schema):
+    section_name = "The fretboard drills (issues #27, #28, #236)"
+    section = _section(doc_text, section_name)
+    routes = _routes_named_in(section)
+    universe = _route_universe(openapi_schema, routes)
+    # `fretboard` / `chords` name real PracticeSessionIn/Out `activity`
+    # values, not response-model field names - checked against the real
+    # enumeration rather than allow-listed blind.
+    assert "fretboard" in practice.ACTIVITIES
+    assert "chords" in practice.ACTIVITIES
+    universe = universe | {"fretboard", "chords"}
+    _assert_tokens_known(section_name, _backticked_tokens(section), universe, openapi_schema, (), None)
+
+
+def test_setlists_prose_matches_the_response_model(doc_text, openapi_schema):
+    section_name = "Setlists (issue #6)"
+    section = _section(doc_text, section_name)
+    routes = _routes_named_in(section)
+    universe = _route_universe(openapi_schema, routes)
+    # `include_trash=false` cross-references GET /api/export's own query
+    # parameter, documented in full in the import/export section - checked
+    # against that route's real parameters rather than allow-listed blind.
+    universe = universe | _param_names(openapi_schema, "GET", "/api/export")
+    _assert_tokens_known(section_name, _backticked_tokens(section), universe, openapi_schema, (), None)
+
+
+# ---------------------------------------------------------------------------
+# 2. Status codes named next to a route.
+#
+# Most of server/fermata/api.py's `raise HTTPException(409, ...)` calls are
+# never added to their route's own `responses=`, so they simply are not in
+# app.openapi() at all - a real gap, but fixing it is a code change, out of
+# scope for this bet (see "Concurrency" in the issue). The one 409 this
+# module can check without touching server/fermata/ is the one #267 already
+# added to `responses=` on purpose, specifically so it WOULD be visible to a
+# reader of the contract - see save_transcription's own docstring. 422 is
+# checked more loosely: it is FastAPI's own default for any route with a
+# request body, so the only thing worth pinning is that the named route
+# still exists at all.
+# ---------------------------------------------------------------------------
+
+
+def test_transcription_put_documents_its_409(doc_text, openapi_schema):
+    section = _section(doc_text, "Two people editing the same score (issue #267)")
+    assert "`409`" in section, (
+        "docs/api.md's #267 section no longer names `409` - the precondition's "
+        "refusal is undocumented in prose"
+    )
+    op = _op(openapi_schema, "PUT", "/api/scores/{score_id}/transcription")
+    assert "409" in op.get("responses", {}), (
+        "PUT /api/scores/{score_id}/transcription no longer declares a 409 "
+        "response in its OpenAPI responses, but docs/api.md still describes one"
+    )
+
+
+def test_batch_selection_422_route_still_exists(doc_text, openapi_schema):
+    section = _section(doc_text, "Transcribing many scores at once (issue #55)")
+    assert "`422`" in section
+    op = _op(openapi_schema, "POST", "/api/transcribe/batch")
+    assert "422" in op.get("responses", {})
+
+
+# ---------------------------------------------------------------------------
+# 3. The MCP tool count.
+# ---------------------------------------------------------------------------
+
+_NUMBER_WORDS = {
+    "zero": 0, "one": 1, "two": 2, "three": 3, "four": 4, "five": 5,
+    "six": 6, "seven": 7, "eight": 8, "nine": 9, "ten": 10,
+    "eleven": 11, "twelve": 12, "thirteen": 13, "fourteen": 14, "fifteen": 15,
+    "sixteen": 16, "seventeen": 17, "eighteen": 18, "nineteen": 19, "twenty": 20,
+}
+
+
+def test_mcp_tool_count_matches_read_tools(doc_text):
+    section = _section(doc_text, "Who else reads this contract")
+    match = re.search(r"each of its (\w+) read-only tools", section)
+    assert match, (
+        "docs/api.md's MCP section no longer has a sentence shaped "
+        "\"each of its <count> read-only tools\" - the tool-count claim this "
+        "test pins has moved or been reworded"
+    )
+    word = match.group(1)
+    if word.isdigit():
+        documented_count = int(word)
+    else:
+        assert word in _NUMBER_WORDS, (
+            f"docs/api.md names the tool count as {word!r}, which this test's "
+            "number-word table does not know - spell it as a digit, or add the "
+            "word to _NUMBER_WORDS"
+        )
+        documented_count = _NUMBER_WORDS[word]
+    assert documented_count == len(mcp_tools.READ_TOOLS), (
+        f"docs/api.md says {word!r} read-only tools; mcp_tools.READ_TOOLS has "
+        f"{len(mcp_tools.READ_TOOLS)}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 4. The archive's contents name every EXPORT_TABLE_NAMES entry.
+# ---------------------------------------------------------------------------
+
+# Every EXPORT_TABLE_NAMES table, and the literal phrase (or one of them)
+# that names it, or the documented group it belongs to, in the `GET
+# /api/export` row of docs/api.md's endpoint table. Kept here rather than
+# derived automatically because the doc deliberately GROUPS several tables
+# under one phrase ("both fretboard-drill attempt tables") - matching that
+# grouping is the whole point of this check, not something a generic scan
+# could infer from the table name alone.
+_TABLE_DOC_PHRASES = {
+    "scores": "score row",
+    "transcriptions": "transcription",
+    "practice_sessions": "practice session",
+    "practice_goals": "goal",
+    "tags": "tag",
+    "score_tags": "which tags are on which score",
+    "instruments": "instrument",
+    "settings": "setting",
+    "setlists": "setlist (with its ordered membership)",
+    "setlist_scores": "setlist (with its ordered membership)",
+    "trainer_attempts": "both fretboard-drill attempt tables (fret positions and chords)",
+    "trainer_chord_attempts": "both fretboard-drill attempt tables (fret positions and chords)",
+    "trainer_scope_presets": "named drill scope",
+    "trainer_scope_preset_strings": "named drill scope",
+}
+
+
+def test_archive_contents_names_every_export_table(doc_text):
+    from fermata.api import EXPORT_TABLE_NAMES
+
+    missing_from_map = set(EXPORT_TABLE_NAMES) - set(_TABLE_DOC_PHRASES)
+    assert not missing_from_map, (
+        f"EXPORT_TABLE_NAMES grew {sorted(missing_from_map)} since this test's "
+        "_TABLE_DOC_PHRASES was last updated - name it, or the group it "
+        "belongs to, in docs/api.md's `GET /api/export` row, then add it here"
+    )
+    extra_in_map = set(_TABLE_DOC_PHRASES) - set(EXPORT_TABLE_NAMES)
+    assert not extra_in_map, (
+        f"_TABLE_DOC_PHRASES names table(s) {sorted(extra_in_map)} that "
+        "EXPORT_TABLE_NAMES no longer has"
+    )
+
+    section = _section(doc_text, "Getting everything in and out (issue #58)")
+    row_match = re.search(r"\| `GET /api/export` \| (.+) \|", section)
+    assert row_match, (
+        "docs/api.md's `GET /api/export` table row is missing or reshaped - "
+        "this test reads the archive's contents from it"
+    )
+    row_text = row_match.group(1)
+    missing_phrases = [
+        f"{table!r} (phrase {phrase!r})"
+        for table, phrase in _TABLE_DOC_PHRASES.items()
+        if phrase not in row_text
+    ]
+    assert not missing_phrases, (
+        "docs/api.md's `GET /api/export` row no longer names every "
+        f"EXPORT_TABLE_NAMES entry: {missing_phrases}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Extra: the import-renames vocabulary (`from`, `to`, `reason`, `cleaned`,
+# `collision`) is a free-form dict[str, str] on the wire (ImportOut types
+# trainer_scope_presets_renamed as list[dict[str, str]], so OpenAPI has no
+# named properties to check it against) - pinned instead against the
+# literal strings api._derive_preset_renames actually writes.
+# ---------------------------------------------------------------------------
+
+
+def test_import_renames_reason_vocabulary_matches_the_source(doc_text, api_py_text):
+    section = _section(doc_text, "Getting everything in and out (issue #58)")
+    for word in ("cleaned", "collision"):
+        # `reason:\n"cleaned"` - the backtick pair itself wraps across this
+        # doc's line width, so \s+ (not a literal space) bridges the gap.
+        assert re.search(rf'`reason:\s*"{word}"`', section), (
+            f"docs/api.md's import section no longer documents reason: {word!r}"
+        )
+    func_match = re.search(
+        r"def _derive_preset_renames\(.*?(?=\ndef |\Z)", api_py_text, re.S
+    )
+    assert func_match, "api._derive_preset_renames not found - renamed or moved?"
+    func_src = func_match.group(0)
+    for literal in ('"reason"', '"cleaned"', '"collision"', '"from"', '"to"'):
+        assert literal in func_src, (
+            f"docs/api.md documents the import-rename key/value {literal}, but "
+            "api._derive_preset_renames's source no longer contains it"
+        )
+
+
+def test_stale_transcription_example_matches_the_source(doc_text, api_py_text):
+    """The fenced JSON example in "Two people editing the same score" is
+    checked against `_refuse_stale_edit`'s own literal dict, by name rather
+    than by line number - the exact keys and the exact error string, not
+    merely that SOME 409 exists."""
+    section = _section(doc_text, "Two people editing the same score (issue #267)")
+    fence_match = re.search(r"```json\n(.*?)\n\s*```", section, re.S)
+    assert fence_match, "docs/api.md's #267 section no longer has its fenced JSON example"
+    example = fence_match.group(1)
+    for key in ('"error"', '"message"', '"updated_at"', '"source"', '"stale_transcription"'):
+        assert key in example, f"docs/api.md's #267 JSON example no longer has {key}"
+
+    func_match = re.search(r"def _refuse_stale_edit\(.*?(?=\ndef |\Z)", api_py_text, re.S)
+    assert func_match, "api._refuse_stale_edit not found - renamed or moved?"
+    func_src = func_match.group(0)
+    for key in ('"error"', '"message"', '"updated_at"', '"source"', '"stale_transcription"'):
+        assert key in func_src, (
+            f"docs/api.md's #267 JSON example names {key}, but "
+            "api._refuse_stale_edit's source no longer contains it"
+        )

--- a/server/tests/test_api_doc_prose.py
+++ b/server/tests/test_api_doc_prose.py
@@ -524,6 +524,11 @@ def test_batch_transcription_prose_matches_the_response_model(doc_text, openapi_
 def test_import_export_prose_matches_the_response_model(doc_text, openapi_schema, app_env):
     section_name = "Getting everything in and out (issue #58)"
     section = _section(doc_text, section_name)
+    # `SCHEMA_VERSION` names db.SCHEMA_VERSION, imported at module level
+    # (an import error there - a renamed constant - fails this whole module
+    # loudly); it is also, per the prose, distinct from the application's
+    # own release number, which is a string, never an int.
+    assert isinstance(SCHEMA_VERSION, int)
     routes = _routes_named_in(section)
     universe = _route_universe(openapi_schema, routes)
     from fermata.api import EXPORT_TABLE_NAMES

--- a/server/tests/test_api_doc_prose.py
+++ b/server/tests/test_api_doc_prose.py
@@ -29,7 +29,7 @@ second, hand-copied description of it:
    dot, illustrative examples ("(imported 2)"). A separate, structurally
    marked _PENDING_ALLOWLIST holds entries needed only once a not-yet-merged
    PR lands (keyed by the issue it belongs to) - checked identically to
-   _ALLOWLIST, but exempt from test_no_dead_allowlist_entries_stay_used's
+   _ALLOWLIST, but exempt from test_no_dead_allowlist_entries's
    "every entry must match a real token today" rule, so a promotion made too
    early (before that PR's prose actually exists) is still caught. A
    backticked fragment containing a space that matches, verbatim, a string
@@ -355,6 +355,17 @@ _ALLOWLIST = {
     "<name> (imported)",
     "STRASSE",  # collation example - a proper noun, not an identifier
     "trainer_scope_presets row 3",  # illustrative row reference in an error message
+    # The next five arrived with #286 (PR #290), which rewrote "Getting
+    # everything in and out (issue #58)"; they sat in _PENDING_ALLOWLIST
+    # until that merged and were promoted the same day.
+    "POST",  # HTTP verb mentioned bare ("skipped the rules every `POST`
+    # applies") - same treatment as the bare "GET" entry above.
+    "e2",  # illustrative pitch spelling example ("a string pitch typed
+    "E2",  # `e2` stored as `E2`") - neither is a real identifier.
+    "{}",  # illustrative empty `cleaned` map ("so `{}` means nothing
+    # needed touching") - a JSON literal, not an identifier.
+    "the archive's practice_sessions row 3 is invalid: ...",  # illustrative
+    # _refuse_row message shape, like "trainer_scope_presets row 3" above.
     "fifths",  # MusicXML's own attribute name, not one of ours
     # ".." and ".fermata-trash" are NOT listed here - both contain "." and
     # are already caught by _is_code_or_file_ref as file references; kept
@@ -392,23 +403,8 @@ _ALLOWLIST = {
 # catch it immediately if one is promoted into _ALLOWLIST before its prose
 # actually exists.
 _PENDING_ALLOWLIST: dict[str, set[str]] = {
-    "#286 (PR #290)": {
-        # #286 rewrites "Getting everything in and out (issue #58)" to add
-        # each of these. Verified against #290's actual branch text, not
-        # guessed - the same false positives #285's own review already
-        # found and fixed once (`instruments.normalise` beating
-        # table.column) do not need re-discovering there.
-        "POST",  # HTTP verb mentioned bare ("skipped the rules every
-        # `POST` applies", "never by a `POST` with a rule of its own") -
-        # same treatment as the existing bare "GET" entry above.
-        "e2",  # illustrative pitch spelling example ("a string pitch typed
-        "E2",  # `e2` stored as `E2`") - neither is a real identifier.
-        "{}",  # illustrative empty `cleaned` map ("so `{}` means nothing
-        # needed touching") - a JSON literal, not an identifier.
-        "the archive's practice_sessions row 3 is invalid: ...",  # illustrative
-        # _refuse_row message shape - same treatment as the existing
-        # "trainer_scope_presets row 3" entry above.
-    },
+    # Empty since #286 (PR #290) merged; its five entries moved into
+    # _ALLOWLIST above. Add the next not-yet-merged PR's tokens here.
 }
 
 
@@ -577,7 +573,45 @@ def _check_quoted_message(token: str, *sources: str) -> bool:
     already matches before this check ever runs."""
     if " " not in token:
         return False
-    return any(f'"{token}"' in src or f"'{token}'" in src for src in sources)
+    return any(token in _message_literals(src) for src in sources)
+
+
+_MESSAGE_LITERALS_CACHE: dict = {}
+
+
+def _message_literals(src: str) -> frozenset:
+    """Every string literal a module's source actually carries as code -
+    read from the parsed tree, never from the raw text, so a comment or a
+    docstring that QUOTES a message cannot vouch for it. The first review
+    of this rule showed exactly that hole: rewording practice.py's
+    `local_date is in the future` while its stale comment one line up still
+    quoted the old text left the doc's dead message "verified". Docstrings
+    of the module, its classes and its functions are dropped the same way
+    _string_constants_excluding_docstring drops a function's own."""
+    cached = _MESSAGE_LITERALS_CACHE.get(src)
+    if cached is not None:
+        return cached
+    tree = ast.parse(src)
+    docstring_nodes: set = set()
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.Module, ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)):
+            body = node.body
+            if (
+                body
+                and isinstance(body[0], ast.Expr)
+                and isinstance(body[0].value, ast.Constant)
+                and isinstance(body[0].value.value, str)
+            ):
+                docstring_nodes.add(id(body[0].value))
+    literals = frozenset(
+        node.value
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Constant)
+        and isinstance(node.value, str)
+        and id(node) not in docstring_nodes
+    )
+    _MESSAGE_LITERALS_CACHE[src] = literals
+    return literals
 
 
 def _real_route_paths() -> set:

--- a/server/tests/test_api_doc_prose.py
+++ b/server/tests/test_api_doc_prose.py
@@ -597,9 +597,15 @@ def _routes_named_in(section_text: str) -> list[tuple[str, str]]:
 def test_contract_overview_prose_names_only_real_routes(doc_text, openapi_schema):
     section_name = "Where the contract actually lives"
     section = _section(doc_text, section_name)
-    routes = _routes_named_in(section)
-    universe = _route_universe(openapi_schema, routes)
-    _assert_tokens_known(section_name, _backticked_tokens(section), universe, openapi_schema, (), None)
+    # `GET /docs` and `GET /openapi.json` are FastAPI's own built-in routes,
+    # not ones this app declares - they never appear in app.openapi()'s own
+    # paths, so _route_universe (which asserts every route it is given
+    # resolves) is not called with them. Both still skip the identifier
+    # check below via _is_route_mention, which only asks "does this look
+    # like a route", never "does app.openapi() actually serve it" - the
+    # right behaviour for the two routes app.openapi() is definitionally
+    # unable to describe.
+    _assert_tokens_known(section_name, _backticked_tokens(section), set(), openapi_schema, (), None)
 
 
 def test_release_expectations_prose_matches_the_response_model(doc_text, openapi_schema):

--- a/server/tests/test_api_doc_prose.py
+++ b/server/tests/test_api_doc_prose.py
@@ -358,6 +358,26 @@ _ALLOWLIST = {
     # "What to expect between releases" - not an identifier itself.
     "response_model",  # FastAPI's own decorator-kwarg name, in "Where the
     # contract actually lives" - not a response field.
+    # -----------------------------------------------------------------
+    # PENDING #286 (PR #290): these six entries name no token in THIS
+    # tree's docs/api.md today - #286 rewrites "Getting everything in and
+    # out (issue #58)" to add each of them. Kept here, ahead of that
+    # merge, as dead entries on this tree and live ones the moment #286
+    # lands, rather than left for that PR to discover the same false
+    # positives #285's own review already found and fixed once
+    # (`instruments.normalise` beating table.column). Verified against
+    # #286's actual branch text, not guessed.
+    # -----------------------------------------------------------------
+    "POST",  # HTTP verb mentioned bare ("skipped the rules every `POST`
+    # applies", "never by a `POST` with a rule of its own") - same
+    # treatment as the existing bare "GET" entry above.
+    "e2",  # illustrative pitch spelling example ("a string pitch typed
+    "E2",  # `e2` stored as `E2`") - neither is a real identifier.
+    "{}",  # illustrative empty `cleaned` map ("so `{}` means nothing
+    # needed touching") - a JSON literal, not an identifier.
+    "the archive's practice_sessions row 3 is invalid: ...",  # illustrative
+    # _refuse_row message shape - same treatment as the existing
+    # "trainer_scope_presets row 3" entry above.
 }
 
 
@@ -700,6 +720,15 @@ def test_import_export_prose_matches_the_response_model(doc_text, openapi_schema
     # where the sessions/presets routes are actually named) - checked
     # against that model directly rather than allow-listed blind.
     universe = universe | _all_field_names(openapi_schema["components"], "PracticeSessionOut")
+    # `target_fret` and `correct` are not named by this doc today - added
+    # ahead of #286, whose rewrite of this section names both directly
+    # (a "target_fret: 99" example, "an attempt's `correct` recomputed") -
+    # both are real TrainerAttemptOut/TrainerChordAttemptOut fields, checked
+    # against those models rather than allow-listed blind, so a rename
+    # would still be caught once #286 lands. A no-op on this tree today:
+    # no token in this section currently resolves to either identifier.
+    universe = universe | _all_field_names(openapi_schema["components"], "TrainerAttemptOut")
+    universe = universe | _all_field_names(openapi_schema["components"], "TrainerChordAttemptOut")
     _assert_tokens_known(
         section_name, _backticked_tokens(section), universe, openapi_schema, EXPORT_TABLE_NAMES, app_env
     )

--- a/server/tests/test_api_doc_prose.py
+++ b/server/tests/test_api_doc_prose.py
@@ -23,12 +23,23 @@ second, hand-copied description of it:
    never from a parallel list of "the fields this section should have".
    Values glued on with `: ` or `=` (`` `score_deleted: true` ``,
    `` `transcribed=yes` ``) are split first; only the identifier is checked.
-   A short, explicit, commented allow-list (_ALLOWLIST, _SUFFIX_TOKENS
+   A short, explicit, commented allow-list (_ALLOWLIST, _strip_suffix
    handling) covers backticked words that are genuinely neither a field, a
    param nor a route: SQL syntax, file names, code references containing a
-   dot, illustrative examples ("(imported 2)"). Route mentions themselves
-   are resolved against app.openapi() too - a route named in prose that no
-   longer exists fails loudly, naming the section and the route.
+   dot, illustrative examples ("(imported 2)"). A separate, structurally
+   marked _PENDING_ALLOWLIST holds entries needed only once a not-yet-merged
+   PR lands (keyed by the issue it belongs to) - checked identically to
+   _ALLOWLIST, but exempt from test_no_dead_allowlist_entries_stay_used's
+   "every entry must match a real token today" rule, so a promotion made too
+   early (before that PR's prose actually exists) is still caught. A
+   backticked fragment containing a space that matches, verbatim, a string
+   literal in api.py or practice.py's own source is read as prose QUOTING a
+   real server-raised message (`` `local_date is in the future` ``), not an
+   identifier - checked against the source directly rather than allow-listed
+   blind. Route mentions themselves are resolved against app.openapi() and,
+   for FastAPI's own built-ins app.openapi() cannot describe (`GET /docs`,
+   `GET /openapi.json`), against full_app.routes - a route named in prose
+   that no longer exists fails loudly, naming the section and the route.
 2. The one status code this module can check without touching server code:
    PUT /api/scores/{id}/transcription's documented `409` (#267) - declared
    through `responses=` in api.py, unlike most of this codebase's other
@@ -55,6 +66,7 @@ on; adding one would be a docs rewrite this bet's own no-gos rule out
 ("no docs rewrite beyond corrections the test forces").
 """
 
+import ast
 import importlib
 import re
 from pathlib import Path
@@ -67,6 +79,7 @@ from fermata.main import app as full_app
 
 DOC_PATH = Path(__file__).resolve().parents[2] / "docs" / "api.md"
 API_PY = Path(__file__).resolve().parents[2] / "server" / "fermata" / "api.py"
+PRACTICE_PY = Path(__file__).resolve().parents[2] / "server" / "fermata" / "practice.py"
 
 _BACKTICK = re.compile(r"`([^`\n]+)`")
 _FENCE = re.compile(r"```.*?```", re.S)
@@ -88,6 +101,11 @@ def openapi_schema():
 @pytest.fixture(scope="module")
 def api_py_text():
     return API_PY.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def practice_py_text():
+    return PRACTICE_PY.read_text(encoding="utf-8")
 
 
 # ---------------------------------------------------------------------------
@@ -358,27 +376,47 @@ _ALLOWLIST = {
     # "What to expect between releases" - not an identifier itself.
     "response_model",  # FastAPI's own decorator-kwarg name, in "Where the
     # contract actually lives" - not a response field.
-    # -----------------------------------------------------------------
-    # PENDING #286 (PR #290): these six entries name no token in THIS
-    # tree's docs/api.md today - #286 rewrites "Getting everything in and
-    # out (issue #58)" to add each of them. Kept here, ahead of that
-    # merge, as dead entries on this tree and live ones the moment #286
-    # lands, rather than left for that PR to discover the same false
-    # positives #285's own review already found and fixed once
-    # (`instruments.normalise` beating table.column). Verified against
-    # #286's actual branch text, not guessed.
-    # -----------------------------------------------------------------
-    "POST",  # HTTP verb mentioned bare ("skipped the rules every `POST`
-    # applies", "never by a `POST` with a rule of its own") - same
-    # treatment as the existing bare "GET" entry above.
-    "e2",  # illustrative pitch spelling example ("a string pitch typed
-    "E2",  # `e2` stored as `E2`") - neither is a real identifier.
-    "{}",  # illustrative empty `cleaned` map ("so `{}` means nothing
-    # needed touching") - a JSON literal, not an identifier.
-    "the archive's practice_sessions row 3 is invalid: ...",  # illustrative
-    # _refuse_row message shape - same treatment as the existing
-    # "trainer_scope_presets row 3" entry above.
 }
+
+# Entries that name no token in THIS tree's docs/api.md today, keyed by the
+# issue whose not-yet-merged PR adds the token they cover - a STRUCTURAL
+# marker (a separate dict, not a comment) so test_no_dead_allowlist_entries
+# below can exempt exactly these from its "every _ALLOWLIST entry must
+# appear somewhere in docs/api.md" rule, rather than trusting a comment to
+# say so. Once the PR named by a key actually merges, its entries stop being
+# no-ops - _assert_tokens_known treats every _PENDING_ALLOWLIST value exactly
+# like _ALLOWLIST, so nothing breaks the moment they go live - but they also
+# become checkable by test_no_dead_allowlist_entries the moment someone
+# moves them into _ALLOWLIST proper; leaving them here after that merge is
+# harmless (they still work, unioned in below) but the dead-entry test will
+# catch it immediately if one is promoted into _ALLOWLIST before its prose
+# actually exists.
+_PENDING_ALLOWLIST: dict[str, set[str]] = {
+    "#286 (PR #290)": {
+        # #286 rewrites "Getting everything in and out (issue #58)" to add
+        # each of these. Verified against #290's actual branch text, not
+        # guessed - the same false positives #285's own review already
+        # found and fixed once (`instruments.normalise` beating
+        # table.column) do not need re-discovering there.
+        "POST",  # HTTP verb mentioned bare ("skipped the rules every
+        # `POST` applies", "never by a `POST` with a rule of its own") -
+        # same treatment as the existing bare "GET" entry above.
+        "e2",  # illustrative pitch spelling example ("a string pitch typed
+        "E2",  # `e2` stored as `E2`") - neither is a real identifier.
+        "{}",  # illustrative empty `cleaned` map ("so `{}` means nothing
+        # needed touching") - a JSON literal, not an identifier.
+        "the archive's practice_sessions row 3 is invalid: ...",  # illustrative
+        # _refuse_row message shape - same treatment as the existing
+        # "trainer_scope_presets row 3" entry above.
+    },
+}
+
+
+def _pending_allowlist_tokens() -> set:
+    tokens: set = set()
+    for issue_tokens in _PENDING_ALLOWLIST.values():
+        tokens |= issue_tokens
+    return tokens
 
 
 def test_redundant_allowlist_entries_are_already_classified():
@@ -396,6 +434,29 @@ def test_redundant_allowlist_entries_are_already_classified():
             f"{token!r} is no longer classified as a code/file reference by "
             "_is_code_or_file_ref - it must go back into _ALLOWLIST"
         )
+
+
+def test_no_dead_allowlist_entries(doc_text):
+    """Every _ALLOWLIST entry earns its place by matching some backticked
+    token that actually appears in docs/api.md today - an entry that stops
+    matching anything (the prose it covered was reworded or deleted, or the
+    entry was copy-pasted for a token that never existed) is dead weight
+    nobody would ever notice was safe to delete, so this fails loudly the
+    moment that happens instead. _PENDING_ALLOWLIST entries are exempt by
+    construction - a STRUCTURAL marker, not a comment this test would have
+    to trust - because they are deliberately not expected to match anything
+    on THIS tree until the PR that introduces their tokens lands; once that
+    PR merges and its entries are promoted into _ALLOWLIST proper, this same
+    test starts covering them, which is what makes the pending set
+    self-cleaning rather than a place allow-list entries go to be
+    forgotten."""
+    all_tokens = set(_backticked_tokens(doc_text))
+    dead = sorted(token for token in _ALLOWLIST if token not in all_tokens)
+    assert not dead, (
+        f"_ALLOWLIST entries {dead} match no backticked token anywhere in "
+        "docs/api.md - remove them, or, if they cover a not-yet-merged PR's "
+        "prose, move them into _PENDING_ALLOWLIST instead"
+    )
 
 
 def _is_route_mention(token: str) -> bool:
@@ -499,6 +560,69 @@ def _check_table_column(token: str, export_tables: tuple, app_env) -> bool:
     return True
 
 
+def _check_quoted_message(token: str, *sources: str) -> bool:
+    """A backticked token containing a space, that appears verbatim as a
+    quoted Python string literal in one of `sources`, is prose QUOTING a
+    real server-raised message (`` `local_date is in the future` `` quotes
+    practice.py's own `raise ValueError("local_date is in the future")`)
+    rather than naming a field, a param or a route - checked directly
+    against the source that raises it, a general rule rather than a
+    one-off allow-list entry, so a reworded message fails loudly here
+    instead of being silently "documented" by an entry that never actually
+    checked anything. A single identifier never contains a space, so this
+    only ever fires for backticked prose fragments; returns False (not
+    handled) for anything else - including an _ALLOWLIST entry that merely
+    happens to contain a space but names no real message
+    (`YYYY-MM-DD HH:MM:SS.mmm`, `{from, to}`), which _ALLOWLIST itself
+    already matches before this check ever runs."""
+    if " " not in token:
+        return False
+    return any(f'"{token}"' in src or f"'{token}'" in src for src in sources)
+
+
+def _real_route_paths() -> set:
+    """Every (method, path) pair the running app actually serves, read
+    straight from `full_app.routes` - not just the ones `app.openapi()`
+    describes. `GET /docs` and `GET /openapi.json` are FastAPI's own
+    built-in routes: real endpoints a browser can hit, but never entries in
+    app.openapi()'s own `paths` (which only ever describes the API this
+    codebase declares), so a route mention naming one of them has nothing
+    to resolve against there. Reading `full_app.routes` directly closes
+    that gap without an allow-list: a route named in prose - built-in or
+    declared - either matches a real Starlette route here or it does not."""
+    paths: set = set()
+    for route in full_app.routes:
+        path = getattr(route, "path", None)
+        methods = getattr(route, "methods", None)
+        if not path or not methods:
+            continue
+        for method in methods:
+            paths.add((method, path))
+    return paths
+
+
+def _route_mention_is_real(token: str, schema: dict) -> bool:
+    """A `GET /some/path`-shaped token is real when it structurally matches
+    (see `_path_matches`) a path FastAPI actually serves for that method -
+    either one `app.openapi()` describes, or one of FastAPI's own built-ins
+    (`_real_route_paths`) that `app.openapi()` has no way to describe.
+    Checked as a boolean here (never asserting directly) so a misspelled
+    route - `GET /opnapi.json`, `GET /dcos` - can be reported as an unknown
+    identifier by the caller, naming the section, rather than raising from
+    two levels down."""
+    m = _ROUTE.match(token)
+    if not m:
+        return False
+    method, path = m.group(1), m.group(2)
+    for real_path, ops in schema.get("paths", {}).items():
+        if method.lower() in ops and _path_matches(path, real_path):
+            return True
+    for real_method, real_path in _real_route_paths():
+        if real_method == method and _path_matches(path, real_path):
+            return True
+    return False
+
+
 def _check_model_dot_field(token: str, components: dict) -> bool:
     """`ImportOut.trainer_scope_presets_renamed` - a Class.field reference -
     is real when `field` is an actual property of the OpenAPI component
@@ -524,10 +648,19 @@ def _assert_tokens_known(
     schema: dict,
     export_tables: tuple,
     app_env,
+    message_sources: tuple = (),
 ):
     unknown = []
+    pending = _pending_allowlist_tokens()
     for raw in tokens:
-        if raw in _ALLOWLIST or _is_route_mention(raw):
+        if raw in _ALLOWLIST or raw in pending:
+            continue
+        if _is_route_mention(raw):
+            assert _route_mention_is_real(raw, schema), (
+                f"docs/api.md, section {section_name!r}: route {raw!r} does not "
+                "match any real route in app.openapi() or on the running app "
+                "(full_app.routes) - misspelled, or removed?"
+            )
             continue
         # Module-function reference checked BEFORE table.column: a module
         # that shares its name with an export table (`instruments` is both)
@@ -539,12 +672,14 @@ def _assert_tokens_known(
             continue
         if _check_model_dot_field(raw, schema["components"]):
             continue
+        if _check_quoted_message(raw, *message_sources):
+            continue
         if _is_code_or_file_ref(raw):
             continue
         if _STATUS_CODE.match(raw):
             continue  # checked separately, by name, below
         identifier = _strip_suffix(raw)
-        if identifier in universe or identifier in _ALLOWLIST:
+        if identifier in universe or identifier in _ALLOWLIST or identifier in pending:
             continue
         unknown.append(raw)
     assert not unknown, (
@@ -614,17 +749,21 @@ def _routes_named_in(section_text: str) -> list[tuple[str, str]]:
 # ---------------------------------------------------------------------------
 
 
-def test_contract_overview_prose_names_only_real_routes(doc_text, openapi_schema):
+def test_contract_overview_prose_routes_and_terms_resolve_against_the_real_app(
+    doc_text, openapi_schema
+):
+    """`GET /docs` and `GET /openapi.json` are FastAPI's own built-in routes,
+    not ones this app declares - they never appear in app.openapi()'s own
+    `paths`, so this section is not given a `_route_universe` built from
+    them the way other sections are. Both are still resolved for real,
+    though: `_assert_tokens_known`'s `_is_route_mention` branch calls
+    `_route_mention_is_real`, which falls back to `full_app.routes` - the
+    Starlette route table FastAPI itself serves from - for exactly the
+    routes app.openapi() has no way to describe. A misspelled route
+    (`GET /opnapi.json`, `GET /dcos`) therefore still fails loudly here,
+    which passing `set()` as the universe alone would not have caught."""
     section_name = "Where the contract actually lives"
     section = _section(doc_text, section_name)
-    # `GET /docs` and `GET /openapi.json` are FastAPI's own built-in routes,
-    # not ones this app declares - they never appear in app.openapi()'s own
-    # paths, so _route_universe (which asserts every route it is given
-    # resolves) is not called with them. Both still skip the identifier
-    # check below via _is_route_mention, which only asks "does this look
-    # like a route", never "does app.openapi() actually serve it" - the
-    # right behaviour for the two routes app.openapi() is definitionally
-    # unable to describe.
     _assert_tokens_known(section_name, _backticked_tokens(section), set(), openapi_schema, (), None)
 
 
@@ -702,7 +841,9 @@ def test_batch_transcription_prose_matches_the_response_model(doc_text, openapi_
     _assert_tokens_known(section_name, _backticked_tokens(section), universe, openapi_schema, (), None)
 
 
-def test_import_export_prose_matches_the_response_model(doc_text, openapi_schema, app_env):
+def test_import_export_prose_matches_the_response_model(
+    doc_text, openapi_schema, app_env, api_py_text, practice_py_text
+):
     section_name = "Getting everything in and out (issue #58)"
     section = _section(doc_text, section_name)
     # `SCHEMA_VERSION` names db.SCHEMA_VERSION, imported at module level
@@ -729,8 +870,18 @@ def test_import_export_prose_matches_the_response_model(doc_text, openapi_schema
     # no token in this section currently resolves to either identifier.
     universe = universe | _all_field_names(openapi_schema["components"], "TrainerAttemptOut")
     universe = universe | _all_field_names(openapi_schema["components"], "TrainerChordAttemptOut")
+    # `local_date is in the future` (#290's f3fadbc) quotes practice.py's own
+    # `raise ValueError("local_date is in the future")` verbatim - a quoted
+    # server message, not an identifier - checked via _check_quoted_message
+    # (see its own docstring) rather than a one-off allow-list entry.
     _assert_tokens_known(
-        section_name, _backticked_tokens(section), universe, openapi_schema, EXPORT_TABLE_NAMES, app_env
+        section_name,
+        _backticked_tokens(section),
+        universe,
+        openapi_schema,
+        EXPORT_TABLE_NAMES,
+        app_env,
+        message_sources=(api_py_text, practice_py_text),
     )
 
 
@@ -900,7 +1051,55 @@ def test_archive_contents_names_every_export_table(doc_text):
 # trainer_scope_presets_renamed as list[dict[str, str]], so OpenAPI has no
 # named properties to check it against) - pinned instead against the
 # literal strings api._derive_preset_renames actually writes.
+#
+# Checked against the CODE, docstring excluded: a hand-picked substring
+# search over the raw function source (the shape this module's own first
+# review left behind) is satisfied by a docstring merely DESCRIBING a
+# literal just as readily as by the code that actually emits it - #285's
+# second review found exactly that gap by renaming the "cleaned" literal to
+# "tidied" in code alone and watching the test stay green, because the
+# docstring above it still said "cleaned". _string_constants_excluding_docstring
+# walks the function's AST and excludes only its own docstring node, so the
+# check is blind to prose ABOUT the code and sees only the code itself.
 # ---------------------------------------------------------------------------
+
+
+def _function_node(module_text: str, func_name: str):
+    """The ast.FunctionDef for the first top-level (or nested) function
+    named `func_name` in `module_text`, or None. Reads the real syntax tree
+    rather than a regex slice ending at the next `\\ndef ` - a regex slice
+    can straddle a decorator boundary (see _refuse_stale_edit, immediately
+    followed by `@router.put(...)` before the next `def`) and hand back text
+    that is not valid Python on its own, which ast.parse would then refuse
+    to parse at all."""
+    tree = ast.parse(module_text)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == func_name:
+            return node
+    return None
+
+
+def _string_constants_excluding_docstring(func_node) -> set:
+    """Every string literal `ast.Constant` reachable inside `func_node`,
+    EXCLUDING its own docstring (the first statement, when it is itself a
+    bare string expression) - so a check phrased as "does the function's
+    source contain this string" cannot be satisfied by prose ABOUT the code
+    instead of the code that actually emits it."""
+    docstring_node = None
+    if (
+        func_node.body
+        and isinstance(func_node.body[0], ast.Expr)
+        and isinstance(func_node.body[0].value, ast.Constant)
+        and isinstance(func_node.body[0].value.value, str)
+    ):
+        docstring_node = func_node.body[0].value
+    literals: set = set()
+    for node in ast.walk(func_node):
+        if node is docstring_node:
+            continue
+        if isinstance(node, ast.Constant) and isinstance(node.value, str):
+            literals.add(node.value)
+    return literals
 
 
 def test_import_renames_reason_vocabulary_matches_the_source(doc_text, api_py_text):
@@ -911,15 +1110,14 @@ def test_import_renames_reason_vocabulary_matches_the_source(doc_text, api_py_te
         assert re.search(rf'`reason:\s*"{word}"`', section), (
             f"docs/api.md's import section no longer documents reason: {word!r}"
         )
-    func_match = re.search(
-        r"def _derive_preset_renames\(.*?(?=\ndef |\Z)", api_py_text, re.S
-    )
-    assert func_match, "api._derive_preset_renames not found - renamed or moved?"
-    func_src = func_match.group(0)
-    for literal in ('"reason"', '"cleaned"', '"collision"', '"from"', '"to"'):
-        assert literal in func_src, (
-            f"docs/api.md documents the import-rename key/value {literal}, but "
-            "api._derive_preset_renames's source no longer contains it"
+    func_node = _function_node(api_py_text, "_derive_preset_renames")
+    assert func_node, "api._derive_preset_renames not found - renamed or moved?"
+    literals = _string_constants_excluding_docstring(func_node)
+    for literal in ("reason", "cleaned", "collision", "from", "to"):
+        assert literal in literals, (
+            f"docs/api.md documents the import-rename key/value {literal!r}, but "
+            "api._derive_preset_renames's own CODE (its docstring does not "
+            "count) no longer contains it"
         )
 
 
@@ -935,11 +1133,12 @@ def test_stale_transcription_example_matches_the_source(doc_text, api_py_text):
     for key in ('"error"', '"message"', '"updated_at"', '"source"', '"stale_transcription"'):
         assert key in example, f"docs/api.md's #267 JSON example no longer has {key}"
 
-    func_match = re.search(r"def _refuse_stale_edit\(.*?(?=\ndef |\Z)", api_py_text, re.S)
-    assert func_match, "api._refuse_stale_edit not found - renamed or moved?"
-    func_src = func_match.group(0)
-    for key in ('"error"', '"message"', '"updated_at"', '"source"', '"stale_transcription"'):
-        assert key in func_src, (
-            f"docs/api.md's #267 JSON example names {key}, but "
-            "api._refuse_stale_edit's source no longer contains it"
+    func_node = _function_node(api_py_text, "_refuse_stale_edit")
+    assert func_node, "api._refuse_stale_edit not found - renamed or moved?"
+    literals = _string_constants_excluding_docstring(func_node)
+    for key in ("error", "message", "updated_at", "source", "stale_transcription"):
+        assert key in literals, (
+            f"docs/api.md's #267 JSON example names {key!r}, but "
+            "api._refuse_stale_edit's own CODE (its docstring does not count) "
+            "no longer contains it"
         )

--- a/server/tests/test_api_doc_prose.py
+++ b/server/tests/test_api_doc_prose.py
@@ -34,11 +34,12 @@ second, hand-copied description of it:
    through `responses=` in api.py, unlike most of this codebase's other
    409s, which are raised via bare HTTPException and were never added to
    `responses=` (a real gap, but a code change, out of scope for a
-   docs-and-tests-only bet - see the module docstring's own note by
-   STATUS_CODE_ANCHORS). Also checks that the two routes named beside `422`
-   for issue #55's batch selection and #58's import each still exist and
-   still carry a 422 (FastAPI's own default for any route with a request
-   body, so this mostly guards against the route disappearing outright).
+   docs-and-tests-only bet). Also checks that the route named beside `422`
+   for issue #55's batch selection still exists and still carries a 422
+   (FastAPI's own default for any route with a request body, so this mostly
+   guards against the route disappearing outright). Issue #58's import
+   section names no status code in prose today, so there is nothing for
+   this module to pin there.
 3. The MCP tool-count sentence agrees with len(mcp_tools.READ_TOOLS).
 4. The archive-contents sentence names every server/fermata/api.py
    EXPORT_TABLE_NAMES entry, directly or as a documented group.
@@ -54,6 +55,7 @@ on; adding one would be a docs rewrite this bet's own no-gos rule out
 ("no docs rewrite beyond corrections the test forces").
 """
 
+import importlib
 import re
 from pathlib import Path
 
@@ -125,6 +127,8 @@ def _section(doc_text: str, heading_text: str) -> str:
 # heading is reported once, clearly, rather than as a pytest.fixture error
 # buried inside whichever test happened to need it first.
 _ANCHORED_HEADINGS = [
+    "Where the contract actually lives",
+    "What to expect between releases",
     "The endpoints that write to your files",
     "What a deleted score may still be asked for",
     "Two people editing the same score (issue #267)",
@@ -144,6 +148,24 @@ def test_every_anchored_heading_is_present(doc_text):
         except AssertionError as exc:
             missing.append(str(exc))
     assert not missing, "\n".join(missing)
+
+
+def test_every_top_level_heading_is_anchored(doc_text):
+    """A `##` heading born in docs/api.md after this test was written must
+    either join _ANCHORED_HEADINGS (and, ideally, get its own prose-matching
+    test) or be refused here by name - so a new section cannot silently ship
+    unchecked the way "Where the contract actually lives" and "What to
+    expect between releases" originally did (issue #285's review). `###`
+    subsections are not required here: "What a deleted score may still be
+    asked for" is one, already anchored explicitly above, and this check
+    only guards the top level a reader skims."""
+    top_level = {text for _, level, text in _headings(doc_text) if level == 2}
+    unanchored = top_level - set(_ANCHORED_HEADINGS)
+    assert not unanchored, (
+        f"docs/api.md has `##` heading(s) {sorted(unanchored)} that "
+        "_ANCHORED_HEADINGS does not cover - add each to that list (and, "
+        "if it names checkable fields, params or codes, a test for it)"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -316,14 +338,44 @@ _ALLOWLIST = {
     "STRASSE",  # collation example - a proper noun, not an identifier
     "trainer_scope_presets row 3",  # illustrative row reference in an error message
     "fifths",  # MusicXML's own attribute name, not one of ours
-    "..",
-    ".fermata-trash",
-    "YYYY-MM-DD HH:MM:SS.mmm",
+    # ".." and ".fermata-trash" are NOT listed here - both contain "." and
+    # are already caught by _is_code_or_file_ref as file references; kept
+    # out to prove that check actually covers them (see
+    # test_redundant_allowlist_entries_are_already_classified below).
+    "YYYY-MM-DD HH:MM:SS.mmm",  # contains a space, so _is_code_or_file_ref's
+    # own space guard would NOT catch this one - it has to stay listed.
     "Straße",  # collation example (a proper noun), paired with STRASSE above
     "SCHEMA_VERSION",  # db.SCHEMA_VERSION - imported at module level below,
     # so an import error (renamed constant) fails this whole module loudly
     # rather than only this one check quietly passing something misspelled.
+    "TranscriptionOut",  # bare model-name mention ("...had to be added to
+    # that model...`TranscriptionOut`") in "What to expect between
+    # releases" - the fields the sentence actually claims (`bars_defective`,
+    # `time_signature_source`) are checked against that same model's real
+    # properties by test_release_expectations_prose_matches_the_response_model
+    # below, which would fail if the model itself were renamed away.
+    "'local'",  # illustrative literal value of the `owner` field, in
+    # "What to expect between releases" - not an identifier itself.
+    "response_model",  # FastAPI's own decorator-kwarg name, in "Where the
+    # contract actually lives" - not a response field.
 }
+
+
+def test_redundant_allowlist_entries_are_already_classified():
+    """`..` and `.fermata-trash` used to sit in _ALLOWLIST alongside genuinely
+    unclassifiable tokens, but both contain a "." and so are already caught
+    by _is_code_or_file_ref - proven here directly, rather than trusted,
+    so a future change to that function's shape cannot silently make this
+    comment wrong."""
+    for token in ("..", ".fermata-trash"):
+        assert token not in _ALLOWLIST, (
+            f"{token!r} is back in _ALLOWLIST, but _is_code_or_file_ref "
+            "already classifies it - remove the redundant entry"
+        )
+        assert _is_code_or_file_ref(token), (
+            f"{token!r} is no longer classified as a code/file reference by "
+            "_is_code_or_file_ref - it must go back into _ALLOWLIST"
+        )
 
 
 def _is_route_mention(token: str) -> bool:
@@ -334,10 +386,24 @@ def _is_code_or_file_ref(token: str) -> bool:
     """A token containing '.', '(' or a '/' with no spaces reads as a code
     or file reference (`scanner.hash_file`, `fermata/db.py`,
     `casefold()`, `manifest.json`) rather than an API field name - real API
-    field names in this document are always bare snake_case words. The two
-    deliberate exceptions this module carves back out - `table.column` and
-    `Model.field` - are handled by _check_table_column and
-    _check_model_dot_field before this classifier ever runs."""
+    field names in this document are always bare snake_case words. The three
+    deliberate exceptions this module carves back out - `table.column`,
+    `Model.field` and `module.function` - are handled by
+    _check_table_column, _check_model_dot_field and _check_module_function
+    before this classifier ever runs, so a module that happens to share its
+    name with an export table (`instruments` is both) is read as the code
+    reference it is rather than forced through the table.column check.
+
+    A lowercase dotted mention of a NESTED response field, like
+    `score.deleted_at` (a setlist member's own `score` sub-object, not a
+    component named `score`), also matches this shape and is treated as a
+    plain code reference rather than independently verified - a narrower,
+    documented gap than table.column/Model.field/module.function, since
+    `score` names neither a table, a component nor a fermata submodule. Left
+    unclosed because `deleted_at` itself is already pinned as a real
+    ScoreOut field by the sections that name DELETE /api/scores/{id} and
+    POST /api/trash/{score_id}/restore directly, so a rename of that field
+    would still fail loudly there - just not by this token."""
     if " " in token:
         return False
     if "(" in token or "." in token or "/" in token:
@@ -346,6 +412,32 @@ def _is_code_or_file_ref(token: str) -> bool:
     # convention for "private, internal" - never an API field name, which
     # this codebase always spells without one.
     return token.startswith("_")
+
+
+def _check_module_function(token: str) -> bool:
+    """`instruments.normalise` - a module.function reference - is real when
+    `function` is an attribute `fermata.<module>` actually defines. Checked
+    BEFORE _check_table_column: `instruments` is both an EXPORT_TABLE_NAMES
+    entry and a real module (`fermata/instruments.py`), and without this
+    check running first, `instruments.normalise` would be forced through the
+    table.column check and fail there, since `normalise` is a function, not
+    a column of the `instruments` table. Returns False (not handled, so the
+    caller falls through to the next check) for anything not shaped
+    `module.attr` with `module` a real fermata submodule, INCLUDING a
+    `module.attr` pair where the module exists but has no such attribute -
+    that case is left for a later check (table.column, here, for the
+    `instruments` collision this module actually has to handle) to give its
+    own, more specific failure."""
+    if "." not in token or " " in token:
+        return False
+    module_name, _, attr = token.partition(".")
+    if "." in attr:
+        return False  # e.g. fastapi.routing.run_endpoint_function - not ours
+    try:
+        module = importlib.import_module(f"fermata.{module_name}")
+    except ImportError:
+        return False
+    return hasattr(module, attr)
 
 
 def _strip_suffix(token: str) -> str:
@@ -417,6 +509,12 @@ def _assert_tokens_known(
     for raw in tokens:
         if raw in _ALLOWLIST or _is_route_mention(raw):
             continue
+        # Module-function reference checked BEFORE table.column: a module
+        # that shares its name with an export table (`instruments` is both)
+        # must be read as the code reference it is, not forced into a
+        # table.column check that fails because a function is not a column.
+        if _check_module_function(raw):
+            continue
         if _check_table_column(raw, export_tables, app_env):
             continue
         if _check_model_dot_field(raw, schema["components"]):
@@ -435,6 +533,38 @@ def _assert_tokens_known(
         "request fields or query parameters - misspelled, renamed in code, "
         "or missing from this test's allow-list?"
     )
+
+
+def test_module_function_reference_beats_table_column_check(openapi_schema, app_env):
+    """`instruments` is both an EXPORT_TABLE_NAMES entry and a real module
+    (`fermata/instruments.py`, which defines `normalise`) - the exact shape
+    #290's docs/api.md adds (`instruments.normalise`). Without
+    _check_module_function running before _check_table_column, this token
+    would be forced through the table.column check and fail, since
+    `normalise` is a function, not a column of the `instruments` table.
+    `instruments.nonexistent` must still fail - real module, no such
+    attribute - falling through to the table.column check, which correctly
+    reports `instruments` has no such column either."""
+    from fermata.api import EXPORT_TABLE_NAMES
+
+    assert "instruments" in EXPORT_TABLE_NAMES
+    _assert_tokens_known(
+        "synthetic: module-function beats table-column",
+        ["instruments.normalise"],
+        set(),
+        openapi_schema,
+        EXPORT_TABLE_NAMES,
+        app_env,
+    )
+    with pytest.raises(AssertionError):
+        _assert_tokens_known(
+            "synthetic: module-function beats table-column",
+            ["instruments.nonexistent"],
+            set(),
+            openapi_schema,
+            EXPORT_TABLE_NAMES,
+            app_env,
+        )
 
 
 # docs/api.md sometimes names a route without its method or `/api` prefix,
@@ -462,6 +592,31 @@ def _routes_named_in(section_text: str) -> list[tuple[str, str]]:
 # ---------------------------------------------------------------------------
 # 1. Backticked field/param names, per section.
 # ---------------------------------------------------------------------------
+
+
+def test_contract_overview_prose_names_only_real_routes(doc_text, openapi_schema):
+    section_name = "Where the contract actually lives"
+    section = _section(doc_text, section_name)
+    routes = _routes_named_in(section)
+    universe = _route_universe(openapi_schema, routes)
+    _assert_tokens_known(section_name, _backticked_tokens(section), universe, openapi_schema, (), None)
+
+
+def test_release_expectations_prose_matches_the_response_model(doc_text, openapi_schema):
+    section_name = "What to expect between releases"
+    section = _section(doc_text, section_name)
+    routes = _routes_named_in(section)
+    universe = _route_universe(openapi_schema, routes)
+    # `bars_defective` / `time_signature_source` are named as TranscriptionOut
+    # fields directly in prose ("...had to be added to that model...
+    # `TranscriptionOut`"), not via a route named by backtick in this section.
+    universe = universe | _all_field_names(openapi_schema["components"], "TranscriptionOut")
+    # `sessions_inferred` (a goal's, when not countable) and `owner` (exists
+    # "in several tables") are both real GoalOut fields - `owner` directly,
+    # `sessions_inferred` nested under GoalOut.progress (GoalProgressOut) -
+    # checked against that one model rather than allow-listed blind.
+    universe = universe | _all_field_names(openapi_schema["components"], "GoalOut")
+    _assert_tokens_known(section_name, _backticked_tokens(section), universe, openapi_schema, (), None)
 
 
 def test_write_endpoints_prose_matches_the_response_models(doc_text, openapi_schema):


### PR DESCRIPTION
## Premise

Re-derived first: `server/tests/test_api_docs.py` never opens `docs/api.md` -
grepped for `open(`, `read_text`, `api.md` and found exactly one hit, a
docstring line at ~:662 naming a section by name, never reading the file.
Confirmed by copying `docs/api.md` to a scratch location, deleting the whole
"Two people editing the same score" section from the copy, swapping it in for
the real file, and running `test_api_docs.py`: 20/20 still passed. Verdict:
**valid** - the file is restored, nothing in the repo changed by that check.

## What the new test pins

`server/tests/test_api_doc_prose.py`, anchored by section heading and by
identifier - never by line number:

| Claim | How it's checked |
| --- | --- |
| Backticked field/param names in a section's prose | extracted from the doc text itself, checked against that section's own routes' response fields, request fields and query parameters, resolved from `app.openapi()` (recursively through nested `$ref`s) |
| `trainer_scope_presets.name`-style `table.column` mentions | `PRAGMA table_info` on a fresh db, the same discipline `test_practice_data_doc.py` (#259) uses |
| `ImportOut.trainer_scope_presets_renamed`-style `Class.field` mentions | the named OpenAPI component's own properties |
| `instruments.normalise`-style `module.function` mentions | `importlib`/`getattr` against `fermata.<module>`, checked BEFORE the table.column check (see "Review fixes" below) |
| A backticked prose fragment containing a space (`` `local_date is in the future` ``) | matched verbatim against a string literal in `api.py`/`practice.py`'s own source - a quoted server message, not an identifier (see "Second review" below) |
| PUT transcription's `409` (#267) | `responses` on the real route |
| The import-renames vocabulary (`reason: "cleaned"`/`"collision"`, `from`, `to`) | `api._derive_preset_renames`'s own literal strings, docstring excluded (free-form `dict[str, str]` on the wire, so OpenAPI has no named properties for it; see "Second review" below) |
| The `#267` JSON example (`stale_transcription`, its four keys) | `api._refuse_stale_edit`'s own literal dict, docstring excluded |
| The MCP tool-count sentence ("fourteen") | `len(mcp_tools.READ_TOOLS)` |
| The archive-contents sentence | every `api.EXPORT_TABLE_NAMES` entry, named directly or as a documented group |
| `GET /docs` / `GET /openapi.json` route mentions | resolved against `full_app.routes` (FastAPI's own built-ins, absent from `app.openapi()`) - see "Second review" below |

Every `##` heading in `docs/api.md` is now anchored and checked - including
the two overview sections ("Where the contract actually lives", "What to
expect between releases") a review found unchecked - and a completeness
test (`test_every_top_level_heading_is_anchored`) fails loudly if a future
`##` heading is added without joining that list.

A short, explicit, commented `_ALLOWLIST` covers backticked words that are
genuinely neither a field, a param nor a route (SQL syntax, file/module
references, illustrative examples like `(imported 2)`). Entries needed only
once a not-yet-merged PR lands live in a separate, structural
`_PENDING_ALLOWLIST` keyed by issue (see "Second review" below).

## Corrections forced

None. Every section checked was already accurate - the doc's prose about
field names, the `409`, the tool count and the archive's contents all agree
with the code today. `docs/api.md` is unchanged in this PR.

## Review fixes

An adversarial review of this PR found five issues, all addressed:

1. **False positive on `module.function` references - fixed for the one
   collision this module hits, not verification of `module.function`
   mentions in general.** `instruments` is both an `EXPORT_TABLE_NAMES`
   entry and a real module (`fermata/instruments.py`, defining `normalise`)
   - `instruments.normalise` was forced through the table.column check and
   failed, since `normalise` is a function, not a column. Fixed by adding
   `_check_module_function`, run before `_check_table_column`: it classifies
   a token as real ONLY when `importlib.import_module("fermata.<module>")`
   succeeds AND the attribute exists on it (`hasattr`); a `module.attr` pair
   naming a real module with no such attribute - or naming no real module at
   all - returns False (not handled, per the helper's own docstring) and
   falls through unchanged to the next check (`_check_table_column`, then
   `_is_code_or_file_ref`, which accepts any dotted token as an unverified
   code reference). So a dotted mention is actually resolved only when it
   happens to collide with an export table name the way `instruments` does;
   every other `module.function`-shaped token in the doc is still an
   unverified code reference, exactly as before this fix. Covered by a new
   test, `test_module_function_reference_beats_table_column_check`.
2. **Unsupported docstring claim.** The module docstring claimed a checked
   `422` beside issue #58's import section; that section names no status
   code and no such test exists. Corrected the docstring to describe only
   the one route (#55's batch selection) this module actually checks, and
   removed a second unsupported reference to a `STATUS_CODE_ANCHORS` name
   that does not exist in this module.
3. **Concurrency with #286 (PR #290).** Verified by fetching #290's branch
   and running this module's tests against a throwaway `git merge
   --no-commit --no-ff` of it onto this branch. #290 does rewrite
   "Getting everything in and out (issue #58)" and `api.py` substantially.
   On that merged tree, one test failed before this fix:
   `test_import_export_prose_matches_the_response_model`, on eight
   unknown tokens (`POST`, `target_fret: 99`, an illustrative
   `_refuse_row` message, `{}`, `e2`, `E2`, `correct` x2) that #290's
   rewrite introduces. Fixed on this branch, ahead of that merge:
   `target_fret` and `correct` are added to that test's universe as real
   `TrainerAttemptOut`/`TrainerChordAttemptOut` fields (so a rename would
   still be caught); the bare `POST`, the `e2`/`E2` spelling example, the
   `{}` literal and the illustrative row message are allow-listed,
   pending #286 - dead entries on this tree today, live the moment #290
   merges (a second review tightened this mechanism further - see below).
   This PR's own `docs/api.md` is unchanged either way.
4. **Two `##` sections were unanchored.** "Where the contract actually
   lives" and "What to expect between releases" named real field names
   (`bars_defective`, `time_signature_source`, `sessions_inferred`,
   `owner`) that nothing checked. Both are now anchored and have their own
   prose-matching tests; a completeness test
   (`test_every_top_level_heading_is_anchored`) also fails if a future
   `##` heading ships without joining the anchor list.
5. **Nits.** Dropped two `_ALLOWLIST` entries (`..`, `.fermata-trash`)
   already covered by `_is_code_or_file_ref`, and added a test proving it
   (`test_redundant_allowlist_entries_are_already_classified`).
   `score.deleted_at` falling through to a plain code reference (rather
   than being verified against `ScoreOut`) is documented as a known,
   narrow gap in `_is_code_or_file_ref`'s own docstring, not closed - the
   field itself is independently pinned elsewhere in this module.

## Second review

A second adversarial review, run after #290's branch was inspected directly
(rather than only diffed), found four more issues, all addressed:

1. **Blocking: the merged tree (main + #290 + this branch) failed.** #290's
   own commit f3fadbc adds a backticked quote of a real refusal message,
   `` `local_date is in the future` `` (docs/api.md:467), to the #58
   section - a token this module had no way to classify. Fixed with a
   general rule rather than another one-off allow-list entry:
   `_check_quoted_message` recognises any backticked fragment containing a
   space that matches, verbatim, a string literal in `api.py` or
   `practice.py`'s own source, as prose quoting a real server message. Only
   the #58 test passes source text in (`api_py_text`, `practice_py_text`
   fixtures); the rule itself is general, so it would also catch a future
   quoted message elsewhere without a new allow-list entry. Re-ran on the
   merged tree: 20/20 passed, 0 failed.
2. **`test_contract_overview_prose_names_only_real_routes` never resolved
   its own routes.** It passed `set()` as the universe and skipped every
   route-shaped token via `_is_route_mention`, which only asks "does this
   look like a route" - never "is it real". `GET /opnapi.json` or
   `GET /dcos` would have stayed green while a genuine field typo
   (`response_model` -> `respons_model`) went red. Fixed by making
   `_is_route_mention` matches in `_assert_tokens_known` actually resolve:
   `_route_mention_is_real` checks `app.openapi()`'s paths first, then
   `full_app.routes` (Starlette's own route table) for FastAPI's built-ins
   app.openapi() cannot describe (`GET /docs`, `GET /openapi.json`) - a
   misspelled route in either category now fails loudly, naming the
   section. Renamed the test to
   `test_contract_overview_prose_routes_and_terms_resolve_against_the_real_app`
   to say what it now actually checks.
3. **The import-renames and stale-edit vocabulary checks were satisfied by
   docstrings, not code.** Both read the function's raw source text and did
   a substring search - changing the `"cleaned"` code literal to `"tidied"`
   while leaving the docstring's own mention of `"cleaned"` untouched stayed
   green, because the search saw the docstring too. Fixed with
   `_function_node` (reads the real `ast.FunctionDef`, not a regex slice
   that can straddle a decorator boundary and produce unparseable text - see
   `_refuse_stale_edit`, immediately followed by `@router.put(...)`) and
   `_string_constants_excluding_docstring` (walks the AST, excluding only
   the function's own docstring node). Applied to both
   `test_import_renames_reason_vocabulary_matches_the_source` and
   `test_stale_transcription_example_matches_the_source`. Proved: changed
   the `"reason": "cleaned"` code literal in `api.py` to `"tidied"` (leaving
   every docstring mention alone) - red; reverted - green.
4. **No test caught a dead `_ALLOWLIST` entry.** Fixed by moving the six
   entries that name no token on this tree today - needed only once #286
   (PR #290) merges - out of a comment and into a separate, structural
   `_PENDING_ALLOWLIST` dict keyed by issue, checked identically to
   `_ALLOWLIST` by `_assert_tokens_known` but exempt from the new
   `test_no_dead_allowlist_entries`, which asserts every remaining
   `_ALLOWLIST` entry matches a real backticked token somewhere in
   `docs/api.md`. Proved: added a bogus fifteenth `_ALLOWLIST` entry - red;
   removed - green. This makes the pending set self-cleaning: an entry
   promoted into `_ALLOWLIST` before its PR's prose actually exists is
   caught by the same dead-entry test, rather than silently doing nothing
   forever.

## Mutations (recorded red, then reverted)

Each mutation was applied to a committed tree, run, recorded, then reverted
with `git checkout --` (or, for the merged-tree-only cases, applied on a
throwaway merge of main + #290 + this branch):

| Mutation | Result |
| --- | --- |
| Misspell a backticked field (`missing_since` -> `missing_sicne`) | red - 2 tests fail, naming the identifier and the section |
| Remove the transcription PUT's declared `409` from its `responses=` | red - `test_transcription_put_documents_its_409` fails by name |
| Change the tool-count word (fourteen -> thirteen) | red - `test_mcp_tool_count_matches_read_tools` fails, `13 == 14` |
| Rename an anchored heading (`Setlists` -> `Song lists`) | red - `test_every_anchored_heading_is_present` names the missing heading; the section-specific test also fails |
| Reorder `_check_module_function` after `_check_table_column` | red - `test_module_function_reference_beats_table_column_check` fails exactly as the review's `instruments.normalise` report described |
| Misspell `bars_defective` in "What to expect between releases" | red - `test_release_expectations_prose_matches_the_response_model` names it |
| Drop the fretboard-attempt-tables phrase from the `GET /api/export` row | red - `test_archive_contents_names_every_export_table` names both missing tables |
| Change the #267 section's two `409`s to `404` | red - `test_transcription_put_documents_its_409` |
| Rename `_refuse_stale_edit` in `api.py` | red - `test_stale_transcription_example_matches_the_source` |
| Drop `"tags"` from `EXPORT_TABLE_NAMES` | red - `test_archive_contents_names_every_export_table` |
| (merged tree) Misspell `GET /openapi.json` -> `GET /opnapi.json` | red - `test_contract_overview_prose_routes_and_terms_resolve_against_the_real_app` names the route |
| (merged tree) Misspell `GET /docs` -> `GET /dcos` | red - same test, names the route |
| (merged tree) Change only the `"reason": "cleaned"` code literal in `_derive_preset_renames` to `"tidied"` (docstring untouched) | red - `test_import_renames_reason_vocabulary_matches_the_source`, naming the literal `'cleaned'` |
| (merged tree) Add a bogus `_ALLOWLIST` entry matching no doc token | red - `test_no_dead_allowlist_entries` |

Every mutation above was reverted and reconfirmed green before the next one.

## Suite

```
server/tests/test_api_doc_prose.py + test_api_docs.py + test_practice_data_doc.py: 52 passed
py -3.13 -m pytest server/tests -rs -q: 1407 passed, 92 skipped (all FERMATA_TEST_LIBRARY / FERMATA_MUSICXML_XSD - expected local-only skips)
server/tests/test_api_doc_prose.py on the throwaway merge of main + #290 + this branch: 20 passed, 0 failed
```

## Concurrency note

Touches only `server/tests/test_api_doc_prose.py`. `docs/api.md` is
untouched, so this does not conflict with #290 (#286) textually. #290's
own rewrite of the #58 section introduces identifiers - and, per the second
review, a quoted server message - this module's tests would otherwise not
recognize; both were verified and fixed ahead of that merge (see "Review
fixes" #3 and "Second review" #1 above), and the merged tree passes in full
(20/20, 0 failed).

Closes #285


## Third review

- The quoted-message rule read raw source text, so a comment or docstring quoting a message could vouch for it after the code stopped raising it (rewording practice.py's raise while its stale comment kept the old text stayed green). It now reads the module's string constants from the parsed tree with docstrings dropped: that same mutation, a comment-only phrase, and a misspelt quoted message in the doc are each red; the tree restored is green.
- PR #290 merged, so its five pending entries moved into the live allow-list where the dead-entry test covers them; the pending dict is empty until the next not-yet-merged PR needs it.
- Stale test name in the module docstring corrected.
- Full server suite on this branch merged with main: 1425 passed, 92 skipped (baseline: FERMATA_TEST_LIBRARY unset, no web/node_modules).
