### PR TITLE
Catch corrupt-CRC archive members on import as 422, not 500 (#292)

### DIFF
--- a/server/fermata/api.py
+++ b/server/fermata/api.py
@@ -8,6 +8,7 @@ import re
 import shutil
 import sqlite3
 import zipfile
+import zlib
 from datetime import datetime, timedelta, timezone
 from pathlib import Path, PurePosixPath
 from typing import Annotated
@@ -4564,6 +4565,11 @@ def _read_and_validate_manifest(zf: zipfile.ZipFile, conn) -> dict:
         raise HTTPException(
             422, f"the archive has no {EXPORT_MANIFEST_NAME} - this is not a Fermata export"
         ) from None
+    except (zipfile.BadZipFile, zlib.error):
+        raise HTTPException(
+            422, f"the archive's {EXPORT_MANIFEST_NAME} could not be read - the archive is "
+            "corrupt. Nothing has been imported."
+        ) from None
     try:
         manifest = json.loads(raw)
     except json.JSONDecodeError as exc:
@@ -5555,6 +5561,11 @@ async def import_library(file: UploadFile, dry_run: bool = True):
         except KeyError:
             raise HTTPException(
                 422, f"the archive is missing the file it names for {name}"
+            ) from None
+        except (zipfile.BadZipFile, zlib.error):
+            raise HTTPException(
+                422, f"the archive's {name} could not be read - the archive is corrupt. "
+                "Nothing has been imported."
             ) from None
         # The same identity the rest of this feature relies on (sha1 of the
         # bytes), applied here to bytes still only in the archive - nothing

--- a/server/tests/test_portability_api.py
+++ b/server/tests/test_portability_api.py
@@ -22,6 +22,7 @@ import hashlib
 import io
 import json
 import re
+import struct
 
 import zipfile
 from pathlib import Path
@@ -1359,6 +1360,35 @@ def _bytes_of_zip(entries: dict[str, bytes]) -> bytes:
     return buf.getvalue()
 
 
+def _corrupt_one_crc_byte(archive: bytes, member: str) -> bytes:
+    """Flip one byte of `member`'s CRC-32 as recorded in the archive's
+    central directory - #292's exact shape: the zip itself stays well-formed
+    (still opens, still lists every name), but `ZipFile.read()` on that ONE
+    member raises `zipfile.BadZipFile` partway through decompressing it,
+    rather than the `KeyError` a missing name raises. That is a different
+    exception than every other rejection test in this file provokes, and is
+    the one the two `zf.read()` calls in api.py did not used to catch.
+
+    Central directory file header layout (`PK\\x01\\x02`): the CRC-32 field
+    sits 16 bytes past the signature - see APPNOTE.TXT section 4.3.12, or
+    just count the fixed fields before it (sig, ver-made-by, ver-needed,
+    flags, method, time, date, then crc)."""
+    sig = b"PK\x01\x02"
+    buf = bytearray(archive)
+    idx = 0
+    while True:
+        idx = buf.find(sig, idx)
+        if idx == -1:
+            raise AssertionError(f"{member!r} not found in central directory")
+        name_len = struct.unpack_from("<H", buf, idx + 28)[0]
+        name = bytes(buf[idx + 46 : idx + 46 + name_len])
+        if name == member.encode():
+            crc_offset = idx + 16
+            buf[crc_offset] ^= 0xFF
+            return bytes(buf)
+        idx += len(sig)
+
+
 def test_import_rejects_a_zip_with_no_manifest(client):
     archive = _bytes_of_zip({"nothing.txt": b"not an export"})
     resp = client.post(
@@ -1420,6 +1450,73 @@ def test_import_rejects_a_corrupted_file_and_writes_nothing(client, add_score, t
     )
     assert resp.status_code == 422
     assert "hash" in resp.json()["detail"] or "corrupt" in resp.json()["detail"]
+    assert client.get("/api/scores").json() == []
+
+
+def test_import_rejects_a_corrupted_manifest_crc_in_both_modes(
+    client, add_score, tmp_path, monkeypatch
+):
+    """#292: a real export whose manifest.json CRC-32 is off by one byte in
+    the central directory used to reach `ZipFile.read()` unhandled -
+    `zipfile.BadZipFile` isn't `KeyError`, so it fell through the manifest
+    reader's existing `except KeyError` and reached the framework as a bare
+    500 instead of this feature's usual unreadable-archive 422. Both dry run
+    and applied import call `_read_and_validate_manifest` before either one
+    opens a transaction, so one corrupted archive proves both."""
+    add_score("Prelude.pdf", title="Prelude")
+    archive = client.get("/api/export").content
+    corrupted = _corrupt_one_crc_byte(archive, "manifest.json")
+
+    _switch_to_a_fresh_environment(monkeypatch, tmp_path, "target")
+
+    dry = client.post(
+        "/api/import", params={"dry_run": "true"},
+        files={"file": ("corrupt.zip", corrupted, "application/zip")},
+    )
+    assert dry.status_code == 422, dry.text
+    assert "manifest.json" in dry.json()["detail"]
+
+    applied = client.post(
+        "/api/import", params={"dry_run": "false"},
+        files={"file": ("corrupt.zip", corrupted, "application/zip")},
+    )
+    assert applied.status_code == 422, applied.text
+    assert "manifest.json" in applied.json()["detail"]
+    assert client.get("/api/scores").json() == []
+
+
+def test_import_rejects_a_corrupted_score_file_crc_in_both_modes(
+    client, add_score, tmp_path, monkeypatch
+):
+    """Same shape as the manifest case above, but for the OTHER `zf.read()`
+    this route makes: a score file's own bytes under `files/`, read inside
+    the `_referenced_files` loop that runs identically before dry run and
+    apply branch apart, so a `BadZipFile` there used to escape its own
+    `except KeyError` the same way manifest.json's did."""
+    add_score("Prelude.pdf", title="Prelude")
+    archive = client.get("/api/export").content
+    names = [n for n in zipfile.ZipFile(io.BytesIO(archive)).namelist() if n.startswith("files/")]
+    assert len(names) == 1
+    corrupted = _corrupt_one_crc_byte(archive, names[0])
+
+    _switch_to_a_fresh_environment(monkeypatch, tmp_path, "target")
+
+    dry = client.post(
+        "/api/import", params={"dry_run": "true"},
+        files={"file": ("corrupt.zip", corrupted, "application/zip")},
+    )
+    assert dry.status_code == 422, dry.text
+    assert names[0] in dry.json()["detail"]
+
+    applied = client.post(
+        "/api/import", params={"dry_run": "false"},
+        files={"file": ("corrupt.zip", corrupted, "application/zip")},
+    )
+    assert applied.status_code == 422, applied.text
+    assert names[0] in applied.json()["detail"]
+    # The refusal happens in the pre-transaction file-collection loop, before
+    # _apply_import ever opens write_tx() - so this is nothing inserted, not
+    # merely something rolled back.
     assert client.get("/api/scores").json() == []
 
 

--- a/server/tests/test_portability_api.py
+++ b/server/tests/test_portability_api.py
@@ -25,6 +25,7 @@ import re
 import struct
 
 import zipfile
+import zlib
 from pathlib import Path
 
 import pytest
@@ -1450,6 +1451,80 @@ def test_import_rejects_a_corrupted_file_and_writes_nothing(client, add_score, t
     )
     assert resp.status_code == 422
     assert "hash" in resp.json()["detail"] or "corrupt" in resp.json()["detail"]
+    assert client.get("/api/scores").json() == []
+
+
+def _corrupt_deflate_stream(archive: bytes, member: str) -> bytes:
+    """Flip one byte INSIDE `member`'s compressed data so that decompressing
+    it raises `zlib.error` - the other exception `ZipFile.read()` can raise
+    on a corrupt member, and the half of api.py's `(BadZipFile, zlib.error)`
+    that a CRC flip alone never exercises (a CRC flip decompresses fine and
+    fails the checksum afterwards). Not every byte position produces a
+    decoder error - many just decompress to different bytes and fail the
+    CRC instead - so this walks the stream until one does, and asserts it
+    found one rather than silently handing back a CRC-shaped corruption.
+
+    Local file header (`PK\x03\x04`): name length at +26, extra length at
+    +28, name at +30, then the data; the central directory entry gives the
+    compressed size (+20) and the local header offset (+42)."""
+    cd_sig = b"PK"
+    idx = 0
+    while True:
+        idx = archive.find(cd_sig, idx)
+        assert idx != -1, f"{member!r} not found in central directory"
+        name_len = struct.unpack_from("<H", archive, idx + 28)[0]
+        if archive[idx + 46 : idx + 46 + name_len] == member.encode():
+            method = struct.unpack_from("<H", archive, idx + 10)[0]
+            csize = struct.unpack_from("<I", archive, idx + 20)[0]
+            local = struct.unpack_from("<I", archive, idx + 42)[0]
+            break
+        idx += len(cd_sig)
+    assert method == zipfile.ZIP_DEFLATED, f"{member!r} is stored, not deflated"
+    assert archive[local : local + 4] == b"PK"
+    lname, lextra = struct.unpack_from("<HH", archive, local + 26)
+    start = local + 30 + lname + lextra
+    for k in range(csize):
+        buf = bytearray(archive)
+        buf[start + k] ^= 0xFF
+        try:
+            zipfile.ZipFile(io.BytesIO(bytes(buf))).read(member)
+        except zlib.error:
+            return bytes(buf)
+        except zipfile.BadZipFile:
+            continue
+    raise AssertionError(f"no byte of {member!r}'s deflate stream raises zlib.error")
+
+
+@pytest.mark.parametrize("which", ["manifest", "score-file"])
+def test_import_rejects_a_corrupted_deflate_stream_in_both_modes(
+    client, add_score, tmp_path, monkeypatch, which
+):
+    """The `zlib.error` half of #292's fix, pinned on its own: a flipped byte
+    inside a member's compressed data makes `ZipFile.read()` raise
+    `zlib.error`, not `BadZipFile`, and the review of the fix showed that
+    narrowing the except tuple to `BadZipFile` alone left both CRC tests
+    green while this shape escaped as a 500 again. One parametrized test per
+    `zf.read()` site, same two-mode, nothing-imported contract as the CRC
+    tests above."""
+    add_score("Prelude.pdf", title="Prelude")
+    archive = client.get("/api/export").content
+    if which == "manifest":
+        member = "manifest.json"
+    else:
+        names = [n for n in zipfile.ZipFile(io.BytesIO(archive)).namelist() if n.startswith("files/")]
+        assert len(names) == 1
+        member = names[0]
+    corrupted = _corrupt_deflate_stream(archive, member)
+
+    _switch_to_a_fresh_environment(monkeypatch, tmp_path, "target")
+
+    for dry_run in ("true", "false"):
+        res = client.post(
+            "/api/import", params={"dry_run": dry_run},
+            files={"file": ("corrupt.zip", corrupted, "application/zip")},
+        )
+        assert res.status_code == 422, (dry_run, res.text)
+        assert member in res.json()["detail"]
     assert client.get("/api/scores").json() == []
 
 


### PR DESCRIPTION
Fixes #292.

**Bug.** A real export archive whose CRC-32 for one member (`manifest.json`,
or a score file under `files/`) is corrupted by even one byte made
`POST /api/import` return an unhandled `500`, in both dry run and applied
mode, instead of the existing unreadable-archive `422` refusal every other
malformed-archive case already gets.

**Cause.** `zipfile.ZipFile(file.file)` was wrapped in
`except zipfile.BadZipFile`, but the two places that actually read a member
out of the archive - the manifest reader's `zf.read(EXPORT_MANIFEST_NAME)`
and the import body's `zf.read(name)` per referenced file - caught only
`KeyError` (a missing name). A corrupt CRC surfaces as `BadZipFile` (or, for
a corrupt deflate stream, `zlib.error`) partway through decompression, which
neither `except` clause caught, so it reached the framework unhandled.

**Fix.** Catch `zipfile.BadZipFile` and `zlib.error` at both `zf.read()`
call sites and route them through a `422` that names the unreadable member,
identical in dry run and applied mode - both reads happen before either
mode opens a transaction, so nothing is ever applied either way.

**Tests** (`server/tests/test_portability_api.py`):
- a corrupted `manifest.json` CRC -> `422` naming it, in both modes
- a corrupted score-file CRC (under `files/`) -> `422` naming it, in both
  modes, with the library left empty
- the existing round-trip and hash-mismatch tests confirm a valid archive
  still imports and other corruption shapes are unaffected

**Verification.** Reproduced the `500` on main with a real export whose
`manifest.json` central-directory CRC was flipped by one byte, confirmed it
is a `zipfile.BadZipFile` escaping unhandled. Removing each new `except`
clause independently sends its corresponding test back to that same
unhandled exception. Full server suite run alongside the fix.


## After review

The review confirmed both CRC tests and the applied-mode "nothing written" contract (two-score archive, either member corrupt: zero rows, zero files), and found the `zlib.error` half of the except tuple load-bearing but unpinned: narrowing it to `BadZipFile` alone left both tests green while a flipped byte inside a deflate stream escaped as a 500. Added a parametrized test per read site that walks the member's compressed data to a byte the decoder rejects and asserts 422 in both modes with nothing imported; the same narrowing now turns exactly those two red. Module: 58 passed.
