### PR TITLE
Import checks every table that has a rule, not only drill scopes

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -405,8 +405,7 @@ only CLEANS (whitespace collapsed, ends trimmed) is not refused: it is
 imported under the cleaned name, and #260's collision check runs against
 THAT name, not the raw one the archive carried - a whitespace-padded name
 that happens to collide once cleaned is renamed exactly as any other
-collision would be. Every other archived table's rows still travel across
-verbatim (`_insert_row`, unchanged by #268) - this bet checks presets only.
+collision would be.
 
 `ImportOut.trainer_scope_presets_renamed` reports both: an entry with no
 `reason` key is a plain #260 collision (the archived name was already a
@@ -417,6 +416,69 @@ changed it, and the cleaned name did not collide with anything; `reason:
 cleaned name was ALSO already taken, so `to` is that cleaned name's own
 #260-derived rename. `from` is always the name exactly as the archive
 carried it, whichever reason applies.
+
+**Every table that has a rule is now checked, not only drill scopes (#286).**
+#268 checked presets and nothing else, which left the archive - a JSON file
+anybody can open, and the documented way to move a library onto this stack -
+as the one route into the database that skipped the rules every `POST`
+applies. Measured before this changed: a manifest whose `practice_sessions`
+row said `seconds: -30` and whose `trainer_attempts` row said
+`target_fret: 99` imported with 200 in both modes and stored both, while
+posting those same two values to `/api/practice/sessions` and
+`/api/trainer/attempts` was refused with 422. Every row of every table below
+now goes through the SAME function that table's own route calls, in the same
+validate-before-anything-is-written pass #268 runs in:
+
+| Table | The rule it is run through |
+| --- | --- |
+| `instruments` | `instruments.normalise` |
+| `setlists` | `api._clean_setlist_name` (its name is a setlist's only rule) |
+| `practice_sessions` | `practice.normalise_session` |
+| `practice_goals` | `practice.normalise_goal` |
+| `trainer_attempts` | `trainer.normalise_attempt` |
+| `trainer_chord_attempts` | `trainer.normalise_chord_attempt` |
+| `trainer_scope_presets` | `trainer.normalise_preset` (#268) |
+
+A row the rule REFUSES refuses the whole import - nothing applied, in either
+mode - naming the table, the row's position in the archive
+(`the archive's practice_sessions row 3 is invalid: ...`) and the rule's own
+reason. Nothing is repaired: a negative duration, a fret outside the drill's
+bounds, a goal with no target, an instrument whose tuning names fewer strings
+than it claims are all refusals, never guesses at what was meant.
+
+A row the rule only CLEANS is imported as the value the route would have
+stored, and counted in the response's `cleaned` map (table name to row count,
+tables with a non-zero count only, so `{}` means nothing needed touching).
+That covers a note that was only padding stored as empty, a string pitch
+typed `e2` stored as `E2`, a goal's `period_end` recomputed from its own
+start, an attempt's `correct` recomputed from the notes the row itself
+records (`correct` is never accepted from a caller either, at any route), and
+a preset name whose whitespace was collapsed - which
+`trainer_scope_presets_renamed` also reports, in more detail. `cleaned` reads
+identically on a dry run and an applied import, the same guarantee the rename
+list makes.
+
+**Two rules are deliberately NOT applied to an archived row**, both because
+an archived row is an already-stored row rather than a claim being made now -
+and both passed exactly the way `PATCH /api/practice/sessions/{id}` and
+`PATCH /api/practice/goals/{id}` already pass them for a stored row:
+
+- How far back a practice day may sit from today. Applied to an archive it
+  would make every backup older than that window unrestorable, which is the
+  opposite of what an archive is for.
+- The requirement that a session on a piece, or a goal about one, names a
+  score. Export itself writes such a row with an empty `score_id` whenever
+  the score was left out of the archive or destroyed while its history
+  stayed; refusing it on the way back in would discard practice history.
+
+**Tables with no rule to run keep the checks they have always had** - a
+manifest that carries them in the right shape, with every foreign key
+resolving inside the archive. They are `scores` (created by the scanner from
+files on disk, never by a `POST` with a rule of its own),
+`tags`, `score_tags`, `transcriptions`, `settings`,
+`setlist_scores` and `trainer_scope_preset_strings` (whose rows are the INPUT
+to a preset's own rule, deduplicated and bounds-checked there rather than one
+row at a time - see #268 above).
 
 **`dry_run` defaults to true**, the same default every bulk operation in this
 API uses (see the five rules above). It validates the archive completely and

--- a/docs/api.md
+++ b/docs/api.md
@@ -440,11 +440,12 @@ validate-before-anything-is-written pass #268 runs in:
 | `trainer_scope_presets` | `trainer.normalise_preset` (#268) |
 
 A row the rule REFUSES refuses the whole import - nothing applied, in either
-mode - naming the table, the row's position in the archive
-(`the archive's practice_sessions row 3 is invalid: ...`) and the rule's own
-reason. Nothing is repaired: a negative duration, a fret outside the drill's
-bounds, a goal with no target, an instrument whose tuning names fewer strings
-than it claims are all refusals, never guesses at what was meant.
+mode - naming the table, the row's position in the archive, 0-based
+(`the archive's practice_sessions row 3 is invalid: ...` names the FOURTH row
+of that table) and the rule's own reason. Nothing is repaired: a negative
+duration, a fret outside the drill's bounds, a goal with no target, an
+instrument whose tuning names fewer strings than it claims are all refusals,
+never guesses at what was meant.
 
 A row the rule only CLEANS is imported as the value the route would have
 stored, and counted in the response's `cleaned` map (table name to row count,
@@ -458,18 +459,26 @@ a preset name whose whitespace was collapsed - which
 identically on a dry run and an applied import, the same guarantee the rename
 list makes.
 
-**Two rules are deliberately NOT applied to an archived row**, both because
-an archived row is an already-stored row rather than a claim being made now -
-and both passed exactly the way `PATCH /api/practice/sessions/{id}` and
-`PATCH /api/practice/goals/{id}` already pass them for a stored row:
+**Two rules are deliberately NOT applied in full to an archived row**, both
+because an archived row is an already-stored row rather than a claim being
+made now:
 
-- How far back a practice day may sit from today. Applied to an archive it
-  would make every backup older than that window unrestorable, which is the
-  opposite of what an archive is for.
+- Only the FLOOR on how far back a practice day may sit from today - not the
+  ceiling. `local_date is in the future` is still refused on import exactly as
+  it is on `POST /api/practice/sessions`, because restoring an archive still
+  claims each session happened on the date it names. What is lifted is the
+  lower bound alone: applying it would make every backup older than that
+  window unrestorable, which is the opposite of what an archive is for. (This
+  is narrower than the exemption `PATCH /api/practice/sessions/{id}` uses,
+  which turns the whole window - both bounds - off when `local_date` is not
+  the field being changed; import always writes a `local_date`, so it cannot
+  use that broader exemption without also silently accepting a future one.)
 - The requirement that a session on a piece, or a goal about one, names a
   score. Export itself writes such a row with an empty `score_id` whenever
   the score was left out of the archive or destroyed while its history
-  stayed; refusing it on the way back in would discard practice history.
+  stayed; refusing it on the way back in would discard practice history. This
+  one IS passed exactly the way `PATCH /api/practice/sessions/{id}` and
+  `PATCH /api/practice/goals/{id}` already pass it for a stored row.
 
 **Tables with no rule to run keep the checks they have always had** - a
 manifest that carries them in the right shape, with every foreign key

--- a/server/fermata/api.py
+++ b/server/fermata/api.py
@@ -4929,8 +4929,8 @@ def _read_and_validate_manifest(zf: zipfile.ZipFile, conn) -> dict:
     manifest["_preset_name_originals"] = original_preset_names
     manifest["_preset_strings_cleaned"] = preset_strings_cleaned
 
-    # #286: the other five tables that have a normaliser, each run through the
-    # SAME function its own POST route calls. See this section's module
+    # #286: the other six tables that have a rule of their own, each run
+    # through the SAME function its own POST route calls. See this section's module
     # comment for what changed and why - in short, #268 checked presets and
     # nothing else, so an archive could still carry a session with a negative
     # duration, an attempt at fret 99, a goal with no target or an instrument
@@ -5007,6 +5007,23 @@ def _read_and_validate_manifest(zf: zipfile.ZipFile, conn) -> dict:
         except (ValueError, TypeError) as exc:
             _refuse_row("practice_sessions", index, exc)
         _store_cleaned("practice_sessions", row, values)
+
+    # A setlist's only rule is its NAME, and `_clean_setlist_name` is where
+    # both POST /api/setlists and PATCH /api/setlists/{id} apply it - so an
+    # archived setlist called nothing but spaces would otherwise import as a
+    # blank entry in a list of named arrangements, which neither route would
+    # ever have stored. That function refuses with an HTTPException of its own
+    # rather than a ValueError (it lives among the routes, not in a domain
+    # module); its `detail` is the reason, re-raised here under this section's
+    # own naming so the message says which archived row is at fault.
+    for index, row in enumerate(tables["setlists"]):
+        if not isinstance(row.get("name"), str):
+            _refuse_row("setlists", index, "a setlist needs a name")
+        try:
+            cleaned_name = _clean_setlist_name(row["name"])
+        except HTTPException as exc:
+            _refuse_row("setlists", index, exc.detail)
+        _store_cleaned("setlists", row, {"name": cleaned_name})
 
     for index, row in enumerate(tables["practice_goals"]):
         try:

--- a/server/fermata/api.py
+++ b/server/fermata/api.py
@@ -4072,10 +4072,12 @@ def score_practice_progress(
 # refuses the whole import, and a row the normaliser only CLEANS travels on
 # as the cleaned value and is counted in `ImportOut.cleaned`. The first
 # premise stands and is what keeps that safe: nothing is repaired, nothing is
-# defaulted over a value the archive actually states, and the two flags that
-# would have let today's rules bite yesterday's rows
-# (`check_day_window`, `allow_missing_score`) are passed exactly as the
-# routes that edit an ALREADY STORED row pass them. What is validated, and
+# defaulted over a value the archive actually states, and the two rules that
+# would have let today's calendar bite yesterday's rows are relaxed only as
+# far as an archive needs: the backdating floor is lifted
+# (`max_backdate_days=None`) while the future-date refusal still runs, and
+# `allow_missing_score` is passed as the routes that edit an ALREADY STORED
+# row pass it. What is validated, and
 # what is deliberately not, is listed in docs/api.md's import section.
 #
 # `_dump_table` and `_insert_row` below are still the only two functions

--- a/server/fermata/api.py
+++ b/server/fermata/api.py
@@ -4053,15 +4053,33 @@ def score_practice_progress(
 # accumulated is not an acceptable price for a file that happened to be
 # offline that day.
 #
-# ROW VALUES TRAVEL VERBATIM, deliberately, rather than through the
-# normalising functions (practice.normalise_session, instruments.normalise,
-# ...) every ordinary write goes through. Those functions exist to validate
-# and default a REQUEST from a person typing into a form today; an archived
-# row already passed them once, when it was first written, and running it
-# through them again on the way back in would let today's defaults quietly
-# overwrite yesterday's actual values - the opposite of a lossless round
-# trip. `_dump_table` and `_insert_row` below are the only two functions
-# either direction needs, and neither one hand-picks which columns matter:
+# ROW VALUES TRAVEL VERBATIM ONCE THEY ARE VALID (#286). The original design
+# ran nothing through the normalising functions (practice.normalise_session,
+# instruments.normalise, ...) every ordinary write goes through, reasoning
+# that those functions validate a REQUEST from a person typing into a form
+# today, that an archived row already passed them once when it was first
+# written, and that running it through them again would let today's defaults
+# quietly overwrite yesterday's actual values.
+#
+# The middle premise turned out to be the weak one: an archive is a JSON file
+# a person can open, and one hand-edited (or written by a Fermata older than
+# the rule in question) carries rows that never passed anything. Measured on
+# 0279b50: a manifest whose practice_sessions row said `seconds: -30` and
+# whose trainer_attempts row said `target_fret: 99` imported with 200 in both
+# modes and stored both, while POST refused each with 422. So every table
+# that HAS a normaliser is now run through it, in
+# `_read_and_validate_manifest` before any transaction opens - a refused row
+# refuses the whole import, and a row the normaliser only CLEANS travels on
+# as the cleaned value and is counted in `ImportOut.cleaned`. The first
+# premise stands and is what keeps that safe: nothing is repaired, nothing is
+# defaulted over a value the archive actually states, and the two flags that
+# would have let today's rules bite yesterday's rows
+# (`check_day_window`, `allow_missing_score`) are passed exactly as the
+# routes that edit an ALREADY STORED row pass them. What is validated, and
+# what is deliberately not, is listed in docs/api.md's import section.
+#
+# `_dump_table` and `_insert_row` below are still the only two functions
+# either direction needs to MOVE a row, and neither one hand-picks columns:
 # every column the live table has going out, every key an archived row
 # carries coming back in. That is what keeps this feature from becoming a
 # third hand-mirrored copy of the schema, alongside the bugs issues #143 and
@@ -4118,10 +4136,9 @@ def score_practice_progress(
 # would otherwise pass this validation - normalise_preset dedupes before
 # checking anything else - and then hit that table's own UNIQUE constraint
 # when applied, a divergence from what POST /api/trainer/presets stores for
-# the same input. Every OTHER archived table's rows still travel through
-# `_insert_row` verbatim - this bet validates presets only (see its own
-# issue for why: repeating this for every table is the rabbit hole it
-# explicitly declines).
+# the same input. #268 validated presets ONLY; #286 then repeated the shape
+# for every other table with a normaliser - see the paragraph above and the
+# blocks that follow the preset one in `_read_and_validate_manifest`.
 #
 # TRANSACTIONAL, AND WHAT THAT ACTUALLY COVERS. Validation - the archive is a
 # real zip, `manifest.json` parses, its schema_version matches, every table
@@ -4797,6 +4814,72 @@ def _read_and_validate_manifest(zf: zipfile.ZipFile, conn) -> dict:
     # remembers which rows changed and what they carried before, for
     # `_derive_preset_renames` to report alongside a genuine collision (see
     # its own note on the two).
+    # #286 turned the three helpers below into the shared shape every
+    # validated table uses; #268's preset block was the first caller and still
+    # produces exactly the message it always did.
+    #
+    # `_refuse_row` is the ONE naming rule for a row a normaliser turned down:
+    # the table, the row's position in the archive, and the normaliser's own
+    # sentence. Position rather than content, because the content is exactly
+    # what is wrong with it - and one rule rather than a message per table, so
+    # a person meeting this for a session reads the same shape they would for
+    # a preset.
+    #
+    # A TypeError is caught alongside ValueError wherever a normaliser is
+    # called from here. The POST routes reach these functions through a
+    # pydantic model that has already settled every field's TYPE, so a
+    # normaliser is entitled to compare an int against its bounds without
+    # first asking whether it is one; an ARCHIVE has no such layer in front of
+    # it, and a hand-edited manifest carrying `"seconds": "lots"` would
+    # otherwise surface as a 500 rather than as the clean 4xx this whole
+    # section promises.
+    cleaned_counts: dict[str, int] = {}
+
+    def _refuse_row(table_name: str, index: int, reason) -> None:
+        raise HTTPException(
+            422, f"the archive's {table_name} row {index} is invalid: {reason}"
+        ) from None
+
+    def _store_cleaned(table_name: str, row: dict, values: dict) -> None:
+        """Write what the normaliser returned back into the archive row, and
+        count the row ONCE if any value it already carried actually changed.
+
+        This is the "imported cleaned, not refused" half of the rule (#268's
+        preset names were the first case): a row the normaliser only tidied -
+        whitespace collapsed, an empty note turned to NULL, a pitch spelling
+        canonicalised, a derived column recomputed - travels on, but travels
+        as the value `POST` would have stored, never as the raw one the
+        archive carried. Everything downstream (`_insert_row`, #260's
+        collision check) then runs against the cleaned row.
+
+        A key the row does not carry at all is still written: it is a real
+        column of this table (the column check above already proved that for
+        every key the archive DOES carry) holding the value the route would
+        have stored, and an archive predating the column simply had nothing to
+        clean. It is not COUNTED as cleaning for the same reason - nothing the
+        archive stated was changed.
+        """
+        changed = False
+        for key, value in values.items():
+            if key in row and row[key] != value:
+                changed = True
+            row[key] = value
+        if changed:
+            cleaned_counts[table_name] = cleaned_counts.get(table_name, 0) + 1
+
+    def _archived_json(row: dict, key: str, table_name: str, index: int):
+        """A column this schema stores as JSON TEXT, back as the Python value
+        the normaliser takes (`trainer_chord_attempts`' shapes and note lists,
+        `instruments.string_pitches`). Anything that is not a string is passed
+        through untouched, so the normaliser gives its own verdict on it."""
+        value = row.get(key)
+        if not isinstance(value, str):
+            return value
+        try:
+            return json.loads(value)
+        except json.JSONDecodeError:
+            _refuse_row(table_name, index, f"{key} is not readable JSON")
+
     preset_strings_by_id: dict[int, list] = {}
     for row in tables["trainer_scope_preset_strings"]:
         preset_strings_by_id.setdefault(row.get("preset_id"), []).append(
@@ -4828,18 +4911,163 @@ def _read_and_validate_manifest(zf: zipfile.ZipFile, conn) -> dict:
                 key_root=row.get("key_root"),
                 key_quality=row.get("key_quality"),
             )
-        except ValueError as exc:
-            raise HTTPException(
-                422,
-                f"the archive's trainer_scope_presets row {index} is invalid: {exc}",
-            ) from None
+        except (ValueError, TypeError) as exc:
+            _refuse_row("trainer_scope_presets", index, exc)
         cleaned_name = cleaned["preset"]["name"]
         if cleaned_name != row.get("name"):
             original_preset_names[row["id"]] = row["name"]
             row["name"] = cleaned_name
+            # #286's count, alongside #268's own richer report of the same
+            # fact in `trainer_scope_presets_renamed` (which says what the
+            # name was and what it became). The count is here so `cleaned`
+            # covers every validated table by the same rule rather than
+            # having one table quietly absent from it.
+            cleaned_counts["trainer_scope_presets"] = (
+                cleaned_counts.get("trainer_scope_presets", 0) + 1
+            )
         preset_strings_cleaned[row["id"]] = cleaned["strings"]
     manifest["_preset_name_originals"] = original_preset_names
     manifest["_preset_strings_cleaned"] = preset_strings_cleaned
+
+    # #286: the other five tables that have a normaliser, each run through the
+    # SAME function its own POST route calls. See this section's module
+    # comment for what changed and why - in short, #268 checked presets and
+    # nothing else, so an archive could still carry a session with a negative
+    # duration, an attempt at fret 99, a goal with no target or an instrument
+    # whose tuning names more strings than it has, none of which the API
+    # itself would ever have created. Measured on 0279b50 before this
+    # changed: an archive whose practice_sessions row carried `seconds: -30`
+    # and whose trainer_attempts row carried `target_fret: 99` imported with
+    # 200 in BOTH modes and stored both values verbatim, while the same two
+    # values posted to /api/practice/sessions and /api/trainer/attempts were
+    # refused 422.
+    #
+    # WHERE A RELATED ROW IS NEEDED, IT IS RESOLVED AGAINST THE ARCHIVE, never
+    # against this library: a session's score, a session's preset and a goal's
+    # score are all checked against the archive's own rows by the referential
+    # block above, which has already refused the archive if any of them
+    # dangles. So the route's own live lookups (_normalise_session's
+    # _live_score_row / _trainer_preset_row) have no counterpart here - the
+    # ids in an archive name rows in the ARCHIVE, and _apply_import remaps
+    # every one of them to this import's own new rows afterwards.
+    #
+    # THE TWO FLAGS BOTH ROUTES ALREADY HAVE are passed the way the route that
+    # edits a STORED row passes them, because an archived row is a stored row:
+    #
+    #   `check_day_window=False` (practice_sessions). How far back a practice
+    #   day may sit from today is a rule about what somebody may CLAIM now -
+    #   patch_session already turns it off when the date is not what is being
+    #   written, for exactly the reason that applying it to an already-stored
+    #   date makes a session permanently uneditable once it is old enough.
+    #   Applied to an archive it would be worse still: every backup older than
+    #   practice.MAX_BACKDATE_DAYS would become unrestorable, which is the
+    #   opposite of what this feature is for.
+    #
+    #   `allow_missing_score` (practice_sessions, practice_goals). A 'piece'
+    #   session or a 'score' goal whose score_id is NULL is a real, already
+    #   stored row - export itself writes one whenever the score it named was
+    #   left out of the archive (a trashed score under include_trash=false) or
+    #   destroyed while the history stayed. patch_session and patch_goal grant
+    #   the same allowance from the STORED row's own values; the expressions
+    #   below are theirs, unchanged.
+    for index, row in enumerate(tables["instruments"]):
+        pitches = _archived_json(row, "string_pitches", "instruments", index)
+        try:
+            values = instruments.normalise(
+                kind=row.get("kind"),
+                name=row.get("name"),
+                fretted=row.get("fretted"),
+                string_count=row.get("string_count"),
+                string_pitches=pitches,
+                fret_count=row.get("fret_count"),
+                capo=row.get("capo"),
+                reference_pitch=row.get("reference_pitch"),
+            )
+        except (ValueError, TypeError) as exc:
+            _refuse_row("instruments", index, exc)
+        # Back into the two shapes the COLUMNS hold, so what is compared and
+        # stored is what create_instrument itself writes: the pitch list as
+        # JSON text, `fretted` as the 0/1 SQLite keeps (a bool would compare
+        # equal to it either way, but only one of the two is what the column
+        # has held since the table existed).
+        values["string_pitches"] = json.dumps(values["string_pitches"])
+        values["fretted"] = int(values["fretted"])
+        _store_cleaned("instruments", row, values)
+
+    for index, row in enumerate(tables["practice_sessions"]):
+        try:
+            values = practice.normalise_session(
+                recorded_on=_server_today(),
+                allow_missing_score=practice.is_orphaned(
+                    row.get("activity"), row.get("score_id")
+                ),
+                check_day_window=False,
+                **{key: row.get(key) for key in _SESSION_COLUMNS},
+            )
+        except (ValueError, TypeError) as exc:
+            _refuse_row("practice_sessions", index, exc)
+        _store_cleaned("practice_sessions", row, values)
+
+    for index, row in enumerate(tables["practice_goals"]):
+        try:
+            values = practice.normalise_goal(
+                allow_missing_score=(
+                    row.get("scope") == "score" and row.get("score_id") is None
+                ),
+                **{key: row.get(key) for key in _GOAL_INPUT_FIELDS},
+            )
+        except (ValueError, TypeError) as exc:
+            _refuse_row("practice_goals", index, exc)
+        # `period_end` is in what comes back but not in what went in: the
+        # normaliser derives it from the start and the period's length, so an
+        # archive whose stored end disagrees with its own start is corrected
+        # to what the period actually means rather than carried across as a
+        # week of some other number of days.
+        _store_cleaned("practice_goals", row, values)
+
+    # `session_id` is left out of what is checked and put back untouched, in
+    # both attempt tables: it is a foreign key into practice_sessions that the
+    # referential block above has already resolved within the archive and
+    # _apply_import remaps, exactly as both POST routes hold it out of the
+    # normaliser and set it themselves afterwards. `correct` is left out for
+    # the opposite reason - it is never an input at all, at either route or
+    # here: the normaliser computes it, so an archived row claiming a verdict
+    # its own target/given values do not support is corrected to the verdict
+    # those values give, which is the one thing this table exists to be
+    # queried on.
+    for index, row in enumerate(tables["trainer_attempts"]):
+        try:
+            values = trainer.normalise_attempt(
+                **{
+                    key: row.get(key)
+                    for key in _ATTEMPT_COLUMNS
+                    if key not in ("session_id", "correct")
+                }
+            )
+        except (ValueError, TypeError) as exc:
+            _refuse_row("trainer_attempts", index, exc)
+        _store_cleaned("trainer_attempts", row, values)
+
+    for index, row in enumerate(tables["trainer_chord_attempts"]):
+        fields = {
+            key: row.get(key)
+            for key in _CHORD_ATTEMPT_COLUMNS
+            if key not in ("session_id", "correct")
+        }
+        # The three columns this table stores as JSON text - a shape shown, a
+        # shape tapped, the notes it sounded. The normaliser takes and returns
+        # the Python values (and re-encodes them itself on the way out), so
+        # what _store_cleaned compares is text against text, encoded the one
+        # way log_trainer_chord_attempt encodes it.
+        for key in ("target_shape", "given_shape", "given_notes"):
+            fields[key] = _archived_json(row, key, "trainer_chord_attempts", index)
+        try:
+            values = trainer.normalise_chord_attempt(**fields)
+        except (ValueError, TypeError) as exc:
+            _refuse_row("trainer_chord_attempts", index, exc)
+        _store_cleaned("trainer_chord_attempts", row, values)
+
+    manifest["_cleaned_counts"] = cleaned_counts
     return manifest
 
 
@@ -5246,6 +5474,11 @@ def _apply_import(conn, manifest: dict, file_bytes: dict[str, bytes], written_pa
         "trainer_presets_imported": len(tables["trainer_scope_presets"]),
         "trainer_preset_strings_imported": len(tables["trainer_scope_preset_strings"]),
         "trainer_scope_presets_renamed": presets_renamed,
+        # #286. Read off the manifest rather than recounted here: the cleaning
+        # itself happened in _read_and_validate_manifest, before any
+        # transaction was open, which is what lets the dry run below report
+        # the identical map without writing anything.
+        "cleaned": manifest.get("_cleaned_counts", {}),
     }
 
 
@@ -5264,10 +5497,13 @@ async def import_library(file: UploadFile, dry_run: bool = True):
     API uses - see #56) validates the archive completely - it really is a
     Fermata export, its schema_version matches this Fermata's, every row's
     foreign keys resolve within the archive, every archived file's bytes
-    hash to what the archive itself claims for them, and every named drill
-    scope (and its string set) passes trainer.normalise_preset (#268) - and
-    reports what it found, WITHOUT opening a database transaction or writing
-    a single file.
+    hash to what the archive itself claims for them, and every row of every
+    table that has a normaliser passes the SAME function that table's own
+    POST route calls (#268 for drill scopes, #286 for instruments, sessions,
+    goals and both attempt tables) - and reports what it found, WITHOUT
+    opening a database transaction or writing a single file. `cleaned` says
+    how many rows per table the normaliser tidied on the way through, and
+    reads the same here as it does on the applied import.
     Nothing is compared against what is already in this library on a dry
     run, which is why `tags_reused` is always 0 there - see ImportOut - with
     one exception: `trainer_scope_presets_renamed` IS computed against this
@@ -5349,6 +5585,7 @@ async def import_library(file: UploadFile, dry_run: bool = True):
             "trainer_presets_imported": len(tables["trainer_scope_presets"]),
             "trainer_preset_strings_imported": len(tables["trainer_scope_preset_strings"]),
             "trainer_scope_presets_renamed": presets_renamed,
+            "cleaned": manifest.get("_cleaned_counts", {}),
         }
 
     _require_library()

--- a/server/fermata/api.py
+++ b/server/fermata/api.py
@@ -4954,14 +4954,17 @@ def _read_and_validate_manifest(zf: zipfile.ZipFile, conn) -> dict:
     # THE TWO FLAGS BOTH ROUTES ALREADY HAVE are passed the way the route that
     # edits a STORED row passes them, because an archived row is a stored row:
     #
-    #   `check_day_window=False` (practice_sessions). How far back a practice
-    #   day may sit from today is a rule about what somebody may CLAIM now -
-    #   patch_session already turns it off when the date is not what is being
-    #   written, for exactly the reason that applying it to an already-stored
-    #   date makes a session permanently uneditable once it is old enough.
-    #   Applied to an archive it would be worse still: every backup older than
-    #   practice.MAX_BACKDATE_DAYS would become unrestorable, which is the
-    #   opposite of what this feature is for.
+    #   `max_backdate_days=None` (practice_sessions). How far back a NEW
+    #   practice day may be claimed is a rule about what somebody may CLAIM
+    #   now, and applying it to an already-stored date would make a session
+    #   permanently uneditable once it is old enough - which is why
+    #   patch_session turns the whole window off (both bounds) when the date
+    #   is not what is being written. An archive is different: restoring it
+    #   still claims each session happened on the date it names, so "local_date
+    #   is in the future" stays enforced (`check_day_window` stays True) -
+    #   only the backdating FLOOR is lifted, since every backup older than
+    #   practice.MAX_BACKDATE_DAYS becoming unrestorable would be the opposite
+    #   of what this feature is for.
     #
     #   `allow_missing_score` (practice_sessions, practice_goals). A 'piece'
     #   session or a 'score' goal whose score_id is NULL is a real, already
@@ -5001,7 +5004,7 @@ def _read_and_validate_manifest(zf: zipfile.ZipFile, conn) -> dict:
                 allow_missing_score=practice.is_orphaned(
                     row.get("activity"), row.get("score_id")
                 ),
-                check_day_window=False,
+                max_backdate_days=None,
                 **{key: row.get(key) for key in _SESSION_COLUMNS},
             )
         except (ValueError, TypeError) as exc:

--- a/server/fermata/api_models.py
+++ b/server/fermata/api_models.py
@@ -1128,8 +1128,8 @@ class ImportOut(BaseModel):
     # reports the same map the real restore will produce - the same guarantee
     # `trainer_scope_presets_renamed` makes.
     #
-    # Tables with no normaliser to run (scores, tags, score_tags,
-    # transcriptions, settings, setlists, setlist_scores,
+    # Tables with no rule of their own to run (scores, tags, score_tags,
+    # transcriptions, settings, setlist_scores,
     # trainer_scope_preset_strings) can never appear here; they keep the
     # referential and shape checks they have always had. See docs/api.md's
     # import section for that list and why each entry is on it.

--- a/server/fermata/api_models.py
+++ b/server/fermata/api_models.py
@@ -1110,6 +1110,30 @@ class ImportOut(BaseModel):
     # nothing) never reaches this list - the whole import is refused before
     # anything is written; see `import_library`'s 422 for that.
     trainer_scope_presets_renamed: list[dict[str, str]]
+    # #286: how many rows of each validated table the normaliser CHANGED on
+    # the way in - table name to row count, and only tables with a non-zero
+    # count, so `{}` means every row was already exactly what the API itself
+    # would have stored. Cleaning is not repair: a row a normaliser refuses
+    # (a negative duration, a fret outside the drill's bounds, a goal with no
+    # target at all) refuses the whole import instead and never appears here.
+    # What DOES appear is a row that was only tidied - a note that was
+    # nothing but spaces stored as NULL, a string pitch spelled "e2" stored
+    # as "E2", a goal's `period_end` recomputed from its own start, an
+    # attempt's `correct` recomputed from the notes it records, a preset name
+    # with its whitespace collapsed (which #268's
+    # `trainer_scope_presets_renamed` also reports, in more detail).
+    #
+    # Identical on a dry run and an applied import: the normalising happens
+    # during validation, before any transaction exists, so the preview
+    # reports the same map the real restore will produce - the same guarantee
+    # `trainer_scope_presets_renamed` makes.
+    #
+    # Tables with no normaliser to run (scores, tags, score_tags,
+    # transcriptions, settings, setlists, setlist_scores,
+    # trainer_scope_preset_strings) can never appear here; they keep the
+    # referential and shape checks they have always had. See docs/api.md's
+    # import section for that list and why each entry is on it.
+    cleaned: dict[str, int]
 
 
 # ---------------------------------------------------------------------------

--- a/server/fermata/instruments.py
+++ b/server/fermata/instruments.py
@@ -280,6 +280,27 @@ def _clean_name(name) -> str:
     return re.sub(r"\s+", " ", stripped).strip()
 
 
+def _whole_number(value, field: str) -> int:
+    """A range check below this needs an int already, not merely something
+    orderable against one: a POST body's pydantic model has settled that
+    before `normalise` ever runs, but an archived row (import runs this same
+    function against a hand-editable manifest, with no such layer in front of
+    it) has not, and comparing an int bound against a str or a None raises
+    TypeError with Python's own wording ("'<=' not supported between
+    instances of..."), not a sentence a person reading a 422 could act on."""
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError(f"{field} must be a whole number")
+    return value
+
+
+def _finite_number(value, field: str) -> float:
+    """Same reasoning as `_whole_number`, for the one field that is a float
+    rather than an int."""
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError(f"{field} must be a number")
+    return value
+
+
 def normalise(
     *,
     kind,
@@ -312,6 +333,7 @@ def normalise(
 
     fretted = bool(fretted)
 
+    string_count = _whole_number(string_count, "string_count")
     if not MIN_STRINGS <= string_count <= MAX_STRINGS:
         raise ValueError(f"string_count must be between {MIN_STRINGS} and {MAX_STRINGS}")
 
@@ -321,9 +343,10 @@ def normalise(
     if fretted:
         if fret_count is None:
             raise ValueError("fret_count is required on a fretted instrument")
+        fret_count = _whole_number(fret_count, "fret_count")
         if not MIN_FRETS <= fret_count <= MAX_FRETS:
             raise ValueError(f"fret_count must be between {MIN_FRETS} and {MAX_FRETS}")
-        capo = 0 if capo is None else capo
+        capo = 0 if capo is None else _whole_number(capo, "capo")
         if not 0 <= capo <= fret_count:
             raise ValueError(f"capo must be between 0 and the fret count ({fret_count})")
     else:
@@ -373,6 +396,7 @@ def normalise(
         # distinction to whoever typed one.
         canonical.append(pitch_name(step, alter, octave))
 
+    reference_pitch = _finite_number(reference_pitch, "reference_pitch")
     if not MIN_REFERENCE_HZ <= reference_pitch <= MAX_REFERENCE_HZ:
         raise ValueError(
             f"reference_pitch must be between {MIN_REFERENCE_HZ} and {MAX_REFERENCE_HZ} Hz"

--- a/server/fermata/practice.py
+++ b/server/fermata/practice.py
@@ -282,6 +282,7 @@ def normalise_session(
     preset_id=None,
     allow_missing_score=False,
     check_day_window=True,
+    max_backdate_days=MAX_BACKDATE_DAYS,
 ) -> dict:
     """Check a session and return the values to store.
 
@@ -301,11 +302,18 @@ def normalise_session(
     an honest claim into a rule about keeping one.
 
     `check_day_window` is False when the practice day is not what is being
-    written. How far back a NEW date may be is a rule about what somebody may
-    claim now; applied to a date already stored it becomes a rule that makes a
-    session permanently uneditable once it is old enough - so a note or a
-    rating on last year's practice could not be corrected, for reasons that
-    have nothing to do with either.
+    written at all - patch_session's case, where the value in `local_date`
+    is only the already-stored one being carried forward unchanged. Turning
+    the window off there is right for BOTH bounds, because neither one is a
+    claim being made now.
+
+    `max_backdate_days` is the separate, narrower exemption import uses: it
+    still wants "local_date is in the future" enforced (an archive claims a
+    date exists, exactly as a POST does), but not the backdating floor, since
+    that floor bounds how far back a NEW claim may reach and a restored
+    archive is not a new claim. Passing None here lifts only that floor,
+    while `check_day_window` stays True and the future check still runs. It
+    has no effect when `check_day_window` is False.
     """
     activity = activity or DEFAULT_ACTIVITY
     if activity not in ACTIVITIES:
@@ -331,8 +339,11 @@ def normalise_session(
         if check_day_window:
             if day > recorded_on + timedelta(days=MAX_FUTURE_DAYS):
                 raise ValueError("local_date is in the future")
-            if day < recorded_on - timedelta(days=MAX_BACKDATE_DAYS):
-                raise ValueError(f"local_date is more than {MAX_BACKDATE_DAYS} days ago")
+            if (
+                max_backdate_days is not None
+                and day < recorded_on - timedelta(days=max_backdate_days)
+            ):
+                raise ValueError(f"local_date is more than {max_backdate_days} days ago")
 
     from_bar, to_bar = _range(from_bar, to_bar, "from_bar", "to_bar", MAX_BAR)
     from_page, to_page = _range(from_page, to_page, "from_page", "to_page", MAX_PAGE)

--- a/server/tests/test_portability_api.py
+++ b/server/tests/test_portability_api.py
@@ -1824,6 +1824,26 @@ def test_an_archived_instrument_with_too_few_string_pitches_is_refused(
     )
 
 
+def test_an_archived_instrument_with_a_wrong_type_field_names_it_in_the_reason(
+    client, tmp_path, monkeypatch
+):
+    """The measured premise: `instruments.normalise` compares string_count,
+    fret_count, capo and reference_pitch against their bounds without first
+    checking they are numbers, which POST /api/instruments never has to
+    worry about (pydantic settles the type first) but an archive can carry
+    anything. On 0279b50 the 422 for a string `string_count` was Python's own
+    `'<=' not supported between instances of 'int' and 'str'` - this asserts
+    a sentence a person could act on instead."""
+    _an_instrument(client)
+    manifest = json.loads(_zip_of(client.get("/api/export")).read("manifest.json"))
+    manifest["tables"]["instruments"][0]["string_count"] = "6"
+
+    _switch_to_a_fresh_environment(monkeypatch, tmp_path, "target")
+    _refused_in_both_modes(
+        client, manifest, "instruments row 0", "string_count must be a whole number"
+    )
+
+
 def test_an_archived_instrument_is_imported_with_its_name_and_pitches_cleaned(
     client, tmp_path, monkeypatch
 ):
@@ -1920,6 +1940,27 @@ def test_an_archived_session_note_is_imported_trimmed_and_counted(
     assert len(sessions) == 1
     assert sessions[0]["note"] == "bar 12 still rushes"
     assert sessions[0]["seconds"] == 600
+
+
+def test_an_archived_session_dated_into_the_future_is_still_refused(
+    client, tmp_path, monkeypatch
+):
+    """The measured premise behind #290's fix: `check_day_window=False` used
+    to gate BOTH bounds on local_date, so exempting import from the
+    backdating floor silently exempted it from "local_date is in the
+    future" too. An archive is still a claim that each session happened on
+    the date it names - restoring one should not be a way to log practice
+    for a day that has not happened, which posting the same date to
+    /api/practice/sessions still refuses. Nothing is applied in either
+    mode."""
+    client.post("/api/practice/sessions", json={"seconds": 600, "activity": "technique"})
+    manifest = json.loads(_zip_of(client.get("/api/export")).read("manifest.json"))
+    manifest["tables"]["practice_sessions"][0]["local_date"] = "2099-01-01"
+
+    _switch_to_a_fresh_environment(monkeypatch, tmp_path, "target")
+    _refused_in_both_modes(
+        client, manifest, "practice_sessions row 0", "local_date is in the future"
+    )
 
 
 def test_an_archived_session_older_than_the_backdating_window_still_imports(

--- a/server/tests/test_portability_api.py
+++ b/server/tests/test_portability_api.py
@@ -21,14 +21,16 @@ feature exists not to have.
 import hashlib
 import io
 import json
+import re
 
 import zipfile
+from pathlib import Path
 
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from fermata import api, db, scanner
+from fermata import api, db, instruments, practice, scanner
 from fermata import trainer as trainer_module
 
 FIXTURE = b"<score-file-bytes-standing-in-for-a-pdf>"
@@ -1686,3 +1688,579 @@ def test_an_archive_carrying_a_table_this_fermata_no_longer_has_is_refused_by_na
     assert resp.status_code == 422, resp.text
     assert "practice_diaries" in resp.json()["detail"]
     assert len(client.get("/api/scores").json()) == 1
+
+
+# ---------------------------------------------------------------------------
+# #286: every table that has a normaliser is run through it on the way in.
+#
+# #268 did this for named drill scopes and said outright that it did presets
+# only. That left the archive - the documented migration path onto the server
+# stack, and a JSON file anybody can open in an editor - as the one way into
+# this database that skipped the rules every POST route applies. Measured on
+# 0279b50 before this section existed: a manifest whose practice_sessions row
+# carried `seconds: -30` and whose trainer_attempts row carried
+# `target_fret: 99` imported with 200 in BOTH modes and stored both values
+# verbatim, while POST /api/practice/sessions and POST /api/trainer/attempts
+# refused those same two values with 422.
+#
+# Each table below gets the same pair of tests: a REFUSED row (4xx, nothing
+# applied, dry run and applied identical) and a CLEANED row (imported as the
+# value POST would have stored, and counted in `ImportOut.cleaned`).
+# ---------------------------------------------------------------------------
+
+
+def _target_library_is_untouched(client):
+    """Every table this feature writes, read back through the API, still
+    empty. Asserted after each refusal rather than trusting the status code:
+    a clean 422 that still left one row behind is exactly the bug this
+    feature exists not to have (see this module's own docstring)."""
+    assert client.get("/api/scores").json() == []
+    assert client.get("/api/instruments").json() == []
+    assert client.get("/api/practice/sessions").json()["sessions"] == []
+    assert client.get("/api/practice/goals").json()["goals"] == []
+    assert client.get("/api/trainer/attempts").json()["attempts"] == []
+    assert client.get("/api/trainer/chord-attempts").json()["attempts"] == []
+    assert client.get("/api/trainer/presets").json() == []
+    assert client.get("/api/tags").json() == []
+    assert client.get("/api/setlists").json() == []
+
+
+def _refused_in_both_modes(client, manifest, *fragments):
+    """Post one hand-edited manifest as a dry run AND as an applied import,
+    and require the two answers to be identical - the parity half of the
+    promise, which is the whole point of validating before a transaction is
+    ever opened. `fragments` are substrings the message has to carry: the
+    table and row position, and the normaliser's own reason."""
+    archive = _bytes_of_zip({"manifest.json": json.dumps(manifest).encode()})
+    answers = []
+    for dry_run in (True, False):
+        resp = client.post(
+            "/api/import", params={"dry_run": str(dry_run).lower()},
+            files={"file": ("hand-edited.zip", archive, "application/zip")},
+        )
+        assert resp.status_code == 422, f"dry_run={dry_run}: {resp.text}"
+        for fragment in fragments:
+            assert fragment in resp.text, f"dry_run={dry_run}: {resp.text}"
+        answers.append((resp.status_code, resp.json()))
+    assert answers[0] == answers[1]
+    _target_library_is_untouched(client)
+
+
+def _imported_in_both_modes(client, manifest, expected_cleaned):
+    """The other side: an archive whose rows the normaliser only CLEANS is
+    imported, and both modes report the same `cleaned` map. Returns the
+    applied import's own response body."""
+    archive = _bytes_of_zip({"manifest.json": json.dumps(manifest).encode()})
+    preview = client.post(
+        "/api/import", files={"file": ("hand-edited.zip", archive, "application/zip")},
+    )
+    assert preview.status_code == 200, preview.text
+    assert preview.json()["cleaned"] == expected_cleaned
+    _target_library_is_untouched(client)
+
+    applied = client.post(
+        "/api/import", params={"dry_run": "false"},
+        files={"file": ("hand-edited.zip", archive, "application/zip")},
+    )
+    assert applied.status_code == 200, applied.text
+    assert applied.json()["cleaned"] == expected_cleaned
+    return applied.json()
+
+
+def _an_instrument(client):
+    resp = client.post(
+        "/api/instruments",
+        json={
+            "name": "Parlour guitar",
+            "string_count": 6,
+            "string_pitches": ["E2", "A2", "D3", "G3", "B3", "E4"],
+            "fretted": True,
+            "fret_count": 19,
+            "capo": 2,
+            "reference_pitch": 442.0,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+def _a_chord_attempt(client, **overrides):
+    body = {
+        "drill": "chord_flashcards",
+        "direction": "shape_to_name",
+        "target_root": "C",
+        "target_quality": "major",
+        "target_shape": [
+            {"string": 5, "fret": 3},
+            {"string": 4, "fret": 2},
+            {"string": 3, "fret": 0},
+            {"string": 2, "fret": 1},
+            {"string": 1, "fret": 0},
+        ],
+        "given_root": "C",
+        "given_quality": "major",
+    }
+    body.update(overrides)
+    resp = client.post("/api/trainer/chord-attempts", json=body)
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+def test_an_archived_instrument_with_too_few_string_pitches_is_refused(
+    client, tmp_path, monkeypatch
+):
+    """A six-string instrument whose tuning names no strings at all. POST
+    /api/instruments cannot produce one (instruments.normalise counts the
+    pitches against string_count), so only a hand-edited archive carries it -
+    and stored, it is an instrument whose neck cannot be drawn."""
+    _an_instrument(client)
+    manifest = json.loads(_zip_of(client.get("/api/export")).read("manifest.json"))
+    # The column holds JSON text, which is what the manifest carries.
+    manifest["tables"]["instruments"][0]["string_pitches"] = "[]"
+
+    _switch_to_a_fresh_environment(monkeypatch, tmp_path, "target")
+    _refused_in_both_modes(
+        client, manifest, "instruments row 0", "0 string pitch(es) were given"
+    )
+
+
+def test_an_archived_instrument_is_imported_with_its_name_and_pitches_cleaned(
+    client, tmp_path, monkeypatch
+):
+    """The cleaned half. A name with doubled spaces and pitch names in
+    lowercase are both things instruments.normalise tidies rather than
+    refuses - so the row is imported as POST would have stored it ("E2", not
+    "e2": storing the typed spelling is what makes a later comparison against
+    a preset or a tuning miss), and the ONE row it changed is counted."""
+    _an_instrument(client)
+    manifest = json.loads(_zip_of(client.get("/api/export")).read("manifest.json"))
+    row = manifest["tables"]["instruments"][0]
+    row["name"] = "  Parlour   guitar  "
+    row["string_pitches"] = json.dumps(["e2", "a2", "d3", "g3", "b3", "e4"])
+
+    _switch_to_a_fresh_environment(monkeypatch, tmp_path, "target")
+    _imported_in_both_modes(client, manifest, {"instruments": 1})
+
+    imported = client.get("/api/instruments").json()
+    assert len(imported) == 1
+    assert imported[0]["name"] == "Parlour guitar"
+    assert imported[0]["string_pitches"] == ["E2", "A2", "D3", "G3", "B3", "E4"]
+
+
+def test_an_archived_setlist_named_only_whitespace_is_refused(
+    client, tmp_path, monkeypatch
+):
+    """A setlist's name is the only rule it has, and `_clean_setlist_name` -
+    which both POST /api/setlists and the rename endpoint apply - refuses a
+    name that is nothing but whitespace rather than storing a blank. An
+    archived one would otherwise restore as an unnamed entry in a list of
+    named arrangements."""
+    created = client.post("/api/setlists", json={"name": "Recital order"})
+    assert created.status_code == 200, created.text
+    manifest = json.loads(_zip_of(client.get("/api/export")).read("manifest.json"))
+    manifest["tables"]["setlists"][0]["name"] = "   "
+
+    _switch_to_a_fresh_environment(monkeypatch, tmp_path, "target")
+    _refused_in_both_modes(client, manifest, "setlists row 0", "a setlist needs a name")
+
+
+def test_an_archived_setlist_name_is_imported_with_its_whitespace_collapsed(
+    client, tmp_path, monkeypatch
+):
+    """And the cleaned half: doubled spaces and padded ends are collapsed and
+    trimmed, exactly as the route would have stored the same name, with the
+    one row it changed counted."""
+    created = client.post("/api/setlists", json={"name": "Recital order"})
+    assert created.status_code == 200, created.text
+    manifest = json.loads(_zip_of(client.get("/api/export")).read("manifest.json"))
+    manifest["tables"]["setlists"][0]["name"] = "  Recital   order  "
+
+    _switch_to_a_fresh_environment(monkeypatch, tmp_path, "target")
+    _imported_in_both_modes(client, manifest, {"setlists": 1})
+
+    setlists = client.get("/api/setlists").json()
+    assert [s["name"] for s in setlists] == ["Recital order"]
+
+
+def test_an_archived_session_with_a_negative_duration_is_refused(
+    client, tmp_path, monkeypatch
+):
+    """The issue's own example, and the measured premise: on 0279b50 this
+    archive imported with 200 in both modes and stored `seconds: -30`, a
+    duration POST /api/practice/sessions refuses with 422 - practice time
+    that ran backwards, counted into every total this library reports."""
+    client.post("/api/practice/sessions", json={"seconds": 600, "activity": "technique"})
+    manifest = json.loads(_zip_of(client.get("/api/export")).read("manifest.json"))
+    manifest["tables"]["practice_sessions"][0]["seconds"] = -30
+
+    _switch_to_a_fresh_environment(monkeypatch, tmp_path, "target")
+    _refused_in_both_modes(
+        client, manifest, "practice_sessions row 0", "seconds must be between 1 and 86400"
+    )
+
+
+def test_an_archived_session_note_is_imported_trimmed_and_counted(
+    client, tmp_path, monkeypatch
+):
+    """A note that is nothing but padding around a sentence. practice's
+    `_optional_text` trims it (and stores a note that is ONLY whitespace as
+    NULL, so "nothing was written" is one value rather than two), which is a
+    cleaning, not a refusal."""
+    client.post(
+        "/api/practice/sessions",
+        json={"seconds": 600, "activity": "technique", "note": "bar 12 still rushes"},
+    )
+    manifest = json.loads(_zip_of(client.get("/api/export")).read("manifest.json"))
+    manifest["tables"]["practice_sessions"][0]["note"] = "   bar 12 still rushes   "
+
+    _switch_to_a_fresh_environment(monkeypatch, tmp_path, "target")
+    _imported_in_both_modes(client, manifest, {"practice_sessions": 1})
+
+    sessions = client.get("/api/practice/sessions").json()["sessions"]
+    assert len(sessions) == 1
+    assert sessions[0]["note"] == "bar 12 still rushes"
+    assert sessions[0]["seconds"] == 600
+
+
+def test_an_archived_session_older_than_the_backdating_window_still_imports(
+    client, tmp_path, monkeypatch
+):
+    """The one rule this section deliberately does NOT apply to an archive.
+    How far back a practice day may sit from today bounds what somebody may
+    CLAIM now (practice.MAX_BACKDATE_DAYS); applied to an already-stored
+    date it would make every backup older than that unrestorable, which is
+    the opposite of what an archive is for. patch_session already turns the
+    same check off when the date is not what is being written, and import
+    passes the flag the same way - so a session from years ago imports
+    untouched and is not counted as cleaned either."""
+    client.post("/api/practice/sessions", json={"seconds": 600, "activity": "technique"})
+    manifest = json.loads(_zip_of(client.get("/api/export")).read("manifest.json"))
+    manifest["tables"]["practice_sessions"][0]["local_date"] = "2019-04-01"
+
+    _switch_to_a_fresh_environment(monkeypatch, tmp_path, "target")
+    _imported_in_both_modes(client, manifest, {})
+
+    sessions = client.get("/api/practice/sessions").json()["sessions"]
+    assert [s["local_date"] for s in sessions] == ["2019-04-01"]
+
+
+def test_an_archived_goal_with_no_target_at_all_is_refused(client, tmp_path, monkeypatch):
+    """A goal has to be concrete enough to be either met or missed, which is
+    the whole point of setting one - practice.normalise_goal requires at
+    least one of days or minutes. A goal with neither cannot be created
+    through POST /api/practice/goals and cannot be counted by anything that
+    reads it back."""
+    resp = client.post("/api/practice/goals", json={"target_days": 3})
+    assert resp.status_code == 200, resp.text
+    manifest = json.loads(_zip_of(client.get("/api/export")).read("manifest.json"))
+    manifest["tables"]["practice_goals"][0]["target_days"] = None
+    manifest["tables"]["practice_goals"][0]["target_minutes"] = None
+
+    _switch_to_a_fresh_environment(monkeypatch, tmp_path, "target")
+    _refused_in_both_modes(client, manifest, "practice_goals row 0", "a goal needs a target")
+
+
+def test_an_archived_goals_period_end_is_recomputed_from_its_own_start(
+    client, tmp_path, monkeypatch
+):
+    """`period_end` is derived, never stated: normalise_goal computes it from
+    the start and the period's length, which is why POST cannot be given one.
+    An archive CAN carry one - and one that disagrees with its own start
+    describes a week of some other number of days, which every query that
+    counts practice into a period would then read as truth. Corrected on the
+    way in, and counted."""
+    resp = client.post("/api/practice/goals", json={"target_days": 3})
+    assert resp.status_code == 200, resp.text
+    manifest = json.loads(_zip_of(client.get("/api/export")).read("manifest.json"))
+    goal_row = manifest["tables"]["practice_goals"][0]
+    real_end = goal_row["period_end"]
+    goal_row["period_end"] = "2099-12-31"
+
+    _switch_to_a_fresh_environment(monkeypatch, tmp_path, "target")
+    _imported_in_both_modes(client, manifest, {"practice_goals": 1})
+
+    goals = client.get("/api/practice/goals").json()["goals"]
+    assert len(goals) == 1
+    assert goals[0]["period_end"] == real_end
+
+
+def test_an_archived_attempt_at_a_fret_outside_the_bounds_is_refused(
+    client, tmp_path, monkeypatch
+):
+    """The issue's second example, and the other half of the measured
+    premise: on 0279b50 an archive carrying `target_fret: 99` imported with
+    200 in both modes and stored it, while POST /api/trainer/attempts refuses
+    the same value with 422. A position no instrument this app accepts could
+    have is not a hard question about drills - it is a row that makes "which
+    positions get missed" answer with a fret nobody ever played."""
+    client.post(
+        "/api/trainer/attempts",
+        json={
+            "drill": "fret_to_note", "direction": "position_to_note",
+            "target_string": 6, "target_fret": 3, "target_note": "G", "given_note": "G",
+        },
+    )
+    manifest = json.loads(_zip_of(client.get("/api/export")).read("manifest.json"))
+    manifest["tables"]["trainer_attempts"][0]["target_fret"] = 99
+
+    _switch_to_a_fresh_environment(monkeypatch, tmp_path, "target")
+    _refused_in_both_modes(
+        client, manifest, "trainer_attempts row 0", "target_fret must be between 0 and 36"
+    )
+
+
+def test_an_archived_attempts_verdict_is_recomputed_from_the_notes_it_records(
+    client, tmp_path, monkeypatch
+):
+    """`correct` is computed by trainer.normalise_attempt and is NEVER
+    accepted from a caller - TrainerAttemptIn has no such field at all. An
+    archive carries the column, so a hand-edited one can claim a verdict its
+    own target/given notes do not support: here, a wrong answer marked
+    correct. Recomputed on the way in from the two notes, which is the one
+    thing this table exists to be queried on, and counted as cleaned."""
+    client.post(
+        "/api/trainer/attempts",
+        json={
+            "drill": "fret_to_note", "direction": "position_to_note",
+            "target_string": 1, "target_fret": 0, "target_note": "E", "given_note": "F",
+        },
+    )
+    manifest = json.loads(_zip_of(client.get("/api/export")).read("manifest.json"))
+    assert manifest["tables"]["trainer_attempts"][0]["correct"] == 0
+    manifest["tables"]["trainer_attempts"][0]["correct"] = 1
+
+    _switch_to_a_fresh_environment(monkeypatch, tmp_path, "target")
+    _imported_in_both_modes(client, manifest, {"trainer_attempts": 1})
+
+    attempts = client.get("/api/trainer/attempts").json()["attempts"]
+    assert len(attempts) == 1
+    assert attempts[0]["target_note"] == "E" and attempts[0]["given_note"] == "F"
+    assert attempts[0]["correct"] is False
+
+
+def test_an_archived_chord_attempt_with_a_shape_outside_the_bounds_is_refused(
+    client, tmp_path, monkeypatch
+):
+    """The same bounds a single position is held to, applied to every
+    position in a shown fingering (trainer._shape). A shape reaching fret 99
+    cannot be posted and cannot be drawn."""
+    _a_chord_attempt(client)
+    manifest = json.loads(_zip_of(client.get("/api/export")).read("manifest.json"))
+    row = manifest["tables"]["trainer_chord_attempts"][0]
+    shape = json.loads(row["target_shape"])
+    shape[0]["fret"] = 99
+    row["target_shape"] = json.dumps(shape)
+
+    _switch_to_a_fresh_environment(monkeypatch, tmp_path, "target")
+    _refused_in_both_modes(
+        client, manifest,
+        "trainer_chord_attempts row 0", "target_shape fret must be between 0 and 36",
+    )
+
+
+def test_an_archived_chord_attempts_verdict_is_recomputed_from_its_tone_sets(
+    client, tmp_path, monkeypatch
+):
+    """The chord drill's own form of the rule above: `correct` is decided by
+    comparing TONE SETS, in trainer.normalise_chord_attempt, and is never
+    accepted from a caller. A C major shape answered "A minor" is wrong; an
+    archive claiming otherwise is corrected, not carried."""
+    attempt = _a_chord_attempt(client, given_root="A", given_quality="minor")
+    assert attempt["correct"] is False
+    manifest = json.loads(_zip_of(client.get("/api/export")).read("manifest.json"))
+    manifest["tables"]["trainer_chord_attempts"][0]["correct"] = 1
+
+    _switch_to_a_fresh_environment(monkeypatch, tmp_path, "target")
+    _imported_in_both_modes(client, manifest, {"trainer_chord_attempts": 1})
+
+    attempts = client.get("/api/trainer/chord-attempts").json()["attempts"]
+    assert len(attempts) == 1
+    assert attempts[0]["correct"] is False
+    assert attempts[0]["given_root"] == "A" and attempts[0]["given_quality"] == "minor"
+
+
+def test_a_real_export_of_every_validated_table_round_trips_with_nothing_cleaned(
+    client, add_score, tmp_path, monkeypatch
+):
+    """The guard on the whole section: everything above rewrites values on
+    the way in, and a rule applied a little too eagerly would show up here as
+    a real export coming back changed. One row in each of the five tables
+    #286 validates (plus the preset #268 already did), written through the
+    API itself, exported and imported - `cleaned` is empty in BOTH modes,
+    which is the claim that normalising an archive Fermata itself wrote is a
+    no-op, and every value is read back identical."""
+    score_id = add_score("Classical/Prelude.pdf", title="Prelude")
+    _an_instrument(client)
+    client.post("/api/setlists", json={"name": "Recital order"})
+    client.post(
+        "/api/trainer/presets",
+        json={"name": "Fifth position", "start_fret": 5, "end_fret": 9, "strings": [1, 2, 3]},
+    )
+    session = client.post(
+        f"/api/scores/{score_id}/practice",
+        json={"seconds": 900, "tempo_bpm": 88, "mode": "section", "rating": 4,
+              "note": "bar 12 still rushes"},
+    ).json()["session"]
+    client.post(
+        "/api/practice/goals",
+        json={"scope": "score", "score_id": score_id, "target_days": 3,
+              "intent": "clean at full tempo"},
+    )
+    client.post(
+        "/api/trainer/attempts",
+        json={
+            "session_id": session["id"], "drill": "fret_to_note",
+            "direction": "position_to_note", "target_string": 6, "target_fret": 3,
+            "target_note": "G", "given_note": "G",
+        },
+    )
+    _a_chord_attempt(client, session_id=session["id"])
+
+    expected_instruments = client.get("/api/instruments").json()
+    expected_sessions = client.get("/api/practice/sessions").json()["sessions"]
+    expected_goals = client.get("/api/practice/goals").json()["goals"]
+    expected_attempts = client.get("/api/trainer/attempts").json()["attempts"]
+    expected_chords = client.get("/api/trainer/chord-attempts").json()["attempts"]
+    expected_setlists = [s["name"] for s in client.get("/api/setlists").json()]
+    archive = client.get("/api/export").content
+
+    _switch_to_a_fresh_environment(monkeypatch, tmp_path, "target")
+    preview = client.post(
+        "/api/import", files={"file": ("export.zip", archive, "application/zip")},
+    )
+    assert preview.status_code == 200, preview.text
+    assert preview.json()["cleaned"] == {}
+
+    applied = client.post(
+        "/api/import", params={"dry_run": "false"},
+        files={"file": ("export.zip", archive, "application/zip")},
+    )
+    assert applied.status_code == 200, applied.text
+    assert applied.json()["cleaned"] == {}
+
+    def _without_ids(rows, *drop):
+        return [
+            {k: v for k, v in row.items() if k not in ("id", "session_id", "score_id", *drop)}
+            for row in rows
+        ]
+
+    assert _without_ids(client.get("/api/instruments").json()) == _without_ids(
+        expected_instruments
+    )
+    assert _without_ids(
+        client.get("/api/practice/sessions").json()["sessions"]
+    ) == _without_ids(expected_sessions)
+    assert _without_ids(client.get("/api/practice/goals").json()["goals"]) == _without_ids(
+        expected_goals
+    )
+    assert _without_ids(
+        client.get("/api/trainer/attempts").json()["attempts"], "created_at"
+    ) == _without_ids(expected_attempts, "created_at")
+    assert _without_ids(
+        client.get("/api/trainer/chord-attempts").json()["attempts"], "created_at"
+    ) == _without_ids(expected_chords, "created_at")
+    assert [s["name"] for s in client.get("/api/setlists").json()] == expected_setlists
+
+
+def test_one_definition_per_rule_and_both_the_route_and_import_run_it(
+    client, tmp_path, monkeypatch
+):
+    """The contract this bet actually rests on: a rule has ONE definition,
+    and the import path and the POST route both call THAT one - not a second
+    copy that can drift from it. Checked two ways, because neither alone is
+    enough. First by source: each rule's `def` appears exactly once in the
+    package, so `grep -n "def normalise_"` shows one definition per rule.
+    Then by behaviour: each definition is replaced with a spy, and both a
+    POST and an import are made - a copy of the rule anywhere would leave one
+    of the two callers unrecorded."""
+    package = Path(api.__file__).resolve().parent
+    sources = {p.name: p.read_text(encoding="utf-8") for p in package.glob("*.py")}
+    # (module, attribute) for every rule import now shares with a route.
+    rules = (
+        (instruments, "normalise"),
+        (practice, "normalise_session"),
+        (practice, "normalise_goal"),
+        (trainer_module, "normalise_attempt"),
+        (trainer_module, "normalise_chord_attempt"),
+        (trainer_module, "normalise_preset"),
+        # A setlist's name is its only rule, and it lives among the routes
+        # rather than in a domain module - three lines with nothing else to
+        # keep them company (see its own docstring). Import calls that one,
+        # not a second copy of the same three lines.
+        (api, "_clean_setlist_name"),
+    )
+    for module, name in rules:
+        definitions = sum(
+            len(re.findall(rf"^def {name}\(", text, re.MULTILINE))
+            for text in sources.values()
+        )
+        assert definitions == 1, f"{name} is defined {definitions} times, not once"
+        # And the one definition lives in the module the route imports it
+        # from, rather than being re-exported from somewhere else.
+        assert re.search(
+            rf"^def {name}\(", sources[Path(module.__file__).name], re.MULTILINE
+        ), f"{name} is not defined in {Path(module.__file__).name}"
+
+    # --- A source library with one row per validated table. ---
+    _an_instrument(client)
+    client.post("/api/setlists", json={"name": "Recital order"})
+    client.post(
+        "/api/trainer/presets",
+        json={"name": "Fifth position", "start_fret": 5, "end_fret": 9, "strings": [1, 2, 3]},
+    )
+    client.post("/api/practice/sessions", json={"seconds": 600, "activity": "technique"})
+    client.post("/api/practice/goals", json={"target_days": 3})
+    client.post(
+        "/api/trainer/attempts",
+        json={
+            "drill": "fret_to_note", "direction": "position_to_note",
+            "target_string": 6, "target_fret": 3, "target_note": "G", "given_note": "G",
+        },
+    )
+    _a_chord_attempt(client)
+    archive = client.get("/api/export").content
+
+    _switch_to_a_fresh_environment(monkeypatch, tmp_path, "target")
+
+    callers: dict[str, set[str]] = {name: set() for _, name in rules}
+    phase = {"who": "route"}
+
+    def _spy(module, name):
+        real = getattr(module, name)
+
+        def wrapper(*args, **kwargs):
+            callers[name].add(phase["who"])
+            return real(*args, **kwargs)
+
+        monkeypatch.setattr(module, name, wrapper)
+
+    for module, name in rules:
+        _spy(module, name)
+
+    # --- The routes, on the fresh library. ---
+    _an_instrument(client)
+    client.post("/api/setlists", json={"name": "Encores"})
+    client.post(
+        "/api/trainer/presets",
+        json={"name": "Ninth position", "start_fret": 9, "end_fret": 12, "strings": [1]},
+    )
+    client.post("/api/practice/sessions", json={"seconds": 600, "activity": "technique"})
+    client.post("/api/practice/goals", json={"target_days": 3})
+    client.post(
+        "/api/trainer/attempts",
+        json={
+            "drill": "fret_to_note", "direction": "position_to_note",
+            "target_string": 6, "target_fret": 3, "target_note": "G", "given_note": "G",
+        },
+    )
+    _a_chord_attempt(client)
+
+    # --- The same six rules, reached through import instead. ---
+    phase["who"] = "import"
+    resp = client.post(
+        "/api/import", files={"file": ("export.zip", archive, "application/zip")},
+    )
+    assert resp.status_code == 200, resp.text
+
+    for _, name in rules:
+        assert callers[name] == {"route", "import"}, f"{name}: only {sorted(callers[name])}"

--- a/server/tests/test_practice_api.py
+++ b/server/tests/test_practice_api.py
@@ -181,6 +181,30 @@ def test_an_impossible_length_or_rating_is_refused_with_a_reason(client, score):
         assert expected in res.text, (body, res.text)
 
 
+def test_a_session_dated_into_the_future_or_too_far_past_is_refused_by_the_route(client):
+    """The two bounds normalise_session's day window enforces, exercised
+    through the route itself rather than the function directly - #290's
+    fix to the import path (max_backdate_days) must leave neither of these
+    changed. A date far enough in the future to clear MAX_FUTURE_DAYS and a
+    date far enough in the past to clear MAX_BACKDATE_DAYS both still 422,
+    exactly as they did before that fix existed."""
+    future = (date.today() + timedelta(days=30)).isoformat()
+    res = client.post(
+        "/api/practice/sessions",
+        json={"seconds": 600, "activity": "technique", "local_date": future},
+    )
+    assert res.status_code == 422, res.text
+    assert "local_date is in the future" in res.text, res.text
+
+    too_old = (date.today() - timedelta(days=500)).isoformat()
+    res = client.post(
+        "/api/practice/sessions",
+        json={"seconds": 600, "activity": "technique", "local_date": too_old},
+    )
+    assert res.status_code == 422, res.text
+    assert "local_date is more than" in res.text and "days ago" in res.text, res.text
+
+
 # ---------------------------------------------------------------------------
 # Adding detail afterwards, and taking it back
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #286.

## Premise: valid

Re-derived on `0279b50` before writing anything. An archive whose
`practice_sessions` row carried `seconds: -30` and whose `trainer_attempts`
row carried `target_fret: 99`:

| | dry run | applied | stored |
| --- | --- | --- | --- |
| `POST /api/import` | **200** | **200** | `seconds: -30`, `target_fret: 99` |
| `POST /api/practice/sessions` with `seconds: -30` | - | **422** | nothing |
| `POST /api/trainer/attempts` with `target_fret: 99` | - | **422** | nothing |

So both values were readable back out of the API afterwards, and neither
could ever have been created through it. #268 checked drill-scope presets and
said outright it did presets only.

## What changed

Every row of every table with a rule now goes through the SAME function that
table's own route calls, in `_read_and_validate_manifest` - before any
transaction opens, which is what makes dry run and applied agree.

| Table | Rule | Refused example (tested) | Cleaned example (tested) |
| --- | --- | --- | --- |
| `instruments` | `instruments.normalise` | tuning names 0 strings for `string_count: 6` | `"  Parlour   guitar  "`, pitches `e2` -> `E2` |
| `setlists` | `api._clean_setlist_name` | name is only whitespace | doubled spaces collapsed |
| `practice_sessions` | `practice.normalise_session` | `seconds: -30` | note trimmed |
| `practice_goals` | `practice.normalise_goal` | no target at all | `period_end` recomputed from its own start |
| `trainer_attempts` | `trainer.normalise_attempt` | `target_fret: 99` | `correct` recomputed from the two notes |
| `trainer_chord_attempts` | `trainer.normalise_chord_attempt` | shape at fret 99 | `correct` recomputed from tone sets |
| `trainer_scope_presets` | `trainer.normalise_preset` | #268's, unchanged | now also counted in `cleaned` |

A refused row refuses the whole import in both modes, named by table and
archive position (0-based - `practice_sessions row 3` names the FOURTH row of
that table) with the rule's own reason (`the archive's practice_sessions row
0 is invalid: seconds must be between 1 and 86400`) - #268's exact message
shape, now shared. Nothing is repaired. A cleaned row is imported as the
value the route would have stored and counted in the new `ImportOut.cleaned`
(table -> rows changed, non-zero entries only, identical in both modes).
Documented in `docs/api.md`'s import section.

**Related rows resolve against the ARCHIVE, never the live database.** A
session's score, a session's preset and a goal's score are already checked
against the archive's own rows by the referential block above; the routes'
live lookups have no counterpart here, and `_apply_import` remaps every id
afterwards as before.

**Two rules deliberately not applied IN FULL**, both because an archived row
is an already-stored row rather than a claim being made now:

- Only the FLOOR on how far back a practice day may sit from today, not the
  ceiling. `normalise_session` now takes `max_backdate_days` separately from
  `check_day_window`: import passes `max_backdate_days=None` (otherwise every
  backup older than 400 days becomes unrestorable) while leaving
  `check_day_window` True, so `local_date is in the future` is still refused
  on import exactly as it is on `POST /api/practice/sessions` - restoring an
  archive still claims each session happened on the date it names. A review
  round caught this: the original single `check_day_window=False` gated BOTH
  bounds, so an archive with `local_date: "2099-01-01"` imported 200 in both
  modes while the same date posted to the route was refused 422. Fixed, with
  tests for the future-dated refusal and for the backdating exemption
  surviving the split.
- The score-required rule (`allow_missing_score` - export itself writes such
  a row when the score was left out or destroyed), passed exactly the way
  `patch_session`/`patch_goal` pass it for a stored row. Unchanged.

## Tables with no rule, left as they were

`scores` (written by the scanner from files on disk, no POST rule of its
own), `tags`, `score_tags`, `transcriptions`, `settings`, `setlist_scores`,
`trainer_scope_preset_strings` (its rows are the INPUT to a preset's rule -
deduplicated and bounds-checked there, per #268, not one row at a time).
They keep today's shape and referential checks.

`setlists` is one MORE table than the issue's sketch listed as having no
rule: `_clean_setlist_name` is a real rule both `POST /api/setlists` and the
rename endpoint apply, so an archived setlist named only whitespace would
have restored as a blank entry. Included for that reason.

## Refactors

None. Every rule was already callable without a request object or a live
connection; `_clean_setlist_name` raises `HTTPException` rather than
`ValueError` (it lives among the routes), so its `detail` is re-raised under
this section's naming. `TypeError` is caught alongside `ValueError` at each
call: the routes reach these functions through a pydantic model that has
already settled every field's type, and an archive has no such layer, so
`"seconds": "lots"` would otherwise be a 500 instead of a clean 4xx -
`instruments.normalise` now turns that into a sentence naming the field
(`string_count must be a whole number`) for `string_count`, `fret_count`,
`capo` and `reference_pitch`, the same way every other table's normaliser
already read.

## Mutations (committed first, recorded red, restored, green again)

| Mutation | Result |
| --- | --- |
| `trainer_attempts` loop iterates `[]` (that table's rule skipped) | 3 failed, 49 passed - including `test_an_archived_attempt_at_a_fret_outside_the_bounds_is_refused` |
| normalisation run in applied mode only (`normalise_rows=not dry_run`) | 19 failed, 33 passed - every parity assertion, plus the four #268 tests |
| cleaned rows counted `+ 2` instead of `+ 1` | 6 failed, 46 passed - exactly the six cleaned-count tests, nothing else |

Restored: 52 passed in `test_portability_api.py`.

A later review round re-ran these three against the current tree (54 tests
now, +2 from the fixes above) and added two of its own:

| Mutation | Result |
| --- | --- |
| `trainer_attempts` loop skipped again | 3 failed, 51 passed - same three tests |
| six-table validation gated to applied mode only (return early on `dry_run`) | 15 failed, 39 passed - the parity assertions, `one_definition_per_rule`, and the two new tests below |
| cleaned rows counted `+ 2` again | 6 failed, 48 passed - the same six tests |
| import's `check_day_window=False` restored (the original single-flag bug) | the new future-dated-archive test failed: dry run returned 200 instead of 422 |
| the instruments type-check sentence removed | the new wrong-type test failed: reason text was Python's own `'<=' not supported between instances of 'int' and 'str'` |

## Suite

`py -3.13 -m pytest server/tests -rs -q`, foreground, `FERMATA_TEST_LIBRARY`
unset: **1405 passed, 92 skipped, 1 warning in 118.83s** (same 92 skips as
main).

The #245/#249/#268/#282 tests are unchanged and green.
