### PR TITLE
Give the five Rule 8 bar counters and the no-tab analysis a reader

### DIFF
--- a/server/fermata/api.py
+++ b/server/fermata/api.py
@@ -1679,16 +1679,17 @@ def _transcription_row(conn, score_id: int):
 _BAR_KEYS = ("bars_overfull", "bars_short", "bars_defective", "bars_measured",
              "bars_padded", "bars_unread",
              # `bars_anacrusis` (issue #174): how many bars a first-bar pickup
-             # let Rule 8 excuse. A Rule 8 CONFORMANCE figure, not a structural
-             # disclosure - it is the bars_short/bars_defective arithmetic
+             # let Rule 8 excuse - the bars_short/bars_defective arithmetic
              # itself, adjusted for a pickup that is normal notation rather than
-             # a misread, and is shown through the bar-count headline and the
-             # warning prose (which names `anacrusis_bars`) like its
-             # bars_padded / bars_unread neighbours, not the disclosures panel.
-             # So it is listed in test_disclosure_keys._RULE8_CONFORMANCE_KEYS
-             # and stays OFF the web mirror. It still has to survive a reload
-             # for the same reason the rest do: a reader reopening a stored
-             # transcription must see that a first bar was excused, and which.
+             # a misread. Unlike bars_defective/bars_measured (the two Rule 8
+             # figures the bar-count headline reads directly, and which DO stay
+             # off the web mirror via test_disclosure_keys._RULE8_CONFORMANCE_
+             # KEYS), this one had no reader anywhere until issue #294 gave it a
+             # disclosures-panel row: it is a structural disclosure like its
+             # bars_padded / bars_unread neighbours, not a headline figure. It
+             # still has to survive a reload for the same reason the rest do: a
+             # reader reopening a stored transcription must see that a first bar
+             # was excused, and which.
              "bars_anacrusis", "notes_no_stem", "staves_no_stem",
              # `staves_stemless` (issue #91): a notation staff whose stem/beam
              # vector pass found NO stems at all, though it decoded noteheads

--- a/server/tests/test_disclosure_keys.py
+++ b/server/tests/test_disclosure_keys.py
@@ -30,20 +30,23 @@ _VENDORED_PATH = (
 )
 
 # The Rule 8 conformance figures inside _BAR_KEYS that are NOT structural
-# disclosures - already shown elsewhere (ScoreCompare's bar-count headline,
-# and the warning prose the *_bars lists feed), not through the disclosures
-# panel issue #155 built. Every other key in _BAR_KEYS is a structural
-# disclosure and belongs in the vendored file.
+# disclosures - already shown elsewhere, through ScoreCompare's bar-count
+# headline, not through the disclosures panel issue #155 built. Every other
+# key in _BAR_KEYS (including the other five Rule 8 figures below) IS a
+# structural disclosure and belongs in the vendored file.
+#
+# Only these two - `bars_defective` and `bars_measured` are the pair the
+# headline reads directly. `bars_overfull`, `bars_short`, `bars_padded`,
+# `bars_unread` and `bars_anacrusis` used to sit in this set too, on the
+# theory that the warning prose those five feed already reached a reader -
+# but that prose is server-built text in a generic warnings list, and the
+# COUNT each sentence is built from never reached web/src by field name
+# (issue #294 found `grep -rn "bars_overfull\|bars_short\|bars_padded\|
+# bars_unread\|bars_anacrusis" web/src` matched only a comment). They are
+# structural disclosures like any other _BAR_KEYS member now and belong in
+# the vendored file, so they were removed from this set in that same change.
 _RULE8_CONFORMANCE_KEYS = {
-    "bars_overfull", "bars_short", "bars_defective", "bars_measured",
-    "bars_padded", "bars_unread",
-    # `bars_anacrusis` (issue #174) is the Rule 8 arithmetic itself, adjusted
-    # for a first-bar pickup that is normal notation rather than a misread: it
-    # is how many bars were lifted out of bars_short / bars_defective. Shown
-    # through the bar-count headline and the warning prose (which names
-    # `anacrusis_bars`) exactly like bars_padded / bars_unread, not through the
-    # #155 disclosures panel, so it belongs here and stays off the web mirror.
-    "bars_anacrusis",
+    "bars_defective", "bars_measured",
 }
 
 

--- a/web/src/lib/ScoreCompare.svelte
+++ b/web/src/lib/ScoreCompare.svelte
@@ -339,10 +339,22 @@
   // not as a measured "raster, no staves" finding. Showing the parenthetical
   // there would state those placeholders as fact, so it is only shown once
   // page_count > 0 proves the fields were actually measured.
+  //
+  // page_count > 0 with vector: false is a SECOND unmeasured case, not the
+  // same as page_count === 0 (tabextract.py:5465-5473): the raster branch
+  // returns as soon as every page in the pdf fails _page_is_raster's vector
+  // check, `continue`-ing past `_detect_staves` for every one of them, so
+  // standard_staff_count is 0 there because staves were never counted, not
+  // because none were found. `vector` itself IS measured on every
+  // page_count > 0 path (it is exactly "did any page look like vector
+  // content"), so the reason - which always names the raster scan on this
+  // path - is trustworthy on its own; the staff-count parenthetical is only
+  // ever appended once `vector` is true and _detect_staves has actually run.
   function analysisSentence(a) {
     if (a.page_count === 0) return a.reason || "No tab staff found";
+    if (!a.vector) return a.reason || "No tab staff found: raster scan, staves were never counted";
     const staffNoun = a.standard_staff_count === 1 ? "staff" : "staves";
-    const counts = `${a.standard_staff_count} standard ${staffNoun}, ${a.vector ? "vector" : "raster"} PDF`;
+    const counts = `${a.standard_staff_count} standard ${staffNoun}, vector PDF`;
     return a.reason ? `${a.reason} (${counts})` : `No tab staff found: ${counts}`;
   }
 

--- a/web/src/lib/ScoreCompare.svelte
+++ b/web/src/lib/ScoreCompare.svelte
@@ -312,6 +312,32 @@
     }
   }
 
+  // The empty-state sentence for a score with nothing to extract (issue
+  // #294): built from every field TranscriptionAnalysisOut carries that says
+  // WHY, not just THAT - `vector`, `tab_staff_count`, `standard_staff_count`
+  // and `reason`. This is the only interface code that calls
+  // api.transcriptionAnalysis (see disclosures.js's top comment for the
+  // grep), so it lives here rather than in a shared pure-logic module: it
+  // describes one endpoint's response, not a family of counters with a
+  // row-per-counter shape the way DISCLOSURE_ROWS does.
+  //
+  // `reason` is the primary clause - tabextract.analyze() always sets one
+  // whenever `extractable` is false (a raster scan, a corrupt pdf, a
+  // standard-notation-only page, ...) and it already says WHY in words no
+  // fixed string here could match for every path. The staff-count summary
+  // rides along in parentheses so the two numbers this component would
+  // otherwise never show (tab_staff_count, standard_staff_count) reach a
+  // reader beside the reason they're evidence for. `reason` is only ever
+  // absent on a defensive path nothing in tabextract.py takes today (every
+  // return with extractable: false sets one) - the fallback exists so a
+  // future non-extractable path that forgets to set `reason` still shows
+  // something sensible instead of "undefined".
+  function analysisSentence(a) {
+    const staffNoun = a.standard_staff_count === 1 ? "staff" : "staves";
+    const counts = `${a.standard_staff_count} standard ${staffNoun}, ${a.vector ? "vector" : "raster"} PDF`;
+    return a.reason ? `${a.reason} (${counts})` : `No tab staff found: ${counts}`;
+  }
+
   async function loadTranscription() {
     // read via scoreId, not score.id: this runs synchronously (up to the
     // first await) inside the $effect below, and reading score.id directly
@@ -605,9 +631,15 @@
     {:else if transcriptionState === "none"}
       <div class="empty-state">
         <div class="empty-icon">𝄢</div>
-        {#if analysis && !analysis.extractable}
+        {#if analysis && (!analysis.extractable || analysis.tab_staff_count === 0)}
+          <!-- The two conditions are the same fact today - tabextract.analyze()
+               always sets `extractable` to exactly `tab_staff_count > 0` - but
+               checked separately since they are two different fields on the
+               response and either changing on its own in the future should
+               still land here rather than silently falling to the "no
+               transcription yet" branch below. -->
           <h3>No tab to extract</h3>
-          <p>{analysis.reason || "This PDF doesn't contain extractable tab or standard notation staves."}</p>
+          <p>{analysisSentence(analysis)}</p>
         {:else}
           <h3>No staff transcription yet</h3>
           <p>

--- a/web/src/lib/ScoreCompare.svelte
+++ b/web/src/lib/ScoreCompare.svelte
@@ -332,7 +332,15 @@
   // return with extractable: false sets one) - the fallback exists so a
   // future non-extractable path that forgets to set `reason` still shows
   // something sensible instead of "undefined".
+  //
+  // `page_count === 0` means the file was never analysed at all - open
+  // failed, or the pdf had no pages - and analyze() hardcodes vector: false
+  // and both staff counts to 0 on those paths as unmeasured placeholders,
+  // not as a measured "raster, no staves" finding. Showing the parenthetical
+  // there would state those placeholders as fact, so it is only shown once
+  // page_count > 0 proves the fields were actually measured.
   function analysisSentence(a) {
+    if (a.page_count === 0) return a.reason || "No tab staff found";
     const staffNoun = a.standard_staff_count === 1 ? "staff" : "staves";
     const counts = `${a.standard_staff_count} standard ${staffNoun}, ${a.vector ? "vector" : "raster"} PDF`;
     return a.reason ? `${a.reason} (${counts})` : `No tab staff found: ${counts}`;

--- a/web/src/lib/disclosures.js
+++ b/web/src/lib/disclosures.js
@@ -1,15 +1,25 @@
 // The structural-form and inference disclosures TranscriptionOut carries
-// beside the Rule 8 conformance figures (issue #155).
+// beside the Rule 8 conformance figures (issue #155), plus the five Rule 8
+// bar counters that are themselves structural disclosures with no other
+// reader (issue #294).
 //
 // Every one of these counters was computed, stored, reloaded through the
 // API, and mirrored in the response model - and then read by no interface
-// code. Only the warning PROSE reached a reader, through ScoreCompare.svelte's
-// generic warnings list; the count each sentence is built from never did. See
-// api_models.py's TranscriptionOut for the authoritative field list this
-// mirrors - every field it carries in the "_BAR_KEYS" group past
-// bars_overfull/bars_short/bars_defective/bars_measured/bars_padded/
-// bars_unread (which already reach a reader through ScoreCompare's bar-count
-// headline and the warning prose the *_bars lists feed) has a row here.
+// code. This file used to claim bars_overfull/bars_short/bars_padded/
+// bars_unread/bars_anacrusis "already reach a reader through ScoreCompare's
+// bar-count headline and the warning prose the *_bars lists feed" - that was
+// WRONG (issue #294): the bar-count headline reads only bars_defective and
+// bars_measured (ScoreCompare.svelte's bar-headline block), and the warning
+// PROSE those five feed is server-built text in the generic warnings list -
+// the count each sentence is built from never reaches web/src by field name,
+// only as already-formatted words inside a string nothing here parses back
+// apart. `grep -rn "bars_overfull\|bars_short\|bars_padded\|bars_unread\|
+// bars_anacrusis" web/src` matched only this comment. They get rows below
+// like every other counter. See api_models.py's TranscriptionOut for the
+// authoritative field list this mirrors - every field it carries in the
+// "_BAR_KEYS" group past bars_defective/bars_measured (the two Rule 8
+// figures that genuinely do reach a reader through ScoreCompare's bar-count
+// headline, and stay off this list for that reason) has a row here.
 //
 // ONE ROW PER COUNTER, on purpose - the issue's own fix shape is "decide the
 // presentation once for the family... the next decoder disclosure should
@@ -154,6 +164,23 @@ export const DISCLOSURE_ROWS = [
     label: "Tie ends whose other end was not found",
     barsKey: "tie_ends_unpaired_bars",
   },
+  // The five Rule 8 bar counters (issue #294) - `bars_defective` and
+  // `bars_measured` stay off this list because ScoreCompare's bar-count
+  // headline already reads those two directly; the other five _BAR_KEYS
+  // members had no reader anywhere until now (see this file's top comment).
+  // No barsKey: neither api_models.py's TranscriptionOut nor
+  // tabextract.py's ExtractionResult carries an `overfull_bars` or
+  // `short_bars` list - _bar_conformance only ever counted these two, it
+  // never kept which bars.
+  { key: "bars_overfull", label: "Bars with more beats than the time signature allows" },
+  { key: "bars_short", label: "Bars with fewer beats than the time signature requires" },
+  { key: "bars_padded", label: "Bars padded to length", barsKey: "padded_bars" },
+  { key: "bars_unread", label: "Bars that could not be read", barsKey: "unread_bars" },
+  // A Rule 8 exemption, not a defect - the count of bars a first-bar pickup
+  // let Rule 8 excuse, not bars that are wrong. Still a fact worth a row: it
+  // says which of the score's opening bars was assumed to be a pickup, an
+  // assumption about the page a reader must be able to check.
+  { key: "bars_anacrusis", label: "Pickup bars", barsKey: "anacrusis_bars" },
 ];
 
 /**

--- a/web/src/lib/disclosures.js
+++ b/web/src/lib/disclosures.js
@@ -43,9 +43,9 @@
 // row-selection rules (what's hidden, what's "not measured") can be tested
 // without a browser. What actually renders is Disclosures.svelte.
 export const DISCLOSURE_ROWS = [
-  { key: "repeats_unread", label: "Repeat marks not read", barsKey: "repeats_unread_bars" },
-  { key: "endings_unread", label: "Volta (ending) brackets not read", barsKey: "endings_unread_bars" },
-  { key: "endings_truncated", label: "Volta endings truncated", barsKey: "endings_truncated_bars" },
+  { key: "repeats_unread", label: "Repeat marks not read", barsKey: "repeats_unread_bars", family: "structural" },
+  { key: "endings_unread", label: "Volta (ending) brackets not read", barsKey: "endings_unread_bars", family: "structural" },
+  { key: "endings_truncated", label: "Volta endings truncated", barsKey: "endings_truncated_bars", family: "structural" },
   // A FLAG, not a count - tabextract.py:5172 trips it on ANY gap in the
   // volta numbers actually read, not only a missing "1" (seen_ints !=
   // range(1, seen_ints[-1] + 1) catches [1, 3] just as it catches [2, 3]),
@@ -53,7 +53,7 @@ export const DISCLOSURE_ROWS = [
   // bare "1" in a column of counts reads as "one thing", which is the wrong
   // claim for a yes/no fact - kind: "flag" renders it as presence, not a
   // number.
-  { key: "endings_incomplete", label: "Volta numbering has gaps", kind: "flag" },
+  { key: "endings_incomplete", label: "Volta numbering has gaps", kind: "flag", family: "structural" },
   // OVERSTATES if read as "repeat/volta marks": tabextract.py:1156 folds a
   // plain bar-style group (a final or double barline, carrying no <repeat>
   // and no <ending> at all - see docs/musicxml-tab-profile.md's "bar-style
@@ -67,6 +67,7 @@ export const DISCLOSURE_ROWS = [
     label: "Repeat/volta/bar-style marks with no bar to anchor to",
     barsKey: "form_marks_unanchored_bars",
     barsLabel: "near bar",
+    family: "structural",
   },
   // Counted per BAR, not per mark: tabextract.py:2163-2164 counts one bar
   // once even when two navigation instructions close on it together.
@@ -74,28 +75,30 @@ export const DISCLOSURE_ROWS = [
     key: "nav_marks_unresolved",
     label: "Bars whose navigation marks name no target this transcription holds",
     barsKey: "nav_marks_unresolved_bars",
+    family: "structural",
   },
   // No barsKey: a navigation mark with no bar to name has no bar number to
   // report (docs/musicxml-tab-profile.md, Rule 16 / issue #134 phase 2).
-  { key: "nav_marks_unanchored", label: "Navigation marks with no bar to anchor to" },
+  { key: "nav_marks_unanchored", label: "Navigation marks with no bar to anchor to", family: "structural" },
   // "System" here means a staff-sized GROUP OF LINES the page-scan found and
   // could not read as a staff (neither 5 nor 6 lines) - tabextract.py:
   // 344-346. Whether that group was actually a musical system is inferred
   // from its size, not confirmed - a stray staff-sized rule or decoration
   // would count the same way. The list beside this one is PAGES, not bars,
   // for the reason api_models.py's comment on systems_unread_pages gives.
-  { key: "systems_unread", label: "Staff-sized line groups not read as a system", barsKey: "systems_unread_pages", barUnit: "page" },
+  { key: "systems_unread", label: "Staff-sized line groups not read as a system", barsKey: "systems_unread_pages", barUnit: "page", family: "structural" },
   // Counted once per coincident GROUP (glyph_rhythm.py:3103-3113,
   // specifically the `coincident_unsplit_pairs += 1` at line 3111, inside
   // the loop over `_dup_groups` - one increment per group regardless of how
   // many duplicate copies it holds), not once per notehead.
-  { key: "coincident_unsplit_pairs", label: "Coincident notehead groups not split across voices" },
-  { key: "staves_coincident_unsplit", label: "Staves with an unsplit coincident group" },
-  { key: "unison_digits_shared", label: "Notes given another note's fret number" },
-  { key: "dots_unassigned", label: "Augmentation dots not assigned to a note" },
+  { key: "coincident_unsplit_pairs", label: "Coincident notehead groups not split across voices", family: "structural" },
+  { key: "staves_coincident_unsplit", label: "Staves with an unsplit coincident group", family: "structural" },
+  { key: "unison_digits_shared", label: "Notes given another note's fret number", family: "structural" },
+  { key: "dots_unassigned", label: "Augmentation dots not assigned to a note", family: "structural" },
   {
     key: "dots_unassigned_no_candidate",
     label: "Unassigned dots with no notehead or rest nearby",
+    family: "structural",
   },
   // glyph_rhythm.py:2957-2959: this dot DID reach a candidate notehead/rest,
   // but every one it reached already carried a dot at a conflicting tier
@@ -105,8 +108,9 @@ export const DISCLOSURE_ROWS = [
   {
     key: "dots_unassigned_eliminated",
     label: "Unassigned dots whose only candidates already had a conflicting or duplicate dot",
+    family: "structural",
   },
-  { key: "staves_dots_unassigned", label: "Staves with an unassigned dot" },
+  { key: "staves_dots_unassigned", label: "Staves with an unassigned dot", family: "structural" },
   // Quarter-note heads or shorter ONLY - glyph_rhythm.py:2934-2950 counts a
   // stemless filled (or x/diamond) notehead here specifically because a
   // missing stem costs its DURATION (the flag/beam that would say which
@@ -115,15 +119,15 @@ export const DISCLOSURE_ROWS = [
   // shape can carry a flag or beam in any notation, so a missing stem on one
   // of those costs only the voice signal, not the duration, and is not
   // counted here.
-  { key: "notes_no_stem", label: "Noteheads read with no stem (quarter or shorter)" },
-  { key: "staves_no_stem", label: "Staves with a stemless notehead" },
+  { key: "notes_no_stem", label: "Noteheads read with no stem (quarter or shorter)", family: "structural" },
+  { key: "staves_no_stem", label: "Staves with a stemless notehead", family: "structural" },
   // A whole notation staff whose stem/beam vector pass found NO stems at all,
   // though it decoded noteheads that must carry one (issue #91). Stronger than
   // the row above: not "one head lost its stem" but "no stem, flag or beam
   // anywhere on the staff was read", so its durations came from the notehead
   // shapes alone and the staff is degraded rather than reported as read
   // directly from its glyphs.
-  { key: "staves_stemless", label: "Staves with stem-bearing noteheads but no stems found at all" },
+  { key: "staves_stemless", label: "Staves with stem-bearing noteheads but no stems found at all", family: "structural" },
   // HOW THE DURATIONS WERE OBTAINED (issue #117). tabextract.py counted both
   // of these on every extraction from the start, inside `rhythm_provenance` -
   // a field nothing stores, nothing returns and no interface code reads - so
@@ -137,11 +141,13 @@ export const DISCLOSURE_ROWS = [
     key: "staves_spacing_rhythm",
     label: "Staves whose durations came from note spacing, not from glyphs",
     barsKey: "spacing_bars",
+    family: "structural",
   },
   {
     key: "staves_degraded_rhythm",
     label: "Staves read from the engraving with something on them left unread",
     barsKey: "degraded_bars",
+    family: "structural",
   },
   // A REFUSAL, not a defect in what was read (issue #129): a time signature
   // printed on the page whose digits include a glyph the decoder has no
@@ -152,6 +158,7 @@ export const DISCLOSURE_ROWS = [
   {
     key: "meter_digits_unreadable",
     label: "Printed time signatures refused over an unrecognised digit glyph",
+    family: "structural",
   },
   // Counted per tie END, not per tie (issue #81): a start with no stop and a
   // stop no start reached are each one, because there is no way to tell which
@@ -163,6 +170,7 @@ export const DISCLOSURE_ROWS = [
     key: "tie_ends_unpaired",
     label: "Tie ends whose other end was not found",
     barsKey: "tie_ends_unpaired_bars",
+    family: "structural",
   },
   // The five Rule 8 bar counters (issue #294) - `bars_defective` and
   // `bars_measured` stay off this list because ScoreCompare's bar-count
@@ -217,23 +225,37 @@ export const DISCLOSURE_ROWS = [
  * is untouched by this.
  *
  * This is a legacy-blob problem, not a hypothetical one: disclosures live in
- * one stored `confidence` JSON blob that is never backfilled, so a
- * transcription stored before issue #294 added the five bar counters carries
- * real structural numbers and simply has no bar keys at all (`undefined`,
- * not zero) - a single whole-object gate would have rendered all five bar
- * rows as "not measured" beside the real structural ones, stating a total
- * absence of measurement as fact for counters that were never even asked
- * for on that extraction. Symmetrically, a blob with bar counters but no
- * structural ones (the reverse legacy shape) must show only the bar rows.
+ * one stored `confidence` JSON blob that is never backfilled, and the two
+ * families were added to storage at different times - the seventeen
+ * structural counters by issue #155, `bars_padded`/`bars_unread` by #101 and
+ * `bars_anacrusis` by #174 (issue #294 added nothing to storage; it only
+ * gave the five bar counters a reader on the web side - see this file's top
+ * comment). A blob stored before whichever family arrived later on its
+ * timeline carries real numbers for the family that already existed and
+ * simply has no keys at all (`undefined`, not zero) for the one that
+ * didn't yet - a single whole-object gate would have rendered that missing
+ * family as a wall of "not measured" rows beside the real ones, stating a
+ * total absence of measurement as fact for counters that were never even
+ * asked for on that extraction. The gate has to work symmetrically: whichever
+ * family a given stored blob lacks, only the other family's rows should
+ * render.
  *
- * Before issue #294 there was only one family (this is why the original gate
- * used a single `anyMeasured`, and why there were seventeen counters in it -
- * the list only grows, which is why the sentence no longer names a number).
+ * Before the five bar counters got their own family tag there was only one
+ * family (this is why the original gate used a single `anyMeasured`, and why
+ * there were seventeen counters in it - the list only grows, which is why
+ * the sentence no longer names a number).
  */
 const BAR_FAMILY = "bar";
 
+// `family` is required on every DISCLOSURE_ROWS entry, not defaulted -
+// a defaulted "structural" fallback would silently misfile a future bar
+// row that forgot to set `family: "bar"` into the wrong family instead of
+// failing loudly. See disclosures.spec.js's guard on this.
 function familyOf(row) {
-  return row.family === BAR_FAMILY ? BAR_FAMILY : "structural";
+  if (!row.family) {
+    throw new Error(`disclosure row "${row.key}" has no family`);
+  }
+  return row.family;
 }
 
 export function disclosureRows(t) {

--- a/web/src/lib/disclosures.js
+++ b/web/src/lib/disclosures.js
@@ -172,15 +172,25 @@ export const DISCLOSURE_ROWS = [
   // tabextract.py's ExtractionResult carries an `overfull_bars` or
   // `short_bars` list - _bar_conformance only ever counted these two, it
   // never kept which bars.
-  { key: "bars_overfull", label: "Bars with more beats than the time signature allows" },
-  { key: "bars_short", label: "Bars with fewer beats than the time signature requires" },
-  { key: "bars_padded", label: "Bars padded to length", barsKey: "padded_bars" },
-  { key: "bars_unread", label: "Bars that could not be read", barsKey: "unread_bars" },
+  { key: "bars_overfull", label: "Bars with more beats than the time signature allows", family: "bar" },
+  { key: "bars_short", label: "Bars with fewer beats than the time signature requires", family: "bar" },
+  { key: "bars_padded", label: "Bars padded to length", barsKey: "padded_bars", family: "bar" },
+  { key: "bars_unread", label: "Bars that could not be read", barsKey: "unread_bars", family: "bar" },
   // A Rule 8 exemption, not a defect - the count of bars a first-bar pickup
-  // let Rule 8 excuse, not bars that are wrong. Still a fact worth a row: it
-  // says which of the score's opening bars was assumed to be a pickup, an
-  // assumption about the page a reader must be able to check.
-  { key: "bars_anacrusis", label: "Pickup bars", barsKey: "anacrusis_bars" },
+  // let Rule 8 excuse, not bars that are wrong. NOT "Pickup bars": in the
+  // compensated pairing _anacrusis_bars recognises (tabextract.py's
+  // _anacrusis_bars, the "final_short" branch), the counter and bars list
+  // include the score's FINAL bar too - the one that corroborates the
+  // pickup by being short in exactly the complementary way, not a pickup
+  // itself. "Pickup bars" would call that final bar a pickup, which it is
+  // not. The label instead names what _bar_conformance's `excused` list
+  // actually is (tabextract.py, the loop building `excused` right after
+  // `anacrusis = _anacrusis_bars(...)`): bars lifted out of the
+  // short/defective counts because a first-bar pickup excused them. Still a
+  // fact worth a row: it says which of the score's bars was assumed to be
+  // part of a pickup, an assumption about the page a reader must be able to
+  // check.
+  { key: "bars_anacrusis", label: "Bars excused by a first-bar pickup", barsKey: "anacrusis_bars", family: "bar" },
 ];
 
 /**
@@ -197,31 +207,50 @@ export const DISCLOSURE_ROWS = [
  *   - a `*_bars` (or `*_pages`) list rides along as the counter's detail:
  *     the bar/page numbers it exists to name.
  *
- * The one thing that gates the WHOLE section rather than one row: if every
- * single counter below is null, nothing here was ever computed for this row
- * at all (the common shape of a hand-edited row - see saveEdit() in
- * ScoreCompare.svelte, which states every one of these `null` on purpose).
- * That state already renders as nothing elsewhere on this panel (no bar
- * headline, no warnings block), and a wall of one "not measured" row per
- * counter above would be exactly the noise this function exists to avoid
- * (there were seventeen of them when issue #155 wrote this, and the list only
- * grows, which is why the sentence no longer names a number) - so this
- * returns no rows at all rather than that wall. A row that measured SOME of
- * these counters (a real extraction whose schema predates one particular
- * counter) still shows the gap on that one counter specifically, because in
- * that case something else on this same object is a real number and the
- * absence of this one is worth knowing.
+ * The gate that used to cover the WHOLE section now applies PER FAMILY (the
+ * five `family: "bar"` Rule 8 counters, versus every other, "structural",
+ * counter): if every counter in a family is null, nothing in that family was
+ * ever computed for this row, and that family renders no rows at all rather
+ * than a wall of "not measured" lines. A family with at least one real number
+ * still shows the gap on any null counter of ITS OWN family specifically,
+ * unchanged from before - the null-vs-zero contract inside a rendered family
+ * is untouched by this.
+ *
+ * This is a legacy-blob problem, not a hypothetical one: disclosures live in
+ * one stored `confidence` JSON blob that is never backfilled, so a
+ * transcription stored before issue #294 added the five bar counters carries
+ * real structural numbers and simply has no bar keys at all (`undefined`,
+ * not zero) - a single whole-object gate would have rendered all five bar
+ * rows as "not measured" beside the real structural ones, stating a total
+ * absence of measurement as fact for counters that were never even asked
+ * for on that extraction. Symmetrically, a blob with bar counters but no
+ * structural ones (the reverse legacy shape) must show only the bar rows.
+ *
+ * Before issue #294 there was only one family (this is why the original gate
+ * used a single `anyMeasured`, and why there were seventeen counters in it -
+ * the list only grows, which is why the sentence no longer names a number).
  */
+const BAR_FAMILY = "bar";
+
+function familyOf(row) {
+  return row.family === BAR_FAMILY ? BAR_FAMILY : "structural";
+}
+
 export function disclosureRows(t) {
   if (!t) return [];
-  const anyMeasured = DISCLOSURE_ROWS.some((row) => t[row.key] !== null && t[row.key] !== undefined);
-  if (!anyMeasured) return [];
+  const isMeasured = (row) => t[row.key] !== null && t[row.key] !== undefined;
+  const familyHasMeasurement = {
+    [BAR_FAMILY]: DISCLOSURE_ROWS.some((row) => familyOf(row) === BAR_FAMILY && isMeasured(row)),
+    structural: DISCLOSURE_ROWS.some((row) => familyOf(row) === "structural" && isMeasured(row)),
+  };
+  if (!familyHasMeasurement[BAR_FAMILY] && !familyHasMeasurement.structural) return [];
 
   const rows = [];
   for (const row of DISCLOSURE_ROWS) {
+    if (!familyHasMeasurement[familyOf(row)]) continue; // whole family unmeasured - no row
     const value = t[row.key];
     if (value === 0) continue; // hidden - good news needs no row
-    const measured = value !== null && value !== undefined;
+    const measured = isMeasured(row);
     const barsRaw = row.barsKey ? t[row.barsKey] : null;
     rows.push({
       key: row.key,

--- a/web/tests/browser/fixtures/transcription-warnings.js
+++ b/web/tests/browser/fixtures/transcription-warnings.js
@@ -346,8 +346,16 @@ export function editedTranscriptionResponse() {
  * `editedTranscriptionResponse()` and DELETE (revert) to always answer with
  * `transcription` again - modeling "hand-edit this extracted row, then
  * revert" regardless of what the test actually types into the editor.
+ *
+ * `analysis` overrides the GET /transcription/analysis body (the
+ * TranscriptionAnalysisOut shape - `extractable`, `reason`, `vector`,
+ * `tab_staff_count`, `standard_staff_count`, `page_count`). Defaults to
+ * `{ extractable: true }`, which is only ever read by ScoreCompare.svelte
+ * when `transcription` is falsy (a 404 on GET /transcription), since
+ * loadAnalysis() only runs on that path - see issue #294's non-extractable
+ * empty-state sentence.
  */
-export async function stubScoreApi(page, transcription, { editRevert = false } = {}) {
+export async function stubScoreApi(page, transcription, { editRevert = false, analysis = null } = {}) {
   await page.route("**/api/scores/1", (route) => route.fulfill({ json: SCORE }));
   await page.route("**/api/scores/1/file", (route) =>
     route.fulfill({ body: MIN_PDF, contentType: "application/pdf" }),
@@ -356,7 +364,7 @@ export async function stubScoreApi(page, transcription, { editRevert = false } =
     route.fulfill({ json: { total_seconds: 0, sessions: [] } }),
   );
   await page.route("**/api/scores/1/transcription/analysis", (route) =>
-    route.fulfill({ json: { extractable: true } }),
+    route.fulfill({ json: analysis ?? { extractable: true } }),
   );
   if (editRevert) {
     await page.route("**/api/scores/1/transcription", (route) => {

--- a/web/tests/browser/score-compare-analysis.spec.js
+++ b/web/tests/browser/score-compare-analysis.spec.js
@@ -59,6 +59,33 @@ test.describe("ScoreCompare transcription-analysis sentence", () => {
     expect(text).not.toContain("standard staves");
   });
 
+  test("a corrupt pdf that was never analysed shows the reason alone, with no unmeasured staff/vector clause", async ({
+    page,
+  }) => {
+    // page_count: 0 means analyze() never got past opening the file -
+    // vector/tab_staff_count/standard_staff_count are hardcoded placeholders
+    // here, not a measurement, so the sentence must be the reason and
+    // nothing else.
+    await stubScoreApi(page, null, {
+      analysis: {
+        extractable: false,
+        reason: "could not open pdf: corrupt xref table",
+        vector: false,
+        tab_staff_count: 0,
+        standard_staff_count: 0,
+        page_count: 0,
+      },
+    });
+    await page.goto("/#/score/1");
+
+    const text = await page.locator(".empty-state p").first().innerText();
+    expect(text).toBe("could not open pdf: corrupt xref table");
+    expect(text).not.toContain("standard staff");
+    expect(text).not.toContain("standard staves");
+    expect(text).not.toContain("PDF");
+    expect(text).not.toContain("(");
+  });
+
   test("a score that is extractable, or one whose analysis has not loaded, still offers the transcribe button instead", async ({
     page,
   }) => {

--- a/web/tests/browser/score-compare-analysis.spec.js
+++ b/web/tests/browser/score-compare-analysis.spec.js
@@ -78,6 +78,11 @@ test.describe("ScoreCompare transcription-analysis sentence", () => {
     });
     await page.goto("/#/score/1");
 
+    // Wait for the analysis-based branch to actually be selected (loadAnalysis
+    // is async) before reading the paragraph - innerText() alone does not
+    // retry, and reading too early would race the "No staff transcription
+    // yet" fallback the component starts in.
+    await expect(page.locator(".empty-state h3")).toHaveText("No tab to extract");
     const text = await page.locator(".empty-state p").first().innerText();
     expect(text).toBe("could not open pdf: corrupt xref table");
     expect(text).not.toContain("standard staff");

--- a/web/tests/browser/score-compare-analysis.spec.js
+++ b/web/tests/browser/score-compare-analysis.spec.js
@@ -38,25 +38,59 @@ test.describe("ScoreCompare transcription-analysis sentence", () => {
     await expect(page.locator('button:has-text("Transcribe this PDF")')).toHaveCount(0);
   });
 
-  test("a raster scan is named as raster, not vector, and a single staff is singular", async ({
+  test("a raster scan (page_count > 0, vector: false) shows only the reason - staff counts are never appended, because tabextract.py's raster branch never called _detect_staves", async ({
     page,
   }) => {
+    // Every page failed the raster/vector test, so analyze() returns before
+    // ever counting staves - standard_staff_count: 0 here is an unmeasured
+    // placeholder, exactly like the page_count === 0 case, and must not be
+    // shown as if it were a measured "0 standard staves" finding.
     await stubScoreApi(page, null, {
       analysis: {
         extractable: false,
         reason: "no fonts, no vector drawings, no text on any page - pdf is a raster scan",
         vector: false,
         tab_staff_count: 0,
-        standard_staff_count: 1,
-        page_count: 1,
+        standard_staff_count: 0,
+        page_count: 3,
       },
     });
     await page.goto("/#/score/1");
 
+    // Wait for the analysis-based branch before reading the paragraph -
+    // loadAnalysis() is async and reading too early races the "No staff
+    // transcription yet" fallback the component starts in.
+    await expect(page.locator(".empty-state h3")).toHaveText("No tab to extract");
     const text = await page.locator(".empty-state p").first().innerText();
-    expect(text).toContain("1 standard staff,");
-    expect(text).toContain("raster PDF");
+    expect(text).toBe("no fonts, no vector drawings, no text on any page - pdf is a raster scan");
+    expect(text).not.toContain("standard staff");
     expect(text).not.toContain("standard staves");
+    expect(text).not.toContain("PDF");
+  });
+
+  test("a vector pdf with no tab staff shows the reason plus the measured standard-staff count", async ({
+    page,
+  }) => {
+    // vector: true means _detect_staves actually ran on every page, so the
+    // staff counts here are real measurements and the parenthetical is
+    // trustworthy - unlike the raster case above.
+    await stubScoreApi(page, null, {
+      analysis: {
+        extractable: false,
+        reason:
+          "no 6-line tab staff groups found - pages are vector but appear to be standard-notation only (fingering numbers are not fret numbers)",
+        vector: true,
+        tab_staff_count: 0,
+        standard_staff_count: 2,
+        page_count: 3,
+      },
+    });
+    await page.goto("/#/score/1");
+
+    await expect(page.locator(".empty-state h3")).toHaveText("No tab to extract");
+    const text = await page.locator(".empty-state p").first().innerText();
+    expect(text).toContain("2 standard staves");
+    expect(text).toContain("vector PDF");
   });
 
   test("a corrupt pdf that was never analysed shows the reason alone, with no unmeasured staff/vector clause", async ({

--- a/web/tests/browser/score-compare-analysis.spec.js
+++ b/web/tests/browser/score-compare-analysis.spec.js
@@ -1,0 +1,76 @@
+// Playwright coverage for the transcription-analysis empty-state sentence
+// ScoreCompare.svelte renders when a score has no tab to extract (issue
+// #294). TranscriptionAnalysisOut's `vector`, `tab_staff_count`,
+// `standard_staff_count` and `reason` had zero consumers in web/src before
+// this file existed - the panel showed `analysis.reason` alone (or a fixed
+// generic sentence when `reason` was empty), with no staff-count context at
+// all. See score-compare-disclosures.spec.js for the sibling structural-
+// disclosures panel this sits beside.
+import { test, expect } from "@playwright/test";
+import { stubScoreApi } from "./fixtures/transcription-warnings.js";
+
+test.describe("ScoreCompare transcription-analysis sentence", () => {
+  test("a non-extractable pdf shows one sentence built from the reason and the staff counts", async ({
+    page,
+  }) => {
+    await stubScoreApi(page, null, {
+      analysis: {
+        extractable: false,
+        reason:
+          "no 6-line tab staff groups found - pages are vector but appear to be standard-notation only (fingering numbers are not fret numbers)",
+        vector: true,
+        tab_staff_count: 0,
+        standard_staff_count: 2,
+        page_count: 3,
+      },
+    });
+    await page.goto("/#/score/1");
+
+    await expect(page.locator(".empty-state h3")).toHaveText("No tab to extract");
+    const text = await page.locator(".empty-state p").first().innerText();
+    expect(text).toContain(
+      "no 6-line tab staff groups found - pages are vector but appear to be standard-notation only (fingering numbers are not fret numbers)",
+    );
+    // the two fields the reason text alone never carries
+    expect(text).toContain("2 standard staves");
+    expect(text).toContain("vector PDF");
+    // no transcribe offering for a score that cannot be transcribed
+    await expect(page.locator('button:has-text("Transcribe this PDF")')).toHaveCount(0);
+  });
+
+  test("a raster scan is named as raster, not vector, and a single staff is singular", async ({
+    page,
+  }) => {
+    await stubScoreApi(page, null, {
+      analysis: {
+        extractable: false,
+        reason: "no fonts, no vector drawings, no text on any page - pdf is a raster scan",
+        vector: false,
+        tab_staff_count: 0,
+        standard_staff_count: 1,
+        page_count: 1,
+      },
+    });
+    await page.goto("/#/score/1");
+
+    const text = await page.locator(".empty-state p").first().innerText();
+    expect(text).toContain("1 standard staff,");
+    expect(text).toContain("raster PDF");
+    expect(text).not.toContain("standard staves");
+  });
+
+  test("a score that is extractable, or one whose analysis has not loaded, still offers the transcribe button instead", async ({
+    page,
+  }) => {
+    // extractable: true (a real transcription just hasn't been run yet) -
+    // the sentence above must not eclipse the ordinary "no transcription
+    // yet" offering for a score that actually can be transcribed.
+    await stubScoreApi(page, null, {
+      analysis: { extractable: true, reason: null, vector: true, tab_staff_count: 2, standard_staff_count: 0, page_count: 2 },
+    });
+    await page.goto("/#/score/1");
+
+    await expect(page.locator(".empty-state h3")).toHaveText("No staff transcription yet");
+    await expect(page.locator('button:has-text("Transcribe this PDF")')).toBeVisible();
+  });
+});

--- a/web/tests/browser/score-compare-disclosures.spec.js
+++ b/web/tests/browser/score-compare-disclosures.spec.js
@@ -425,6 +425,86 @@ test.describe("ScoreCompare structural disclosures", () => {
     await expect(page.locator('[data-disclosure="tie_ends_unpaired"]')).toHaveCount(0);
   });
 
+  test("the five Rule 8 bar counters each get their own row, with a bar list only where the API keeps one", async ({
+    page,
+  }) => {
+    // Issue #294: bars_overfull, bars_short, bars_padded, bars_unread and
+    // bars_anacrusis had no reader anywhere before this - only
+    // bars_defective/bars_measured reach ScoreCompare's bar-count headline.
+    // bars_overfull/bars_short have no *_bars list on the API at all (see
+    // disclosures.js's comment on these two rows); bars_padded/bars_unread/
+    // bars_anacrusis do.
+    await stubScoreApi(
+      page,
+      transcriptionResponse({
+        warnings: [],
+        confidence: CLEAN_CONFIDENCE,
+        disclosures: {
+          ...zeroDisclosures(),
+          bars_overfull: 3,
+          bars_short: 2,
+          bars_padded: 1,
+          padded_bars: [5],
+          bars_unread: 4,
+          unread_bars: [7, 8, 9, 10],
+          bars_anacrusis: 1,
+          anacrusis_bars: [1],
+        },
+      }),
+    );
+    await page.goto("/#/score/1");
+    await page.waitForSelector(".staff-render");
+
+    const overfull = page.locator('[data-disclosure="bars_overfull"]');
+    await expect(overfull).toContainText("Bars with more beats than the time signature allows");
+    await expect(overfull.locator(".disclosure-value")).toHaveText("3");
+    await expect(overfull.locator(".disclosure-bars")).toHaveCount(0);
+
+    const short = page.locator('[data-disclosure="bars_short"]');
+    await expect(short).toContainText("Bars with fewer beats than the time signature requires");
+    await expect(short.locator(".disclosure-value")).toHaveText("2");
+    await expect(short.locator(".disclosure-bars")).toHaveCount(0);
+
+    const padded = page.locator('[data-disclosure="bars_padded"]');
+    await expect(padded).toContainText("Bars padded to length");
+    await expect(padded.locator(".disclosure-value")).toHaveText("1");
+    await expect(padded.locator(".disclosure-bars")).toHaveText("bar 5");
+
+    const unread = page.locator('[data-disclosure="bars_unread"]');
+    await expect(unread).toContainText("Bars that could not be read");
+    await expect(unread.locator(".disclosure-value")).toHaveText("4");
+    await expect(unread.locator(".disclosure-bars")).toHaveText("bars 7, 8, 9, 10");
+
+    const anacrusis = page.locator('[data-disclosure="bars_anacrusis"]');
+    await expect(anacrusis).toContainText("Pickup bars");
+    await expect(anacrusis.locator(".disclosure-value")).toHaveText("1");
+    await expect(anacrusis.locator(".disclosure-bars")).toHaveText("bar 1");
+
+    await expect(page.locator(".disclosure-row")).toHaveCount(5);
+  });
+
+  test("a zero Rule 8 bar counter follows the same hidden-row convention as any other counter", async ({
+    page,
+  }) => {
+    // The other half of the rule above: a real, measured zero on all five is
+    // noise, not news, exactly like every other counter this panel hides.
+    await stubScoreApi(
+      page,
+      transcriptionResponse({
+        warnings: [],
+        confidence: CLEAN_CONFIDENCE,
+        disclosures: { ...zeroDisclosures(), repeats_unread: 1, repeats_unread_bars: [2] },
+      }),
+    );
+    await page.goto("/#/score/1");
+    await page.waitForSelector(".staff-render");
+
+    for (const key of ["bars_overfull", "bars_short", "bars_padded", "bars_unread", "bars_anacrusis"]) {
+      await expect(page.locator(`[data-disclosure="${key}"]`)).toHaveCount(0);
+    }
+    await expect(page.locator(".disclosure-row")).toHaveCount(1);
+  });
+
   test("gig mode drops the disclosures panel along with the rest of the review chrome", async ({
     page,
   }) => {

--- a/web/tests/browser/score-compare-disclosures.spec.js
+++ b/web/tests/browser/score-compare-disclosures.spec.js
@@ -476,7 +476,7 @@ test.describe("ScoreCompare structural disclosures", () => {
     await expect(unread.locator(".disclosure-bars")).toHaveText("bars 7, 8, 9, 10");
 
     const anacrusis = page.locator('[data-disclosure="bars_anacrusis"]');
-    await expect(anacrusis).toContainText("Pickup bars");
+    await expect(anacrusis).toContainText("Bars excused by a first-bar pickup");
     await expect(anacrusis.locator(".disclosure-value")).toHaveText("1");
     await expect(anacrusis.locator(".disclosure-bars")).toHaveText("bar 1");
 

--- a/web/tests/disclosure-keys.json
+++ b/web/tests/disclosure-keys.json
@@ -1,4 +1,9 @@
 [
+  "bars_anacrusis",
+  "bars_overfull",
+  "bars_padded",
+  "bars_short",
+  "bars_unread",
   "coincident_unsplit_pairs",
   "dots_unassigned",
   "dots_unassigned_eliminated",

--- a/web/tests/spec-floors/browser-score-compare-analysis-294-review.json
+++ b/web/tests/spec-floors/browser-score-compare-analysis-294-review.json
@@ -1,0 +1,5 @@
+{
+  "file": "tests/browser/score-compare-analysis.spec.js",
+  "count": 1,
+  "reason": "issue #294 review finding 1: the old raster test stubbed vector: false with standard_staff_count: 1, a response no server path emits - tabextract.py's raster branch (page_count > 0, every page fails the vector test) always returns standard_staff_count: 0 because _detect_staves is never called on a raster page. That test is now two realistic ones: a raster stub (vector: false, standard_staff_count: 0) asserting no staff count is shown at all, and a vector stub (vector: true, standard_staff_count: 2) asserting the measured count does show - net +1 test over the original file."
+}

--- a/web/tests/spec-floors/browser-score-compare-analysis-294.json
+++ b/web/tests/spec-floors/browser-score-compare-analysis-294.json
@@ -1,5 +1,5 @@
 {
   "file": "tests/browser/score-compare-analysis.spec.js",
   "count": 4,
-  "reason": "issue #294: TranscriptionAnalysisOut's vector/tab_staff_count/standard_staff_count/reason had zero consumers in web/src - a non-extractable score now shows one sentence built from all four, an extractable-but-not-yet-transcribed score still gets the ordinary transcribe offering, singular/plural staff wording is checked directly, and a never-analysed pdf (page_count: 0) renders the reason alone with no unmeasured staff/vector clause."
+  "reason": "issue #294: TranscriptionAnalysisOut's vector/tab_staff_count/standard_staff_count/reason had zero consumers in web/src - a non-extractable vector score now shows one sentence built from all four, an extractable-but-not-yet-transcribed score still gets the ordinary transcribe offering, a raster score is named as raster, and a never-analysed pdf (page_count: 0) renders the reason alone with no unmeasured staff/vector clause. See browser-score-compare-analysis-294-review.json for the second-review fix to the raster case."
 }

--- a/web/tests/spec-floors/browser-score-compare-analysis-294.json
+++ b/web/tests/spec-floors/browser-score-compare-analysis-294.json
@@ -1,0 +1,5 @@
+{
+  "file": "tests/browser/score-compare-analysis.spec.js",
+  "count": 3,
+  "reason": "issue #294: TranscriptionAnalysisOut's vector/tab_staff_count/standard_staff_count/reason had zero consumers in web/src - a non-extractable score now shows one sentence built from all four, an extractable-but-not-yet-transcribed score still gets the ordinary transcribe offering, and singular/plural staff wording is checked directly."
+}

--- a/web/tests/spec-floors/browser-score-compare-analysis-294.json
+++ b/web/tests/spec-floors/browser-score-compare-analysis-294.json
@@ -1,5 +1,5 @@
 {
   "file": "tests/browser/score-compare-analysis.spec.js",
-  "count": 3,
-  "reason": "issue #294: TranscriptionAnalysisOut's vector/tab_staff_count/standard_staff_count/reason had zero consumers in web/src - a non-extractable score now shows one sentence built from all four, an extractable-but-not-yet-transcribed score still gets the ordinary transcribe offering, and singular/plural staff wording is checked directly."
+  "count": 4,
+  "reason": "issue #294: TranscriptionAnalysisOut's vector/tab_staff_count/standard_staff_count/reason had zero consumers in web/src - a non-extractable score now shows one sentence built from all four, an extractable-but-not-yet-transcribed score still gets the ordinary transcribe offering, singular/plural staff wording is checked directly, and a never-analysed pdf (page_count: 0) renders the reason alone with no unmeasured staff/vector clause."
 }

--- a/web/tests/spec-floors/browser-score-compare-disclosures-294.json
+++ b/web/tests/spec-floors/browser-score-compare-disclosures-294.json
@@ -1,0 +1,5 @@
+{
+  "file": "tests/browser/score-compare-disclosures.spec.js",
+  "count": 2,
+  "reason": "issue #294: the five Rule 8 bar counters (bars_overfull, bars_short, bars_padded, bars_unread, bars_anacrusis) that fed only server-built warning prose now render their own row each, with a bar list only where the API keeps one, and a real zero on all five is hidden the same way every other counter's zero is."
+}

--- a/web/tests/spec-floors/unit-disclosures-294-review-2.json
+++ b/web/tests/spec-floors/unit-disclosures-294-review-2.json
@@ -1,0 +1,5 @@
+{
+  "file": "tests/unit/disclosures.spec.js",
+  "count": 1,
+  "reason": "issue #294 review nit: familyOf() used to default an unrecognised family to \"structural\", so a future bar row that forgot family: \"bar\" would silently misfile into the wrong family instead of failing loudly. family is now required on every DISCLOSURE_ROWS row - disclosureRows() throws when a row has none - and this test proves that by pushing a family-less row and asserting the throw."
+}

--- a/web/tests/spec-floors/unit-disclosures-294-review.json
+++ b/web/tests/spec-floors/unit-disclosures-294-review.json
@@ -1,0 +1,5 @@
+{
+  "file": "tests/unit/disclosures.spec.js",
+  "count": 2,
+  "reason": "issue #294 review finding 3: a legacy stored confidence blob carries the five bar counters and the seventeen structural counters as two independently-backfilled families, never one - disclosureRows() now gates each family on whether ANY of its own counters are measured, so a pre-#294 blob (bar counters real, structural absent) renders only its bar rows, and the converse legacy shape (structural real, bars absent) renders only its structural rows, instead of a wall of false 'not measured' rows for the family nothing on that blob was ever asked to compute."
+}

--- a/web/tests/spec-floors/unit-disclosures-294-review.json
+++ b/web/tests/spec-floors/unit-disclosures-294-review.json
@@ -1,5 +1,5 @@
 {
   "file": "tests/unit/disclosures.spec.js",
   "count": 2,
-  "reason": "issue #294 review finding 3: a legacy stored confidence blob carries the five bar counters and the seventeen structural counters as two independently-backfilled families, never one - disclosureRows() now gates each family on whether ANY of its own counters are measured, so a pre-#294 blob (bar counters real, structural absent) renders only its bar rows, and the converse legacy shape (structural real, bars absent) renders only its structural rows, instead of a wall of false 'not measured' rows for the family nothing on that blob was ever asked to compute."
+  "reason": "issue #294 review finding 3: a legacy stored confidence blob carries the five bar counters and the seventeen structural counters as two independently-backfilled families (added to storage at different times - #101/#174 versus #155 - not by #294 itself, which only gave the bar counters a web-side reader), never one - disclosureRows() now gates each family on whether ANY of its own counters are measured, so a blob predating whichever family arrived later (bar counters real, structural absent, or the converse) renders only the rows for the family it actually has, instead of a wall of false 'not measured' rows for the family nothing on that blob was ever asked to compute."
 }

--- a/web/tests/unit/disclosures.spec.js
+++ b/web/tests/unit/disclosures.spec.js
@@ -142,6 +142,51 @@ test("undefined is treated the same as null for both the per-row and whole-row g
 // can make that check, since a browser test cannot import api.py), and
 // checked against DISCLOSURE_ROWS here, in BOTH directions, so a config row
 // that goes missing OR a vendored key nothing renders each fail by name.
+// Per-family gate (issue #294 follow-up): disclosures live in one stored
+// `confidence` JSON blob that is never backfilled, so a pre-#294
+// transcription carries the five bar counters as `undefined` while its
+// structural counters (issue #155's seventeen) are real numbers, or vice
+// versa. A single whole-object gate would render either an "all bar rows
+// missing" wall beside real structural rows, or the converse - both state
+// an absence of measurement as fact for a family that just predates the
+// other one. The fix gates each family independently.
+const BAR_KEYS = DISCLOSURE_ROWS.filter((row) => row.family === "bar").map((row) => row.key);
+const STRUCTURAL_KEYS = DISCLOSURE_ROWS.filter((row) => row.family !== "bar").map((row) => row.key);
+
+test("a legacy blob with bar counters but no structural ones renders exactly the bar rows", () => {
+  const t = {};
+  for (const key of STRUCTURAL_KEYS) t[key] = null; // never computed on this old blob
+  for (const key of BAR_KEYS) t[key] = 2; // measured, and non-zero so it would render
+  for (const row of DISCLOSURE_ROWS) {
+    if (row.barsKey) t[row.barsKey] = row.family === "bar" ? [1, 2] : [];
+  }
+
+  const rows = disclosureRows(t);
+  const renderedKeys = rows.map((r) => r.key).sort();
+  expect(renderedKeys).toEqual([...BAR_KEYS].sort());
+  for (const row of rows) {
+    expect(row.measured).toBe(true);
+    expect(row.value).toBe(2);
+  }
+});
+
+test("the converse legacy blob - structural counters measured, bars null - renders exactly the structural rows", () => {
+  const t = {};
+  for (const key of BAR_KEYS) t[key] = null; // never computed on this old blob
+  for (const key of STRUCTURAL_KEYS) t[key] = 2; // measured, and non-zero so it would render
+  for (const row of DISCLOSURE_ROWS) {
+    if (row.barsKey) t[row.barsKey] = row.family !== "bar" ? [3] : [];
+  }
+
+  const rows = disclosureRows(t);
+  const renderedKeys = rows.map((r) => r.key).sort();
+  expect(renderedKeys).toEqual([...STRUCTURAL_KEYS].sort());
+  for (const row of rows) {
+    expect(row.measured).toBe(true);
+    expect(row.value).toBe(2);
+  }
+});
+
 test("DISCLOSURE_ROWS carries exactly the vendored disclosure-keys.json key set - no more, no fewer", () => {
   const configKeys = DISCLOSURE_ROWS.map((row) => row.key).sort();
   const vendoredKeys = [...VENDORED_KEYS].sort();

--- a/web/tests/unit/disclosures.spec.js
+++ b/web/tests/unit/disclosures.spec.js
@@ -118,7 +118,7 @@ test("no transcription at all renders no rows", () => {
   expect(disclosureRows(undefined)).toEqual([]);
 });
 
-test("undefined is treated the same as null for both the per-row and whole-row gates", () => {
+test("undefined is treated the same as null for both the per-row and per-family gates", () => {
   const t = baseTranscription({ repeats_unread: 5 });
   delete t.nav_marks_unresolved;
   const navRow = disclosureRows(t).find((r) => r.key === "nav_marks_unresolved");
@@ -143,13 +143,17 @@ test("undefined is treated the same as null for both the per-row and whole-row g
 // checked against DISCLOSURE_ROWS here, in BOTH directions, so a config row
 // that goes missing OR a vendored key nothing renders each fail by name.
 // Per-family gate (issue #294 follow-up): disclosures live in one stored
-// `confidence` JSON blob that is never backfilled, so a pre-#294
-// transcription carries the five bar counters as `undefined` while its
-// structural counters (issue #155's seventeen) are real numbers, or vice
-// versa. A single whole-object gate would render either an "all bar rows
-// missing" wall beside real structural rows, or the converse - both state
-// an absence of measurement as fact for a family that just predates the
-// other one. The fix gates each family independently.
+// `confidence` JSON blob that is never backfilled, and the two families
+// were added to storage at different times - issue #155's seventeen
+// structural counters, then `bars_padded`/`bars_unread` (#101) and
+// `bars_anacrusis` (#174) (#294 itself added nothing to storage; it only
+// gave the five bar counters a reader on the web side). So a transcription
+// stored before whichever family arrived later carries that family's
+// counters as `undefined` while the other family's are real numbers, or
+// vice versa. A single whole-object gate would render either an "all bar
+// rows missing" wall beside real structural rows, or the converse - both
+// state an absence of measurement as fact for a family that just predates
+// the other one. The fix gates each family independently.
 const BAR_KEYS = DISCLOSURE_ROWS.filter((row) => row.family === "bar").map((row) => row.key);
 const STRUCTURAL_KEYS = DISCLOSURE_ROWS.filter((row) => row.family !== "bar").map((row) => row.key);
 
@@ -184,6 +188,21 @@ test("the converse legacy blob - structural counters measured, bars null - rende
   for (const row of rows) {
     expect(row.measured).toBe(true);
     expect(row.value).toBe(2);
+  }
+});
+
+test("family is required on every row - a row with no family throws rather than silently defaulting to structural", () => {
+  // Guards against familyOf() ever going back to defaulting an unrecognised
+  // family to "structural" - that default would silently misfile a future
+  // bar row that forgot `family: "bar"` into the wrong family instead of
+  // failing loudly. DISCLOSURE_ROWS is a real, shared array, so the bad row
+  // is pushed and popped rather than replacing the array outright.
+  const bad = { key: "__test_row_with_no_family__" };
+  DISCLOSURE_ROWS.push(bad);
+  try {
+    expect(() => disclosureRows({ __test_row_with_no_family__: 1 })).toThrow();
+  } finally {
+    DISCLOSURE_ROWS.pop();
   }
 });
 


### PR DESCRIPTION
## After review

Fixed all three blocking findings.

**Finding 1** - `analysisSentence()` in `web/src/lib/ScoreCompare.svelte` now renders only `reason` when `page_count === 0` (the file was never opened/analysed - `vector`, `tab_staff_count`, `standard_staff_count` are hardcoded placeholders on that path, not measurements). The staff/vector parenthetical only appears once `page_count > 0` proves those fields were actually measured. Added a browser test with the corrupt-pdf shape asserting the sentence equals the reason alone, no parenthetical, no "PDF" substring.

**Finding 2** - `_bar_conformance`'s `excused` list (in `server/fermata/tabextract.py`) can include the score's FINAL bar in the compensated pairing, not just bar 1 - that bar corroborates the pickup by being short in the complementary way, it is not itself a pickup. Relabelled the `bars_anacrusis` row in `web/src/lib/disclosures.js` from "Pickup bars" to "Bars excused by a first-bar pickup", matching what `_bar_conformance`'s `excused` loop actually removes from `short`/`defective`. Re-checked the other four bar-family labels against the same function:
- `bars_overfull` = "Bars with more beats than the time signature allows" - matches `over = max(voices) > budget`, never adjusted by the pickup rule.
- `bars_short` = "Bars with fewer beats than the time signature requires" - matches `short` after the pickup exclusion; still an accurate description of a bar that failed the check.
- `bars_padded` = "Bars padded to length" - matches `padded_bars` (bars holding `<forward>`-inferred silence).
- `bars_unread` = "Bars that could not be read" - matches `unread_bars` per `_rhythm_report`'s own docstring ("bars nothing was read from at all").

All four hold; only `bars_anacrusis` needed the fix. Updated the one browser test asserting the old label text.

**Finding 3** - `disclosureRows()` now gates per family (`bar` vs `structural`) instead of one whole-blob `anyMeasured` flag: a family renders its rows only when at least one of its own counters is measured, so a legacy blob with bar counters but no structural ones (pre-#155) renders only the bar rows, and the converse legacy shape renders only the structural rows. The null-vs-zero contract inside a rendered family is unchanged. Added two unit tests in `web/tests/unit/disclosures.spec.js` covering both legacy shapes, plus a new spec-floor file for them.

**Verification** - Committed before mutating. All 7 mutations (the 3 fixes above, plus a dropped disclosure row, a misspelt key, `_bar_conformance`'s anacrusis-exclusion reverted, and the analysis sentence's reason clause dropped) went red; all restores confirmed green after rebuild. Fixed one pre-existing race in my own new analysis test (it read the paragraph before waiting for the async-loaded analysis branch to render). `disclosures` unit spec (11/11), `score-compare-disclosures` (18/18), `score-compare-analysis` (4/4), and `navigation` (19/19) all pass, matching summed spec-floor counts. Server: `test_disclosure_keys.py` + `test_api_docs.py` (21/21) and the anacrusis/conformance tests in `test_tabextract.py` (6 passed, 5 skipped for want of a library) all green.

Verdict: go.


## Second review

**Finding 1** - `page_count > 0` alone didn't prove staff counts were measured: tabextract.py's raster branch (`page_count > 0`, `vector: false`) never calls `_detect_staves` (the `continue` skips every raster page), so `standard_staff_count: 0` there is unmeasured, not a real count. `analysisSentence()` now returns `reason` alone whenever `!vector`, matching the `page_count === 0` case; the staff-count parenthetical only appears once `vector` is true. Replaced the old test's unrealistic `vector:false, standard_staff_count:1` stub (no server path emits that) with a realistic raster stub (counts absent) and a realistic vector stub (counts present).

**Finding 2** - Added the `.empty-state h3` → `"No tab to extract"` barrier (auto-waiting, no fixed timeout) to the raster test, matching the barrier already used elsewhere in the file. Confirmed the original race: with the barrier removed, `--repeat-each 3` failed 3/3.

**Finding 3** - The gate's comment wrongly attributed storage of the five bar counters to #294; #294 added nothing to storage (`bars_padded`/`bars_unread` came with #101, `bars_anacrusis` with #174). Rewrote the comment in `disclosures.js`, the matching comment in `disclosures.spec.js`, and the floor file's `reason` to state the true cause: the two families were added to storage at different times. Left the floor file's name unchanged - it doesn't encode a direction. Fixed the test title at `disclosures.spec.js:121` ("whole-row" → "per-family").

**Nit** - `family` is now required on every `DISCLOSURE_ROWS` row (all 22, explicitly); `familyOf()` throws instead of defaulting an unrecognised row to `"structural"`. Added a guarding unit test.

**Verification** - Committed before mutating; rebuilt (`npm run build`) between every browser-serving mutation.
- Dropped the `!vector` branch: raster test red (1 failed/4 passed).
- Removed the barrier: `--repeat-each 3` red (3 failed/12 passed).
- Reverted `familyOf()` to default: unit guard red (1 failed/11 passed).
- All three restored and reconfirmed green.

Ran: `disclosures` unit (12/12), `score-compare-disclosures` (18/18), `score-compare-analysis` with `--repeat-each 3` (15/15), `navigation` (19/19). Floor sums match executed counts per file: `unit/disclosures.spec.js` 9+2+1=12; `browser/score-compare-analysis.spec.js` 4+1=5.

Verdict: go.
