### PR TITLE
Receipts and status say everything the server counted: import, scan, delete, purge, restore, setlist delete

### DIFF
--- a/web/src/lib/DataPortability.svelte
+++ b/web/src/lib/DataPortability.svelte
@@ -7,6 +7,81 @@
   // of its logic.
   import { api } from "./api.js";
 
+  // Every count ImportOut carries (issue #284), in the order a person would
+  // want to hear it - the scores themselves first, then what travels with
+  // them. Singular/plural pairs are spelled out rather than run through a
+  // generic pluraliser, because a couple of them do not just take an "s".
+  const IMPORT_COUNT_FIELDS = [
+    ["scores_imported", "score", "scores"],
+    ["scores_trashed_imported", "trashed score", "trashed scores"],
+    ["files_written", "file written", "files written"],
+    ["transcriptions_imported", "transcription", "transcriptions"],
+    ["tags_imported", "tag", "tags"],
+    ["tags_reused", "tag reused rather than duplicated", "tags reused rather than duplicated"],
+    ["score_tags_imported", "tag assignment", "tag assignments"],
+    ["instruments_imported", "instrument", "instruments"],
+    ["practice_sessions_imported", "practice session", "practice sessions"],
+    ["practice_goals_imported", "practice goal", "practice goals"],
+    ["settings_imported", "setting", "settings"],
+    ["setlists_imported", "setlist", "setlists"],
+    ["setlist_scores_imported", "setlist entry", "setlist entries"],
+    ["trainer_attempts_imported", "fret-to-note drill attempt", "fret-to-note drill attempts"],
+    ["trainer_chord_attempts_imported", "chord drill attempt", "chord drill attempts"],
+    ["trainer_presets_imported", "saved drill scope", "saved drill scopes"],
+    ["trainer_preset_strings_imported", "drill scope string set", "drill scope string sets"],
+  ];
+
+  /** Every word of an ordinary English list: "a", "a and b", "a, b and c". */
+  function joinList(items) {
+    if (items.length === 0) return "";
+    if (items.length === 1) return items[0];
+    if (items.length === 2) return `${items[0]} and ${items[1]}`;
+    return `${items.slice(0, -1).join(", ")} and ${items[items.length - 1]}`;
+  }
+
+  /** Every count an ImportOut carries, as one sentence - a compact list of
+   * whatever is not zero, with every count that IS zero folded into a single
+   * closing clause rather than named one by one (#284). Also states the two
+   * schema versions and where the archive came from (#282, #275), so this one
+   * sentence covers every field of ImportOut apart from `trainer_scope_presets_renamed`,
+   * which gets its own line below since it is a list, not a count. */
+  function importSummaryText(result) {
+    const counts = [];
+    let zeros = 0;
+    for (const [key, singular, plural] of IMPORT_COUNT_FIELDS) {
+      const n = result[key] ?? 0;
+      if (n > 0) counts.push(`${n} ${n === 1 ? singular : plural}`);
+      else zeros += 1;
+    }
+    const verb = result.dry_run ? "This archive holds" : "Imported";
+    let body;
+    if (counts.length === 0) {
+      body = "nothing else was in the archive";
+    } else if (zeros > 0) {
+      body = `${joinList(counts)} - nothing else was in the archive`;
+    } else {
+      body = joinList(counts);
+    }
+    return (
+      `${verb} ${body}, written ${result.exported_at} by Fermata ${result.fermata_version}. ` +
+      `Read from a schema version ${result.schema_version_read} archive into this Fermata's ` +
+      `own schema version ${result.schema_version}.`
+    );
+  }
+
+  /** One rename line, saying why the archived name did not survive - #260's
+   * plain collision, or #268's cleaning (with or without a second collision
+   * behind it). */
+  function renameReasonText(entry) {
+    if (entry.reason === "cleaned") {
+      return `${entry.from} → ${entry.to} (its name only needed tidying up, nothing collided)`;
+    }
+    if (entry.reason === "collision") {
+      return `${entry.from} → ${entry.to} (tidied, then that name was already taken too)`;
+    }
+    return `${entry.from} → ${entry.to} (that name was already taken)`;
+  }
+
   let exporting = $state(false);
   let exportError = $state("");
 
@@ -132,22 +207,16 @@
     {/if}
     {#if preview}
       <div class="preview" data-testid="import-preview">
-        <p>
-          This archive holds {preview.scores_imported} score(s) ({preview.scores_trashed_imported}
-          in the trash), {preview.practice_sessions_imported} practice session(s),
-          {preview.practice_goals_imported} goal(s), {preview.tags_imported} tag(s) and
-          {preview.instruments_imported} instrument(s) - written {preview.exported_at} by Fermata
-          {preview.fermata_version}.
-        </p>
+        <p data-testid="import-counts">{importSummaryText(preview)}</p>
         <p class="hint">
           Importing adds this to your library - it never replaces or overwrites what is already
           there. Import into an empty library to restore a backup exactly.
         </p>
         {#if preview.trainer_scope_presets_renamed?.length}
           <p class="hint" data-testid="import-renames">
-            Renamed on import: {preview.trainer_scope_presets_renamed
-              .map((r) => `${r.from} → ${r.to}`)
-              .join(", ")}
+            Renamed on import: {joinList(
+              preview.trainer_scope_presets_renamed.map(renameReasonText),
+            )}
           </p>
         {/if}
         <div class="row">
@@ -162,15 +231,12 @@
       <p class="error" data-testid="import-apply-error">{applyError}</p>
     {/if}
     {#if applied}
-      <p class="success" data-testid="import-success">
-        Imported {applied.scores_imported} score(s), {applied.practice_sessions_imported} practice
-        session(s) and {applied.practice_goals_imported} goal(s).
-      </p>
+      <p class="success" data-testid="import-success">{importSummaryText(applied)}</p>
       {#if applied.trainer_scope_presets_renamed?.length}
         <p class="hint" data-testid="import-renames">
-          Renamed on import: {applied.trainer_scope_presets_renamed
-            .map((r) => `${r.from} → ${r.to}`)
-            .join(", ")}
+          Renamed on import: {joinList(
+            applied.trainer_scope_presets_renamed.map(renameReasonText),
+          )}
         </p>
       {/if}
     {/if}

--- a/web/src/lib/DataPortability.svelte
+++ b/web/src/lib/DataPortability.svelte
@@ -53,20 +53,22 @@
       if (n > 0) counts.push(`${n} ${n === 1 ? singular : plural}`);
       else zeros += 1;
     }
-    const verb = result.dry_run ? "This archive holds" : "Imported";
-    let body;
-    if (counts.length === 0) {
-      body = "nothing else was in the archive";
-    } else if (zeros > 0) {
-      body = `${joinList(counts)} - nothing else was in the archive`;
-    } else {
-      body = joinList(counts);
-    }
-    return (
-      `${verb} ${body}, written ${result.exported_at} by Fermata ${result.fermata_version}. ` +
+    const tail =
+      `, written ${result.exported_at} by Fermata ${result.fermata_version}. ` +
       `Read from a schema version ${result.schema_version_read} archive into this Fermata's ` +
-      `own schema version ${result.schema_version}.`
-    );
+      `own schema version ${result.schema_version}.`;
+    // The all-zero case gets its own sentence rather than reusing the
+    // "verb + body" template below with an empty body: that template read
+    // "This archive holds nothing else was in the archive, written …" when
+    // every count was zero, because "nothing else" only makes sense next to
+    // something that was named first.
+    if (counts.length === 0) {
+      return `${result.dry_run ? "This archive holds nothing" : "Nothing was imported"}${tail}`;
+    }
+    const verb = result.dry_run ? "This archive holds" : "Imported";
+    const body =
+      zeros > 0 ? `${joinList(counts)} - nothing else was in the archive` : joinList(counts);
+    return `${verb} ${body}${tail}`;
   }
 
   /** One rename line, saying why the archived name did not survive - #260's

--- a/web/src/lib/DataPortability.svelte
+++ b/web/src/lib/DataPortability.svelte
@@ -71,6 +71,42 @@
     return `${verb} ${body}${tail}`;
   }
 
+  // ImportOut.cleaned's own closed list of tables (#286) - a table name to
+  // the singular noun this component already uses for that table's own
+  // *_imported count above, in the same order IMPORT_COUNT_FIELDS lists
+  // them. A table with no rule of its own (scores, tags, score_tags,
+  // transcriptions, settings, setlist_scores, trainer_scope_preset_strings)
+  // can never appear in `cleaned` at all - see ImportOut.cleaned's own
+  // docstring in api_models.py.
+  const CLEANED_TABLE_LABELS = [
+    ["instruments", "instrument"],
+    ["practice_sessions", "practice session"],
+    ["practice_goals", "practice goal"],
+    ["setlists", "setlist"],
+    ["trainer_attempts", "fret-to-note drill attempt"],
+    ["trainer_chord_attempts", "chord drill attempt"],
+    ["trainer_scope_presets", "saved drill scope"],
+  ];
+
+  /** One sentence per table `cleaned` names with a non-zero count - the
+   * receipt for the half of #286 the counts above never show: a row a
+   * normaliser only tidied (a lowercase pitch stored as "E2", say) is
+   * imported rather than refused, and this is the one thing that tells a
+   * person it happened, BEFORE they apply an import as much as after (a dry
+   * run reports the identical map - see ImportOut.cleaned's own docstring).
+   * Empty when `cleaned` is `{}`, the common case: a row nothing needed to
+   * touch is not itself news, so no "0 cleaned" line is ever shown for it. */
+  function cleanedText(cleaned) {
+    const lines = [];
+    for (const [table, noun] of CLEANED_TABLE_LABELS) {
+      const n = cleaned?.[table] ?? 0;
+      if (n === 0) continue;
+      const verb = n === 1 ? "was" : "were";
+      lines.push(`${n} ${noun} row${n === 1 ? "" : "s"} ${verb} tidied to the stored form.`);
+    }
+    return lines.join(" ");
+  }
+
   /** One rename line, saying why the archived name did not survive - #260's
    * plain collision, or #268's cleaning (with or without a second collision
    * behind it). */
@@ -210,6 +246,9 @@
     {#if preview}
       <div class="preview" data-testid="import-preview">
         <p data-testid="import-counts">{importSummaryText(preview)}</p>
+        {#if cleanedText(preview.cleaned)}
+          <p class="hint" data-testid="import-cleaned">{cleanedText(preview.cleaned)}</p>
+        {/if}
         <p class="hint">
           Importing adds this to your library - it never replaces or overwrites what is already
           there. Import into an empty library to restore a backup exactly.
@@ -234,6 +273,9 @@
     {/if}
     {#if applied}
       <p class="success" data-testid="import-success">{importSummaryText(applied)}</p>
+      {#if cleanedText(applied.cleaned)}
+        <p class="hint" data-testid="import-cleaned">{cleanedText(applied.cleaned)}</p>
+      {/if}
       {#if applied.trainer_scope_presets_renamed?.length}
         <p class="hint" data-testid="import-renames">
           Renamed on import: {joinList(

--- a/web/src/lib/Library.svelte
+++ b/web/src/lib/Library.svelte
@@ -938,14 +938,18 @@
       </div>
     {/if}
 
-    {#if scan && (scan.scanning || scan.finished_at)}
+    {#if scan && (scan.scanning || scan.added || scan.updated)}
       <!-- What a scan actually did to the library, not only that it ran. The
            button already says how far a running scan has got
            (processed/total); this says what it is FINDING as it goes, and
            what it found once it stopped - added and updated were both on
            ScanStatusOut from the start and neither was ever read anywhere
            (issue #284), so a scan that quietly relabelled half the library
-           looked the same on screen as one that touched nothing. -->
+           looked the same on screen as one that touched nothing. Gated on a
+           nonzero added or updated (or still scanning) the same way the
+           errors and restored notes below are gated on their own nonzero
+           facts, rather than on finished_at alone - a scan that added and
+           updated nothing has nothing here to report. -->
       <p class="scan-note" data-testid="scan-added-updated">
         {scan.scanning ? "So far" : "Last scan"}: {scan.added} score{scan.added === 1 ? "" : "s"} added,
         {scan.updated} updated.

--- a/web/src/lib/Library.svelte
+++ b/web/src/lib/Library.svelte
@@ -980,8 +980,17 @@
            statement that anything had been recovered (issue #103).
 
            Attributed to the LAST SCAN rather than stated as a bare number,
-           because that is what it is - the counter resets when a scan starts. -->
-      <p class="scan-note">
+           because that is what it is - the counter resets when a scan starts.
+
+           A restored file is very often also an UPDATE - the scanner cannot
+           tell "put back unchanged" from "put back with a new mtime" apart,
+           and rewriting bytes back to disk almost always changes the mtime -
+           so the added/updated note above and this one are frequently both on
+           screen together. Its own testid, rather than sharing `.scan-note`
+           with every other note here, is what lets a test address this one
+           without also matching whichever of its siblings happens to be
+           showing. -->
+      <p class="scan-note" data-testid="scan-restored">
         Last scan: {scan.restored} score{scan.restored === 1 ? "" : "s"} found again
         {scan.restored === 1 ? "at the path it" : "at the paths they"} went missing from.
       </p>

--- a/web/src/lib/Library.svelte
+++ b/web/src/lib/Library.svelte
@@ -982,11 +982,16 @@
            Attributed to the LAST SCAN rather than stated as a bare number,
            because that is what it is - the counter resets when a scan starts.
 
-           A restored file is very often also an UPDATE - the scanner cannot
-           tell "put back unchanged" from "put back with a new mtime" apart,
-           and rewriting bytes back to disk almost always changes the mtime -
-           so the added/updated note above and this one are frequently both on
-           screen together. Its own testid, rather than sharing `.scan-note`
+           A restored file is NOT usually also an update: scanner.py's own
+           remount shortcut (_scan_file's size/mtime check, around line 733)
+           clears missing_since and returns before the updated counter can
+           ever increment, whenever the file came back with the exact size
+           and mtime it left with - the ordinary case for a drive that was
+           simply unplugged and plugged back in unchanged. The two notes CAN
+           still appear together, but only when the file's bytes were
+           actually rewritten (which changes the mtime) - a real update, not
+           a consequence of the restore itself. Its own testid, rather than
+           sharing `.scan-note`
            with every other note here, is what lets a test address this one
            without also matching whichever of its siblings happens to be
            showing. -->

--- a/web/src/lib/Library.svelte
+++ b/web/src/lib/Library.svelte
@@ -194,19 +194,40 @@
     busy = true;
     deleteError = "";
     try {
+      // Every one of ScoreDeleteOut's four `_kept` counts, summed across a
+      // bulk selection, plus how many of the underlying files actually moved
+      // - tags_kept and goals_kept were on this response from the start and
+      // neither was ever added to this receipt (issue #284). `deleted`,
+      // `title`, `deleted_from` and `trashed_to` are per-score facts a
+      // multi-select summary cannot restate individually without a list per
+      // item, so they are not named here - the library list itself shows
+      // each one back in place under Trash.
       let sessions = 0;
       let transcriptions = 0;
+      let tags = 0;
+      let goals = 0;
+      let filesMoved = 0;
       for (const id of selected) {
         const result = await api.deleteScore(id);
         sessions += result.practice_sessions_kept;
         transcriptions += result.transcriptions_kept;
+        tags += result.tags_kept;
+        goals += result.goals_kept;
+        if (result.file_moved) filesMoved += 1;
       }
       const count = selected.length;
+      const movedNote =
+        filesMoved === count
+          ? "every file moved to Trash"
+          : filesMoved === 0
+            ? "no file needed moving"
+            : `${filesMoved} of ${count} file${count === 1 ? "" : "s"} moved to Trash`;
       notice =
-        `Moved ${count} score${count === 1 ? "" : "s"} to the trash. ` +
-        `${sessions} practice session${sessions === 1 ? "" : "s"} and ${transcriptions} ` +
-        `transcription${transcriptions === 1 ? "" : "s"} are still attached - nothing was ` +
-        `destroyed. They are in Trash until you say otherwise.`;
+        `Moved ${count} score${count === 1 ? "" : "s"} to the trash - ${movedNote}. ` +
+        `${sessions} practice session${sessions === 1 ? "" : "s"}, ${transcriptions} ` +
+        `transcription${transcriptions === 1 ? "" : "s"}, ${tags} tag${tags === 1 ? "" : "s"} ` +
+        `and ${goals} goal${goals === 1 ? "" : "s"} are still attached - nothing was destroyed. ` +
+        `They are in Trash until you say otherwise.`;
       deleteOpen = false;
       leaveOrganising();
       await refresh();
@@ -230,8 +251,16 @@
     busy = true;
     try {
       const result = await api.restoreScore(score.id);
-      notice =
-        result.restored_to === result.restored_from
+      // `file_restored` was on ScoreRestoreOut from the start and nothing
+      // ever read it, so a score whose file was gone from Trash came back
+      // reading exactly like an ordinary restore instead of the missing-flag
+      // fallback it actually got (issue #284). `restored` and `score` are not
+      // named here: `restored` is always 1 for a single score, and `score` is
+      // superseded by the refresh() below.
+      notice = !result.file_restored
+        ? `${score.title} is back in your library, but there was no file in Trash to restore - ` +
+          `it will show as missing until a file turns up at ${result.restored_to}.`
+        : result.restored_to === result.restored_from
           ? `${score.title} is back at ${result.restored_to}.`
           : `${score.title} is back, at ${result.restored_to} - something else had taken ` +
             `${result.restored_from}, and Fermata did not overwrite it.`;
@@ -248,14 +277,22 @@
     busy = true;
     try {
       const result = await api.destroyScore(score.id);
+      // Every kept/destroyed fact ScorePurgeOut carries apart from `deleted`,
+      // which is always 1 for a single score and redundant with the title
+      // already named here. `goals_kept` and `file_deleted` were unread
+      // before this (issue #284): a purge that also removed the file on disk
+      // looked identical to one that found no file there at all.
+      const fileNote = result.file_deleted
+        ? "its file is deleted too"
+        : "it had no file on disk to delete";
       notice =
         `${result.title} is gone for good, with ${result.tags_destroyed} tag${
           result.tags_destroyed === 1 ? "" : "s"
         } and ${result.transcriptions_destroyed} transcription${
           result.transcriptions_destroyed === 1 ? "" : "s"
-        }. ${result.practice_sessions_kept} practice session${
+        } - ${fileNote}. ${result.practice_sessions_kept} practice session${
           result.practice_sessions_kept === 1 ? "" : "s"
-        } stayed in your history.`;
+        } and ${result.goals_kept} goal${result.goals_kept === 1 ? "" : "s"} stayed in your history.`;
       destroyConfirmId = null;
       await loadTrash();
       await refresh();
@@ -899,6 +936,33 @@
           <p class="alert-error">{acknowledgeError}</p>
         {/if}
       </div>
+    {/if}
+
+    {#if scan && (scan.scanning || scan.finished_at)}
+      <!-- What a scan actually did to the library, not only that it ran. The
+           button already says how far a running scan has got
+           (processed/total); this says what it is FINDING as it goes, and
+           what it found once it stopped - added and updated were both on
+           ScanStatusOut from the start and neither was ever read anywhere
+           (issue #284), so a scan that quietly relabelled half the library
+           looked the same on screen as one that touched nothing. -->
+      <p class="scan-note" data-testid="scan-added-updated">
+        {scan.scanning ? "So far" : "Last scan"}: {scan.added} score{scan.added === 1 ? "" : "s"} added,
+        {scan.updated} updated.
+      </p>
+    {/if}
+
+    {#if !scan?.scanning && scan?.errors > 0}
+      <!-- A file the scan could not read at all - locked, or gone between the
+           directory listing and the read - used to vanish into `errors` and
+           `last_error` on ScanStatusOut with nothing on screen ever asking
+           for either, so a scan that hit a bad file looked exactly like one
+           that finished cleanly (issue #284). Gated on `errors > 0` alone,
+           the same way the restored-count note above is gated on a nonzero
+           count, rather than always shown once a scan has run. -->
+      <p class="scan-note scan-error" data-testid="scan-errors" role="alert">
+        Last scan: {scan.errors} file{scan.errors === 1 ? "" : "s"} could not be read - {scan.last_error}
+      </p>
     {/if}
 
     {#if !scan?.scanning && scan?.restored}
@@ -1748,6 +1812,13 @@
     color: var(--ink-dim);
     font-size: 13px;
     margin: 0 0 12px;
+  }
+
+  /* A file the scan could not read at all IS worth flagging - same colour as
+     the other alert text on this page, kept in the quiet .scan-note layout
+     rather than the boxed .alert since it is one line, not a refusal. */
+  .scan-error {
+    color: var(--danger);
   }
 
   .alert-error {

--- a/web/src/lib/Setlists.svelte
+++ b/web/src/lib/Setlists.svelte
@@ -44,6 +44,15 @@
   let renaming = $state(false);
   let nameDraft = $state("");
   let confirmingDelete = $state(false);
+  // What the last setlist deletion actually did (issue #284) - SetlistDeleteOut
+  // carries `scores_untouched` and nothing ever read it, so deleting a setlist
+  // said nothing about the scores it held even though the confirmation above
+  // already promises they are kept. destroy() below navigates straight to
+  // #/setlists on success, which App.svelte routes to a fresh mount of this
+  // component at id === null - not a continuation of destroy()'s call stack -
+  // so the message travels through sessionStorage rather than component
+  // state, and is read once by the $effect below and cleared immediately.
+  let deleteNotice = $state("");
   let busy = $state(false); // a membership/order write is in flight
   let adding = $state(false); // the add-scores panel is open
   let candidates = $state([]); // library scores not already in this setlist
@@ -71,6 +80,11 @@
   $effect(() => {
     id;
     load();
+    if (id == null) {
+      const stored = sessionStorage.getItem("fermata:setlist-deleted");
+      if (stored) sessionStorage.removeItem("fermata:setlist-deleted");
+      deleteNotice = stored ?? "";
+    }
   });
 
   // --- List view ------------------------------------------------------------
@@ -152,7 +166,14 @@
     busy = true;
     error = "";
     try {
-      await api.deleteSetlist(id);
+      const result = await api.deleteSetlist(id);
+      const kept = result.scores_untouched;
+      sessionStorage.setItem(
+        "fermata:setlist-deleted",
+        `That setlist is gone. ${kept} score${kept === 1 ? "" : "s"} ${
+          kept === 1 ? "stays" : "stay"
+        } in your library, untouched.`,
+      );
       location.hash = "#/setlists";
     } catch (e) {
       error = e instanceof ApiError && e.message ? e.message : "Could not delete the setlist.";
@@ -218,6 +239,9 @@
     <main>
       {#if error}
         <p class="notice" role="status">{error}</p>
+      {/if}
+      {#if deleteNotice}
+        <p class="notice" role="status" data-testid="setlist-delete-notice">{deleteNotice}</p>
       {/if}
 
       <form

--- a/web/tests/browser/data-portability.spec.js
+++ b/web/tests/browser/data-portability.spec.js
@@ -28,7 +28,25 @@
 // resolved. Nothing reads /api/export or /api/import's result through the
 // request context and assumes it landed - a click's promise resolving is not
 // the write (or, here, the read) actually finishing.
+//
+// WHAT NEVER GOES THROUGH THE API HERE: a POST to /api/trainer/attempts or
+// /api/trainer/chord-attempts. Neither table has a DELETE route (see
+// fret-weak-spots.spec.js's own file header on why trainer_attempts has to
+// stay untouched by every OTHER spec in this shared-database suite), so a
+// row logged here would leak into the rest of the run with no way to clean
+// it back up. The "newer tables" test below needs a real, nonzero fact in
+// both of those tables anyway - so it edits a real exported archive's own
+// manifest.json directly (via tests/browser/fixtures/zip.js) rather than
+// seed either table through its endpoint. That is exactly the path under
+// test - _apply_import reads `tables["trainer_attempts"]` verbatim, never
+// anything about how the row got into the archive - and it leaves the live
+// tables exactly as they were found, proved by reading their counts before
+// and after.
+import fs from "node:fs";
+
 import { expect, test } from "@playwright/test";
+
+import { buildZip, readZip } from "./fixtures/zip.js";
 
 const exportButton = (page) => page.getByTestId("export-button");
 const fileInput = (page) => page.getByTestId("import-file-input");
@@ -101,11 +119,26 @@ test("a preview names the newer tables too, when the archive actually carries th
   request,
 }) => {
   // ImportOut carries counts for setlists, saved drill scopes and drill
-  // history that the preview never named before this (issue #284). Seeded
-  // here so each is a real, nonzero fact in the exported archive rather than
-  // depending on whatever the shared library happens to hold when this spec
-  // runs - and torn down in `finally` regardless of how the assertions come
-  // out, the same discipline the rename test above uses.
+  // history that the preview never named before this (issue #284). The
+  // setlist, its membership and the preset below are seeded through the
+  // real API and torn down in `finally` regardless of how the assertions
+  // come out, the same discipline the rename test above uses - every one of
+  // those tables has a real DELETE route, so a real POST here leaves
+  // nothing behind.
+  //
+  // trainer_attempts and trainer_chord_attempts are the two exceptions:
+  // NEITHER has a delete route at all (see fret-weak-spots.spec.js's own
+  // file header on why trainer_attempts has to stay untouched by every
+  // OTHER spec in this shared-database suite - the same is true of
+  // trainer_chord_attempts, just not yet load-bearing for an ordering
+  // rule). A row POSTed to either endpoint here would leak into every later
+  // spec in this run with no way to clean it up again - which is exactly
+  // what a real archive's own export/import round trip already carries
+  // without ever touching those live tables: the two rows below are
+  // written directly into a REAL exported archive's own manifest.json (the
+  // import path this test actually means to exercise, never the POST
+  // routes), and the counts read before and after prove neither table was
+  // touched.
   // /api/upload answers with only { saved: <path> } - the score row it
   // starts a scan to create is read back separately, the same way
   // zzz-library-organise.spec.js's own upload() helper does.
@@ -144,29 +177,12 @@ test("a preview names the newer tables too, when the archive actually carries th
       },
     })
   ).json();
+  const attemptsBefore = (await (await request.get("/api/trainer/attempts")).json()).total;
+  const chordAttemptsBefore = (
+    await (await request.get("/api/trainer/chord-attempts")).json()
+  ).total;
   try {
     await request.post(`/api/setlists/${setlist.id}/scores`, { data: { score_id: score.id } });
-    await request.post("/api/trainer/attempts", {
-      data: {
-        drill: "fret_to_note",
-        direction: "position_to_note",
-        target_string: 6,
-        target_fret: 3,
-        target_note: "G",
-        given_note: "G",
-      },
-    });
-    await request.post("/api/trainer/chord-attempts", {
-      data: {
-        drill: "chord_flashcards",
-        direction: "shape_to_name",
-        target_root: "C",
-        target_quality: "major",
-        target_shape: [{ string: 5, fret: 3 }],
-        given_root: "C",
-        given_quality: "major",
-      },
-    });
 
     await page.goto("/#/settings");
     const downloadPromise = page.waitForEvent("download");
@@ -174,7 +190,55 @@ test("a preview names the newer tables too, when the archive actually carries th
     const download = await downloadPromise;
     const archivePath = await download.path();
 
-    await fileInput(page).setInputFiles(archivePath);
+    // The real export, edited rather than replayed through the two POST
+    // routes that leak (see the comment above): read its own manifest.json
+    // back out, add one fret-to-note and one chord attempt directly to the
+    // tables the import path reads, and re-pack the SAME files/ entries
+    // (untouched, still hashing to what the manifest already claims for
+    // them) into a new archive. Every OTHER table here - the score, the
+    // setlist, the preset - is still the real export's own real row;
+    // nothing about this fabricates a whole manifest from nothing (that is
+    // the OTHER new test in this file, which needs exactly that).
+    const entries = readZip(fs.readFileSync(archivePath));
+    const manifestEntry = entries.find((e) => e.name === "manifest.json");
+    const manifest = JSON.parse(manifestEntry.data.toString("utf-8"));
+    manifest.tables.trainer_attempts.push({
+      owner: "local",
+      session_id: null,
+      drill: "fret_to_note",
+      direction: "position_to_note",
+      target_string: 6,
+      target_fret: 3,
+      target_note: "G",
+      given_string: null,
+      given_fret: null,
+      given_note: "G",
+      correct: 1,
+      response_ms: null,
+    });
+    manifest.tables.trainer_chord_attempts.push({
+      owner: "local",
+      session_id: null,
+      drill: "chord_flashcards",
+      direction: "shape_to_name",
+      target_root: "C",
+      target_quality: "major",
+      target_shape: JSON.stringify([{ string: 5, fret: 3 }]),
+      given_root: "C",
+      given_quality: "major",
+      given_notes: null,
+      given_shape: null,
+      correct: 1,
+      response_ms: null,
+    });
+    manifestEntry.data = Buffer.from(JSON.stringify(manifest), "utf-8");
+    const editedArchive = buildZip(entries);
+
+    await fileInput(page).setInputFiles({
+      name: "edited-export.zip",
+      mimeType: "application/zip",
+      buffer: editedArchive,
+    });
     const preview = importPreview(page);
     await expect(preview).toBeVisible();
     // One count named for each table this component could not say anything
@@ -192,6 +256,94 @@ test("a preview names the newer tables too, when the archive actually carries th
     await request.delete(`/api/scores/${score.id}`);
     await request.delete(`/api/trash/${score.id}`);
   }
+  // Neither trainer table was ever written to - the archive was edited, not
+  // replayed through the POST routes that leak - so both counts are exactly
+  // what they were before this test ran.
+  expect((await (await request.get("/api/trainer/attempts")).json()).total).toBe(attemptsBefore);
+  expect((await (await request.get("/api/trainer/chord-attempts")).json()).total).toBe(
+    chordAttemptsBefore,
+  );
+});
+
+test("previewing an archive that carries only scores names just that, with every other count folded away", async ({
+  page,
+}) => {
+  // importSummaryText's zero-fold (issue #284): every IMPORT_COUNT_FIELD
+  // that is 0 disappears into one closing clause rather than being named
+  // one by one, and the ALL-zero case gets its own sentence rather than
+  // reusing that clause with nothing named first - see that function's own
+  // comment on the wording bug this replaced ("This archive holds nothing
+  // else was in the archive"). None of the five tests above build an
+  // archive isolated enough to prove the PARTIAL fold - one real count,
+  // every other one genuinely zero - still reads correctly: the shared
+  // library's own export always carries a mix of nonzero counts. So this
+  // one is built from nothing rather than downloaded and edited, with a
+  // single scores row and every other table empty - format, schema_version,
+  // exported_at and fermata_version are still the real export's own (read
+  // back the same way the test above does), only `tables` is replaced, so
+  // this is never a guess at what a valid manifest looks like.
+  await page.goto("/#/settings");
+  const downloadPromise = page.waitForEvent("download");
+  await exportButton(page).click();
+  const download = await downloadPromise;
+  const real = JSON.parse(
+    readZip(fs.readFileSync(await download.path()))
+      .find((e) => e.name === "manifest.json")
+      .data.toString("utf-8"),
+  );
+
+  const onlyScores = {
+    ...real,
+    tables: {
+      instruments: [],
+      tags: [],
+      // file_included: false, so nothing here needs a matching files/ entry
+      // (see api.py's _referenced_files) - only the row, which is all this
+      // preview ever reads a count from.
+      scores: [
+        {
+          id: 1,
+          path: "Uploads/only-scores-preview.musicxml",
+          hash: "0".repeat(40),
+          deleted_at: null,
+          file_included: false,
+        },
+      ],
+      score_tags: [],
+      transcriptions: [],
+      practice_sessions: [],
+      practice_goals: [],
+      settings: [],
+      setlists: [],
+      setlist_scores: [],
+      trainer_attempts: [],
+      trainer_chord_attempts: [],
+      trainer_scope_presets: [],
+      trainer_scope_preset_strings: [],
+    },
+  };
+  const archive = buildZip([
+    { name: "manifest.json", data: Buffer.from(JSON.stringify(onlyScores), "utf-8") },
+  ]);
+
+  await fileInput(page).setInputFiles({
+    name: "only-scores.zip",
+    mimeType: "application/zip",
+    buffer: archive,
+  });
+  await expect(importPreview(page)).toBeVisible();
+  // The exact sentence importSummaryText produces when exactly one count is
+  // real and every other one folds away - not a substring, so a mutation
+  // that breaks that fold (dropping the "- nothing else..." clause, or
+  // reusing the all-zero branch's own wording here instead) shows up as a
+  // mismatch here rather than passing unnoticed the way it did before this
+  // test existed.
+  const expected =
+    `This archive holds 1 score - nothing else was in the archive, written ` +
+    `${real.exported_at} by Fermata ${real.fermata_version}. Read from a schema version ` +
+    `${real.schema_version} archive into this Fermata's own schema version ` +
+    `${real.schema_version}.`;
+  await expect(page.getByTestId("import-counts")).toHaveText(expected);
 });
 
 test("previewing an archive that collides with a preset already here shows the rename", async ({

--- a/web/tests/browser/data-portability.spec.js
+++ b/web/tests/browser/data-portability.spec.js
@@ -53,6 +53,31 @@ const fileInput = (page) => page.getByTestId("import-file-input");
 const importError = (page) => page.getByTestId("import-error");
 const importPreview = (page) => page.getByTestId("import-preview");
 const importRenames = (page) => page.getByTestId("import-renames");
+const importCleaned = (page) => page.getByTestId("import-cleaned");
+
+// The 14 tables a manifest's `tables` object always carries (api.py's
+// EXPORT_TABLE_NAMES) - every key `_read_and_validate_manifest` requires
+// present as a list, empty unless a test below fills one in. Kept once here
+// rather than repeated per test, the way the "only scores" manifest above
+// builds its own inline (that one predates this helper).
+function emptyTables() {
+  return {
+    instruments: [],
+    tags: [],
+    scores: [],
+    score_tags: [],
+    transcriptions: [],
+    practice_sessions: [],
+    practice_goals: [],
+    settings: [],
+    setlists: [],
+    setlist_scores: [],
+    trainer_attempts: [],
+    trainer_chord_attempts: [],
+    trainer_scope_presets: [],
+    trainer_scope_preset_strings: [],
+  };
+}
 
 test("exporting the library downloads a real archive", async ({ page }) => {
   await page.goto("/#/settings");
@@ -388,5 +413,131 @@ test("previewing an archive that collides with a preset already here shows the r
     );
   } finally {
     await request.delete(`/api/trainer/presets/${created.id}`);
+  }
+});
+
+test("a row a normaliser only tidies is reported before AND after the import, and a clean archive says nothing", async ({
+  page,
+  request,
+}) => {
+  // ImportOut.cleaned (#286): the counts above name what arrived, but never
+  // said which of those rows a normaliser had to tidy on the way in - a
+  // lowercase pitch stored as "E2", say. This is the guaranteed case
+  // instruments.normalise makes (see server/tests/test_portability_api.py's
+  // own `test_an_archived_instrument_is_imported_with_its_name_and_pitches_cleaned`,
+  // which proves the same fact server-side): a POST to /api/instruments
+  // already normalises, so no instrument stored through the real API is
+  // ever dirty - the only way to get one INTO an archive is to hand-edit a
+  // manifest directly, exactly as the newer-tables test above does for
+  // trainer_attempts and trainer_chord_attempts.
+  //
+  // Two manifests, built from nothing rather than downloaded and edited
+  // (the "only scores" test's own technique) so applying the dirty one
+  // never touches anything already in the shared library: format,
+  // schema_version, exported_at and fermata_version are the real export's
+  // own, only `tables` is replaced, with a single instruments row and every
+  // other table empty.
+  await page.goto("/#/settings");
+  const downloadPromise = page.waitForEvent("download");
+  await exportButton(page).click();
+  const download = await downloadPromise;
+  const real = JSON.parse(
+    readZip(fs.readFileSync(await download.path()))
+      .find((e) => e.name === "manifest.json")
+      .data.toString("utf-8"),
+  );
+
+  const instrumentName = "Data portability cleaning check";
+  const baseRow = {
+    id: 1,
+    owner: "local",
+    kind: "string",
+    name: instrumentName,
+    fretted: 1,
+    string_count: 6,
+    fret_count: 19,
+    capo: 0,
+    reference_pitch: 440.0,
+    created_at: "2024-01-01T00:00:00",
+    updated_at: "2024-01-01T00:00:00",
+  };
+
+  // The column holds text written by Python's own `json.dumps` (api.py's
+  // create_instrument, and _apply_import's own `_store_cleaned` call, both
+  // use its default separators - see server/fermata/api.py) - `", "`
+  // between items, not JS's compact `JSON.stringify`. A "clean" row's
+  // string_pitches has to be byte-identical to what the normaliser would
+  // itself produce, or `_store_cleaned`'s own `row[key] != value` string
+  // comparison sees a spacing difference as a change and (wrongly, for the
+  // purposes of this test) counts the row as cleaned.
+  function pyJsonStringArray(items) {
+    return `[${items.map((item) => JSON.stringify(item)).join(", ")}]`;
+  }
+
+  function archiveWith(stringPitches) {
+    const manifest = {
+      ...real,
+      tables: {
+        ...emptyTables(),
+        instruments: [{ ...baseRow, string_pitches: pyJsonStringArray(stringPitches) }],
+      },
+    };
+    return buildZip([
+      { name: "manifest.json", data: Buffer.from(JSON.stringify(manifest), "utf-8") },
+    ]);
+  }
+
+  // Nothing to tidy: every pitch is already the canonical spelling
+  // instruments.normalise would store, so `cleaned` is `{}` and no line
+  // renders at all - the common case this line must stay silent for.
+  const cleanArchive = archiveWith(["E2", "A2", "D3", "G3", "B3", "E4"]);
+  await fileInput(page).setInputFiles({
+    name: "clean-instrument.zip",
+    mimeType: "application/zip",
+    buffer: cleanArchive,
+  });
+  await expect(importPreview(page)).toBeVisible();
+  await expect(importCleaned(page)).toHaveCount(0);
+
+  // One pitch spelled lowercase - a row instruments.normalise tidies rather
+  // than refuses. Choosing a new file resets this component's own import
+  // state (chooseFile calls resetImportState first), so the clean preview
+  // above is gone before this one is built.
+  const dirtyArchive = archiveWith(["e2", "A2", "D3", "G3", "B3", "E4"]);
+  await fileInput(page).setInputFiles({
+    name: "dirty-instrument.zip",
+    mimeType: "application/zip",
+    buffer: dirtyArchive,
+  });
+  await expect(importPreview(page)).toBeVisible();
+  // BEFORE anything is applied - the whole point of a dry run reporting this
+  // at all - a person sees the exact row that will be changed.
+  await expect(importCleaned(page)).toHaveText(
+    "1 instrument row was tidied to the stored form.",
+  );
+
+  let insertedId;
+  try {
+    await page.getByTestId("import-confirm").click();
+    await expect(page.getByTestId("import-success")).toBeVisible();
+    // AFTER applying, the same receipt - identical wording, since `cleaned`
+    // reads the same on a dry run and an applied import (ImportOut.cleaned's
+    // own docstring).
+    await expect(importCleaned(page)).toHaveText(
+      "1 instrument row was tidied to the stored form.",
+    );
+
+    const stored = (await (await request.get("/api/instruments")).json()).find(
+      (i) => i.name === instrumentName,
+    );
+    expect(stored, `${instrumentName} never appeared in the library`).toBeTruthy();
+    insertedId = stored.id;
+    // The value POST would have stored, not the raw one the archive
+    // carried - "E2", never "e2".
+    expect(stored.string_pitches[0]).toBe("E2");
+  } finally {
+    if (insertedId !== undefined) {
+      await request.delete(`/api/instruments/${insertedId}`);
+    }
   }
 });

--- a/web/tests/browser/data-portability.spec.js
+++ b/web/tests/browser/data-portability.spec.js
@@ -79,10 +79,119 @@ test("choosing a real exported archive shows what it actually holds", async ({ p
   await expect(importPreview(page)).toBeVisible();
   await expect(importPreview(page)).toContainText("This archive holds");
   await expect(importPreview(page)).toContainText("written");
+  // schema_version_read (#282) - always readable on a dry run, since a
+  // preview never gets far enough to see an archive whose version this
+  // Fermata refuses.
+  await expect(importPreview(page)).toContainText("schema version");
+  // ImportOut.tags_reused is 0 on every dry run by construction (the merge
+  // decision it counts is never made without a write transaction open - see
+  // ImportOut's own docstring), which makes this the one count in the whole
+  // response a preview can never show as nonzero. Its absence here is what
+  // proves the zero-fold in importSummaryText actually folds it away rather
+  // than the field simply never having been wired up.
+  await expect(importPreview(page)).not.toContainText("reused");
   // The confirm control is offered - proving this got as far as a real,
   // applicable preview rather than an error rendered under a different
   // testid - but is never clicked; see the module comment on why.
   await expect(page.getByTestId("import-confirm")).toBeVisible();
+});
+
+test("a preview names the newer tables too, when the archive actually carries them", async ({
+  page,
+  request,
+}) => {
+  // ImportOut carries counts for setlists, saved drill scopes and drill
+  // history that the preview never named before this (issue #284). Seeded
+  // here so each is a real, nonzero fact in the exported archive rather than
+  // depending on whatever the shared library happens to hold when this spec
+  // runs - and torn down in `finally` regardless of how the assertions come
+  // out, the same discipline the rename test above uses.
+  // /api/upload answers with only { saved: <path> } - the score row it
+  // starts a scan to create is read back separately, the same way
+  // zzz-library-organise.spec.js's own upload() helper does.
+  const uploadName = "data-portability-seed.musicxml";
+  await request.post("/api/upload?folder=Uploads", {
+    multipart: {
+      file: {
+        name: uploadName,
+        mimeType: "application/xml",
+        buffer: Buffer.from(
+          '<?xml version="1.0"?><score-partwise><part-list>' +
+            '<score-part id="P1"><part-name>Seed</part-name></score-part>' +
+            "</part-list><part id=\"P1\"></part></score-partwise>",
+        ),
+      },
+    },
+  });
+  let score;
+  await expect(async () => {
+    const found = (await (await request.get("/api/scores")).json()).find(
+      (s) => s.path === `Uploads/${uploadName}`,
+    );
+    expect(found, `${uploadName} never appeared in the library`).toBeTruthy();
+    score = found;
+  }).toPass({ timeout: 30_000 });
+  const setlist = await (
+    await request.post("/api/setlists", { data: { name: "Data portability setlist check" } })
+  ).json();
+  const preset = await (
+    await request.post("/api/trainer/presets", {
+      data: {
+        name: "Data portability preset check",
+        start_fret: 0,
+        end_fret: 4,
+        strings: [1, 2],
+      },
+    })
+  ).json();
+  try {
+    await request.post(`/api/setlists/${setlist.id}/scores`, { data: { score_id: score.id } });
+    await request.post("/api/trainer/attempts", {
+      data: {
+        drill: "fret_to_note",
+        direction: "position_to_note",
+        target_string: 6,
+        target_fret: 3,
+        target_note: "G",
+        given_note: "G",
+      },
+    });
+    await request.post("/api/trainer/chord-attempts", {
+      data: {
+        drill: "chord_flashcards",
+        direction: "shape_to_name",
+        target_root: "C",
+        target_quality: "major",
+        target_shape: [{ string: 5, fret: 3 }],
+        given_root: "C",
+        given_quality: "major",
+      },
+    });
+
+    await page.goto("/#/settings");
+    const downloadPromise = page.waitForEvent("download");
+    await exportButton(page).click();
+    const download = await downloadPromise;
+    const archivePath = await download.path();
+
+    await fileInput(page).setInputFiles(archivePath);
+    const preview = importPreview(page);
+    await expect(preview).toBeVisible();
+    // One count named for each table this component could not say anything
+    // about before - the wording each field's own label produces in
+    // importSummaryText, not a paraphrase of it.
+    await expect(preview).toContainText("setlist");
+    await expect(preview).toContainText("setlist entr"); // entry/entries
+    await expect(preview).toContainText("saved drill scope");
+    await expect(preview).toContainText("drill scope string set");
+    await expect(preview).toContainText("fret-to-note drill attempt");
+    await expect(preview).toContainText("chord drill attempt");
+  } finally {
+    await request.delete(`/api/trainer/presets/${preset.id}`);
+    await request.delete(`/api/setlists/${setlist.id}`);
+    await request.delete(`/api/scores/${score.id}`);
+    await request.delete(`/api/trash/${score.id}`);
+  }
 });
 
 test("previewing an archive that collides with a preset already here shows the rename", async ({
@@ -117,8 +226,13 @@ test("previewing an archive that collides with a preset already here shows the r
     await fileInput(page).setInputFiles(archivePath);
     await expect(importPreview(page)).toBeVisible();
     await expect(importRenames(page)).toBeVisible();
+    // The rename line now also names WHY (#260 vs #268's cleaning), read from
+    // ImportOut.trainer_scope_presets_renamed's own `reason` field - a plain
+    // name collision here, since nothing about this preset's name needed
+    // cleaning up.
     await expect(importRenames(page)).toContainText(
-      "Data portability rename check → Data portability rename check (imported)",
+      "Data portability rename check → Data portability rename check (imported) " +
+        "(that name was already taken)",
     );
   } finally {
     await request.delete(`/api/trainer/presets/${created.id}`);

--- a/web/tests/browser/fixtures/zip.js
+++ b/web/tests/browser/fixtures/zip.js
@@ -1,0 +1,117 @@
+// A tiny, self-contained ZIP reader and writer for tests that need to build
+// or round-trip a real archive without a new dependency - the same
+// discipline navigation-score.js's own buildMxl() already applies to a
+// single fixed pair of files. This one is generic (any number of named
+// entries) so data-portability.spec.js can read a REAL exported archive's
+// manifest.json, edit it, and re-pack the same files/ bytes into a new
+// archive - never hand-assembling a whole archive's worth of rows that
+// only the server's own export already knows how to produce correctly.
+import zlib from "node:zlib";
+
+/** Build a real ZIP archive (DEFLATE + a proper central directory) from
+ * `entries`, an array of {name, data: Buffer}. See buildMxl in
+ * navigation-score.js for the twin of this for the one fixed pair of files
+ * that fixture needs; this is the same format, generalised. */
+export function buildZip(entries) {
+  const locals = [];
+  const central = [];
+  let offset = 0;
+  for (const file of entries) {
+    const name = Buffer.from(file.name, "utf-8");
+    const deflated = zlib.deflateRawSync(file.data);
+    const crc = zlib.crc32 ? zlib.crc32(file.data) : crc32(file.data);
+    const local = Buffer.alloc(30);
+    local.writeUInt32LE(0x04034b50, 0);
+    local.writeUInt16LE(20, 4); // version needed
+    local.writeUInt16LE(0, 6); // flags - no data descriptor, so sizes are real
+    local.writeUInt16LE(8, 8); // deflate
+    local.writeUInt32LE(crc, 14);
+    local.writeUInt32LE(deflated.length, 18);
+    local.writeUInt32LE(file.data.length, 22);
+    local.writeUInt16LE(name.length, 26);
+    locals.push(local, name, deflated);
+
+    const entry = Buffer.alloc(46);
+    entry.writeUInt32LE(0x02014b50, 0);
+    entry.writeUInt16LE(20, 4); // version made by
+    entry.writeUInt16LE(20, 6); // version needed
+    entry.writeUInt16LE(0, 8);
+    entry.writeUInt16LE(8, 10);
+    entry.writeUInt32LE(crc, 16);
+    entry.writeUInt32LE(deflated.length, 20);
+    entry.writeUInt32LE(file.data.length, 24);
+    entry.writeUInt16LE(name.length, 28);
+    entry.writeUInt32LE(offset, 42);
+    central.push(entry, name);
+    offset += local.length + name.length + deflated.length;
+  }
+  const centralBuffer = Buffer.concat(central);
+  const eocd = Buffer.alloc(22);
+  eocd.writeUInt32LE(0x06054b50, 0);
+  eocd.writeUInt16LE(entries.length, 8);
+  eocd.writeUInt16LE(entries.length, 10);
+  eocd.writeUInt32LE(centralBuffer.length, 12);
+  eocd.writeUInt32LE(offset, 16);
+  return Buffer.concat([...locals, centralBuffer, eocd]);
+}
+
+/** Read a real ZIP archive back into {name, data} entries - a real parse of
+ * the central directory and each entry's local header (store OR deflate),
+ * not a guess at fixed offsets. Used only to round-trip an archive this
+ * suite itself downloaded a moment earlier (a real Fermata export written
+ * by Python's own zipfile), never anything untrusted. */
+export function readZip(buffer) {
+  const EOCD_SIZE = 22;
+  // Every archive this reads (this suite's own downloads) is a plain zip
+  // with no trailing comment, so the End Of Central Directory record is
+  // always exactly the last 22 bytes.
+  const eocdOffset = buffer.length - EOCD_SIZE;
+  if (eocdOffset < 0 || buffer.readUInt32LE(eocdOffset) !== 0x06054b50) {
+    throw new Error("readZip: no end-of-central-directory record at the expected offset");
+  }
+  const entryCount = buffer.readUInt16LE(eocdOffset + 10);
+  const centralDirOffset = buffer.readUInt32LE(eocdOffset + 16);
+
+  const out = [];
+  let pos = centralDirOffset;
+  for (let i = 0; i < entryCount; i++) {
+    if (buffer.readUInt32LE(pos) !== 0x02014b50) {
+      throw new Error(`readZip: central directory entry ${i} has a bad signature`);
+    }
+    const method = buffer.readUInt16LE(pos + 10);
+    const compressedSize = buffer.readUInt32LE(pos + 20);
+    const uncompressedSize = buffer.readUInt32LE(pos + 24);
+    const nameLen = buffer.readUInt16LE(pos + 28);
+    const extraLen = buffer.readUInt16LE(pos + 30);
+    const commentLen = buffer.readUInt16LE(pos + 32);
+    const localOffset = buffer.readUInt32LE(pos + 42);
+    const name = buffer.toString("utf-8", pos + 46, pos + 46 + nameLen);
+    pos += 46 + nameLen + extraLen + commentLen;
+
+    if (buffer.readUInt32LE(localOffset) !== 0x04034b50) {
+      throw new Error(`readZip: local file header for ${name} has a bad signature`);
+    }
+    const localNameLen = buffer.readUInt16LE(localOffset + 26);
+    const localExtraLen = buffer.readUInt16LE(localOffset + 28);
+    const dataStart = localOffset + 30 + localNameLen + localExtraLen;
+    const raw = buffer.subarray(dataStart, dataStart + compressedSize);
+    const data =
+      method === 0
+        ? Buffer.from(raw)
+        : zlib.inflateRawSync(raw, { maxOutputLength: uncompressedSize + 1 });
+    out.push({ name, data });
+  }
+  return out;
+}
+
+// node's zlib.crc32 only arrived in 22.2; this is the same polynomial, for
+// older runners - copied from navigation-score.js's own fallback rather than
+// imported, since that one is not exported.
+function crc32(buffer) {
+  let crc = ~0;
+  for (const byte of buffer) {
+    crc ^= byte;
+    for (let i = 0; i < 8; i++) crc = (crc >>> 1) ^ (0xedb88320 & -(crc & 1));
+  }
+  return (~crc) >>> 0;
+}

--- a/web/tests/browser/zz-library-missing.spec.js
+++ b/web/tests/browser/zz-library-missing.spec.js
@@ -409,13 +409,19 @@ test("a scan that found a missing file again says so, rather than only clearing 
   await expect(page.locator(`.card[href="#/score/${first.id}"] .missing-flag`)).toBeVisible();
   await expect(page.locator(".scan-note")).toHaveCount(0);
 
-  // Back at the path it left from.
+  // Back at the path it left from. Rewriting the bytes almost always changes
+  // the mtime even though the content is identical, so this scan is very
+  // likely ALSO an update (the scanner cannot tell "put back unchanged" from
+  // "put back with a new mtime" apart) - the added/updated note above can be
+  // on screen at the same time as the restored note this test cares about,
+  // which is why the assertions below target the restored note by its own
+  // testid rather than the shared `.scan-note` class.
   fs.writeFileSync(filePath(FIRST), bytes);
   const recovered = await scanAndWait(request);
   expect(recovered.restored, JSON.stringify(recovered)).toBe(1);
 
   await page.reload();
-  const note = page.locator(".scan-note");
+  const note = page.locator('[data-testid="scan-restored"]');
   await expect(note).toBeVisible();
   await expect(note).toContainText("1 score found again");
   await expect(note).toContainText("at the path it went missing from");

--- a/web/tests/browser/zz-library-missing.spec.js
+++ b/web/tests/browser/zz-library-missing.spec.js
@@ -409,13 +409,17 @@ test("a scan that found a missing file again says so, rather than only clearing 
   await expect(page.locator(`.card[href="#/score/${first.id}"] .missing-flag`)).toBeVisible();
   await expect(page.locator(".scan-note")).toHaveCount(0);
 
-  // Back at the path it left from. Rewriting the bytes almost always changes
-  // the mtime even though the content is identical, so this scan is very
-  // likely ALSO an update (the scanner cannot tell "put back unchanged" from
-  // "put back with a new mtime" apart) - the added/updated note above can be
-  // on screen at the same time as the restored note this test cares about,
-  // which is why the assertions below target the restored note by its own
-  // testid rather than the shared `.scan-note` class.
+  // Back at the path it left from - but via fs.writeFileSync, not a real
+  // remount. An ordinary remount leaves size and mtime exactly as they were,
+  // which is what lets scanner.py's own shortcut (_scan_file's size/mtime
+  // check, around line 733) return before the updated counter ever
+  // increments - so a genuine "put back unchanged" remount is NOT also an
+  // update. Rewriting the bytes here, though, does change the mtime even
+  // though the content is identical, so THIS scan is also an update - an
+  // artifact of how this test puts the file back, not something a real
+  // remount would show - which is why the assertions below target the
+  // restored note by its own testid rather than the shared `.scan-note`
+  // class.
   fs.writeFileSync(filePath(FIRST), bytes);
   const recovered = await scanAndWait(request);
   expect(recovered.restored, JSON.stringify(recovered)).toBe(1);

--- a/web/tests/browser/zzz-library-organise.spec.js
+++ b/web/tests/browser/zzz-library-organise.spec.js
@@ -242,6 +242,17 @@ test("deleting a score takes it to the trash with its history, and one press bri
   await request.post(`/api/scores/${score.id}/practice`, {
     data: { seconds: 3600, note: "hours on this" },
   });
+  // ScoreDeleteOut's tags_kept and goals_kept were never named in the receipt
+  // (issue #284) - seeded here so deleting actually carries a nonzero count
+  // of each, not only the sessions and transcriptions the receipt already
+  // stated. A period far from "this week" so it cannot collide with a goal
+  // any other spec in this shared library has set for the current one.
+  await request.patch(`/api/scores/${score.id}`, { data: { tags: ["organise-delete-tag"] } });
+  const goal = await (
+    await request.post("/api/practice/goals", {
+      data: { period_start: "2019-03-04", target_days: 1, scope: "score", score_id: score.id },
+    })
+  ).json();
 
   await organise(page);
   await choose(page, score);
@@ -253,9 +264,14 @@ test("deleting a score takes it to the trash with its history, and one press bri
   await expect(dialog).toContainText("practice history");
   await dialog.locator(".delete-apply").click();
 
-  // Gone from the grid, and the receipt says what is still attached.
+  // Gone from the grid, and the receipt says what is still attached - every
+  // fact ScoreDeleteOut carries about what was kept and moved, not only the
+  // two this receipt named before.
   await expect(page.locator(`.card[href="#/score/${score.id}"]`)).toHaveCount(0);
+  await expect(page.locator(".notice")).toContainText("every file moved to Trash");
   await expect(page.locator(".notice")).toContainText("1 practice session");
+  await expect(page.locator(".notice")).toContainText("1 tag");
+  await expect(page.locator(".notice")).toContainText("1 goal");
   await expect(page.locator(".notice")).toContainText("nothing was destroyed");
 
   // In the trash, saying where it came from.
@@ -280,6 +296,67 @@ test("deleting a score takes it to the trash with its history, and one press bri
   // there - which is exactly what this assertion must not be reading.
   await page.reload();
   await expect(page.locator(`.card[href="#/score/${score.id}"]`)).toBeVisible();
+  await request.delete(`/api/practice/goals/${goal.id}`);
+});
+
+test("deleting a score whose file was already missing needs no file moved", async ({
+  page,
+  request,
+}) => {
+  // The other end of ScoreDeleteOut's `file_moved` fold (issue #284): a score
+  // that was already flagged missing before it was deleted has nothing on
+  // disk to move to Trash, and the receipt says so rather than the "every
+  // file moved" wording the test above expects. A second file is left in
+  // place so the scan that marks the first one missing sees a library that
+  // still has SOME readable files - scanner._implausible refuses a pass that
+  // finds none at all, on purpose, regardless of how small the library is.
+  const score = await upload(request, "organise-delete-missing.musicxml");
+  await upload(request, "organise-delete-keepalive.musicxml");
+  fs.unlinkSync(path.join(libraryDir(), "Uploads", "organise-delete-missing.musicxml"));
+  await (await request.post("/api/scan")).json();
+  await scanSettled(request);
+  await expect(async () => {
+    const after = await (await request.get(`/api/scores/${score.id}`)).json();
+    expect(after.missing_since, "the scan should have flagged it missing").not.toBeNull();
+  }).toPass({ timeout: SCAN_DEADLINE_MS });
+
+  await page.goto("/#/");
+  await organise(page);
+  await choose(page, score);
+  await page.locator(".delete-open").click();
+  await page.locator(".dialog.delete .delete-apply").click();
+
+  await expect(page.locator(".notice")).toContainText("no file needed moving");
+});
+
+test("restoring a score whose file already left the trash still comes back, flagged missing", async ({
+  page,
+  request,
+}) => {
+  // ScoreRestoreOut's `file_restored` was never read (issue #284): the trash
+  // folder is a real folder a person may empty by hand (docs/deployment.md),
+  // and until now restoring after that said exactly the same "is back at"
+  // words as an ordinary restore, with nothing on screen distinguishing the
+  // row that actually needs a file put back from the one that does not.
+  const score = await upload(request, "organise-restore-nofile.musicxml");
+  const deleted = await request.delete(`/api/scores/${score.id}`);
+  expect(deleted.ok(), await deleted.text()).toBe(true);
+  const trashed = await deleted.json();
+  fs.unlinkSync(path.join(libraryDir(), trashed.trashed_to));
+
+  await page.goto("/#/");
+  await page.locator(".trash-link").click();
+  const row = page.locator(".trash-row");
+  await expect(row).toHaveCount(1);
+  await row.locator(".trash-restore").click();
+
+  await expect(page.locator(".notice")).toContainText("there was no file in Trash to restore");
+  await expect(page.locator(".notice")).toContainText("show as missing");
+  await expect(async () => {
+    const after = await (await request.get(`/api/scores/${score.id}`)).json();
+    expect(after.deleted_at).toBeNull();
+    expect(after.missing_since, "no file came back, so it must read as missing").not.toBeNull();
+  }).toPass({ timeout: SCAN_DEADLINE_MS });
 });
 
 test("destroying a score takes two presses and says what it destroys", async ({
@@ -289,6 +366,15 @@ test("destroying a score takes two presses and says what it destroys", async ({
   const score = await upload(request, "organise-destroy.musicxml");
   const logged = await (
     await request.post(`/api/scores/${score.id}/practice`, { data: { seconds: 600 } })
+  ).json();
+  // ScorePurgeOut's goals_kept and file_deleted were never named in the
+  // "gone for good" receipt (issue #284) - a goal here makes the first
+  // nonzero, and this score's real file on disk (see upload()) makes the
+  // second true rather than the "no file on disk" case.
+  const goal = await (
+    await request.post("/api/practice/goals", {
+      data: { period_start: "2019-03-11", target_days: 1, scope: "score", score_id: score.id },
+    })
   ).json();
   const deleted = await request.delete(`/api/scores/${score.id}`);
   expect(deleted.ok(), await deleted.text()).toBe(true);
@@ -308,6 +394,8 @@ test("destroying a score takes two presses and says what it destroys", async ({
   await confirm.click();
   await expect(page.locator(".trash-row")).toHaveCount(0);
   await expect(page.locator(".notice")).toContainText("gone for good");
+  await expect(page.locator(".notice")).toContainText("its file is deleted too");
+  await expect(page.locator(".notice")).toContainText("1 goal");
   await expect(page.locator(".notice")).toContainText("stayed in your history");
 
   await expect(async () => {
@@ -321,6 +409,7 @@ test("destroying a score takes two presses and says what it destroys", async ({
   expect(survivor, "the practice session went with the score").toBeTruthy();
   expect(survivor.seconds).toBe(600);
   expect(survivor.score_id).toBeNull();
+  await request.delete(`/api/practice/goals/${goal.id}`);
 });
 
 test("practice on a deleted score still counts, and stops being a way into it", async ({

--- a/web/tests/browser/zzzzz-setlists.spec.js
+++ b/web/tests/browser/zzzzz-setlists.spec.js
@@ -227,10 +227,37 @@ test("deleting a setlist removes it while its scores remain", async ({ page, req
   await expect(page.locator(".setlists")).toBeVisible();
   await expect(setlistRows(page)).toHaveCount(0);
   await expect(page.locator(".empty")).toBeVisible();
+  // SetlistDeleteOut's scores_untouched was never read anywhere (issue #284) -
+  // the confirmation dialog already promised the scores would be kept, and
+  // until now nothing on the list page that arrives at said whether that
+  // promise actually held for THIS setlist.
+  await expect(page.getByTestId("setlist-delete-notice")).toContainText("1 score");
+  await expect(page.getByTestId("setlist-delete-notice")).toContainText("untouched");
 
   // The score it held is still in the library.
   const stillThere = await (await request.get(`/api/scores/${a.id}`)).json();
   expect(stillThere.id).toBe(a.id);
+});
+
+test("deleting an empty setlist says so - zero scores, stated rather than hidden", async ({
+  page,
+  request,
+}) => {
+  // The other end of the same receipt: an empty setlist's scores_untouched
+  // is 0, and that is worth a sentence too rather than a blank one, the same
+  // "0 tags"-style rule the other receipts in this issue follow.
+  const created = await (
+    await request.post("/api/setlists", { data: { name: "Empty on purpose" } })
+  ).json();
+
+  await page.goto(`/#/setlists/${created.id}`);
+  await expect(members(page)).toHaveCount(0);
+
+  await page.locator(".delete-setlist").click();
+  await page.locator(".confirm-delete-yes").click();
+
+  await expect(page.locator(".setlists")).toBeVisible();
+  await expect(page.getByTestId("setlist-delete-notice")).toContainText("0 scores");
 });
 
 test("Start practising opens the first member in the real viewer", async ({ page, request }) => {

--- a/web/tests/browser/zzzzzzz-library-scan-poll.spec.js
+++ b/web/tests/browser/zzzzzzz-library-scan-poll.spec.js
@@ -61,8 +61,8 @@ const NAMES = {
   // `errors` count - only a file the scan cannot even OPEN is (see
   // scanner._scan's per-file OSError handler and its own test in
   // server/tests/test_scanner.py). A .gp file is hashed and nothing else, so
-  // locking it below is what actually reaches that handler.
-  locked: "scan-poll-locked.gp",
+  // denying it read permission below is what actually reaches that handler.
+  unreadable: "scan-poll-unreadable.gp",
 };
 
 const libraryDir = () => {
@@ -355,8 +355,8 @@ test("a file the scan cannot read shows an errors line naming what went wrong", 
   // screen, exactly like one that finished cleanly. The file is denied read
   // permission for the whole scan rather than only briefly, so this is not
   // a race against the scanner - the OSError is guaranteed, not hoped for.
-  placeFile(NAMES.locked);
-  const repair = breakFileForReading(filePath(NAMES.locked));
+  placeFile(NAMES.unreadable);
+  const repair = breakFileForReading(filePath(NAMES.unreadable));
   let status;
   try {
     status = await scanAndWait(request);
@@ -364,15 +364,16 @@ test("a file the scan cannot read shows an errors line naming what went wrong", 
     repair();
   }
   expect(status.errors, JSON.stringify(status)).toBe(1);
-  expect(status.last_error, JSON.stringify(status)).toContain(relPath(NAMES.locked));
+  expect(status.last_error, JSON.stringify(status)).toContain(relPath(NAMES.unreadable));
 
   await page.goto("/#/");
   const errorsLine = page.locator('[data-testid="scan-errors"]');
   await expect(errorsLine).toContainText("1 file could not be read");
-  await expect(errorsLine).toContainText(relPath(NAMES.locked));
+  await expect(errorsLine).toContainText(relPath(NAMES.unreadable));
 
-  // A second, real scan (the lock is gone now) proves the file was only ever
-  // unreadable rather than genuinely broken, and lets afterEach's cleanup
-  // find the row it expects instead of a file that was never added.
+  // A second, real scan (the permission denial is undone now) proves the
+  // file was only ever unreadable rather than genuinely broken, and lets
+  // afterEach's cleanup find the row it expects instead of a file that was
+  // never added.
   await scanAndWait(request);
 });

--- a/web/tests/browser/zzzzzzz-library-scan-poll.spec.js
+++ b/web/tests/browser/zzzzzzz-library-scan-poll.spec.js
@@ -39,7 +39,7 @@
 // before this point. The third test never touches the library at all, but
 // stays in this file rather than a new one because it is testing the same
 // poll the first two are.
-import { spawn } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -129,42 +129,50 @@ async function openLibrary(page) {
   await Promise.all([firstStatus, firstScores]);
 }
 
-/** Hold a real, OS-level exclusive lock on a file until told to let go.
+/** Make a file's bytes unreadable by this OS user, portably, and return a
+ *  function that undoes it.
  *
- * Neither Node's fs.open nor Python's own open() deny other readers by
- * default on Windows, so a second handle from either would simply succeed -
- * there is no way to reproduce "a file locked by something else" without a
- * handle opened with FileShare.None specifically, which only .NET's own
- * File.Open exposes here. PowerShell is used as the one thing on this box
- * that can hold such a handle across the scan below without becoming this
- * test's own subject. */
-function lockFileExclusively(absPath) {
-  const escaped = absPath.replace(/'/g, "''");
-  const ps = spawn("powershell.exe", [
-    "-NoProfile",
-    "-NonInteractive",
-    "-Command",
-    `$fs = [System.IO.File]::Open('${escaped}', 'Open', 'Read', 'None'); ` +
-      "Write-Output 'locked'; " +
-      "[Console]::In.ReadLine() | Out-Null; " +
-      "$fs.Close()",
-  ]);
-  let settle;
-  const ready = new Promise((resolve, reject) => {
-    settle = resolve;
-    ps.once("error", reject);
-    ps.stdout.on("data", (chunk) => {
-      if (chunk.toString().includes("locked")) settle();
-    });
-  });
-  return {
-    ready,
-    release: () =>
-      new Promise((resolve) => {
-        ps.once("exit", resolve);
-        ps.stdin.write("go\n");
-      }),
-  };
+ * The previous version of this held a real, OS-level EXCLUSIVE LOCK open for
+ * the whole scan, via a `powershell.exe` process spawned just to hold a
+ * .NET `FileShare.None` handle open across it - the one thing on Windows
+ * that denies even other readers. Two things sank that approach the moment
+ * it had to run somewhere other than this box: CI's Browser tests job runs
+ * on `ubuntu-latest` (.github/workflows/ci.yml), which has no
+ * `powershell.exe` at all, so the `spawn` itself failed there - not
+ * skipped, failed, on every run; and even a `pwsh` build of the same
+ * FileShare.None handle is merely ADVISORY on Linux, so Python's own
+ * `open()` would not have raised for it regardless.
+ *
+ * A permission denial needs no process held open on either OS, and is a
+ * real OSError from Python's own `open()`, not an advisory lock:
+ *
+ *   - POSIX (Linux, where CI's Browser tests job actually runs): `chmod 0`
+ *     removes read permission outright, and `open()` raises
+ *     PermissionError as long as this process is not root - which the
+ *     GitHub Actions runner user is not.
+ *   - Windows: `chmod` does not gate reads at all here - it only toggles
+ *     the read-only attribute, which blocks writes, not reads - so an ACL
+ *     deny entry is used instead (`icacls ... /deny`), which Python's
+ *     `open()` also surfaces as PermissionError. This branch never runs in
+ *     CI; it exists so this test still demonstrates the errors line when
+ *     the suite is run locally on Windows.
+ *
+ * Either way this lands in scanner.py's own per-file `except OSError`
+ * around its `_scan_file` call (scanner.py:587), which is what actually
+ * increments `errors` and sets `last_error` - the same handler the
+ * corresponding server-side unit test drives with a mocked OSError
+ * (server/tests/test_scanner.py, `test_the_scan_survives_a_file_that_cannot_be_read...`).
+ * This test needs the real thing, end to end, because what it is proving is
+ * that the count and the message reach the SCREEN, not that the handler
+ * exists. */
+function breakFileForReading(absPath) {
+  if (process.platform === "win32") {
+    const user = process.env.USERNAME;
+    execFileSync("icacls", [absPath, "/deny", `${user}:(R)`]);
+    return () => execFileSync("icacls", [absPath, "/remove:d", user]);
+  }
+  fs.chmodSync(absPath, 0o000);
+  return () => fs.chmodSync(absPath, 0o644);
 }
 
 test.beforeEach(async ({ request }) => {
@@ -344,17 +352,16 @@ test("a file the scan cannot read shows an errors line naming what went wrong", 
 }) => {
   // ScanStatusOut's `errors` and `last_error` were never read anywhere
   // (issue #284): a scan that hit a locked or vanishing file looked, on
-  // screen, exactly like one that finished cleanly. The file is locked for
-  // the whole scan rather than only briefly, so this is not a race against
-  // the scanner - the OSError is guaranteed, not hoped for.
+  // screen, exactly like one that finished cleanly. The file is denied read
+  // permission for the whole scan rather than only briefly, so this is not
+  // a race against the scanner - the OSError is guaranteed, not hoped for.
   placeFile(NAMES.locked);
-  const lock = lockFileExclusively(filePath(NAMES.locked));
-  await lock.ready;
+  const repair = breakFileForReading(filePath(NAMES.locked));
   let status;
   try {
     status = await scanAndWait(request);
   } finally {
-    await lock.release();
+    repair();
   }
   expect(status.errors, JSON.stringify(status)).toBe(1);
   expect(status.last_error, JSON.stringify(status)).toContain(relPath(NAMES.locked));

--- a/web/tests/browser/zzzzzzz-library-scan-poll.spec.js
+++ b/web/tests/browser/zzzzzzz-library-scan-poll.spec.js
@@ -39,6 +39,7 @@
 // before this point. The third test never touches the library at all, but
 // stays in this file rather than a new one because it is testing the same
 // poll the first two are.
+import { spawn } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -54,6 +55,14 @@ const FIXTURE = path.join(here, "..", "..", "test-fixtures", "notation-only.musi
 const NAMES = {
   noticed: "scan-poll-noticed.musicxml",
   survived: "scan-poll-survived.musicxml",
+  // .gp, not .pdf or .musicxml: scanner.py's PDF and MusicXML metadata readers
+  // (thumbs.pdf_info, metadata.musicxml_info) both catch every exception and
+  // return empty metadata, so a corrupt file of either kind is never an
+  // `errors` count - only a file the scan cannot even OPEN is (see
+  // scanner._scan's per-file OSError handler and its own test in
+  // server/tests/test_scanner.py). A .gp file is hashed and nothing else, so
+  // locking it below is what actually reaches that handler.
+  locked: "scan-poll-locked.gp",
 };
 
 const libraryDir = () => {
@@ -120,6 +129,44 @@ async function openLibrary(page) {
   await Promise.all([firstStatus, firstScores]);
 }
 
+/** Hold a real, OS-level exclusive lock on a file until told to let go.
+ *
+ * Neither Node's fs.open nor Python's own open() deny other readers by
+ * default on Windows, so a second handle from either would simply succeed -
+ * there is no way to reproduce "a file locked by something else" without a
+ * handle opened with FileShare.None specifically, which only .NET's own
+ * File.Open exposes here. PowerShell is used as the one thing on this box
+ * that can hold such a handle across the scan below without becoming this
+ * test's own subject. */
+function lockFileExclusively(absPath) {
+  const escaped = absPath.replace(/'/g, "''");
+  const ps = spawn("powershell.exe", [
+    "-NoProfile",
+    "-NonInteractive",
+    "-Command",
+    `$fs = [System.IO.File]::Open('${escaped}', 'Open', 'Read', 'None'); ` +
+      "Write-Output 'locked'; " +
+      "[Console]::In.ReadLine() | Out-Null; " +
+      "$fs.Close()",
+  ]);
+  let settle;
+  const ready = new Promise((resolve, reject) => {
+    settle = resolve;
+    ps.once("error", reject);
+    ps.stdout.on("data", (chunk) => {
+      if (chunk.toString().includes("locked")) settle();
+    });
+  });
+  return {
+    ready,
+    release: () =>
+      new Promise((resolve) => {
+        ps.once("exit", resolve);
+        ps.stdin.write("go\n");
+      }),
+  };
+}
+
 test.beforeEach(async ({ request }) => {
   // The same tolerant refusal every spec that shares Uploads/ makes: rows this
   // suite left under Uploads/, and rows already marked missing, are expected;
@@ -178,6 +225,11 @@ test("a scan started while the page is open is noticed without a reload", async 
 
   // One idle interval (15s) plus margin, and no reload anywhere in this test.
   await expect(card).toBeVisible({ timeout: 45_000 });
+  // ScanStatusOut's `added` was never read anywhere on this page (issue
+  // #284) - the same poll that put the card on screen also carries the count
+  // that says why, and this is the one test in the suite where "1 score
+  // added" is a real, nonzero fact rather than a fixture.
+  await expect(page.locator('[data-testid="scan-added-updated"]')).toContainText("1 score added");
 });
 
 test("one failed status request does not end the poll", async ({ page, request }) => {
@@ -284,4 +336,36 @@ test("the scan button reflects a scan the page did not start, at the fast poll c
       message: "expected at least 3 status requests within 5s at the fast cadence",
     })
     .toBeGreaterThanOrEqual(3);
+});
+
+test("a file the scan cannot read shows an errors line naming what went wrong", async ({
+  page,
+  request,
+}) => {
+  // ScanStatusOut's `errors` and `last_error` were never read anywhere
+  // (issue #284): a scan that hit a locked or vanishing file looked, on
+  // screen, exactly like one that finished cleanly. The file is locked for
+  // the whole scan rather than only briefly, so this is not a race against
+  // the scanner - the OSError is guaranteed, not hoped for.
+  placeFile(NAMES.locked);
+  const lock = lockFileExclusively(filePath(NAMES.locked));
+  await lock.ready;
+  let status;
+  try {
+    status = await scanAndWait(request);
+  } finally {
+    await lock.release();
+  }
+  expect(status.errors, JSON.stringify(status)).toBe(1);
+  expect(status.last_error, JSON.stringify(status)).toContain(relPath(NAMES.locked));
+
+  await page.goto("/#/");
+  const errorsLine = page.locator('[data-testid="scan-errors"]');
+  await expect(errorsLine).toContainText("1 file could not be read");
+  await expect(errorsLine).toContainText(relPath(NAMES.locked));
+
+  // A second, real scan (the lock is gone now) proves the file was only ever
+  // unreadable rather than genuinely broken, and lets afterEach's cleanup
+  // find the row it expects instead of a file that was never added.
+  await scanAndWait(request);
 });

--- a/web/tests/spec-floors/browser-data-portability-58.json
+++ b/web/tests/spec-floors/browser-data-portability-58.json
@@ -1,5 +1,5 @@
 {
   "file": "tests/browser/data-portability.spec.js",
-  "count": 4,
-  "reason": "issue #58: exporting the library downloads a real archive, a non-archive file is refused with a clear message, a real exported archive previews what it actually holds through the same upload path, and a preview colliding with a preset already in the library shows the rename it would make (#260 follow-up)."
+  "count": 5,
+  "reason": "issue #58: exporting the library downloads a real archive, a non-archive file is refused with a clear message, a real exported archive previews what it actually holds through the same upload path, a preview colliding with a preset already in the library shows the rename it would make and why (#260, #268), and a preview seeded with a setlist, a drill scope and drill history names every one of those counts too (#284)."
 }

--- a/web/tests/spec-floors/browser-data-portability-58.json
+++ b/web/tests/spec-floors/browser-data-portability-58.json
@@ -1,5 +1,5 @@
 {
   "file": "tests/browser/data-portability.spec.js",
-  "count": 5,
-  "reason": "issue #58: exporting the library downloads a real archive, a non-archive file is refused with a clear message, a real exported archive previews what it actually holds through the same upload path, a preview colliding with a preset already in the library shows the rename it would make and why (#260, #268), and a preview seeded with a setlist, a drill scope and drill history names every one of those counts too (#284)."
+  "count": 6,
+  "reason": "issue #58: exporting the library downloads a real archive, a non-archive file is refused with a clear message, a real exported archive previews what it actually holds through the same upload path, a preview colliding with a preset already in the library shows the rename it would make and why (#260, #268), a preview of a real export edited to also carry a setlist, a drill scope and drill history names every one of those counts too (#284), and a preview of an archive carrying only scores states the exact sentence importSummaryText's zero-fold produces when every other count is genuinely zero."
 }

--- a/web/tests/spec-floors/browser-data-portability-cleaned-284.json
+++ b/web/tests/spec-floors/browser-data-portability-cleaned-284.json
@@ -1,0 +1,5 @@
+{
+  "file": "tests/browser/data-portability.spec.js",
+  "count": 1,
+  "reason": "issue #284 follow-up: ImportOut.cleaned is rendered too, not just the counts - an archive with one instrument row a normaliser only tidies (a lowercase pitch) shows the exact tidied-row line in the preview BEFORE the import is applied, shows the identical line again in the applied block after, and an archive with nothing to tidy shows no such line at all."
+}

--- a/web/tests/spec-floors/browser-library-scan-poll-250.json
+++ b/web/tests/spec-floors/browser-library-scan-poll-250.json
@@ -1,5 +1,5 @@
 {
   "file": "tests/browser/zzzzzzz-library-scan-poll.spec.js",
-  "count": 3,
-  "reason": "issue #250: an already-open library page notices a scan it did not start, one failed status request does not end the poll, and the scan button shows and polls a scan the page did not start at the fast cadence."
+  "count": 4,
+  "reason": "issue #250: an already-open library page notices a scan it did not start, one failed status request does not end the poll, and the scan button shows and polls a scan the page did not start at the fast cadence. Issue #284 adds a fourth: a file locked for the whole scan produces a real errors:1 and last_error, shown as the scan-errors line."
 }

--- a/web/tests/spec-floors/browser-library-scan-poll-250.json
+++ b/web/tests/spec-floors/browser-library-scan-poll-250.json
@@ -1,5 +1,5 @@
 {
   "file": "tests/browser/zzzzzzz-library-scan-poll.spec.js",
   "count": 4,
-  "reason": "issue #250: an already-open library page notices a scan it did not start, one failed status request does not end the poll, and the scan button shows and polls a scan the page did not start at the fast cadence. Issue #284 adds a fourth: a file locked for the whole scan produces a real errors:1 and last_error, shown as the scan-errors line."
+  "reason": "issue #250: an already-open library page notices a scan it did not start, one failed status request does not end the poll, and the scan button shows and polls a scan the page did not start at the fast cadence. Issue #284 adds a fourth: a file denied read permission for the whole scan produces a real errors:1 and last_error, shown as the scan-errors line."
 }

--- a/web/tests/spec-floors/browser-setlists-6.json
+++ b/web/tests/spec-floors/browser-setlists-6.json
@@ -1,5 +1,5 @@
 {
   "file": "tests/browser/zzzzz-setlists.spec.js",
-  "count": 6,
-  "reason": "issue #6: the setlist UI seam - a setlist created from the page appears; scores added from the page render in order and a reorder survives a reload (so it was written, not rearranged locally); removing a member leaves the score in the library; a trashed score renders marked and unlinked (#56); deleting a setlist removes it while its scores remain; and Start practising opens the first member in the real viewer."
+  "count": 7,
+  "reason": "issue #6: the setlist UI seam - a setlist created from the page appears; scores added from the page render in order and a reorder survives a reload (so it was written, not rearranged locally); removing a member leaves the score in the library; a trashed score renders marked and unlinked (#56); deleting a setlist removes it while its scores remain, and says how many (#284); an empty setlist's zero-score delete receipt is stated rather than hidden (#284); and Start practising opens the first member in the real viewer."
 }

--- a/web/tests/spec-floors/browser-zzz-library-organise-56.json
+++ b/web/tests/spec-floors/browser-zzz-library-organise-56.json
@@ -1,5 +1,5 @@
 {
   "file": "tests/browser/zzz-library-organise.spec.js",
-  "count": 5,
-  "reason": "issue #56: moving, renaming a folder, deleting to the trash and restoring, destroying in two presses, and a batch move whose collision is blocked - each previewed or explained on the page before it happens."
+  "count": 7,
+  "reason": "issue #56: moving, renaming a folder, deleting to the trash and restoring, destroying in two presses, and a batch move whose collision is blocked - each previewed or explained on the page before it happens. Issue #284 adds two: a score already missing when it is deleted needs no file moved, and a score whose file already left the trash by hand still comes back, flagged missing rather than silently restored."
 }


### PR DESCRIPTION
## Premise, re-derived on main `0279b50`

Fields of each model, whether `web/src/` reads them **before** this change, and the read status **after**.

### `ImportOut` (23 fields)

| field | before | after |
|---|---|---|
| `dry_run` | unread | read (selects "This archive holds" vs "Imported") |
| `schema_version` | unread | read (stated alongside `schema_version_read`) |
| `schema_version_read` | unread | read (#282) |
| `exported_at` | read | read |
| `fermata_version` | read | read |
| `scores_imported` | read | read |
| `scores_trashed_imported` | read | read |
| `files_written` | unread | read |
| `transcriptions_imported` | unread | read |
| `tags_imported` | read | read |
| `tags_reused` | unread | read |
| `score_tags_imported` | unread | read |
| `instruments_imported` | read | read |
| `practice_sessions_imported` | read | read |
| `practice_goals_imported` | read | read |
| `settings_imported` | unread | read |
| `setlists_imported` | unread | read |
| `setlist_scores_imported` | unread | read |
| `trainer_attempts_imported` | unread | read |
| `trainer_chord_attempts_imported` | unread | read |
| `trainer_presets_imported` | unread | read |
| `trainer_preset_strings_imported` | unread | read |
| `trainer_scope_presets_renamed` (`.from`/`.to` only) | partially read | fully read, incl. `.reason` |

All 23 fields are read now. Every count folds into one sentence (`importSummaryText` in `DataPortability.svelte`); whatever is zero is folded into a trailing "nothing else was in the archive" clause instead of being named.

### `ScanStatusOut` (19 fields)

Before: `scanning`, `total`, `processed`, `refused`, `refused_reason`, `unmatched_paths`, `unmatched_count`, `acknowledge_token`, `restored`, `transcribe_batch_note`, `finished_at` (internal bookkeeping only, never shown) were read. `added`, `updated`, `errors`, `last_error`, `missing`, `unmatched_moves`, `started_at`, `transcribe_batch_started` were not.

After: `added`/`updated` are shown while scanning and after ("So far"/"Last scan: N added, M updated"). `errors`/`last_error` are shown as an alert-styled line when `errors > 0`. `missing`, `unmatched_moves`, `started_at`, `transcribe_batch_started` remain unread - `missing` and `unmatched_moves` are internal counters the refusal/reconciliation flow already reports through `refused_reason`/`unmatched_count`, and `started_at`/`transcribe_batch_started` are timestamps/flags with no reader-facing fact not already carried by `finished_at`/`transcribe_batch_note`. Not in scope per the issue's No-gos (no redesign, no touching the poll or refusal flow, #250).

### `ScoreDeleteOut` (9 fields)

Before: only `practice_sessions_kept`, `transcriptions_kept` read.
After: adds `tags_kept`, `goals_kept` (summed across a bulk selection) and `file_moved` (folded into "every file moved to Trash" / "no file needed moving" / "N of M files moved to Trash"). `deleted`, `title`, `deleted_from`, `trashed_to` remain unread by design: this is a bulk-select receipt, and per-item titles/paths cannot be stated individually in one sentence for a multi-score selection without a list per item - the library grid and Trash view already show each one back in place.

### `ScoreRestoreOut` (5 fields)

Before: `restored_to`, `restored_from` read.
After: adds `file_restored` - when false, the receipt says the file was not in Trash and the score reads as missing rather than the ordinary "is back at" wording. `restored` (always 1) and `score` (superseded by the `refresh()` immediately after) remain unread, both redundant with what the receipt/refresh already states.

### `ScorePurgeOut` (7 fields)

Before: `title`, `tags_destroyed`, `transcriptions_destroyed`, `practice_sessions_kept` read.
After: adds `goals_kept` and `file_deleted` ("its file is deleted too" / "it had no file on disk to delete"). `deleted` (always 1) remains unread, redundant with the title already named.

### `SetlistDeleteOut` (2 fields)

Before: neither read - the response wasn't even captured.
After: both `deleted` and `scores_untouched` are read; `scores_untouched` renders in a new notice on the setlists list page (`sessionStorage`-relayed across the navigate-away), `deleted` documented as redundant with "That setlist is gone."

## Done-when

- [x] After an import the panel names every table's count and the schema version read.
- [x] A scan with one unreadable file shows `errors: 1` and the error text.
- [x] Deleting a score with two tags and a goal says tags and goals were kept and where the file went.
- [x] Every field of the six models is read in `web/src/`, or documented above as deliberately not shown, with a reason.
- [x] Mutations (below) recorded red then green.
- [x] Floors updated (`web/tests/spec-floors/`).

## Mutations (each: mutate -> build -> run -> red -> revert -> build -> run -> green)

| # | Mutation | File | Spec run | Result |
|---|---|---|---|---|
| 1 | Import counts paragraph hardcoded to a literal string | `DataPortability.svelte` | `data-portability.spec.js` | 2 tests red (baseline preview test, seeded-tables test), reverted -> green |
| 2 | Scan errors line gated behind `false &&` | `Library.svelte` | `zzzzzzz-library-scan-poll.spec.js` | 1 test red (locked-file errors test), reverted -> green |
| 3 | Delete receipt's tags/goals clause dropped from the sentence | `Library.svelte` | `zzz-library-organise.spec.js` | 1 test red (delete-with-tag-and-goal test), reverted -> green |
| 4 | Setlist delete notice gated behind `false &&` | `Setlists.svelte` | `zzzzz-setlists.spec.js` | 2 tests red (nonzero and zero delete-notice tests), reverted -> green |

## Specs touched (all in `web/tests/browser/`, floors updated to match)

- `data-portability.spec.js`: extended the rename assertion for `.reason`; added a zero-fold assertion (`tags_reused` never shown, always 0 on a dry run); added a new test seeding a setlist, a two-string drill scope and one attempt of each drill, asserting every new label appears (4 -> 5 tests).
- `zzzzzzz-library-scan-poll.spec.js`: added an `added`-count assertion to the existing noticing test; added a new test that denies read permission on a file for the whole scan (a real OS-level `PermissionError`, not a mock) and asserts `errors: 1` and the errors line (3 -> 4 tests).
- `zzz-library-organise.spec.js`: extended the delete test with a tag and a goal (asserts `tags_kept`/`goals_kept`/`file_moved` fold); extended the destroy test with a goal (asserts `goals_kept`/`file_deleted`); added a delete-of-an-already-missing-score test (`file_moved: false` fold) and a restore-without-a-trashed-file test (`file_restored: false`) (6 -> 8 tests, combined with the adjacent F6 review floor).
- `zzzzz-setlists.spec.js`: extended the setlist-delete test with the new notice assertion; added an empty-setlist delete test for the zero case (6 -> 7 tests).

## Runs

- Unit: `npx playwright test tests/unit/practice.spec.js` - 41 passed.
- Browser (touched specs only, `FERMATA_TEST_PORT=9251`, `PLAYWRIGHT_ALLOW_PARTIAL=1`, foreground): `data-portability.spec.js`, `zzz-library-organise.spec.js`, `zzzzzzz-library-scan-poll.spec.js`, `zzzzz-setlists.spec.js` - 24 passed, plus the 41 unit tests in the same combined run - 65 passed total.
- Pytest: not run - no `server/` change.
- Full suite: not run, per instructions. `gh pr checks --watch`: not run, per instructions.

## Scope

Touched only `web/src/lib/DataPortability.svelte`, `web/src/lib/Library.svelte`, `web/src/lib/Setlists.svelte`, the four browser specs named above, and their floor entries under `web/tests/spec-floors/`. Nothing under `server/`, `docs/`, `trainer/`, the editor, or the viewer.

## After review

- The scan-added/updated line (`Library.svelte`) was gated on `scan.scanning || scan.finished_at`, so it showed up after every scan even when nothing was added or updated - `zz-library-missing.spec.js`'s "nothing to report yet" assertion caught this. Regated on `scan.scanning || scan.added || scan.updated`, the same nonzero-fact pattern the errors and restored lines already use.
- `zzzzzzz-library-scan-poll.spec.js`'s errors test held an OS-level exclusive lock by spawning `powershell.exe`, which does not exist on the `ubuntu-latest` runner CI's Browser tests job actually uses - the spawn itself failed there, and even a Linux-capable lock would only be advisory and would not make Python's `open()` raise. Replaced with a portable permission denial: `chmod 0` on POSIX (real `PermissionError`, no subprocess), `icacls ... /deny` on Windows (chmod alone does not block reads there) - both land in `scanner.py`'s own per-file `except OSError` around its `_scan_file` call.
- `importSummaryText` (`DataPortability.svelte`) read "This archive holds nothing else was in the archive, written …" when every count was zero. The all-zero case now gets its own sentence ("This archive holds nothing, written …" / "Nothing was imported, written …").
- Corrected `ScoreRestoreOut`'s field count above (5, not 6).

Closes #284



## Third review

Fixed three findings from a third review pass.

**Blocking (CI red, run 34150218774).** The "newer tables" test in `data-portability.spec.js` POSTed to `/api/trainer/attempts` and `/api/trainer/chord-attempts` to seed the archive. Neither table has a DELETE route, so both rows leaked into the shared suite database: `fret-weak-spots.spec.js`'s first test (which has to see `trainer_attempts` at exactly 0 - see that file's own header on why it sorts first) failed `Expected: 0 Received: 1`, and a `trainer_chord_attempts` row leaked too (latent - `chord-flashcards.spec.js` sorts before this file, so it never noticed). Fixed by never POSTing to either endpoint: the test now downloads a real export, reads its own `manifest.json` back out (`tests/browser/fixtures/zip.js`, a small hand-rolled zip reader/writer - the same format `navigation-score.js`'s own `buildMxl` already uses, generalised), adds one fret-to-note and one chord attempt row directly to `tables.trainer_attempts`/`tables.trainer_chord_attempts`, and re-packs the same `files/` entries into a new archive for the preview. That is the import path actually under test - `_apply_import` reads those tables verbatim, never caring how a row got into the archive. The test now also reads both tables' counts before and after and asserts they are unchanged.

**Uninstanced claim.** `importSummaryText`'s all-zero branch had no test exercising the "one real count, everything else genuinely zero" fold that sits right next to it - the five existing tests only ever hit archives with a mix of nonzero counts. Added a new test that builds a from-scratch manifest (real `format`/`schema_version`/`exported_at`/`fermata_version`, read back from a real export; only `tables` is replaced) carrying a single `scores` row and nothing else, and asserts the exact sentence `importSummaryText` produces. Reverting the fix's wording (dropping the "- nothing else was in the archive" clause) turns this new test red while leaving the other five green, closing the gap.

**Nits.** `browser-library-scan-poll-250.json`'s `reason`, `NAMES.locked`/its comment, and "the lock is gone now" in `zzzzzzz-library-scan-poll.spec.js` still described a file lock; the mechanism is a permission denial (`chmod 0` / `icacls ... /deny`), so the name is now `NAMES.unreadable` and the wording follows. `Library.svelte`'s restored-note comment and its mirror in `zz-library-missing.spec.js` claimed a restored file is "frequently" also an update; `scanner.py`'s own remount shortcut (`_scan_file`, around line 733) keeps size and mtime for a genuine remount and returns before the `updated` counter increments, so the two never naturally co-occur - the comments now say the co-occurrence in that test is an artifact of the test rewriting bytes, not something a real remount does.

**Verification.**
- Three-spec ordered invocation (`data-portability.spec.js fret-weak-spots.spec.js chord-flashcards.spec.js`, one `playwright test` call): before the fix, reproduced `Expected: 0 Received: 1` on `fret-weak-spots.spec.js`'s first test; after the fix, all 23 tests pass.
- Wording mutation: reverting the "- nothing else was in the archive" clause turns only the new zero-fold test red (5 other data-portability tests stay green); reverted, green again.
- Floors: `browser-data-portability-58.json` raised 5 -> 6 (6 tests now in the file, matches); `browser-library-scan-poll-250.json` unchanged at 4 (4 tests, matches); `browser-zz-library-missing-95.json` unchanged at 3 (3 tests, matches).
- `navigation.spec.js`: 19 passed.
- Previous-round mutations re-verified: gating the restored note on `scan.finished_at` instead of `scan.restored` turns `zz-library-missing.spec.js`'s "found again" test red (reverted -> green); removing the scan-errors block turns `zzzzzzz-library-scan-poll.spec.js`'s permission-denial test red (reverted -> green).

Verdict: go.


## Cleaned receipt (#284 follow-up)

`ImportOut.cleaned` (added by #290: a table-name to row-count map of rows a
normaliser tidied rather than refused - a lowercase pitch stored as "E2",
say) was not rendered anywhere in `web/src/` (`grep -rn cleaned web/src/` was
empty), even though `DataPortability.svelte` already renders every other
`ImportOut` count. Fixed by rendering one sentence per non-zero table in
both the preview (dry run) and applied blocks, in the vocabulary
`docs/api.md`'s import section already uses ("tidied"): e.g. `"1 instrument
row was tidied to the stored form."` A table with a zero count, or `cleaned`
being `{}` (the common case), renders no line at all - no "0 cleaned" line
is ever shown.

This is the dry-run-matters case: a person sees which rows will be changed
*before* confirming the import, not only after.

**Test.** `data-portability.spec.js` gained one test that builds a minimal,
from-scratch manifest (real `format`/`schema_version`/`exported_at`/
`fermata_version`, only `tables` replaced - the "only scores" test's own
technique, so applying it never touches anything already in the shared
library) carrying one `instruments` row. First with every pitch already
canonical - previewed, asserts no `import-cleaned` element renders at all.
Then with one pitch spelled lowercase - `instruments.normalise` tidies
rather than refuses this, exactly as
`test_an_archived_instrument_is_imported_with_its_name_and_pitches_cleaned`
proves server-side. Previews it and asserts the exact line; clicks Import;
asserts the identical line in the applied block; confirms via `GET
/api/instruments` that the stored pitch is `"E2"`, not `"e2"`; deletes the
one row the apply inserted in `finally`.

One snag found and fixed while writing it: the archived `string_pitches`
column holds text from Python's `json.dumps` (`", "` between items), not
JS's compact `JSON.stringify` - the first version of the "clean" manifest
built the JSON text without spaces, which `_store_cleaned`'s own
`row[key] != value` string comparison read as a change, wrongly counting an
already-canonical row as cleaned.

**Mutations.** Dropping the cleaned line from the preview block only turns
the new test red at the pre-apply assertion (baseline: 7 passed); reverted,
green. Dropping it from the applied block only turns the same test red at
the post-apply assertion instead, proving that assertion is independent;
reverted, green. Both rebuilt before and after.

**Floor.** New file `browser-data-portability-cleaned-284.json`, `count: 1`
(summed with the existing `browser-data-portability-58.json`'s 6 -> 7,
matching 7 executed tests).

**Runs.** `data-portability.spec.js fret-weak-spots.spec.js
chord-flashcards.spec.js` (ordered, one invocation): 24 passed.
`navigation.spec.js`: 19 passed. `DataPortability.svelte` is not in
`practice.spec.js`'s `COMPONENTS` guard; new strings hand-checked against
`FORBIDDEN_WORDS` - clean.

Verdict: go.
