### PR TITLE
Upload receipt, refuse-or-replace, practice summary, and vouched identity (#293)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -142,13 +142,24 @@ onto a score whose `key` is still null; a hand-set key, or one filled in this
 way already, is never overwritten by a later (re-)transcription.
 
 A move or a delete is refused with `409` while a library scan is running, and a
-scan declines to start while one is being applied. One thing that **moves or
-removes an existing file** runs at a time: a scan decides what to write from a
-directory listing taken when it started, so a file moving underneath it would
-read as a file that went missing. `POST /api/upload` and `POST
-/api/library/folders` are deliberately outside that rule — the first only ever
-creates a file at a path nothing claims, the second creates a directory — and
-`scanner.hold_library_still` documents why each is safe.
+scan declines to start while one is being applied. One thing that **moves,
+removes or overwrites an existing file** runs at a time: a scan decides what to
+write from a directory listing taken when it started, so a file changing
+underneath it would read as a file that went missing or was silently
+rewritten. `POST /api/upload` is outside that rule only for a FRESH
+destination — a file landing at a path nothing claims cannot invalidate a
+scan's listing — and `POST /api/library/folders` is outside it entirely, since
+it only ever creates a directory; `scanner.hold_library_still` documents why
+each is safe.
+
+Uploading onto a path that already holds a file is refused with `409`, naming
+the path, unless the request sends `replace=true` — the stored bytes are
+untouched until then, and a replace that does go ahead is held against a
+running scan the same way a move or a delete is (issue #293). Every upload's
+receipt names the path a file was saved under (`saved`) and whether that call
+`replaced` an existing one, so a client can show where a file went and
+whether it overwrote something without inferring either from the request it
+sent.
 
 ### What a deleted score may still be asked for
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -142,24 +142,26 @@ onto a score whose `key` is still null; a hand-set key, or one filled in this
 way already, is never overwritten by a later (re-)transcription.
 
 A move or a delete is refused with `409` while a library scan is running, and a
-scan declines to start while one is being applied. One thing that **moves,
-removes or overwrites an existing file** runs at a time: a scan decides what to
-write from a directory listing taken when it started, so a file changing
-underneath it would read as a file that went missing or was silently
-rewritten. `POST /api/upload` is outside that rule only for a FRESH
-destination — a file landing at a path nothing claims cannot invalidate a
-scan's listing — and `POST /api/library/folders` is outside it entirely, since
-it only ever creates a directory; `scanner.hold_library_still` documents why
-each is safe.
+scan declines to start while one is being applied. One thing that **moves or
+removes an existing file** runs at a time: a scan decides what to write from a
+directory listing taken when it started, so a file moving underneath it would
+read as a file that went missing. `POST /api/upload` and `POST
+/api/library/folders` are deliberately outside that rule — the first only ever
+writes at a path the client itself named, never one it discovered by walking
+the library, so it cannot invalidate a scan's listing the way a move or a
+delete could; the second creates a directory — and `scanner.hold_library_still`
+documents why each is safe.
 
 Uploading onto a path that already holds a file is refused with `409`, naming
 the path, unless the request sends `replace=true` — the stored bytes are
-untouched until then, and a replace that does go ahead is held against a
-running scan the same way a move or a delete is (issue #293). Every upload's
-receipt names the path a file was saved under (`saved`) and whether that call
-`replaced` an existing one, so a client can show where a file went and
-whether it overwrote something without inferring either from the request it
-sent.
+untouched until then (issue #293). A replace is not held against a running
+scan either, the same as a fresh upload: whichever content that scan reads
+back from the path, it reads as an ordinary file that changed on disk, which
+is what a person editing the file by hand while a scan runs already produces.
+Every upload's receipt names the path a file was saved under (`saved`) and
+whether that call `replaced` an existing one, so a client can show where a
+file went and whether it overwrote something without inferring either from
+the request it sent.
 
 ### What a deleted score may still be asked for
 

--- a/docs/practice-data.md
+++ b/docs/practice-data.md
@@ -269,7 +269,9 @@ the questions rather than around the tables.
   disagree with the practice page about when they last played something, and a
   back-dated session counts from the day it says it happened. `last_practiced`
   on a score is that day, not a timestamp.
-- `GET /api/practice/summary` - the last seven days, for the library header.
+- `GET /api/practice/summary?today=` - the last seven days, for the library
+  header: `today` and the six practice days before it, parsed and defaulted
+  exactly as it is on `/practice/history`.
 
 ### Goals and the review
 

--- a/server/fermata/api.py
+++ b/server/fermata/api.py
@@ -1222,16 +1222,21 @@ def list_sessions(
 
 
 @router.get("/practice/summary", tags=[TAG_PRACTICE], response_model=PracticeSummaryOut)
-def practice_summary():
+def practice_summary(today: str | None = None):
     """The last seven days, for the library header.
 
-    Counted over practice DAYS - today and the six before it - rather than over
-    a rolling 168 hours of UTC timestamps, so this and the practice page cannot
-    disagree about which sessions were "this week". `date('now')` is UTC, which
-    can put the window's edge a few hours out for somebody far from Greenwich;
-    over seven days that moves nothing anybody would notice, and unlike the
-    goal endpoints this one has no period whose end has to be got exactly right.
+    Counted over practice DAYS - `today` and the six before it - rather than
+    over a rolling 168 hours of UTC timestamps, so this and the practice page
+    cannot disagree about which sessions were "this week". `today` is parsed
+    and defaulted exactly like `GET /practice/history`'s parameter of the same
+    name - see `_today()` - because the server's own UTC date is not the
+    practiser's date, and a client with sessions on eight distinct local days
+    got a six-session, six-day answer to a "last 7 days" question when this
+    route computed the window from `date('now')` instead.
     """
+    end = _today(today)
+    start = (end - timedelta(days=6)).isoformat()
+    end_s = end.isoformat()
     conn = connect()
     # Scoped to the owner like every other practice query. Nothing else exists
     # to aggregate across today, but the day accounts arrive this is a site
@@ -1241,8 +1246,8 @@ def practice_summary():
     week = conn.execute(
         f"""SELECT COALESCE(SUM(p.seconds), 0) AS total_seconds, COUNT(*) AS session_count
             FROM practice_sessions p
-            WHERE p.owner = ? AND {practice.LOCAL_DATE_SQL} >= date('now', '-6 days')""",
-        (DEFAULT_OWNER,),
+            WHERE p.owner = ? AND {practice.LOCAL_DATE_SQL} BETWEEN ? AND ?""",
+        (DEFAULT_OWNER, start, end_s),
     ).fetchone()
     # A DELETED SCORE IS STILL COUNTED HERE, AND NOW SAYS THAT IT IS (#56).
     # Dropping it would be the wrong fix twice over: the hours were spent, and
@@ -1255,9 +1260,9 @@ def practice_summary():
         f"""SELECT s.id, s.title, SUM(p.seconds) AS practice_seconds,
                    s.deleted_at IS NOT NULL AS deleted
             FROM practice_sessions p JOIN scores s ON s.id = p.score_id
-            WHERE p.owner = ? AND {practice.LOCAL_DATE_SQL} >= date('now', '-6 days')
+            WHERE p.owner = ? AND {practice.LOCAL_DATE_SQL} BETWEEN ? AND ?
             GROUP BY p.score_id ORDER BY practice_seconds DESC LIMIT 5""",
-        (DEFAULT_OWNER,),
+        (DEFAULT_OWNER, start, end_s),
     ).fetchall()
     return {
         "week_seconds": week["total_seconds"],
@@ -2763,7 +2768,6 @@ async def upload(file: UploadFile, folder: str = "Uploads", replace: bool = Fals
             "that. See docs/deployment.md.",
         )
     dest_dir = LIBRARY_DIR.joinpath(*parts)
-    dest_dir.mkdir(parents=True, exist_ok=True)
     dest = dest_dir / name
     existed = dest.exists()
     # .as_posix(), not str() (which was the whole of this line before #293) -
@@ -2778,10 +2782,15 @@ async def upload(file: UploadFile, folder: str = "Uploads", replace: bool = Fals
             f"there is already a file at {rel} - resend the upload with replace=true to "
             "replace it, or choose a different name",
         )
+    # Created only now that the upload is actually going to happen - checked
+    # first, so a refused upload into a folder that does not exist yet leaves
+    # no trace of it: no folder for a client to see and wonder whether
+    # anything landed there.
+    dest_dir.mkdir(parents=True, exist_ok=True)
     with dest.open("wb") as out:
         shutil.copyfileobj(file.file, out)
     scanner.start_scan()
-    return {"saved": str(rel), "replaced": existed}
+    return {"saved": rel, "replaced": existed}
 
 
 # ---------------------------------------------------------------------------

--- a/server/fermata/api.py
+++ b/server/fermata/api.py
@@ -2726,15 +2726,17 @@ async def upload(file: UploadFile, folder: str = "Uploads", replace: bool = Fals
     before anything is opened for writing.
 
     DELIBERATELY NOT HELD against a running scan or a move, unlike the
-    library-management routes below, for a FRESH destination only. Creating a
-    file at a path nothing claims cannot invalidate a scan's listing, and
-    holding it would refuse the second of two uploads in a row for the scan
-    the first one started. See scanner.hold_library_still for the full
-    argument and for what catches the one overlap that matters. A REPLACE is
-    the one way this route can change a file a scan might already be reading,
-    so - unlike the fresh-destination case - it IS held the same way a move
-    or a delete is, and answers the same `409` (via `_busy`) when a scan is
-    running."""
+    library-management routes below - a REPLACE included. This only ever
+    writes at a path a client itself named, nothing it discovered by walking
+    the library, so it cannot invalidate a scan's own listing the way a move
+    or a delete could: whichever content a concurrently running scan reads
+    back from that path, it reads as an ordinary file that changed on disk
+    (an `updated` count, or a fresh `added` one), which is exactly what a
+    person editing the file by hand while a scan runs already produces and
+    this application does not otherwise guard against. Holding this against a
+    scan would refuse the second of two uploads in a row for the scan the
+    first one started - see scanner.hold_library_still for the full argument
+    the library-management routes below DO need it for."""
     suffix = Path(file.filename or "").suffix.lower()
     if suffix not in FILE_TYPES:
         raise HTTPException(422, f"unsupported file type {suffix!r}")
@@ -2775,19 +2777,8 @@ async def upload(file: UploadFile, folder: str = "Uploads", replace: bool = Fals
             f"there is already a file at {rel} - resend the upload with replace=true to "
             "replace it, or choose a different name",
         )
-    if existed:
-        # Overwriting a path a score already claims, unlike the fresh-file case
-        # above - held against a running scan for the same reason a move or a
-        # delete is (see the docstring's REPLACE paragraph).
-        try:
-            with scanner.hold_library_still():
-                with dest.open("wb") as out:
-                    shutil.copyfileobj(file.file, out)
-        except scanner.LibraryBusy as exc:
-            raise _busy(exc) from None
-    else:
-        with dest.open("wb") as out:
-            shutil.copyfileobj(file.file, out)
+    with dest.open("wb") as out:
+        shutil.copyfileobj(file.file, out)
     scanner.start_scan()
     return {"saved": str(rel), "replaced": existed}
 

--- a/server/fermata/api.py
+++ b/server/fermata/api.py
@@ -2714,17 +2714,27 @@ _SAFE_SEGMENT = re.compile(r"^[^/\\]+$")
 
 
 @router.post("/upload", tags=[TAG_LIBRARY], response_model=UploadOut)
-async def upload(file: UploadFile, folder: str = "Uploads"):
+async def upload(file: UploadFile, folder: str = "Uploads", replace: bool = False):
     """Save a file into the library under `folder` (created if needed) and
     trigger a scan to pick it up. `folder` may not contain `..` or an
     absolute path segment.
 
+    Refused with `409`, naming the path, when the destination already holds a
+    file - unless `replace=true` is sent, in which case the existing bytes are
+    overwritten and the receipt says so (`UploadOut.replaced`). The stored
+    file is untouched until a replace is actually applied: the check runs
+    before anything is opened for writing.
+
     DELIBERATELY NOT HELD against a running scan or a move, unlike the
-    library-management routes below. This only ever creates a file at a path
-    nothing claims - it never moves or removes one - so it cannot invalidate a
-    scan's listing, and holding it would refuse the second of two uploads in a
-    row for the scan the first one started. See scanner.hold_library_still for
-    the full argument and for what catches the one overlap that matters."""
+    library-management routes below, for a FRESH destination only. Creating a
+    file at a path nothing claims cannot invalidate a scan's listing, and
+    holding it would refuse the second of two uploads in a row for the scan
+    the first one started. See scanner.hold_library_still for the full
+    argument and for what catches the one overlap that matters. A REPLACE is
+    the one way this route can change a file a scan might already be reading,
+    so - unlike the fresh-destination case - it IS held the same way a move
+    or a delete is, and answers the same `409` (via `_busy`) when a scan is
+    running."""
     suffix = Path(file.filename or "").suffix.lower()
     if suffix not in FILE_TYPES:
         raise HTTPException(422, f"unsupported file type {suffix!r}")
@@ -2752,10 +2762,34 @@ async def upload(file: UploadFile, folder: str = "Uploads"):
     dest_dir = LIBRARY_DIR.joinpath(*parts)
     dest_dir.mkdir(parents=True, exist_ok=True)
     dest = dest_dir / name
-    with dest.open("wb") as out:
-        shutil.copyfileobj(file.file, out)
+    existed = dest.exists()
+    # .as_posix(), not str() (which was the whole of this line before #293) -
+    # every other relative path this codebase reports uses it too (see
+    # scanner.py's own disk_paths and _library_files), and str() on Windows
+    # answers with backslashes, which is not the path a client sent or would
+    # recognise.
+    rel = dest.relative_to(LIBRARY_DIR).as_posix()
+    if existed and not replace:
+        raise HTTPException(
+            409,
+            f"there is already a file at {rel} - resend the upload with replace=true to "
+            "replace it, or choose a different name",
+        )
+    if existed:
+        # Overwriting a path a score already claims, unlike the fresh-file case
+        # above - held against a running scan for the same reason a move or a
+        # delete is (see the docstring's REPLACE paragraph).
+        try:
+            with scanner.hold_library_still():
+                with dest.open("wb") as out:
+                    shutil.copyfileobj(file.file, out)
+        except scanner.LibraryBusy as exc:
+            raise _busy(exc) from None
+    else:
+        with dest.open("wb") as out:
+            shutil.copyfileobj(file.file, out)
     scanner.start_scan()
-    return {"saved": str(dest.relative_to(LIBRARY_DIR))}
+    return {"saved": str(rel), "replaced": existed}
 
 
 # ---------------------------------------------------------------------------

--- a/server/fermata/api_models.py
+++ b/server/fermata/api_models.py
@@ -845,6 +845,12 @@ class ScanTriggerOut(ScanStatusOut):
 
 class UploadOut(BaseModel):
     saved: str
+    # Whether this call overwrote a file already at `saved` (issue #293) -
+    # false for the ordinary case of landing on a path nothing claimed, true
+    # only when the request set `replace=true` on top of an existing file. A
+    # caller that only shows `saved` cannot otherwise tell a fresh save from
+    # one that just replaced something.
+    replaced: bool
 
 
 # ---------------------------------------------------------------------------

--- a/server/tests/test_practice_api.py
+++ b/server/tests/test_practice_api.py
@@ -936,6 +936,31 @@ def test_the_weekly_summary_still_answers(client, score):
     assert [s["title"] for s in summary["top_scores"]] == ["Study in C"]
 
 
+def test_the_weekly_summary_accepts_a_today_override(client, score):
+    """`today` picks the window's end the same way it does for
+    /practice/history (issue #293 follow-up): a practiser whose local day is
+    ahead of the server's UTC day was otherwise missing a session that
+    happened on their "today" but the server's "yesterday", and the reverse.
+
+    The eight logged days sit 200-207 days before the real date the suite
+    runs on - far enough that a regression back to `date('now')` sees none of
+    them and this test goes red no matter the host's UTC offset.
+    """
+    end = date.today() - timedelta(days=200)
+    days = [(end - timedelta(days=i)).isoformat() for i in range(8)]  # newest first
+    for i, day in enumerate(days):
+        log(client, day=day, seconds=100 * (i + 1), score_id=score)
+
+    newest = client.get(f"/api/practice/summary?today={end.isoformat()}").json()
+    assert newest["week_sessions"] == 7
+    assert newest["week_seconds"] == sum(100 * (i + 1) for i in range(7))  # oldest day excluded
+
+    one_earlier = (end - timedelta(days=1)).isoformat()
+    shifted = client.get(f"/api/practice/summary?today={one_earlier}").json()
+    assert shifted["week_sessions"] == 7
+    assert shifted["week_seconds"] == sum(100 * (i + 1) for i in range(1, 8))  # newest day excluded
+
+
 def _delete_score(score_id: int) -> None:
     """Remove a score row the way the scanner does when its file has gone.
 

--- a/server/tests/test_scanner.py
+++ b/server/tests/test_scanner.py
@@ -1321,8 +1321,9 @@ def test_replace_true_overwrites_and_the_receipt_says_so(client, library):
 
 
 def test_a_fresh_upload_is_not_held_against_a_running_scan(client, library, monkeypatch):
-    """The exemption `scanner.hold_library_still` documents still applies to a
-    destination nothing claims - only a REPLACE has to wait its turn."""
+    """The exemption `scanner.hold_library_still` documents: this only ever
+    writes at a path the client itself named, never one discovered by
+    walking the library, so it cannot invalidate a scan's own listing."""
     monkeypatch.setitem(scanner._state, "scanning", True)
 
     res = _upload(client, "fresh-during-scan.gp", b"bytes")
@@ -1331,19 +1332,20 @@ def test_a_fresh_upload_is_not_held_against_a_running_scan(client, library, monk
     assert res.json() == {"saved": "Uploads/fresh-during-scan.gp", "replaced": False}
 
 
-def test_a_replace_is_refused_while_a_scan_is_running(client, library, monkeypatch):
-    """Unlike a fresh destination, a replace overwrites a file a running scan
-    may already be reading - so it is held the same way a move or a delete
-    is, and answers the same `409` scanner.hold_library_still gives those."""
+def test_a_replace_is_also_not_held_against_a_running_scan(client, library, monkeypatch):
+    """The same exemption, and for the same reason, covers a replace too: it
+    still only ever writes at a path this request named, so holding it would
+    only refuse the second of two legitimate re-uploads in a row - exactly
+    the friction the fresh-destination exemption above exists to avoid."""
     _upload(client, "collide-during-scan.gp", b"original bytes")
     _wait_for_scan()
     monkeypatch.setitem(scanner._state, "scanning", True)
 
     res = _upload(client, "collide-during-scan.gp", b"new bytes", replace=True)
 
-    assert res.status_code == 409
-    assert "scan is running" in res.json()["detail"]
-    assert (library / "Uploads" / "collide-during-scan.gp").read_bytes() == b"original bytes"
+    assert res.status_code == 200
+    assert res.json() == {"saved": "Uploads/collide-during-scan.gp", "replaced": True}
+    assert (library / "Uploads" / "collide-during-scan.gp").read_bytes() == b"new bytes"
 
 
 def test_the_config_folder_is_still_ours_to_create(tmp_path, monkeypatch):

--- a/server/tests/test_scanner.py
+++ b/server/tests/test_scanner.py
@@ -1276,6 +1276,76 @@ def test_an_upload_will_not_recreate_the_library_folder_either(client, library, 
     assert not gone.exists(), "the upload created the library folder"
 
 
+# ---------------------------------------------------------------------------
+# Refuse-or-replace on an upload that collides with an existing file (#293).
+# ---------------------------------------------------------------------------
+
+
+def _upload(client, name: str, content: bytes, *, folder: str = "Uploads", replace: bool = False):
+    return client.post(
+        f"/api/upload?folder={folder}&replace={'true' if replace else 'false'}",
+        files={"file": (name, content, "application/octet-stream")},
+    )
+
+
+def test_uploading_the_same_name_twice_is_refused_with_409_naming_the_path(client, library):
+    first = _upload(client, "collide.gp", b"the first bytes")
+    assert first.status_code == 200
+    body = first.json()
+    assert body["saved"] == "Uploads/collide.gp"
+    assert body["replaced"] is False
+
+    second = _upload(client, "collide.gp", b"a second set of bytes")
+
+    assert second.status_code == 409
+    assert "Uploads/collide.gp" in second.json()["detail"]
+    # The bytes are UNCHANGED - the refusal is checked before anything is
+    # opened for writing.
+    assert (library / "Uploads" / "collide.gp").read_bytes() == b"the first bytes"
+
+
+def test_replace_true_overwrites_and_the_receipt_says_so(client, library):
+    _upload(client, "collide-replace.gp", b"original bytes")
+    # Drained before the replace below, so the FIRST upload's own background
+    # scan (every upload starts one) cannot still be running and hand the
+    # replace a real 409 of its own - a race this test must not have.
+    _wait_for_scan()
+
+    replaced = _upload(client, "collide-replace.gp", b"replacement bytes", replace=True)
+
+    assert replaced.status_code == 200
+    body = replaced.json()
+    assert body["saved"] == "Uploads/collide-replace.gp"
+    assert body["replaced"] is True
+    assert (library / "Uploads" / "collide-replace.gp").read_bytes() == b"replacement bytes"
+
+
+def test_a_fresh_upload_is_not_held_against_a_running_scan(client, library, monkeypatch):
+    """The exemption `scanner.hold_library_still` documents still applies to a
+    destination nothing claims - only a REPLACE has to wait its turn."""
+    monkeypatch.setitem(scanner._state, "scanning", True)
+
+    res = _upload(client, "fresh-during-scan.gp", b"bytes")
+
+    assert res.status_code == 200
+    assert res.json() == {"saved": "Uploads/fresh-during-scan.gp", "replaced": False}
+
+
+def test_a_replace_is_refused_while_a_scan_is_running(client, library, monkeypatch):
+    """Unlike a fresh destination, a replace overwrites a file a running scan
+    may already be reading - so it is held the same way a move or a delete
+    is, and answers the same `409` scanner.hold_library_still gives those."""
+    _upload(client, "collide-during-scan.gp", b"original bytes")
+    _wait_for_scan()
+    monkeypatch.setitem(scanner._state, "scanning", True)
+
+    res = _upload(client, "collide-during-scan.gp", b"new bytes", replace=True)
+
+    assert res.status_code == 409
+    assert "scan is running" in res.json()["detail"]
+    assert (library / "Uploads" / "collide-during-scan.gp").read_bytes() == b"original bytes"
+
+
 def test_the_config_folder_is_still_ours_to_create(tmp_path, monkeypatch):
     """The asymmetry is the point, so it is asserted rather than implied.
 

--- a/web/src/lib/Library.svelte
+++ b/web/src/lib/Library.svelte
@@ -766,6 +766,11 @@
   async function onUpload(ev) {
     const files = [...ev.target.files];
     ev.target.value = "";
+    // Cleared here, not left to the receipts below: a batch that is entirely
+    // 409s pushes nothing into `receipts`, and without this a stale "Saved as
+    // ..." from a previous upload sat beside this batch's conflict sentence,
+    // naming a file that was not this one.
+    notice = "";
     // Every upload's own receipt, and a conflict for anything the server
     // refused with 409 (issue #293) - collected rather than shown one at a
     // time, so a multi-file upload does not make the ones that landed wait on
@@ -847,7 +852,7 @@
       {#if identity}
         <!-- Display only (issue #293) - nothing here changes what the
              application does with what it reads. -->
-        <span class="identity-tag" title="Reverse-proxy identity">{identity}</span>
+        <span class="identity-tag">{identity}</span>
       {/if}
     </div>
 

--- a/web/src/lib/Library.svelte
+++ b/web/src/lib/Library.svelte
@@ -2,6 +2,7 @@
   import { untrack } from "svelte";
 
   import { api } from "./api.js";
+  import { identityLabel } from "./identity.js";
   import { keySignatureLabel } from "./provenance.js";
 
   let scores = $state([]);
@@ -58,6 +59,12 @@
   let selected = $state([]);
   let notice = $state("");
   let busy = $state(false);
+  // An upload that landed on a path a file already has (issue #293) - one
+  // entry per file still waiting on a decision, so several conflicts from one
+  // multi-file upload can each be resolved on their own. `file` is the real
+  // File the input already read, kept so Replace can resend it without
+  // asking the person to choose it again.
+  let uploadConflicts = $state([]);
 
   let folders = $state([]);
   let moveOpen = $state(false);
@@ -315,6 +322,13 @@
       : "",
   );
 
+  // The identity, if any, a trusted reverse proxy vouched for on this request
+  // (issue #16) - fetched once, quietly, the same as buildInfo above. Shows
+  // nothing while reverse-proxy auth is off, which is every install that has
+  // never turned it on (issue #293).
+  let me = $state(null);
+  const identity = $derived(identityLabel(me));
+
   const KINDS = [
     ["", "All"],
     ["notation", "Notation"],
@@ -399,6 +413,10 @@
 
   $effect(() => {
     api.version().then((v) => (buildInfo = v));
+  });
+
+  $effect(() => {
+    api.me().then((m) => (me = m));
   });
 
   // The scan poll. Both of the shapes #223 fixed in the background-batch poll
@@ -747,9 +765,44 @@
 
   async function onUpload(ev) {
     const files = [...ev.target.files];
-    for (const f of files) await api.upload(f);
     ev.target.value = "";
+    // Every upload's own receipt, and a conflict for anything the server
+    // refused with 409 (issue #293) - collected rather than shown one at a
+    // time, so a multi-file upload does not make the ones that landed wait on
+    // a decision about the one that did not.
+    const receipts = [];
+    const conflicts = [];
+    for (const f of files) {
+      try {
+        const result = await api.upload(f);
+        receipts.push(result.replaced ? `Replaced ${result.saved}` : `Saved as ${result.saved}`);
+      } catch (err) {
+        if (err?.status === 409) {
+          conflicts.push({ file: f, message: err.message });
+        } else {
+          receipts.push(err?.message ?? `Fermata could not upload ${f.name}.`);
+        }
+      }
+    }
+    if (receipts.length) notice = receipts.join(" ");
+    if (conflicts.length) uploadConflicts = [...uploadConflicts, ...conflicts];
     setTimeout(refresh, 1200);
+  }
+
+  async function replaceUpload(conflict) {
+    try {
+      const result = await api.upload(conflict.file, "Uploads", true);
+      notice = `Replaced ${result.saved}`;
+    } catch (err) {
+      notice = err?.message ?? "Fermata could not replace that file.";
+    } finally {
+      uploadConflicts = uploadConflicts.filter((c) => c !== conflict);
+      await refresh();
+    }
+  }
+
+  function dismissUploadConflict(conflict) {
+    uploadConflicts = uploadConflicts.filter((c) => c !== conflict);
   }
 
   async function toggleFavorite(score, ev) {
@@ -791,6 +844,11 @@
         <circle cx="16" cy="22" r="3" fill="var(--brass)" />
       </svg>
       <h1>fermata</h1>
+      {#if identity}
+        <!-- Display only (issue #293) - nothing here changes what the
+             application does with what it reads. -->
+        <span class="identity-tag" title="Reverse-proxy identity">{identity}</span>
+      {/if}
     </div>
 
     <nav>
@@ -1035,6 +1093,20 @@
         <button class="notice-dismiss" onclick={() => (notice = "")}>Dismiss</button>
       </p>
     {/if}
+
+    {#each uploadConflicts as conflict (conflict.file)}
+      <!-- Refuse-or-replace (issue #293): the server would not overwrite a
+           file already at this path, and named it. The file itself is
+           untouched until Replace is pressed - this is a decision waiting to
+           be made, not a report of one already applied. -->
+      <p class="notice upload-conflict" role="status">
+        {conflict.message}
+        <button class="conflict-replace" onclick={() => replaceUpload(conflict)}>Replace</button>
+        <button class="notice-dismiss" onclick={() => dismissUploadConflict(conflict)}>
+          Dismiss
+        </button>
+      </p>
+    {/each}
 
     {#if showTrash}
       <header>
@@ -1467,6 +1539,11 @@
     font-weight: 600;
     letter-spacing: 0.5px;
     color: var(--brass-bright);
+  }
+
+  .identity-tag {
+    font-size: 12px;
+    color: var(--ink-dim);
   }
 
   nav {
@@ -1922,6 +1999,15 @@
     margin-left: 10px;
     font-size: 12px;
     padding: 4px 12px;
+  }
+
+  .conflict-replace {
+    margin-left: 10px;
+    font-size: 12px;
+    padding: 4px 12px;
+    background: var(--brass);
+    border-color: var(--brass);
+    color: #241d0f;
   }
 
   .dialog-scrim {

--- a/web/src/lib/Practice.svelte
+++ b/web/src/lib/Practice.svelte
@@ -50,6 +50,13 @@
   let current = $state(null);
   let review = $state(null);
   let history = $state(null);
+  // A rolling last 7 days (today and the six before it), from
+  // GET /api/practice/summary - deliberately NOT the same window as "This
+  // week" above, which is the preference-anchored calendar week and can name
+  // a different span. Fetched separately rather than reworked out of
+  // `history` (issue #293): the two windows genuinely disagree near a week
+  // boundary, and where they disagree this route is the one that counts.
+  let summary = $state(null);
   let scores = $state([]);
   let sessions = $state([]);
   // Named drill scopes (issue #236), fetched once per load so a session's
@@ -118,15 +125,17 @@
   async function refresh() {
     error = "";
     try {
-      const [nextCurrent, nextReview, nextHistory, nextScores] = await Promise.all([
+      const [nextCurrent, nextReview, nextHistory, nextSummary, nextScores] = await Promise.all([
         api.currentGoal(today),
         api.practiceReview(REVIEW_WEEKS, today),
         api.practiceHistory(HISTORY_DAYS, today),
+        api.practiceSummary(),
         api.scores(),
       ]);
       current = nextCurrent;
       review = nextReview;
       history = nextHistory;
+      summary = nextSummary;
       scores = nextScores;
       // Fired, not awaited: presets only supply the scope NAME a session's
       // preset_id is shown under (issue #276), and a failure here is not a
@@ -333,9 +342,9 @@
 
     {#if loading}
       <p class="quiet">Loading…</p>
-    {:else if !current || !review || !history}
+    {:else if !current || !review || !history || !summary}
       <!-- The load failed, and the message above says why. Everything below
-           reads from these three answers, and rendering it without them put
+           reads from these four answers, and rendering it without them put
            "NaN undefined" on screen where the week should be - a page that
            looks broken rather than one that says what happened. -->
       <p class="quiet">
@@ -469,6 +478,47 @@
               {goal ? "Adjust this goal" : "Set a goal for this week"}
             </button>
           </div>
+        {/if}
+      </section>
+
+      <!-- --------------------------------------------------- last 7 days -->
+      <!-- Deliberately its own window, not a restatement of "This week"
+           above. That section's week is the preference-anchored calendar
+           week ("This week" started Monday, say); this one is a rolling last
+           seven days from GET /api/practice/summary, and the two can name a
+           different span near a week boundary. Where they disagree this is
+           the one that counts (issue #293). -->
+      <section class="last7">
+        <div class="section-head">
+          <h2>Last 7 days</h2>
+          <span class="quiet">today and the six before it</span>
+        </div>
+        <p class="statement-text totals last7-totals">
+          {#if summary.week_seconds}
+            {formatDuration(summary.week_seconds)} across {summary.week_sessions}
+            session{summary.week_sessions === 1 ? "" : "s"}.
+          {:else}
+            No practice recorded in the last 7 days.
+          {/if}
+        </p>
+        {#if summary.top_scores.length}
+          <ul class="spent last7-scores">
+            {#each summary.top_scores as row (row.id)}
+              <li>
+                {#if row.deleted}
+                  <span
+                    class="deleted-piece"
+                    title="This score is in the trash. The practice still counts."
+                  >
+                    {row.title} <span class="deleted-mark">deleted</span>
+                  </span>
+                {:else}
+                  <a href={"#/score/" + row.id}>{row.title}</a>
+                {/if}
+                <span class="quiet">{formatDuration(row.practice_seconds)}</span>
+              </li>
+            {/each}
+          </ul>
         {/if}
       </section>
 

--- a/web/src/lib/Practice.svelte
+++ b/web/src/lib/Practice.svelte
@@ -129,7 +129,7 @@
         api.currentGoal(today),
         api.practiceReview(REVIEW_WEEKS, today),
         api.practiceHistory(HISTORY_DAYS, today),
-        api.practiceSummary(),
+        api.practiceSummary(today),
         api.scores(),
       ]);
       current = nextCurrent;

--- a/web/src/lib/api.js
+++ b/web/src/lib/api.js
@@ -87,7 +87,8 @@ export const api = {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(body),
     }).then(j),
-  practiceSummary: () => fetch("/api/practice/summary").then(j),
+  practiceSummary: (today) =>
+    fetch(`/api/practice/summary?today=${today}`).then(j),
   // How one piece is going (#57): its whole record, the window's per-day
   // totals, the tempo each session was practised at, how the time split
   // between section work and run-throughs, the sessions with their notes, and

--- a/web/src/lib/api.js
+++ b/web/src/lib/api.js
@@ -157,13 +157,16 @@ export const api = {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ token }),
     }).then(j),
-  upload: (file, folder = "Uploads") => {
+  // `replace` (#293) resends the same call after a 409 named the path
+  // already there - the stored bytes are untouched unless this is true, and
+  // the receipt's `replaced` says which happened.
+  upload: (file, folder = "Uploads", replace = false) => {
     const fd = new FormData();
     fd.append("file", file);
-    return fetch(`/api/upload?folder=${encodeURIComponent(folder)}`, {
-      method: "POST",
-      body: fd,
-    }).then(j);
+    return fetch(
+      `/api/upload?folder=${encodeURIComponent(folder)}&replace=${replace}`,
+      { method: "POST", body: fd },
+    ).then(j);
   },
   // --- Managing the library (issue #56) ------------------------------------
   // The one part of this API that writes to the user's own files. Two habits
@@ -328,6 +331,11 @@ export const api = {
     }).then(j),
   deleteTrainerPreset: (id) => fetch(`/api/trainer/presets/${id}`, { method: "DELETE" }).then(j),
   version: () => fetch("/api/version").then(j),
+  // The identity, if any, a trusted reverse proxy vouched for on this request
+  // (issue #16, #293) - display only, always 200. `enabled` is whether
+  // reverse-proxy auth is configured at all; `username` is null whenever it
+  // is not, or when it is but this request carried none.
+  me: () => fetch("/api/me").then(j),
   settings: () => fetch("/api/settings").then(j),
   putSettings: (values) =>
     fetch("/api/settings", {

--- a/web/src/lib/identity.js
+++ b/web/src/lib/identity.js
@@ -1,0 +1,21 @@
+// What the header shows about who a trusted reverse proxy vouched for on
+// this request (issue #16, #293) - display only, and nothing here changes
+// what the application does with what it reads.
+//
+// No runes and no imports, the same reason practice.js has none: this is a
+// pure function of MeOut's own shape, so a test can call it directly with
+// both shapes rather than mounting a component to prove the text.
+
+/**
+ * What to show for `GET /api/me`'s answer, or null to show nothing.
+ *
+ * `enabled` false means reverse-proxy auth is not configured at all - the
+ * out-of-the-box state - and nothing is shown, the same as before this
+ * feature existed. `enabled` true with `username` null means auth IS
+ * configured but this particular request carried no identity, which is a
+ * different fact from auth being off and is said as one.
+ */
+export function identityLabel(me) {
+  if (!me || !me.enabled) return null;
+  return me.username || "no identity on this request";
+}

--- a/web/tests/browser/data-portability.spec.js
+++ b/web/tests/browser/data-portability.spec.js
@@ -164,9 +164,10 @@ test("a preview names the newer tables too, when the archive actually carries th
   // import path this test actually means to exercise, never the POST
   // routes), and the counts read before and after prove neither table was
   // touched.
-  // /api/upload answers with only { saved: <path> } - the score row it
-  // starts a scan to create is read back separately, the same way
-  // zzz-library-organise.spec.js's own upload() helper does.
+  // /api/upload answers with { saved: <path>, replaced: <bool> } (#293), not
+  // a score row - the row it starts a scan to create is read back
+  // separately, the same way zzz-library-organise.spec.js's own upload()
+  // helper does.
   const uploadName = "data-portability-seed.musicxml";
   await request.post("/api/upload?folder=Uploads", {
     multipart: {

--- a/web/tests/browser/practice.spec.js
+++ b/web/tests/browser/practice.spec.js
@@ -11,9 +11,16 @@
 // screen, the colours it reaches it in, the values that survive a reload, and
 // the fact that a session logged from this page lands in the record the server
 // keeps.
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
 import { expect, test } from "@playwright/test";
 
 import { addDays, forbiddenWord, localDay, weekStart } from "../../src/lib/practice.js";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const FIXTURE = path.join(here, "..", "..", "test-fixtures", "notation-only.musicxml");
 
 const week = (page) => page.locator("section.week");
 const statements = (page) => page.locator("section.week .statement");
@@ -609,4 +616,62 @@ test("nothing on this page says anything that grades the person", async ({ page,
 
   const text = await page.locator("main").innerText();
   expect(forbiddenWord(text), text).toBeNull();
+});
+
+test("the last 7 days section shows the route's own totals, a different window than This week", async ({
+  page,
+  request,
+}) => {
+  // Issue #293: GET /api/practice/summary (week_seconds, week_sessions,
+  // top_scores) had zero callers. Practised against a real piece, so
+  // top_scores has something to name, and this file's own beforeEach
+  // refuses to run against a library that has scores in it - so this test
+  // uploads its own score and is the one that removes it again, in `finally`,
+  // regardless of how the assertions below turn out.
+  const name = "practice-summary-293.musicxml";
+  const uploaded = await request.post("/api/upload?folder=Uploads", {
+    multipart: {
+      file: { name, mimeType: "application/xml", buffer: fs.readFileSync(FIXTURE) },
+    },
+  });
+  expect(uploaded.ok(), await uploaded.text()).toBe(true);
+  let score;
+  await expect(async () => {
+    const scores = await (await request.get("/api/scores")).json();
+    score = scores.find((s) => s.path === `Uploads/${name}`);
+    expect(score, `${name} never appeared in the library`).toBeTruthy();
+  }).toPass({ timeout: 30_000 });
+  await expect(async () => {
+    const status = await (await request.get("/api/scan/status")).json();
+    expect(status.scanning).toBe(false);
+  }).toPass({ timeout: 30_000 });
+
+  const sessionIds = [];
+  try {
+    const piece = await (
+      await request.post(`/api/scores/${score.id}/practice`, {
+        data: { seconds: 1800, local_date: today },
+      })
+    ).json();
+    sessionIds.push(piece.session.id);
+    const other = await request.post("/api/practice/sessions", {
+      data: { activity: "technique", seconds: 900, local_date: today },
+    });
+    expect(other.ok(), await other.text()).toBe(true);
+    sessionIds.push((await other.json()).id);
+
+    await page.reload();
+    const summary = page.locator("section.last7");
+    await expect(summary).toBeVisible();
+    // 1800s + 900s = 2700s = 45m, across the 2 sessions just logged - the
+    // route's own arithmetic, not this page reworking history itself.
+    await expect(summary.locator(".last7-totals")).toContainText("45m across 2 sessions");
+    const row = summary.locator(".last7-scores li", { hasText: score.title });
+    await expect(row).toContainText("30m");
+    await expect(row.locator("a")).toHaveAttribute("href", `#/score/${score.id}`);
+  } finally {
+    for (const id of sessionIds) await request.delete(`/api/practice/sessions/${id}`);
+    await request.delete(`/api/scores/${score.id}`);
+    await request.delete(`/api/trash/${score.id}`);
+  }
 });

--- a/web/tests/browser/viewer-practice.spec.js
+++ b/web/tests/browser/viewer-practice.spec.js
@@ -55,7 +55,12 @@ async function waitForScore(request, name) {
 }
 
 async function upload(request, name) {
-  const res = await request.post("/api/upload?folder=Uploads", {
+  // replace=true (#293): beforeEach below uploads to this SAME path every
+  // test, on purpose (see this file's own "WHY THE FILES ARE NOT TAKEN BACK
+  // OUT" comment) - the file genuinely already exists here from the previous
+  // test in this run, and this is the one spec that means to overwrite it
+  // rather than to be refused for colliding with itself.
+  const res = await request.post("/api/upload?folder=Uploads&replace=true", {
     multipart: {
       file: { name, mimeType: "application/xml", buffer: fs.readFileSync(FIXTURE) },
     },

--- a/web/tests/browser/zzz-library-organise.spec.js
+++ b/web/tests/browser/zzz-library-organise.spec.js
@@ -29,8 +29,15 @@ import { fileURLToPath } from "node:url";
 
 import { expect, test } from "@playwright/test";
 
+import { localDay } from "../../src/lib/practice.js";
+
 const here = path.dirname(fileURLToPath(import.meta.url));
 const FIXTURE = path.join(here, "..", "..", "test-fixtures", "notation-only.musicxml");
+// The browser's own date, the same way Viewer.svelte stamps a practice
+// session (Viewer.svelte:558) - not the server's UTC date, which stamped
+// these sessions one day into the future on a machine west of Greenwich
+// after 18:00 local, dropping them off the practice page's local-day window.
+const today = localDay();
 
 const libraryDir = () => {
   const dir = process.env.FERMATA_TEST_LIBRARY_DIR;
@@ -151,7 +158,7 @@ test("a move is previewed before it happens, and the move that happens is the on
   // Practice on it FIRST, so what survives the move is something a person put
   // there rather than an empty row.
   const logged = await request.post(`/api/scores/${score.id}/practice`, {
-    data: { seconds: 1800, note: "before the move" },
+    data: { seconds: 1800, note: "before the move", local_date: today },
   });
   expect(logged.ok(), await logged.text()).toBe(true);
 
@@ -240,7 +247,7 @@ test("deleting a score takes it to the trash with its history, and one press bri
 }) => {
   const score = await upload(request, "organise-delete.musicxml");
   await request.post(`/api/scores/${score.id}/practice`, {
-    data: { seconds: 3600, note: "hours on this" },
+    data: { seconds: 3600, note: "hours on this", local_date: today },
   });
   // ScoreDeleteOut's tags_kept and goals_kept were never named in the receipt
   // (issue #284) - seeded here so deleting actually carries a nonzero count
@@ -365,7 +372,9 @@ test("destroying a score takes two presses and says what it destroys", async ({
 }) => {
   const score = await upload(request, "organise-destroy.musicxml");
   const logged = await (
-    await request.post(`/api/scores/${score.id}/practice`, { data: { seconds: 600 } })
+    await request.post(`/api/scores/${score.id}/practice`, {
+      data: { seconds: 600, local_date: today },
+    })
   ).json();
   // ScorePurgeOut's goals_kept and file_deleted were never named in the
   // "gone for good" receipt (issue #284) - a goal here makes the first
@@ -422,7 +431,7 @@ test("practice on a deleted score still counts, and stops being a way into it", 
   // being is a LINK, into a library that no longer holds the score.
   const score = await upload(request, "organise-history.musicxml");
   const logged = await request.post(`/api/scores/${score.id}/practice`, {
-    data: { seconds: 2700, note: "before it went" },
+    data: { seconds: 2700, note: "before it went", local_date: today },
   });
   expect(logged.ok(), await logged.text()).toBe(true);
 
@@ -492,6 +501,11 @@ test("uploading the same name twice is refused until Replace is pressed, and the
   await input.setInputFiles({ name, mimeType: "application/xml", buffer: replacement });
   const conflict = page.locator(".upload-conflict");
   await expect(conflict).toContainText(`Uploads/${name}`);
+  // This batch was one file and it 409'd, so it posts no receipt of its own -
+  // and must not leave the PREVIOUS batch's "Saved as ..." sitting beside the
+  // conflict sentence, naming a file that already existed as if this upload
+  // had just written it.
+  await expect(receipt).toHaveCount(0);
   const replaceButton = conflict.locator(".conflict-replace");
   await expect(replaceButton).toBeVisible();
   expect(fs.readFileSync(path.join(libraryDir(), "Uploads", name))).toEqual(original);

--- a/web/tests/browser/zzz-library-organise.spec.js
+++ b/web/tests/browser/zzz-library-organise.spec.js
@@ -456,6 +456,52 @@ test("practice on a deleted score still counts, and stops being a way into it", 
   await expect(sessionAfter.locator("a")).toHaveCount(0);
 });
 
+test("uploading the same name twice is refused until Replace is pressed, and the file is untouched until then", async ({
+  page,
+  request,
+}) => {
+  // Issue #293: the upload route used to overwrite a same-named file
+  // silently, with no receipt of any kind (Library.svelte's onUpload
+  // discarded the response). This drives the real file input, the way a
+  // person actually uploads, rather than posting to /api/upload directly.
+  const name = "organise-upload-conflict.musicxml";
+  const original = Buffer.concat([fs.readFileSync(FIXTURE), Buffer.from(`<!-- ${name} original -->\n`)]);
+  const replacement = Buffer.concat([
+    fs.readFileSync(FIXTURE),
+    Buffer.from(`<!-- ${name} replacement -->\n`),
+  ]);
+
+  await page.goto("/#/");
+  const input = page.locator('input[type="file"]');
+
+  await input.setInputFiles({ name, mimeType: "application/xml", buffer: original });
+  await expect(page.locator(".notice")).toContainText(`Saved as Uploads/${name}`);
+  await expect(async () => {
+    const scores = await (await request.get("/api/scores")).json();
+    expect(scores.find((s) => s.path === `Uploads/${name}`), `${name} never appeared`).toBeTruthy();
+  }).toPass({ timeout: SCAN_DEADLINE_MS });
+  await scanSettled(request);
+
+  // The second upload of the same name is refused, and shown as a decision
+  // still waiting to be made - not as a receipt of something already done.
+  await input.setInputFiles({ name, mimeType: "application/xml", buffer: replacement });
+  const conflict = page.locator(".upload-conflict");
+  await expect(conflict).toContainText(`Uploads/${name}`);
+  const replaceButton = conflict.locator(".conflict-replace");
+  await expect(replaceButton).toBeVisible();
+  expect(fs.readFileSync(path.join(libraryDir(), "Uploads", name))).toEqual(original);
+
+  // Pressing Replace is the second, deliberate request that actually changes
+  // the file - and only now does it change.
+  await replaceButton.click();
+  await expect(page.locator(".notice")).toContainText(`Replaced Uploads/${name}`);
+  await expect(conflict).toHaveCount(0);
+  await expect(async () => {
+    expect(fs.readFileSync(path.join(libraryDir(), "Uploads", name))).toEqual(replacement);
+  }).toPass({ timeout: SCAN_DEADLINE_MS });
+  await scanSettled(request);
+});
+
 test("a batch move shows every line, and a collision is blocked rather than overwritten", async ({
   page,
   request,

--- a/web/tests/browser/zzz-library-organise.spec.js
+++ b/web/tests/browser/zzz-library-organise.spec.js
@@ -474,8 +474,13 @@ test("uploading the same name twice is refused until Replace is pressed, and the
   await page.goto("/#/");
   const input = page.locator('input[type="file"]');
 
+  // ".notice:not(.upload-conflict)" throughout, not plain ".notice" - the
+  // conflict paragraph below carries "notice" too (issue #293's own upload
+  // receipt uses the same styling as every other receipt on this page), and
+  // once both are on screen at once a plain ".notice" is not one element.
+  const receipt = page.locator(".notice:not(.upload-conflict)");
   await input.setInputFiles({ name, mimeType: "application/xml", buffer: original });
-  await expect(page.locator(".notice")).toContainText(`Saved as Uploads/${name}`);
+  await expect(receipt).toContainText(`Saved as Uploads/${name}`);
   await expect(async () => {
     const scores = await (await request.get("/api/scores")).json();
     expect(scores.find((s) => s.path === `Uploads/${name}`), `${name} never appeared`).toBeTruthy();
@@ -494,7 +499,7 @@ test("uploading the same name twice is refused until Replace is pressed, and the
   // Pressing Replace is the second, deliberate request that actually changes
   // the file - and only now does it change.
   await replaceButton.click();
-  await expect(page.locator(".notice")).toContainText(`Replaced Uploads/${name}`);
+  await expect(receipt).toContainText(`Replaced Uploads/${name}`);
   await expect(conflict).toHaveCount(0);
   await expect(async () => {
     expect(fs.readFileSync(path.join(libraryDir(), "Uploads", name))).toEqual(replacement);

--- a/web/tests/browser/zzzzzz-score-metadata.spec.js
+++ b/web/tests/browser/zzzzzz-score-metadata.spec.js
@@ -63,7 +63,11 @@ async function waitForScore(request, name) {
 }
 
 async function uploadNamed(request, name, title) {
-  const res = await request.post("/api/upload?folder=Uploads", {
+  // replace=true (#293): this file's own beforeEach calls this with the SAME
+  // two names every test and leaves the files in place between tests on
+  // purpose (see this file's own header) - a genuine, intentional overwrite,
+  // not the accidental collision refuse-or-replace exists to catch.
+  const res = await request.post("/api/upload?folder=Uploads&replace=true", {
     multipart: {
       file: { name, mimeType: "application/xml", buffer: fs.readFileSync(FIXTURE) },
     },

--- a/web/tests/spec-floors/browser-library-organise-upload-293.json
+++ b/web/tests/spec-floors/browser-library-organise-upload-293.json
@@ -1,0 +1,5 @@
+{
+  "file": "tests/browser/zzz-library-organise.spec.js",
+  "count": 1,
+  "reason": "issue #293: uploading the same name twice through the real file input is refused with a decision still waiting (a path named, a Replace control) rather than a silent overwrite, and the stored bytes are untouched until Replace is actually pressed."
+}

--- a/web/tests/spec-floors/browser-practice-summary-293.json
+++ b/web/tests/spec-floors/browser-practice-summary-293.json
@@ -1,0 +1,5 @@
+{
+  "file": "tests/browser/practice.spec.js",
+  "count": 1,
+  "reason": "issue #293: the practice page's Last 7 days section renders week_seconds, week_sessions and top_scores from GET /api/practice/summary - a rolling window distinct from This week's calendar-week arithmetic, and previously fetched nowhere in the interface."
+}

--- a/web/tests/spec-floors/unit-identity-293.json
+++ b/web/tests/spec-floors/unit-identity-293.json
@@ -1,0 +1,5 @@
+{
+  "file": "tests/unit/identity.spec.js",
+  "count": 3,
+  "reason": "issue #293: the header's vouched-name display is a pure function of GET /api/me's shape - nothing shown when reverse-proxy auth is off, the username when it is on and the request carried one, and a distinct sentence when it is on but this request carried none."
+}

--- a/web/tests/unit/identity.spec.js
+++ b/web/tests/unit/identity.spec.js
@@ -1,0 +1,22 @@
+// The header's identity display (issue #293) - a pure function of MeOut's
+// own shape, checked directly with both shapes rather than through a
+// mounted component. See fermata/authproxy.py and GET /api/me for what
+// produces the shape this checks.
+import { expect, test } from "@playwright/test";
+
+import { identityLabel } from "../../src/lib/identity.js";
+
+test("nothing is shown when reverse-proxy auth is off", () => {
+  expect(identityLabel({ enabled: false, username: null })).toBeNull();
+  // A response that never arrived (still loading) reads the same as off,
+  // never as a name - a null answer must not flash a stale prior value.
+  expect(identityLabel(null)).toBeNull();
+});
+
+test("the vouched name is shown when auth is on and the request carried one", () => {
+  expect(identityLabel({ enabled: true, username: "alex" })).toBe("alex");
+});
+
+test("a request that carried no identity says so, distinctly from auth being off", () => {
+  expect(identityLabel({ enabled: true, username: null })).toBe("no identity on this request");
+});


### PR DESCRIPTION
## Summary

Wires up three server halves issue #293 found with no reader.

- **Upload receipt and refuse-or-replace.** `POST /api/upload` now refuses a same-named file with `409` naming the relative path, unless the request sends `replace=true`; the stored bytes are untouched until then. The receipt (`UploadOut`) now names the saved path and whether the call `replaced` an existing file. `Library.svelte` shows the path per upload and, on a 409, an inline conflict with a **Replace** control that resends with `replace=true`.
- **Practice page's Last 7 days.** `GET /api/practice/summary` (`week_seconds`, `week_sessions`, `top_scores`) had zero callers. The practice page's own "This week" section uses a preference-anchored *calendar* week, a genuinely different window from this route's rolling last-7-days - so rather than merge them, `Practice.svelte` renders a separate **Last 7 days** section from the route directly.
- **Vouched identity in the header.** When `GET /api/me` reports `enabled: true`, the sidebar shows the proxy-vouched `username` (or "no identity on this request" when none was carried); nothing renders when auth is off. The display logic is a pure `identityLabel()` function, unit-tested with both shapes.

### Premise re-derivation (measured against main 0d27896)

- Upload's missing existence check - **valid**. `dest.open("wb")` had no prior existence check; a same-named upload silently overwrote the file.
- Discarded `saved` receipt - **valid**. `Library.svelte`'s `onUpload` was `for (const f of files) await api.upload(f);` - the response was never read.
- Zero callers of `practiceSummary` - **valid**. `api.js` had the wrapper; nothing in `web/src` called it.
- No `/api/me` fetch anywhere - **valid**. Confirmed by grep.

### A design correction found by the shared-database verification pass

The first cut held a `replace` against `scanner.hold_library_still()`, reasoning it could overwrite a file a running scan is mid-read on. Running the full shared-browser-DB test set (per this repo's own verification discipline) surfaced that two existing specs (`viewer-practice.spec.js`, `zzzzzz-score-metadata.spec.js`) deliberately re-upload the same fixture path every test - a legitimate pattern the hold made flaky. On reflection, a replace only ever writes at a path *the request itself named*, never one discovered by walking the library, so it cannot invalidate a scan's listing the way a move or delete can - the same exemption a fresh upload already has. Dropped the hold; updated the two specs to pass `replace=true` explicitly (which is what they mean); replaced the now-wrong "refused while scanning" test with one proving the opposite.

### Mutation testing (all reverted afterward)

| Removed / broken | Test that went red |
| --- | --- |
| The `existed and not replace` 409 check | `test_uploading_the_same_name_twice_is_refused_with_409_naming_the_path` |
| The `replaced` field (forced to `False`) | `test_replace_true_overwrites_and_the_receipt_says_so` |
| Reintroducing `hold_library_still` on replace | `test_a_replace_is_also_not_held_against_a_running_scan` |
| `identityLabel`'s `enabled` check | unit test "nothing is shown when reverse-proxy auth is off" |
| `api.practiceSummary()` fetch (stubbed to zeros) | new practice.spec.js browser test |
| `Library.svelte`'s receipt/conflict handling (reverted to discarding the response) | new zzz-library-organise.spec.js browser test |

### Verification

- Server suite: `1429 passed, 92 skipped` (unchanged skip count), `FERMATA_TEST_LIBRARY` unset, `web/node_modules` absent for that run.
- `npm run build` before every browser run; `web/tests/spec-floors/*` gained three new entries (never edited existing ones).
- Shared-database browser rule: ran `navigation.spec.js`, `practice.spec.js`, and every spec sorting after it that asserts emptiness or an exact count (`scope-presets`, `score-compare-disclosures`, `score-compare-warnings`, `score-editor-native-262`, `score-editor-range-251`, `viewer-practice`, `zz-library-missing`, `zzz-library-organise`, `zzzz-library-auto-transcribe`, `zzzz-library-transcribe-batch`, `zzzz-score-progress`, `zzzzz-setlists`, `zzzzzz-score-metadata`) together, in that order, on a private port: **158/159 passed**.
- The one failure (`zzz-library-organise.spec.js`'s pre-existing "practice on a deleted score still counts" test) is **not caused by this change** - confirmed by re-running it against fully unmodified `Practice.svelte`, `api.py` and `api_models.py` in this environment, where it fails identically. It's a timezone-dependent gap: this machine is UTC-6 and past midnight UTC, so a session logged with no explicit `local_date` lands on tomorrow's UTC date, outside `practice/history`'s 90-day window ending at the browser's local "today" - the same class of bug this codebase's `local_date_source` field exists to name, just untested here since this particular spec doesn't pin a timezone. Left alone as out of scope for this bet.

## Test plan

- [x] `server/tests/test_scanner.py` - refuse/replace/not-held-against-a-scan, mutation-verified
- [x] `server/tests/test_api_doc_prose.py`, `test_api_docs.py` - green
- [x] `web/tests/unit/identity.spec.js` - both shapes, mutation-verified
- [x] `web/tests/browser/zzz-library-organise.spec.js` - real file-input upload/conflict/replace flow
- [x] `web/tests/browser/practice.spec.js` - Last 7 days renders the route's own totals
- [x] Full server suite: 1429 passed / 92 skipped (baseline-matching)
- [x] Ordered shared-DB browser set: 158/159 (one pre-existing, unrelated, environment-specific flake)

## After review

Fixed the flake named above rather than leaving it out of scope: `GET /api/practice/summary` now accepts an optional `today` query parameter, parsed and defaulted exactly the way `GET /api/practice/history` already does, and computes its window as `today` and the six local days before it instead of `date('now')` (UTC). `Practice.svelte` and `api.js` pass the browser's local date the same way the history call does. Added a server test (sessions on eight consecutive local days, mutation-verified against a revert to `date('now')`) and updated `docs/practice-data.md`.

The flake itself was `zzz-library-organise.spec.js`'s practice POSTs, several of which never sent `local_date` and so were stamped with the server's UTC date - dropping them from the practice page's local-day window on a machine west of Greenwich after 18:00 local. All four are fixed to pass `local_date` the way `Viewer.svelte` does.

Nits: `Library.svelte`'s `onUpload` now clears the stale `notice` at the start of each upload batch, so a batch that 409s on every file no longer shows a leftover "Saved as ..." beside the conflict sentence (browser test updated to assert the receipt is gone in that case); the upload route now creates the destination folder only after the existing-file check passes, so a refused upload into a brand-new folder leaves nothing behind; dropped a dead `str()` around an already-string path; and the identity tag (which renders on the library page only) no longer carries a deployment-jargon `title` attribute.
